### PR TITLE
fix: add missing test assertions for SonarQube S2699 blockers

### DIFF
--- a/XLibur.Tests/Excel/Cells/XLCellFormulaTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellFormulaTests.cs
@@ -23,9 +23,9 @@ public class XLCellFormulaTests
     [Test]
     public void DataTable_MaintainProperties()
     {
-        TestHelper.LoadSaveAndCompare(
+        Assert.DoesNotThrow(() => TestHelper.LoadSaveAndCompare(
             @"Other\Formulas\DataTableFormula-Excel-Input.xlsx",
-            @"Other\Formulas\DataTableFormula-Output.xlsx");
+            @"Other\Formulas\DataTableFormula-Output.xlsx"));
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Columns/ColumnTests.cs
+++ b/XLibur.Tests/Excel/Columns/ColumnTests.cs
@@ -225,6 +225,9 @@ public class ColumnTests
         var ws = new XLWorkbook().AddWorksheet("Sheet1");
         ws.Columns(1, 2).Group();
         ws.Columns(1, 2).Ungroup(true);
+
+        Assert.That(ws.Column(1).OutlineLevel, Is.EqualTo(0));
+        Assert.That(ws.Column(2).OutlineLevel, Is.EqualTo(0));
     }
 
     [Test]
@@ -295,7 +298,11 @@ public class ColumnTests
         // has a defined name with an invalid formula.
         var wb = new XLWorkbook();
         wb.DefinedNames.Add("TestName", XLError.NameNotRecognized.ToDisplayString());
-        wb.AddWorksheet().FirstColumn().InsertColumnsAfter(1);
-        wb.AddWorksheet().FirstColumn().InsertColumnsBefore(1);
+        var ws1 = wb.AddWorksheet();
+        ws1.FirstColumn().InsertColumnsAfter(1);
+        var ws2 = wb.AddWorksheet();
+        ws2.FirstColumn().InsertColumnsBefore(1);
+
+        Assert.That(wb.Worksheets.Count, Is.EqualTo(2));
     }
 }

--- a/XLibur.Tests/Excel/Columns/ColumnTests.cs
+++ b/XLibur.Tests/Excel/Columns/ColumnTests.cs
@@ -299,9 +299,9 @@ public class ColumnTests
         var wb = new XLWorkbook();
         wb.DefinedNames.Add("TestName", XLError.NameNotRecognized.ToDisplayString());
         var ws1 = wb.AddWorksheet();
-        ws1.FirstColumn().InsertColumnsAfter(1);
+        Assert.DoesNotThrow(() => ws1.FirstColumn().InsertColumnsAfter(1));
         var ws2 = wb.AddWorksheet();
-        ws2.FirstColumn().InsertColumnsBefore(1);
+        Assert.DoesNotThrow(() => ws2.FirstColumn().InsertColumnsBefore(1));
 
         Assert.That(wb.Worksheets.Count, Is.EqualTo(2));
     }

--- a/XLibur.Tests/Excel/Drawings/PictureTests.cs
+++ b/XLibur.Tests/Excel/Drawings/PictureTests.cs
@@ -17,7 +17,7 @@ public class PictureTests
     [TestCase("Other.Drawings.picture-webp.xlsx")]
     public void Can_load_and_save_workbook_with_image_type(string resourceWithImageType)
     {
-        TestHelper.LoadSaveAndCompare(resourceWithImageType, resourceWithImageType);
+        Assert.DoesNotThrow(() => TestHelper.LoadSaveAndCompare(resourceWithImageType, resourceWithImageType));
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Loading/LoadingTests.cs
+++ b/XLibur.Tests/Excel/Loading/LoadingTests.cs
@@ -173,6 +173,8 @@ public class LoadingTests
         using var wb = new XLWorkbook(stream);
         using var ms = new MemoryStream();
         wb.SaveAs(ms, true);
+
+        Assert.That(ms.Length, Is.GreaterThan(0));
     }
 
     [Test]
@@ -238,6 +240,8 @@ public class LoadingTests
         using var wb = new XLWorkbook(stream);
         using var ms = new MemoryStream();
         wb.SaveAs(ms, true);
+
+        Assert.That(ms.Length, Is.GreaterThan(0));
     }
 
     [Test]
@@ -268,6 +272,8 @@ public class LoadingTests
         using var wb = new XLWorkbook(stream);
         using var ms = new MemoryStream();
         wb.SaveAs(ms, true);
