### PR TITLE
fix: correct coverlet format and pin coverage to net10.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,8 +65,10 @@ jobs:
           dotnet test XLibur.Tests/XLibur.Tests.csproj
           --configuration Release
           --no-build
+          --framework net10.0
           --logger "trx;LogFileName=test-results.trx"
-          --collect:"XPlat Code Coverage;Format=opencover"
+          --collect:"XPlat Code Coverage"
+          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
 
       - name: End SonarCloud analysis
         if: env.SONAR_TOKEN != ''


### PR DESCRIPTION
## Summary
- Fix coverlet `Format=opencover` parameter syntax — the inline semicolon syntax was silently ignored, producing cobertura instead of opencover XML that SonarCloud expects
- Pin test coverage run to `--framework net10.0` to avoid duplicate coverage reports from multi-TFM execution

## Test plan
- [ ] CI build passes with SonarCloud analysis
- [ ] SonarCloud reports code coverage (was previously 0% due to format mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)