### PR TITLE
fix: resolve SonarCloud security hotspots

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -59,11 +59,15 @@ jobs:
 
       - name: Push to NuGet
         if: ${{ inputs.dry-run == false }}
-        run: dotnet nuget push ./artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push ./artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate
 
       - name: Push symbols to NuGet
         if: ${{ inputs.dry-run == false }}
-        run: dotnet nuget push ./artifacts/*.snupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push ./artifacts/*.snupkg --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate
 
       - name: Dry run — skipped NuGet publish
         if: ${{ inputs.dry-run == true }}

--- a/XLibur.Benchmarks/ClosedXmlReadBenchmarks.cs
+++ b/XLibur.Benchmarks/ClosedXmlReadBenchmarks.cs
@@ -20,7 +20,9 @@ public class ClosedXmlReadBenchmarks
         using var workbook = new XLWorkbook();
         var ws = workbook.AddWorksheet("Data");
 
+#pragma warning disable S2245 // Deterministic seed for reproducible benchmarks
         var random = new Random(42);
+#pragma warning restore S2245
         var baseDate = new DateTime(2020, 1, 1);
         string[] regions = { "North", "South", "East", "West", "Central" };
         string[] statuses = { "Active", "Pending", "Closed", "Review", "Draft" };

--- a/XLibur.Benchmarks/MemoryProfile.cs
+++ b/XLibur.Benchmarks/MemoryProfile.cs
@@ -173,7 +173,9 @@ public static class MemoryProfile
         using var workbook = new XLWorkbook();
         var ws = workbook.AddWorksheet("Data");
 
+#pragma warning disable S2245 // Deterministic seed for reproducible benchmarks
         var random = new Random(42);
+#pragma warning restore S2245
         var baseDate = new DateTime(2020, 1, 1);
         string[] regions = { "North", "South", "East", "West", "Central" };
         string[] statuses = { "Active", "Pending", "Closed", "Review", "Draft" };

--- a/XLibur.Benchmarks/StyleKeyHashCodeBenchmarks.cs
+++ b/XLibur.Benchmarks/StyleKeyHashCodeBenchmarks.cs
@@ -25,7 +25,9 @@ public class StyleKeyHashCodeBenchmarks
     [GlobalSetup]
     public void Setup()
     {
+#pragma warning disable S2245 // Deterministic seed for reproducible benchmarks
         var random = new Random(42);
+#pragma warning restore S2245
 
         _colorKeys = new XLColorKey[Iterations];
         for (var i = 0; i < Iterations; i++)

--- a/XLibur.Benchmarks/XLiburReadBenchmarks.cs
+++ b/XLibur.Benchmarks/XLiburReadBenchmarks.cs
@@ -20,7 +20,9 @@ public class XLiburReadBenchmarks
         using var workbook = new XLWorkbook();
         var ws = workbook.AddWorksheet("Data");
 
+#pragma warning disable S2245 // Deterministic seed for reproducible benchmarks
         var random = new Random(42);
+#pragma warning restore S2245
         var baseDate = new DateTime(2020, 1, 1);
         string[] regions = { "North", "South", "East", "West", "Central" };
         string[] statuses = { "Active", "Pending", "Closed", "Review", "Draft" };

--- a/XLibur/Excel/IO/DefinedNameReader.cs
+++ b/XLibur/Excel/IO/DefinedNameReader.cs
@@ -14,7 +14,7 @@ namespace XLibur.Excel.IO;
 /// </summary>
 internal static class DefinedNameReader
 {
-    private static readonly Regex DefinedNameRegex = new(@"\A('?).*\1!.*\z", RegexOptions.Compiled);
+    private static readonly Regex DefinedNameRegex = new(@"\A('?).*\1!.*\z", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
     internal static void LoadDefinedNames(Workbook workbook, XLWorkbook xlWorkbook)
     {

--- a/XLibur/Graphics/SvgInfoReader.cs
+++ b/XLibur/Graphics/SvgInfoReader.cs
@@ -86,7 +86,7 @@ internal sealed partial class SvgInfoReader : ImageInfoReader
     {
         // Match attribute="value" or attribute='value'
         var pattern = $@"\b{name}\s*=\s*[""']([^""']*)[""']";
-        var match = Regex.Match(element, pattern, RegexOptions.IgnoreCase);
+        var match = Regex.Match(element, pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(5));
         return match.Success ? match.Groups[1].Value : null;
     }
 


### PR DESCRIPTION
## Summary
- Add regex timeout (5s) to `DefinedNameReader` and `SvgInfoReader` to prevent ReDoS
- Pass secrets via `env:` block in `release-prerelease.yml` instead of inline expansion in `run`
- Suppress S2245 (insecure random) for deterministic `Random(42)` seeds in benchmark files

## Test plan
- [ ] CI build passes
- [ ] SonarCloud security hotspots resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)