+
+        Assert.That(ms.Length, Is.GreaterThan(0));
     }
 
     /// <summary>

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -337,9 +337,9 @@ public class XLPivotTableTests
         // Load an excel that contains a table which has various combinations of types in columns.
         // The pivot cache definition contain various flags in shared items for each field and the
         // test checks the flags in cache are set correctly (they are determined in cache writer).
-        TestHelper.LoadSaveAndCompare(
+        Assert.DoesNotThrow(() => TestHelper.LoadSaveAndCompare(
             @"Other\PivotTableReferenceFiles\VariousDataTypesInTableColumns\input.xlsx",
-            @"Other\PivotTableReferenceFiles\VariousDataTypesInTableColumns\output.xlsx");
+            @"Other\PivotTableReferenceFiles\VariousDataTypesInTableColumns\output.xlsx"));
     }
 
     [Test]
@@ -694,9 +694,9 @@ public class XLPivotTableTests
     {
         // Make sure that if the original file has *subtotals*, the subtotals are
         // turned on even after loading into XLibur and then saving the document.
-        TestHelper.LoadSaveAndCompare(
+        Assert.DoesNotThrow(() => TestHelper.LoadSaveAndCompare(
             @"Other\PivotTableReferenceFiles\PivotSubtotalsSource\input.xlsx",
-            @"Other\PivotTableReferenceFiles\PivotSubtotalsSource\output.xlsx");
+            @"Other\PivotTableReferenceFiles\PivotSubtotalsSource\output.xlsx"));
     }
 
     [Test]
@@ -803,9 +803,9 @@ public class XLPivotTableTests
         // At this time, there is no content, only shape, because we don't have an engine
         // to determine correct layout and values. Change RefreshDataOnOpen to 0 and change
         // PT in Excel to see the values (aka gimp on Excel PT engine).
-        TestHelper.LoadSaveAndCompare(
+        Assert.DoesNotThrow(() => TestHelper.LoadSaveAndCompare(
             @"Other\PivotTableReferenceFiles\PivotTableWithoutSourceData-input.xlsx",
-            @"Other\PivotTableReferenceFiles\PivotTableWithoutSourceData-output.xlsx");
+            @"Other\PivotTableReferenceFiles\PivotTableWithoutSourceData-output.xlsx"));
     }
 
     [Test]
@@ -988,6 +988,8 @@ public class XLPivotTableTests
         using var wb = new XLWorkbook(stream);
         using var ms = new MemoryStream();
         wb.SaveAs(ms);
+
+        Assert.That(ms.Length, Is.GreaterThan(0));
     }
 
     [Test]
@@ -998,6 +1000,8 @@ public class XLPivotTableTests
         using var wb = new XLWorkbook(stream);
         using var ms = new MemoryStream();
         wb.SaveAs(ms);
+
+        Assert.That(ms.Length, Is.GreaterThan(0));
     }
 
     [Test]

--- a/XLibur.Tests/Excel/RichText/XLRichStringTests.cs
+++ b/XLibur.Tests/Excel/RichText/XLRichStringTests.cs
@@ -862,8 +862,8 @@ public class XLRichStringTests
         // contains phonetic run for the kanji in the text that would be out-of-bounds if space
         // attribute there. The input is from Excel, output is by XLibur. Output must contain
         // the space attribute.
-        TestHelper.LoadSaveAndCompare(
+        Assert.DoesNotThrow(() => TestHelper.LoadSaveAndCompare(
             @"Other\RichText\kanji-with-new-line-input.xlsx",
-            @"Other\RichText\kanji-with-new-line-output.xlsx");
+            @"Other\RichText\kanji-with-new-line-output.xlsx"));
     }
 }


### PR DESCRIPTION
## Summary
- Add explicit assertions to 13 test methods flagged as **BLOCKER** by SonarQube rule S2699 ("Add at least one assertion to this test case")
- Tests with `LoadSaveAndCompare`/`CreateAndCompare` helpers (which assert internally) are wrapped in `Assert.DoesNotThrow`
- Manual load/save tests get `Assert.That(ms.Length, Is.GreaterThan(0))` to verify output was written
- `UngroupFromAll` and column insertion tests get meaningful state assertions (`OutlineLevel`, `Worksheets.Count`)

## Test plan
- [x] All 13 affected tests pass on both net8.0 and net10.0 (28/28 passed)
- [x] Build succeeds with zero warnings and zero errors
- [ ] SonarCloud analysis confirms blockers are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced assertions across Excel tests to explicitly verify no exceptions occur during load/save operations.
  * Added basic post-save validations to confirm saved output is non-empty.
  * Strengthened column-related tests to verify outline level resets and expected worksheet structure after column operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->