### PR TITLE
fix: resolve SonarQube high severity issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,28 @@ dotnet run -c Release --project XLibur.Benchmarks/XLibur.Benchmarks.csproj -- --
 dotnet run -c Release --project XLibur.Benchmarks/XLibur.Benchmarks.csproj -- --filter '*ClosedXmlWorkbookBenchmarks*'
 ```
 
+## Mutation Testing
+
+[Stryker.NET](https://stryker-mutator.io/docs/stryker-net/introduction/) runs daily in CI to measure test effectiveness. To run locally:
+
+```sh
+# Restore the Stryker tool (first time only)
+dotnet tool restore
+
+# Set StrykerEnabled to disable TreatWarningsAsErrors so mutants can compile
+# PowerShell:  $env:StrykerEnabled="true"
+# CMD:         set StrykerEnabled=true
+# Bash:        export StrykerEnabled=true
+
+# Run mutation testing with the default config
+dotnet stryker -f stryker-config.json
+
+# Run against a specific file or folder
+dotnet stryker -f stryker-config.json --mutate "XLibur/Excel/Cells/**/*.cs"
+```
+
+Reports are generated in `StrykerOutput/` — open the HTML report to see surviving mutants.
+
 ## Developer guidelines
 
 Before submitting a PR, run the formatter to ensure your code matches the project style:

--- a/XLibur.Examples/Misc/AdjustToContents.cs
+++ b/XLibur.Examples/Misc/AdjustToContents.cs
@@ -5,7 +5,6 @@ namespace XLibur.Examples.Misc;
 
 public class AdjustToContents : IXLExample
 {
-    // Public
     public void Create(string filePath)
     {
         using var wb = new XLWorkbook();
@@ -23,12 +22,8 @@ public class AdjustToContents : IXLExample
         // Adjust row heights
         ws.Rows(1, 2).AdjustToContents();
 
-        // You can also adjust all rows/columns in one shot
-        // ws.Rows().AdjustToContents();
-        // ws.Columns().AdjustToContents();
-
         // We'll now select which cells should be used for calculating the
-        // column widths (same method applies for row heights)
+        // column widths (the same method applies for row heights)
 
         // Set the values
         ws.Cell(4, 2).Value = "Width ignored because calling column.AdjustToContents(5, 7)";
@@ -38,16 +33,12 @@ public class AdjustToContents : IXLExample
         ws.Cell(7, 2).Value = "Width should adjust to this cell";
         ws.Cell(8, 2).Value = "Width ignored because calling column.AdjustToContents(5, 7)";
 
-        // Adjust column widths only taking into account rows 5-7
-        // (merged cells will be ignored)
+        // Adjust column widths only taking into account rows 5-7 (merged cells will be ignored)
         ws.Column(2).AdjustToContents(5, 7);
-
-        // You can also specify the starting row to start calculating the widths:
-        // e.g. ws.Column(3).AdjustToContents(9);
 
         var ws2 = wb.Worksheets.Add("Adjust Widths");
         ws2.Cell(1, 1).SetValue("Text to adjust - 255").Style.Alignment.TextRotation = 255;
-        for (int co = 0; co < 90; co += 5)
+        for (var co = 0; co < 90; co += 5)
         {
             ws2.Cell(1, (co / 5) + 2).SetValue("Text to adjust - " + co).Style.Alignment.TextRotation = co;
         }
@@ -56,7 +47,7 @@ public class AdjustToContents : IXLExample
 
         var ws4 = wb.Worksheets.Add("Adjust Widths 2");
         ws4.Cell(1, 1).SetValue("Text to adjust - 255").Style.Alignment.TextRotation = 255;
-        for (int co = 0; co < 90; co += 5)
+        for (var co = 0; co < 90; co += 5)
         {
             var c = ws4.Cell(1, (co / 5) + 2);
 
@@ -69,11 +60,12 @@ public class AdjustToContents : IXLExample
             c.GetRichText().AddText("Hello").SetBold();
             c.Style.Alignment.SetTextRotation(co);
         }
+
         ws4.Columns().AdjustToContents();
 
         var ws3 = wb.Worksheets.Add("Adjust Heights");
         ws3.Cell(1, 1).SetValue("Text to adjust - 255").Style.Alignment.TextRotation = 255;
-        for (int ro = 0; ro < 90; ro += 5)
+        for (var ro = 0; ro < 90; ro += 5)
         {
             ws3.Cell((ro / 5) + 2, 1).SetValue("Text to adjust - " + ro).Style.Alignment.TextRotation = ro;
         }
@@ -82,7 +74,7 @@ public class AdjustToContents : IXLExample
 
         var ws5 = wb.Worksheets.Add("Adjust Heights 2");
         ws5.Cell(1, 1).SetValue("Text to adjust - 255").Style.Alignment.TextRotation = 255;
-        for (int ro = 0; ro < 90; ro += 5)
+        for (var ro = 0; ro < 90; ro += 5)
         {
             var c = ws5.Cell((ro / 5) + 2, 1);
             c.GetRichText().AddText("Text to adjust - " + ro).SetBold();
@@ -101,7 +93,8 @@ public class AdjustToContents : IXLExample
         ws6.Cell("A1").Value = "Some string";
 
         // This column's width should be capped at 255
-        ws6.Cell("B1").Value = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.";
+        ws6.Cell("B1").Value =
+            "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.";
 
         ws6.Columns().AdjustToContents();
 

--- a/XLibur.Examples/Misc/Hyperlinks.cs
+++ b/XLibur.Examples/Misc/Hyperlinks.cs
@@ -52,10 +52,10 @@ public class Hyperlinks : IXLExample
         // browser: http, ftp, mailto, gopher, news, nntp, etc.
 
         ws.Cell(++ro, 1).Value = "Link to a web page, no tooltip - Yahoo!";
-        ws.Cell(ro, 1).SetHyperlink(new XLHyperlink("http://www.yahoo.com"));
+        ws.Cell(ro, 1).SetHyperlink(new XLHyperlink("https://www.yahoo.com"));
 
         ws.Cell(++ro, 1).Value = "Link to a web page, with a tooltip - Yahoo!";
-        ws.Cell(ro, 1).SetHyperlink(new XLHyperlink("http://www.yahoo.com", "Click to go to Yahoo!"));
+        ws.Cell(ro, 1).SetHyperlink(new XLHyperlink("https://www.yahoo.com", "Click to go to Yahoo!"));
 
         ws.Cell(++ro, 1).Value = "Link to a file - same folder";
         ws.Cell(ro, 1).SetHyperlink(new XLHyperlink("Test.xlsx"));

--- a/XLibur.Examples/PivotTables/PivotTables.cs
+++ b/XLibur.Examples/PivotTables/PivotTables.cs
@@ -153,7 +153,7 @@ public class PivotTables : IXLExample
 
         ptSheet = wb.Worksheets.Add("pvtHideSubTotals");
 
-        // Create the pivot table, using the data from the "PastrySalesData" table
+        // Create the pivot table using the data from the "PastrySalesData" table
         pt = ptSheet.PivotTables.Add("pvtHidesubTotals", ptSheet.Cell(1, 1), table);
 
         // The rows in our pivot table will be the names of the pastries

--- a/XLibur.Tests/Excel/Ranges/RangeRowCopyToTests.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeRowCopyToTests.cs
@@ -1,0 +1,150 @@
+using NUnit.Framework;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Ranges;
+
+[TestFixture]
+public class RangeRowCopyToTests
+{
+    [Test]
+    public void CopyTo_Cell_CopiesValuesAndStyles()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        ws.Cell("A1").Value = "Hello";
+        ws.Cell("B1").Value = 42;
+        ws.Cell("C1").Value = true;
+        ws.Cell("A1").Style.Font.Bold = true;
+        ws.Cell("B1").Style.Fill.BackgroundColor = XLColor.Red;
+
+        var sourceRow = ws.Range("A1:C1").Row(1);
+        var result = sourceRow.CopyTo(ws.Cell("A3"));
+
+        Assert.That(ws.Cell("A3").Value, Is.EqualTo((XLCellValue)"Hello"));
+        Assert.That(ws.Cell("B3").Value, Is.EqualTo((XLCellValue)42));
+        Assert.That(ws.Cell("C3").Value, Is.EqualTo((XLCellValue)true));
+        Assert.That(ws.Cell("A3").Style.Font.Bold, Is.True);
+        Assert.That(ws.Cell("B3").Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+
+        // Verify the returned range row covers the correct address
+        Assert.That(result.RangeAddress.FirstAddress.RowNumber, Is.EqualTo(3));
+        Assert.That(result.RangeAddress.FirstAddress.ColumnNumber, Is.EqualTo(1));
+        Assert.That(result.RangeAddress.LastAddress.ColumnNumber, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void CopyTo_Cell_DoesNotModifySource()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        ws.Cell("A1").Value = "Original";
+        ws.Cell("B1").Value = 99;
+
+        var sourceRow = ws.Range("A1:B1").Row(1);
+        sourceRow.CopyTo(ws.Cell("A3"));
+
+        // Modify the copy
+        ws.Cell("A3").Value = "Modified";
+
+        // Source should be unchanged
+        Assert.That(ws.Cell("A1").Value, Is.EqualTo((XLCellValue)"Original"));
+        Assert.That(ws.Cell("B1").Value, Is.EqualTo((XLCellValue)99));
+    }
+
+    [Test]
+    public void CopyTo_Cell_CrossWorksheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws1 = wb.AddWorksheet("Source");
+        var ws2 = wb.AddWorksheet("Dest");
+
+        ws1.Cell("A1").Value = "Cross-sheet";
+        ws1.Cell("B1").Value = 123;
+        ws1.Cell("A1").Style.Font.Italic = true;
+
+        var sourceRow = ws1.Range("A1:B1").Row(1);
+        var result = sourceRow.CopyTo(ws2.Cell("C5"));
+
+        Assert.That(ws2.Cell("C5").Value, Is.EqualTo((XLCellValue)"Cross-sheet"));
+        Assert.That(ws2.Cell("D5").Value, Is.EqualTo((XLCellValue)123));
+        Assert.That(ws2.Cell("C5").Style.Font.Italic, Is.True);
+        Assert.That(result.Worksheet.Name, Is.EqualTo("Dest"));
+    }
+
+    [Test]
+    public void CopyTo_RangeBase_CopiesValuesAndStyles()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        ws.Cell("A1").Value = "First";
+        ws.Cell("B1").Value = "Second";
+        ws.Cell("C1").Value = "Third";
+        ws.Cell("B1").Style.Font.Underline = XLFontUnderlineValues.Single;
+
+        var sourceRow = ws.Range("A1:C1").Row(1);
+        var targetRange = ws.Range("D5:F5");
+        var result = sourceRow.CopyTo(targetRange);
+
+        Assert.That(ws.Cell("D5").Value, Is.EqualTo((XLCellValue)"First"));
+        Assert.That(ws.Cell("E5").Value, Is.EqualTo((XLCellValue)"Second"));
+        Assert.That(ws.Cell("F5").Value, Is.EqualTo((XLCellValue)"Third"));
+        Assert.That(ws.Cell("E5").Style.Font.Underline, Is.EqualTo(XLFontUnderlineValues.Single));
+
+        Assert.That(result.RangeAddress.FirstAddress.RowNumber, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void CopyTo_Cell_ReturnsCorrectRangeRow()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        ws.Cell("B2").Value = 1;
+        ws.Cell("C2").Value = 2;
+        ws.Cell("D2").Value = 3;
+
+        var sourceRow = ws.Range("B2:D2").Row(1);
+        var result = sourceRow.CopyTo(ws.Cell("E10"));
+
+        // Result should be a range row starting at E10 with 3 cells
+        Assert.That(result.CellCount(), Is.EqualTo(3));
+        Assert.That(result.Cell(1).Value, Is.EqualTo((XLCellValue)1));
+        Assert.That(result.Cell(2).Value, Is.EqualTo((XLCellValue)2));
+        Assert.That(result.Cell(3).Value, Is.EqualTo((XLCellValue)3));
+    }
+
+    [Test]
+    public void CopyTo_Cell_CopiesFormulas()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        ws.Cell("A1").Value = 10;
+        ws.Cell("B1").FormulaA1 = "=A1*2";
+
+        var sourceRow = ws.Range("A1:B1").Row(1);
+        sourceRow.CopyTo(ws.Cell("A3"));
+
+        Assert.That(ws.Cell("A3").Value, Is.EqualTo((XLCellValue)10));
+        // Formula should be shifted to reference A3
+        Assert.That(ws.Cell("B3").FormulaA1, Is.EqualTo("A3*2"));
+    }
+
+    [Test]
+    public void CopyTo_Cell_EmptyRowCopiesWithoutError()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        var sourceRow = ws.Range("A1:C1").Row(1);
+        var result = sourceRow.CopyTo(ws.Cell("A5"));
+
+        Assert.That(ws.Cell("A5").IsEmpty(), Is.True);
+        Assert.That(ws.Cell("B5").IsEmpty(), Is.True);
+        Assert.That(ws.Cell("C5").IsEmpty(), Is.True);
+        Assert.That(result.RangeAddress.FirstAddress.RowNumber, Is.EqualTo(5));
+    }
+}

--- a/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
@@ -18,7 +18,6 @@ internal static class MathTrig
     /// </summary>
     private const double MaxDoubleInt = 9007199254740991;
 
-    private static readonly Random _rnd = new Random();
 
     /// <summary>
     /// Key: roman form. Value: A collection of subtract symbols and subtract value.
@@ -840,7 +839,7 @@ internal static class MathTrig
 
     private static ScalarValue Rand()
     {
-        return _rnd.NextDouble();
+        return Random.Shared.NextDouble();
     }
 
     private static ScalarValue RandBetween(CalcContext ctx, double lowerBound, double upperBound)
@@ -852,7 +851,7 @@ internal static class MathTrig
         upperBound = Math.Ceiling(upperBound);
 
         var range = upperBound - lowerBound;
-        return lowerBound + Math.Round(_rnd.NextDouble() * range, MidpointRounding.AwayFromZero);
+        return lowerBound + Math.Round(Random.Shared.NextDouble() * range, MidpointRounding.AwayFromZero);
     }
 
     private static ScalarValue Roman(CalcContext ctx, double number, double formValue)

--- a/XLibur/Excel/CalcEngine/Functions/XLMatrix.cs
+++ b/XLibur/Excel/CalcEngine/Functions/XLMatrix.cs
@@ -247,11 +247,10 @@ internal sealed class XLMatrix
 
     public static XLMatrix RandomMatrix(int iRows, int iCols, int dispersion) // Function generates the zero matrix
     {
-        var random = new Random();
         var matrix = new XLMatrix(iRows, iCols);
         for (var i = 0; i < iRows; i++)
             for (var j = 0; j < iCols; j++)
-                matrix[i, j] = random.Next(-dispersion, dispersion);
+                matrix[i, j] = Random.Shared.Next(-dispersion, dispersion);
         return matrix;
     }
 

--- a/XLibur/Excel/CalcEngine/TimeSpanParser.cs
+++ b/XLibur/Excel/CalcEngine/TimeSpanParser.cs
@@ -4,20 +4,20 @@ using System.Globalization;
 namespace XLibur.Excel.CalcEngine;
 
 /// <summary>
-/// A parser of timespan format used by excel during coercion from text to number. <see cref="TimeSpan" /> parsing methods
-/// don't allow for several features required by excel (e.g. seconds/minutes over 60, hours over 24).
-/// Parser can parse following formats from ECMA-376, Part 1, §18.8.30. due to standard text-to-number coercion:
+/// A parser of timespan format used by Excel during coercion from text to number. <see cref="TimeSpan" /> parsing methods
+/// don't allow for several features required by Excel (e.g., seconds/minutes over 60, hours over 24).
+/// Parser can parse the following formats from ECMA-376, Part 1, §18.8.30. Due to standard text-to-number coercion:
 /// <list type="bullet">
 ///     <item>Format 20 - <c>h:mm</c>.</item>
 ///     <item>Format 21 - <c>h:mm:ss</c>.</item>
-///     <item>Format 47 - <c>mm:ss.0</c> (format is incorrectly described as <c>mmss.0</c> in the standard,
-///           but fixed in an implementation errata).</item>
+///     <item>Format 47 - <c>mm:ss.0</c> (a format is incorrectly described as <c>mmss.0</c> in the standard,
+///           but fixed in an implementation erratum).</item>
 /// </list>
-/// Timespan is never interpreted through format 45 (<c>mm:ss</c>), instead preferring the format 20 (<c>h:mm</c>).
+/// Timespan is never interpreted through format 45 (<c>mm:ss</c>), instead preferring format 20 (<c>h:mm</c>).
 /// Timespan is never interpreted through format 46 (<c>[h]:mm:ss</c>], such values are covered by format 21 (<c>h:mm:ss</c>).
 /// </summary>
 /// <remarks>
-/// Note that the decimal fraction differs format 20 and 47, thus mere addition of decimal
+/// Note that the decimal fraction differs format 20 and 47, thus the mere addition of a decimal
 /// place means significantly different values. Parser also copies features of Excel, like whitespaces around
 /// a decimal place (<c>10:20 . 5</c> is allowed).
 /// <example>
@@ -31,7 +31,7 @@ internal static class TimeSpanParser
     {
         var timeSeparator = ci.DateTimeFormat.TimeSeparator;
         var decimalSeparator = ci.NumberFormat.NumberDecimalSeparator;
-        result = default;
+        result = TimeSpan.Zero;
         var i = 0;
         SkipWhitespace(ref i, s);
         if (!TryReadNumber(ref i, s, out var hoursOrMinutes))
@@ -60,13 +60,13 @@ internal static class TimeSpanParser
             return hoursOrMinutes < 24 || minutesOrSeconds < 60;
         }
 
-        if (InputMatches(ref i, s, decimalSeparator))
-            return TryParseFormat47(ref i, s, hoursOrMinutes, minutesOrSeconds, out result);
-
-        return TryParseHMS(ref i, s, timeSeparator, decimalSeparator, hoursOrMinutes, minutesOrSeconds, out result);
+        return InputMatches(ref i, s, decimalSeparator)
+            ? TryParseFormat47(ref i, s, hoursOrMinutes, minutesOrSeconds, out result)
+            : TryParseHMS(ref i, s, timeSeparator, decimalSeparator, hoursOrMinutes, minutesOrSeconds, out result);
     }
 
-    private static bool TryParseFormat47(ref int i, string s, int hoursOrMinutes, int minutesOrSeconds, out TimeSpan result)
+    private static bool TryParseFormat47(ref int i, string s, int hoursOrMinutes, int minutesOrSeconds,
+        out TimeSpan result)
     {
         SkipWhitespace(ref i, s);
         var ms = ReadFractionInMs(ref i, s);
@@ -79,7 +79,7 @@ internal static class TimeSpanParser
     private static bool TryParseHMS(ref int i, string s, string timeSeparator, string decimalSeparator,
         int hoursOrMinutes, int minutesOrSeconds, out TimeSpan result)
     {
-        result = default;
+        result = TimeSpan.Zero;
 
         if (!InputMatches(ref i, s, timeSeparator))
             return false;
@@ -104,20 +104,21 @@ internal static class TimeSpanParser
             return true;
         }
 
-        return TryParseHMSWithDecimal(ref i, s, decimalSeparator, hoursOrMinutes, minutesOrSeconds, seconds, out result);
+        return TryParseHMSWithDecimal(ref i, s, decimalSeparator, hoursOrMinutes, minutesOrSeconds, seconds,
+            out result);
     }
 
     private static bool HasTwoOrMoreOutOfBoundsComponents(int hours, int minutes, int seconds)
     {
         return (hours >= 24 && minutes >= 60)
-            || (hours >= 24 && seconds >= 60)
-            || (minutes >= 60 && seconds >= 60);
+               || (hours >= 24 && seconds >= 60)
+               || (minutes >= 60 && seconds >= 60);
     }
 
     private static bool TryParseHMSWithDecimal(ref int i, string s, string decimalSeparator,
         int hours, int minutes, int seconds, out TimeSpan result)
     {
-        result = default;
+        result = TimeSpan.Zero;
 
         if (!InputMatches(ref i, s, decimalSeparator))
             return false;

--- a/XLibur/Excel/CalcEngine/Visitors/RenameRefModVisitor.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/RenameRefModVisitor.cs
@@ -34,11 +34,11 @@ internal sealed class RenameRefModVisitor : RefModVisitor
         return sheetName;
     }
 
-    protected override string? ModifyTable(ModContext ctx, string tableName)
+    protected override string? ModifyTable(ModContext ctx, string table)
     {
-        if (_tables is not null && _tables.TryGetValue(tableName, out var newName))
+        if (_tables is not null && _tables.TryGetValue(table, out var newName))
             return newName;
 
-        return tableName;
+        return table;
     }
 }

--- a/XLibur/Excel/Cells/IXLCell.cs
+++ b/XLibur/Excel/Cells/IXLCell.cs
@@ -8,61 +8,11 @@ using XLibur.Excel.Drawings;
 
 namespace XLibur.Excel;
 
-/// <summary>
-/// A value that is in the cell.
-/// </summary>
-public enum XLDataType
-{
-    /// <summary>
-    /// The value is a blank (either blank cells or the omitted optional argument of a function, e.g. <c>IF(TRUE,,)</c>.
-    /// </summary>
-    /// <remarks>Keep as the first, so the default values are blank.</remarks>
-    Blank = 0,
-
-    /// <summary>
-    /// The value is a logical value.
-    /// </summary>
-    Boolean = 1,
-
-    /// <summary>
-    /// The value is a double-precision floating points number, excluding <see cref="Double.NaN"/>,
-    /// <see cref="Double.PositiveInfinity"/> or <see cref="double.NegativeInfinity"/>.
-    /// </summary>
-    Number = 2,
-
-    /// <summary>
-    /// A text or a rich text. Can't be <c>null</c> and can be at most 32767 characters long.
-    /// </summary>
-    Text = 3,
-
-    /// <summary>
-    /// The value is one of <see cref="XLError"/>.
-    /// </summary>
-    Error = 4,
-
-    /// <summary>
-    /// The value is a <see cref="DateTime"/>, represented as a serial date time number.
-    /// </summary>
-    /// <remarks>
-    /// Serial date time 60 is a 1900-02-29, nonexistent day kept for compatibility,
-    /// but unrepresentable by <c>DateTime</c>. Don't use.
-    /// </remarks>
-    DateTime = 5,
-
-    /// <summary>
-    /// The value is a <see cref="TimeSpan"/>, represented in a serial date time (24 hours is 1, 36 hours is 1.5 ect.).
-    /// </summary>
-    TimeSpan = 6,
-}
-
-public enum XLTableCellType { None, Header, Data, Total }
-
 public interface IXLCell
 {
     /// <summary>
-    /// Is this cell the <see cref="IXLWorksheet.ActiveCell">active cell of
-    /// the worksheet</see>? Setting false deactivates cell only when the
-    /// cell is currently active.
+    /// Is this cell the <see cref="IXLWorksheet.ActiveCell">active cell of the worksheet</see>?
+    /// Setting false deactivates a cell only when the cell is currently active. 
     /// </summary>
     bool Active { get; set; }
 
@@ -76,7 +26,7 @@ public interface IXLCell
     /// doesn't contain a formula, it returns same value as <see cref="Value"/>.
     /// May hold invalid value when <see cref="NeedsRecalculation"/> flag is True.
     /// </summary>
-    /// <remarks>Can be useful to decrease a number of formula evaluations.</remarks>
+    /// <remarks>Can be useful to decrease the number of formula evaluations.</remarks>
     XLCellValue CachedValue { get; }
 
     /// <summary>
@@ -118,8 +68,8 @@ public interface IXLCell
     string FormulaR1C1 { get; set; }
 
     /// <summary>
-    /// An indication that value of this cell is calculated by a array formula
-    /// that calculates values for cells in the referenced address. Null if not part of such formula.
+    /// An indication that the value of this cell is calculated by an array formula
+    /// that calculates values for cells in the referenced address. Null if not part of such a formula.
     /// </summary>
     IXLRangeAddress? FormulaReference { get; set; }
 
@@ -157,7 +107,7 @@ public interface IXLCell
     void RemoveCellImage();
 
     /// <summary>
-    /// Flag indicating that previously calculated cell value may be not valid anymore and has to be re-evaluated.
+    /// Flag indicating that a previously calculated cell value may be not valid anymore and has to be re-evaluated.
     /// Only cells with formula may return <c>true</c>, value cells always return <c>false</c>.
     /// </summary>
     bool NeedsRecalculation { get; }
@@ -166,7 +116,7 @@ public interface IXLCell
     /// Gets or sets a value indicating whether this cell's text should be shared or not.
     /// </summary>
     /// <value>
-    ///   If false the cell's text will not be shared and stored as an inline value.
+    ///   If false, the cell's text will not be shared and stored as an inline value.
     /// </value>
     bool ShareString { get; set; }
 
@@ -180,11 +130,11 @@ public interface IXLCell
     /// <summary>
     /// Gets or sets the cell's value.
     /// <para>
-    /// Getter will return value of a cell or value of formula. Getter will evaluate a formula, if the cell
+    /// Getter will return the value of a cell or value of a formula. Getter will evaluate a formula, if the cell
     /// <see cref="NeedsRecalculation"/>, before returning up-to-date value.
     /// </para>
     /// <para>
-    /// Setter will clear a formula, if the cell contains a formula.
+    /// Setter will clear a formula if the cell contains a formula.
     /// If the value is a text that starts with a single quote, setter will prefix the value with a single quote through
     /// <see cref="IXLStyle.IncludeQuotePrefix"/> in Excel too and the value of cell is set to to non-quoted text.
     /// </para>
@@ -194,7 +144,7 @@ public interface IXLCell
     IXLWorksheet Worksheet { get; }
 
     /// <summary>
-    /// Should the cell show phonetic (i.e. furigana) above the rich text of the cell?
+    /// Should the cell show phonetic (i.e., furigana) above the rich text of the cell?
     /// It shows phonetic runs in the rich text, it is not autogenerated. Default
     /// is <c>false</c>.
     /// </summary>
@@ -259,8 +209,8 @@ public interface IXLCell
     IXLCell CopyFrom(string otherCell);
 
     /// <summary>
-    /// Copy range content to an area of same size starting at the cell.
-    /// Original content of cells is overwritten.
+    /// Copy range content to an area of the same size starting at the cell.
+    /// The original content of cells is overwritten.
     /// </summary>
     /// <param name="rangeBase">Range whose content to copy.</param>
     /// <returns>This cell.</returns>
@@ -523,9 +473,6 @@ public interface IXLCell
 
     IXLCell SetActive(bool value = true);
 
-    [Obsolete("Use GetDataValidation to access the existing rule, or CreateDataValidation() to create a new one.")]
-    IXLDataValidation SetDataValidation();
-
     IXLCell SetFormulaA1(string formula);
 
     /// <summary>
@@ -541,8 +488,8 @@ public interface IXLCell
     IXLCell SetFormulaR1C1(string formula);
 
     /// <summary>
-    /// Set hyperlink of a cell. When user clicks on a cell with hyperlink,
-    /// the Excel opens the target or moves cursor to the target cells in a
+    /// Set a hyperlink of a cell. When a user clicks on a cell with hyperlink,
+    /// the Excel opens the target or moves the cursor to the target cells in a
     /// worksheet. The text of hyperlink is a cell value, the hyperlink
     /// target and tooltip are defined by the <paramref name="hyperlink"/>
     /// parameter.
@@ -554,6 +501,7 @@ public interface IXLCell
     /// <param name="hyperlink">The new cell hyperlink. Use <c>null</c> to
     ///   remove the hyperlink.</param>
     void SetHyperlink(XLHyperlink? hyperlink);
+
     /// <inheritdoc cref="Value"/>
     /// <returns>This cell.</returns>
     IXLCell SetValue(XLCellValue value);

--- a/XLibur/Excel/Cells/IXLCells.cs
+++ b/XLibur/Excel/Cells/IXLCells.cs
@@ -7,7 +7,7 @@ public interface IXLCells : IEnumerable<IXLCell>
     /// <summary>
     /// Sets the cells' value.
     /// <para>
-    /// Setter will clear a formula, if the cell contains a formula.
+    /// Setter will clear a formula if the cell contains a formula.
     /// If the value is a text that starts with a single quote, setter will prefix the value with a single quote through
     /// <see cref="IXLStyle.IncludeQuotePrefix"/> in Excel too and the value of cell is set to to non-quoted text.
     /// </para>

--- a/XLibur/Excel/Cells/SharedStringTable.cs
+++ b/XLibur/Excel/Cells/SharedStringTable.cs
@@ -83,7 +83,7 @@ internal sealed class SharedStringTable
 
     /// <summary>
     /// The principle is that every entry is a text, but only some are rich text.
-    /// This tries to get a rich text, if it is one. If it is just plain text, return null.
+    /// This tries to get a rich text if it is one. If it is just plain text, return null.
     /// </summary>
     internal XLImmutableRichText? GetRichText(int id)
     {
@@ -95,16 +95,16 @@ internal sealed class SharedStringTable
     }
 
     /// <summary>
-    /// Get id for a text and increase a number of references to the text by one.
+    /// Get id for a text and increase the number of references to the text by one.
     /// </summary>
-    /// <returns>Id of a text in the SST.</returns>
+    /// <returns>ID of a text in the SST.</returns>
     internal int IncreaseRef(string text, bool inline) => IncreaseTextRef(new Text(text, inline));
 
     /// <inheritdoc cref="IncreaseRef(string, bool)"/>
     internal int IncreaseRef(XLImmutableRichText text, bool inline) => IncreaseTextRef(new Text(text, inline));
 
     /// <summary>
-    /// Decrease reference count of a text and free if necessary.
+    /// Decrease the reference count of a text and free if necessary.
     /// </summary>
     internal void DecreaseRef(int id)
     {
@@ -124,8 +124,8 @@ internal sealed class SharedStringTable
     }
 
     /// <summary>
-    /// Get a map that takes the actual string id and returns an continuous sequence (i.e. no gaps).
-    /// If an id if free (no ref count), the id is mapped to -1.
+    /// Get a map that takes the actual string id and returns a continuous sequence (i.e., no gaps).
+    /// If an id is free (no ref count), the id is mapped to -1.
     /// </summary>
     internal int[] GetConsecutiveMap()
     {
@@ -136,7 +136,7 @@ internal sealed class SharedStringTable
             var entry = _table[i];
             var isShared =
                 entry.RefCount > 0 && // Only used entry can be written to sst
-                !entry.Text.Inline;  // Inline texts shouldn't be written to sst
+                !entry.Text.Inline; // Inline texts shouldn't be written to sst
             map[i] = isShared ? mappedStringId++ : -1;
         }
 

--- a/XLibur/Excel/Cells/Slice.cs
+++ b/XLibur/Excel/Cells/Slice.cs
@@ -6,8 +6,8 @@ using System.Diagnostics;
 namespace XLibur.Excel;
 
 /// <summary>
-/// Slice is a sparse array that stores a part of cell information (e.g. only values,
-/// only styles ...). Slice has same size as a worksheet. If some cells are pushed out
+/// Slice is a sparse array that stores a part of cell information (e.g., only values,
+/// only styles ...). Slice has the same size as a worksheet. If some cells are pushed out
 /// of the permitted range, they are gone.
 /// </summary>
 /// <remarks>
@@ -21,19 +21,19 @@ internal sealed partial class Slice<TElement> : ISlice
     private readonly TElement _defaultValue = default!;
 
     /// <summary>
-    /// The content of the slice. Note that LUT uses index that starts from 0,
-    /// so rows and columns must be adjusted to retrieved the value.
+    /// The content of the slice. Note that LUT uses an index that starts from 0,
+    /// so rows and columns must be adjusted to retrieve the value.
     /// </summary>
     private readonly Lut<RowData> _data;
 
     /// <summary>
-    /// Key is column number, value is number of cells in the column that are used.
+    /// Key is the column number, value is the number of cells in the column that are used.
     /// </summary>
     private readonly Dictionary<int, int> _columnUsage = new();
 
     internal Slice()
     {
-        _data = new();
+        _data = new Lut<RowData>();
     }
 
     /// <summary>

--- a/XLibur/Excel/Cells/XLDataType.cs
+++ b/XLibur/Excel/Cells/XLDataType.cs
@@ -42,7 +42,7 @@ public enum XLDataType
     DateTime = 5,
 
     /// <summary>
-    /// The value is a <see cref="TimeSpan"/>, represented in a serial date time (24 hours is 1, 36 hours is 1.5 ect.).
+    /// The value is a <see cref="TimeSpan"/>, represented in a serial date time (24 hours is 1, 36 hours is 1.5 etc.).
     /// </summary>
     TimeSpan = 6,
 }

--- a/XLibur/Excel/Cells/XLDataType.cs
+++ b/XLibur/Excel/Cells/XLDataType.cs
@@ -1,0 +1,48 @@
+﻿namespace XLibur.Excel;
+
+/// <summary>
+/// A value that is in the cell.
+/// </summary>
+public enum XLDataType
+{
+    /// <summary>
+    /// The value is a blank (either blank cells or the omitted optional argument of a function, e.g. <c>IF(TRUE,,)</c>.
+    /// </summary>
+    /// <remarks>Keep as the first, so the default values are blank.</remarks>
+    Blank = 0,
+
+    /// <summary>
+    /// The value is a logical value.
+    /// </summary>
+    Boolean = 1,
+
+    /// <summary>
+    /// The value is a double-precision floating points number, excluding <see cref="double.NaN"/>,
+    /// <see cref="double.PositiveInfinity"/> or <see cref="double.NegativeInfinity"/>.
+    /// </summary>
+    Number = 2,
+
+    /// <summary>
+    /// A text or a rich text. Can't be <c>null</c> and can be at most 32767 characters long.
+    /// </summary>
+    Text = 3,
+
+    /// <summary>
+    /// The value is one of <see cref="XLError"/>.
+    /// </summary>
+    Error = 4,
+
+    /// <summary>
+    /// The value is a <see cref="DateTime"/>, represented as a serial date time number.
+    /// </summary>
+    /// <remarks>
+    /// Serial date time 60 is a 1900-02-29, nonexistent day kept for compatibility,
+    /// but unrepresentable by <c>DateTime</c>. Don't use.
+    /// </remarks>
+    DateTime = 5,
+
+    /// <summary>
+    /// The value is a <see cref="TimeSpan"/>, represented in a serial date time (24 hours is 1, 36 hours is 1.5 ect.).
+    /// </summary>
+    TimeSpan = 6,
+}

--- a/XLibur/Excel/Cells/XLTableCellType.cs
+++ b/XLibur/Excel/Cells/XLTableCellType.cs
@@ -1,0 +1,3 @@
+﻿namespace XLibur.Excel;
+
+public enum XLTableCellType { None, Header, Data, Total }

--- a/XLibur/Excel/Columns/XLColumn.cs
+++ b/XLibur/Excel/Columns/XLColumn.cs
@@ -83,10 +83,10 @@ internal sealed class XLColumn : XLRangeBase, IXLColumn
         return Cell(rowNumber, 1);
     }
 
-    public override XLCells Cells(string cellsInColumn)
+    public override XLCells Cells(string cells)
     {
         var retVal = new XLCells(false, XLCellsUsedOptions.All);
-        var rangePairs = cellsInColumn.Split(',');
+        var rangePairs = cells.Split(',');
         foreach (string pair in rangePairs)
             retVal.Add(Range(pair.Trim()).RangeAddress);
         return retVal;

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -496,7 +496,7 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
         return Style;
     }
 
-    public IXLStyle WhenIsBottom(int value, XLTopBottomType topBottomType = XLTopBottomType.Items)
+    public IXLStyle WhenIsBottom(int value, XLTopBottomType topBottomType)
     {
         Values.Initialize(new XLFormula(value));
         Percent = topBottomType == XLTopBottomType.Percent;

--- a/XLibur/Excel/Coordinates/XLAddress.cs
+++ b/XLibur/Excel/Coordinates/XLAddress.cs
@@ -360,9 +360,9 @@ internal struct XLAddress : IXLAddress, IEquatable<XLAddress>
         return _packed == other._packed;
     }
 
-    public override bool Equals(object? other)
+    public override bool Equals(object? obj)
     {
-        return Equals(other as IXLAddress);
+        return Equals(obj as IXLAddress);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/XLibur/Excel/Drawings/XLPicture.cs
+++ b/XLibur/Excel/Drawings/XLPicture.cs
@@ -53,7 +53,7 @@ internal sealed class XLPicture : IXLPicture
 
     public IXLCell BottomRightCell
     {
-        get { return Markers[XLMarkerPosition.BottomRight]!.Cell; }
+        get => Markers[XLMarkerPosition.BottomRight]!.Cell;
 
         private set
         {
@@ -68,18 +68,19 @@ internal sealed class XLPicture : IXLPicture
 
     public int Height
     {
-        get { return _height; }
+        get => _height;
         set
         {
             if (Placement == XLPicturePlacement.MoveAndSize)
-                throw new ArgumentException("To set the height, the placement should be FreeFloating or Move");
+                throw new ArgumentException(
+                    $"Cannot set the height when placement is '{Placement}'. Change the placement to FreeFloating or Move first.");
             _height = value;
         }
     }
 
     public int Id
     {
-        get { return _id; }
+        get => _id;
         internal set
         {
             if ((Worksheet.Pictures.FirstOrDefault(p => p.Id.Equals(value)) ?? this) != this)
@@ -93,11 +94,12 @@ internal sealed class XLPicture : IXLPicture
 
     public int Left
     {
-        get { return Markers[XLMarkerPosition.TopLeft]?.Offset.X ?? 0; }
+        get => Markers[XLMarkerPosition.TopLeft]?.Offset.X ?? 0;
         set
         {
             if (Placement != XLPicturePlacement.FreeFloating)
-                throw new ArgumentException("To set the left-hand offset, the placement should be FreeFloating");
+                throw new ArgumentException(
+                    $"Cannot set the left-hand offset when placement is '{Placement}'. Change the placement to FreeFloating first.");
 
             Markers[XLMarkerPosition.TopLeft] = new XLMarker(Worksheet.Cell(1, 1), new Point(value, Top));
         }
@@ -105,7 +107,7 @@ internal sealed class XLPicture : IXLPicture
 
     public string Name
     {
-        get { return _name; }
+        get => _name;
         set
         {
             ArgumentException.ThrowIfNullOrEmpty(value);
@@ -115,7 +117,11 @@ internal sealed class XLPicture : IXLPicture
                  this) != this)
                 throw new ArgumentException($"The picture name '{value}' already exists.");
 
-            SetName(value);
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException("Picture name cannot be empty or consist only of whitespace.",
+                    nameof(value));
+
+            _name = value;
         }
     }
 
@@ -127,11 +133,12 @@ internal sealed class XLPicture : IXLPicture
 
     public int Top
     {
-        get { return Markers[XLMarkerPosition.TopLeft]?.Offset.Y ?? 0; }
+        get => Markers[XLMarkerPosition.TopLeft]?.Offset.Y ?? 0;
         set
         {
             if (Placement != XLPicturePlacement.FreeFloating)
-                throw new ArgumentException("To set the top offset, the placement should be FreeFloating");
+                throw new ArgumentException(
+                    $"Cannot set the top offset when placement is '{Placement}'. Change the placement to FreeFloating first.");
 
             Markers[XLMarkerPosition.TopLeft] = new XLMarker(Worksheet.Cell(1, 1), new Point(Left, value));
         }
@@ -139,7 +146,7 @@ internal sealed class XLPicture : IXLPicture
 
     public IXLCell TopLeftCell
     {
-        get { return Markers[XLMarkerPosition.TopLeft]!.Cell; }
+        get => Markers[XLMarkerPosition.TopLeft]!.Cell;
 
         private set
         {
@@ -152,11 +159,12 @@ internal sealed class XLPicture : IXLPicture
 
     public int Width
     {
-        get { return _width; }
+        get => _width;
         set
         {
             if (Placement == XLPicturePlacement.MoveAndSize)
-                throw new ArgumentException("To set the width, the placement should be FreeFloating or Move");
+                throw new ArgumentException(
+                    $"Cannot set the width when placement is '{Placement}'. Change the placement to FreeFloating or Move first.");
             _width = value;
         }
     }
@@ -288,8 +296,6 @@ internal sealed class XLPicture : IXLPicture
 
     private IXLPicture CopyTo(XLWorksheet targetSheet)
     {
-        targetSheet ??= (XLWorksheet)Worksheet;
-
         var newPicture = targetSheet == Worksheet
             ? targetSheet.AddPicture(ImageStream, Format)
             : targetSheet.AddPicture(ImageStream, Format, Name);
@@ -314,8 +320,6 @@ internal sealed class XLPicture : IXLPicture
                     targetSheet.Cell(BottomRightCell.Address),
                     GetOffset(XLMarkerPosition.BottomRight));
                 break;
-            default:
-                throw new ArgumentOutOfRangeException();
         }
 
         return newPicture;
@@ -324,7 +328,7 @@ internal sealed class XLPicture : IXLPicture
     internal void SetName(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
-            throw new ArgumentException("Picture names cannot be empty");
+            throw new ArgumentException("Picture name cannot be empty or consist only of whitespace.", nameof(value));
 
         _name = value;
     }

--- a/XLibur/Excel/Drawings/XLPicture.cs
+++ b/XLibur/Excel/Drawings/XLPicture.cs
@@ -341,3 +341,4 @@ internal sealed class XLPicture : IXLPicture
         _height = OriginalHeight = size.Height;
     }
 }
+

--- a/XLibur/Excel/InsertData/SimpleNullableTypeReader.cs
+++ b/XLibur/Excel/InsertData/SimpleNullableTypeReader.cs
@@ -27,7 +27,7 @@ internal sealed class SimpleNullableTypeReader : IInsertDataReader
         return 1;
     }
 
-    public string GetPropertyName(int propertyIndex = 0)
+    public string GetPropertyName(int propertyIndex)
     {
         if (propertyIndex != 0)
             throw new ArgumentException("SimpleNullableTypeReader supports only a single property");

--- a/XLibur/Excel/InsertData/SimpleTypeReader.cs
+++ b/XLibur/Excel/InsertData/SimpleTypeReader.cs
@@ -27,7 +27,7 @@ internal sealed class SimpleTypeReader : IInsertDataReader
         return 1;
     }
 
-    public string GetPropertyName(int propertyIndex = 0)
+    public string GetPropertyName(int propertyIndex)
     {
         if (propertyIndex != 0)
             throw new ArgumentException("SimpleTypeReader supports only a single property");

--- a/XLibur/Excel/PivotTables/Areas/XLPivotFieldBase.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotFieldBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;
@@ -50,7 +51,7 @@ internal abstract class XLPivotFieldBase : IXLPivotField
         set => GetField().SubtotalCaption = value;
     }
 
-    public IReadOnlyCollection<XLSubtotalFunction> Subtotals => GetField().Subtotals;
+    public IReadOnlyCollection<XLSubtotalFunction> Subtotals => GetFieldValue<IReadOnlyCollection<XLSubtotalFunction>>(f => f.Subtotals, Array.Empty<XLSubtotalFunction>());
 
     public bool IncludeNewItemsInFilter
     {

--- a/XLibur/Excel/PivotTables/Areas/XLPivotFieldBase.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotFieldBase.cs
@@ -1,0 +1,198 @@
+using System.Collections.Generic;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// Shared implementation of <see cref="IXLPivotField"/> fluent setters and property
+/// delegates. Subclasses provide the concrete <see cref="GetField"/> resolution.
+/// </summary>
+internal abstract class XLPivotFieldBase : IXLPivotField
+{
+    private protected readonly XLPivotTable PivotTable;
+
+    private protected XLPivotFieldBase(XLPivotTable pivotTable)
+    {
+        PivotTable = pivotTable;
+    }
+
+    // --- Abstract / virtual members that subclasses must provide ---
+
+    public abstract string SourceName { get; }
+    public abstract string CustomName { get; set; }
+    public abstract IReadOnlyList<XLCellValue> SelectedValues { get; }
+    public abstract IXLPivotField AddSelectedValue(XLCellValue value);
+    public abstract IXLPivotField AddSelectedValues(IEnumerable<XLCellValue> values);
+    public abstract IXLPivotFieldStyleFormats StyleFormats { get; }
+    public abstract bool IsOnRowAxis { get; }
+    public abstract bool IsOnColumnAxis { get; }
+    public abstract bool IsInFilterList { get; }
+    public abstract int Offset { get; }
+
+    /// <summary>
+    /// Get the underlying <see cref="XLPivotTableField"/> for this pivot field.
+    /// </summary>
+    private protected abstract XLPivotTableField GetField();
+
+    /// <summary>
+    /// Get a value from the underlying field, or return a default when the field
+    /// cannot provide one (e.g. data fields on an axis).
+    /// </summary>
+    private protected virtual T GetFieldValue<T>(System.Func<XLPivotTableField, T> getter, T defaultValue)
+    {
+        return getter(GetField());
+    }
+
+    // --- Properties delegated to GetField() ---
+
+    public string SubtotalCaption
+    {
+        get => GetFieldValue(f => f.SubtotalCaption, string.Empty);
+        set => GetField().SubtotalCaption = value;
+    }
+
+    public IReadOnlyCollection<XLSubtotalFunction> Subtotals => GetField().Subtotals;
+
+    public bool IncludeNewItemsInFilter
+    {
+        get => GetFieldValue(f => f.IncludeNewItemsInFilter, false);
+        set => GetField().IncludeNewItemsInFilter = value;
+    }
+
+    public bool Outline
+    {
+        get => GetFieldValue(f => f.Outline, true);
+        set => GetField().Outline = value;
+    }
+
+    public bool Compact
+    {
+        get => GetFieldValue(f => f.Compact, true);
+        set => GetField().Compact = value;
+    }
+
+    public bool? SubtotalsAtTop
+    {
+        get => GetFieldValue(f => f.SubtotalTop, true);
+        set => GetField().SubtotalTop = value ?? true;
+    }
+
+    public bool RepeatItemLabels
+    {
+        get => GetFieldValue(f => f.RepeatItemLabels, false);
+        set => GetField().RepeatItemLabels = value;
+    }
+
+    public bool InsertBlankLines
+    {
+        get => GetFieldValue(f => f.InsertBlankRow, false);
+        set => GetField().InsertBlankRow = value;
+    }
+
+    public bool ShowBlankItems
+    {
+        get => GetFieldValue(f => f.ShowAll, true);
+        set => GetField().ShowAll = value;
+    }
+
+    public bool InsertPageBreaks
+    {
+        get => GetFieldValue(f => f.InsertPageBreak, false);
+        set => GetField().InsertPageBreak = value;
+    }
+
+    public virtual bool Collapsed
+    {
+        get => GetFieldValue(f => f.Collapsed, false);
+        set => GetField().Collapsed = value;
+    }
+
+    public XLPivotSortType SortType
+    {
+        get => GetFieldValue(f => f.SortType, XLPivotSortType.Default);
+        set => GetField().SortType = value;
+    }
+
+    // --- Fluent setters ---
+
+    public IXLPivotField SetCustomName(string value)
+    {
+        CustomName = value;
+        return this;
+    }
+
+    public IXLPivotField SetSubtotalCaption(string value)
+    {
+        SubtotalCaption = value;
+        return this;
+    }
+
+    public IXLPivotField SetSubtotal(XLSubtotalFunction function, bool enabled)
+    {
+        if (enabled)
+            GetField().AddSubtotal(function);
+        else
+            GetField().RemoveSubtotal(function);
+
+        return this;
+    }
+
+    public IXLPivotField AddSubtotal(XLSubtotalFunction value)
+    {
+        GetField().AddSubtotal(value);
+        return this;
+    }
+
+    public IXLPivotField SetIncludeNewItemsInFilter(bool value = true)
+    {
+        IncludeNewItemsInFilter = value;
+        return this;
+    }
+
+    public IXLPivotField SetLayout(XLPivotLayout value)
+    {
+        GetField().SetLayout(value);
+        return this;
+    }
+
+    public IXLPivotField SetSubtotalsAtTop(bool value = true)
+    {
+        SubtotalsAtTop = value;
+        return this;
+    }
+
+    public IXLPivotField SetRepeatItemLabels(bool value = true)
+    {
+        RepeatItemLabels = value;
+        return this;
+    }
+
+    public IXLPivotField SetInsertBlankLines(bool value = true)
+    {
+        InsertBlankLines = value;
+        return this;
+    }
+
+    public IXLPivotField SetShowBlankItems(bool value = true)
+    {
+        ShowBlankItems = value;
+        return this;
+    }
+
+    public IXLPivotField SetInsertPageBreaks(bool value = true)
+    {
+        InsertPageBreaks = value;
+        return this;
+    }
+
+    public IXLPivotField SetCollapsed(bool value = true)
+    {
+        Collapsed = value;
+        return this;
+    }
+
+    public IXLPivotField SetSort(XLPivotSortType value)
+    {
+        SortType = value;
+        return this;
+    }
+}

--- a/XLibur/Excel/PivotTables/Areas/XLPivotTableAxisField.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotTableAxisField.cs
@@ -99,10 +99,10 @@ internal sealed class XLPivotTableAxisField : XLPivotFieldBase
         return PivotTable.PivotFields[_index];
     }
 
-    private protected override T GetFieldValue<T>(Func<XLPivotTableField, T> getter, T dataFieldValue)
+    private protected override T GetFieldValue<T>(Func<XLPivotTableField, T> getter, T defaultValue)
     {
         if (_index.IsDataField)
-            return dataFieldValue;
+            return defaultValue;
 
         return getter(PivotTable.PivotFields[_index]);
     }

--- a/XLibur/Excel/PivotTables/Areas/XLPivotTableAxisField.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotTableAxisField.cs
@@ -167,7 +167,7 @@ internal sealed class XLPivotTableAxisField : IXLPivotField
         return this;
     }
 
-    public IXLPivotField SetIncludeNewItemsInFilter(bool value)
+    public IXLPivotField SetIncludeNewItemsInFilter(bool value = true)
     {
         IncludeNewItemsInFilter = value;
         return this;
@@ -179,37 +179,37 @@ internal sealed class XLPivotTableAxisField : IXLPivotField
         return this;
     }
 
-    public IXLPivotField SetSubtotalsAtTop(bool value)
+    public IXLPivotField SetSubtotalsAtTop(bool value = true)
     {
         SubtotalsAtTop = value;
         return this;
     }
 
-    public IXLPivotField SetRepeatItemLabels(bool value)
+    public IXLPivotField SetRepeatItemLabels(bool value = true)
     {
         RepeatItemLabels = value;
         return this;
     }
 
-    public IXLPivotField SetInsertBlankLines(bool value)
+    public IXLPivotField SetInsertBlankLines(bool value = true)
     {
         InsertBlankLines = value;
         return this;
     }
 
-    public IXLPivotField SetShowBlankItems(bool value)
+    public IXLPivotField SetShowBlankItems(bool value = true)
     {
         ShowBlankItems = value;
         return this;
     }
 
-    public IXLPivotField SetInsertPageBreaks(bool value)
+    public IXLPivotField SetInsertPageBreaks(bool value = true)
     {
         InsertPageBreaks = value;
         return this;
     }
 
-    public IXLPivotField SetCollapsed(bool value)
+    public IXLPivotField SetCollapsed(bool value = true)
     {
         Collapsed = true;
         return this;

--- a/XLibur/Excel/PivotTables/Areas/XLPivotTableAxisField.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotTableAxisField.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8,112 +8,48 @@ namespace XLibur.Excel;
 /// A fluent API for one field in <see cref="XLPivotTableAxis"/>, either
 /// <see cref="XLPivotTable.RowLabels"/> or <see cref="XLPivotTable.ColumnLabels"/>.
 /// </summary>
-internal sealed class XLPivotTableAxisField : IXLPivotField
+internal sealed class XLPivotTableAxisField : XLPivotFieldBase
 {
-    private readonly XLPivotTable _pivotTable;
     private readonly FieldIndex _index;
 
     internal XLPivotTableAxisField(XLPivotTable pivotTable, FieldIndex index)
+        : base(pivotTable)
     {
-        _pivotTable = pivotTable;
         _index = index;
     }
 
-    #region IXLPivotField memebers
-
-    public string SourceName
+    public override string SourceName
     {
         get
         {
             if (_index.IsDataField)
                 return XLConstants.PivotTable.ValuesSentinalLabel;
 
-            return _pivotTable.PivotCache.FieldNames[_index];
+            return PivotTable.PivotCache.FieldNames[_index];
         }
     }
 
-    public string CustomName
+    public override string CustomName
     {
-        get => GetFieldValue(f => f.Name!, _pivotTable.DataCaption);
+        get => GetFieldValue(f => f.Name!, PivotTable.DataCaption);
         set
         {
             if (_index.IsDataField)
             {
-                _pivotTable.DataCaption = value;
+                PivotTable.DataCaption = value;
                 return;
             }
 
-            if (_pivotTable.TryGetCustomNameFieldIndex(value, out var idx) && idx != _index)
+            if (PivotTable.TryGetCustomNameFieldIndex(value, out var idx) && idx != _index)
                 throw new ArgumentException($"Custom name '{value}' is already used by another field.");
 
-            _pivotTable.PivotFields[_index].Name = value;
+            PivotTable.PivotFields[_index].Name = value;
         }
     }
 
-    public string SubtotalCaption
+    public override bool Collapsed
     {
-        get => GetFieldValue(f => f.SubtotalCaption, string.Empty);
-        set => GetField().SubtotalCaption = value;
-    }
-
-    public IReadOnlyCollection<XLSubtotalFunction> Subtotals
-    {
-        get => GetField().Subtotals;
-    }
-
-    public bool IncludeNewItemsInFilter
-    {
-        get => GetFieldValue(f => f.IncludeNewItemsInFilter, false);
-        set => GetField().IncludeNewItemsInFilter = value;
-    }
-
-    public bool Outline
-    {
-        get => GetFieldValue(f => f.Outline, true);
-        set => GetField().Outline = value;
-    }
-    public bool Compact
-    {
-        get => GetFieldValue(f => f.Compact, true);
-        set => GetField().Compact = value;
-    }
-
-    public bool? SubtotalsAtTop
-    {
-        get => GetFieldValue(f => f.SubtotalTop, true);
-        set => GetField().SubtotalTop = value ?? true;
-    }
-
-    public bool RepeatItemLabels
-    {
-        get => GetFieldValue(f => f.RepeatItemLabels, false);
-        set => GetField().RepeatItemLabels = value;
-    }
-
-    public bool InsertBlankLines
-    {
-        get => GetFieldValue(f => f.InsertBlankRow, false);
-        set => GetField().InsertBlankRow = value;
-    }
-
-    public bool ShowBlankItems
-    {
-        get => GetFieldValue(f => f.ShowAll, true);
-        set => GetField().ShowAll = value;
-    }
-
-    public bool InsertPageBreaks
-    {
-        get => GetFieldValue(f => f.InsertPageBreak, false);
-        set => GetField().InsertPageBreak = value;
-    }
-
-    public bool Collapsed
-    {
-        get
-        {
-            return GetFieldValue(f => !f.Items.Any(i => i.ShowDetails), false);
-        }
+        get => GetFieldValue(f => !f.Items.Any(i => i.ShowDetails), false);
         set
         {
             foreach (var item in GetField().Items)
@@ -121,111 +57,21 @@ internal sealed class XLPivotTableAxisField : IXLPivotField
         }
     }
 
-    public XLPivotSortType SortType
-    {
-        get => GetFieldValue(f => f.SortType, XLPivotSortType.Default);
-        set => GetField().SortType = value;
-    }
+    public override IReadOnlyList<XLCellValue> SelectedValues => Array.Empty<XLCellValue>();
 
-    public IReadOnlyList<XLCellValue> SelectedValues => Array.Empty<XLCellValue>();
+    public override IXLPivotFieldStyleFormats StyleFormats => new XLPivotTableAxisFieldStyleFormats(PivotTable, this);
 
-    public IXLPivotFieldStyleFormats StyleFormats => new XLPivotTableAxisFieldStyleFormats(_pivotTable, this);
+    public override bool IsOnRowAxis => GetFieldValue(f => f.Axis == XLPivotAxis.AxisRow, PivotTable.DataOnRows);
 
-    public bool IsOnRowAxis => GetFieldValue(f => f.Axis == XLPivotAxis.AxisRow, _pivotTable.DataOnRows);
+    public override bool IsOnColumnAxis => GetFieldValue(f => f.Axis == XLPivotAxis.AxisCol, !PivotTable.DataOnRows);
 
-    public bool IsOnColumnAxis => GetFieldValue(f => f.Axis == XLPivotAxis.AxisCol, !_pivotTable.DataOnRows);
+    public override bool IsInFilterList => false;
 
-    public bool IsInFilterList => false;
+    public override int Offset => _index;
 
-    public int Offset => _index;
+    public override IXLPivotField AddSelectedValue(XLCellValue value) => this;
 
-    public IXLPivotField SetCustomName(string value)
-    {
-        CustomName = value;
-        return this;
-    }
-
-    public IXLPivotField SetSubtotalCaption(string value)
-    {
-        SubtotalCaption = value;
-        return this;
-    }
-
-    public IXLPivotField SetSubtotal(XLSubtotalFunction function, bool enabled)
-    {
-        if (enabled)
-            GetField().AddSubtotal(function);
-        else
-            GetField().RemoveSubtotal(function);
-
-        return this;
-    }
-
-    public IXLPivotField AddSubtotal(XLSubtotalFunction value)
-    {
-        GetField().AddSubtotal(value);
-        return this;
-    }
-
-    public IXLPivotField SetIncludeNewItemsInFilter(bool value = true)
-    {
-        IncludeNewItemsInFilter = value;
-        return this;
-    }
-
-    public IXLPivotField SetLayout(XLPivotLayout value)
-    {
-        GetField().SetLayout(value);
-        return this;
-    }
-
-    public IXLPivotField SetSubtotalsAtTop(bool value = true)
-    {
-        SubtotalsAtTop = value;
-        return this;
-    }
-
-    public IXLPivotField SetRepeatItemLabels(bool value = true)
-    {
-        RepeatItemLabels = value;
-        return this;
-    }
-
-    public IXLPivotField SetInsertBlankLines(bool value = true)
-    {
-        InsertBlankLines = value;
-        return this;
-    }
-
-    public IXLPivotField SetShowBlankItems(bool value = true)
-    {
-        ShowBlankItems = value;
-        return this;
-    }
-
-    public IXLPivotField SetInsertPageBreaks(bool value = true)
-    {
-        InsertPageBreaks = value;
-        return this;
-    }
-
-    public IXLPivotField SetCollapsed(bool value = true)
-    {
-        Collapsed = true;
-        return this;
-    }
-
-    public IXLPivotField SetSort(XLPivotSortType value)
-    {
-        SortType = value;
-        return this;
-    }
-
-    public IXLPivotField AddSelectedValue(XLCellValue value) => this;
-
-    public IXLPivotField AddSelectedValues(IEnumerable<XLCellValue> values) => this;
-
-    #endregion IXLPivotField members
+    public override IXLPivotField AddSelectedValues(IEnumerable<XLCellValue> values) => this;
 
     internal XLPivotAxis Axis => IsOnColumnAxis ? XLPivotAxis.AxisCol : XLPivotAxis.AxisRow;
 
@@ -236,7 +82,7 @@ internal sealed class XLPivotTableAxisField : IXLPivotField
     {
         get
         {
-            var axis = IsOnColumnAxis ? _pivotTable.ColumnAxis : _pivotTable.RowAxis;
+            var axis = IsOnColumnAxis ? PivotTable.ColumnAxis : PivotTable.RowAxis;
             var position = axis.IndexOf(_index);
             if (position == -1)
                 throw new InvalidOperationException("Field is not on the axis.");
@@ -245,19 +91,19 @@ internal sealed class XLPivotTableAxisField : IXLPivotField
         }
     }
 
-    private XLPivotTableField GetField()
+    private protected override XLPivotTableField GetField()
     {
         if (_index.IsDataField)
             throw new InvalidOperationException("Can't set this property on a data field.");
 
-        return _pivotTable.PivotFields[_index];
+        return PivotTable.PivotFields[_index];
     }
 
-    private T GetFieldValue<T>(Func<XLPivotTableField, T> getter, T dataFieldValue)
+    private protected override T GetFieldValue<T>(Func<XLPivotTableField, T> getter, T dataFieldValue)
     {
         if (_index.IsDataField)
             return dataFieldValue;
-        var field = _pivotTable.PivotFields[_index];
-        return getter(field);
+
+        return getter(PivotTable.PivotFields[_index]);
     }
 }

--- a/XLibur/Excel/PivotTables/Areas/XLPivotTablePageField.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotTablePageField.cs
@@ -123,7 +123,7 @@ internal sealed class XLPivotTablePageField : IXLPivotField
         return this;
     }
 
-    public IXLPivotField SetIncludeNewItemsInFilter(bool value)
+    public IXLPivotField SetIncludeNewItemsInFilter(bool value = true)
     {
         IncludeNewItemsInFilter = value;
         return this;
@@ -135,37 +135,37 @@ internal sealed class XLPivotTablePageField : IXLPivotField
         return this;
     }
 
-    public IXLPivotField SetSubtotalsAtTop(bool value)
+    public IXLPivotField SetSubtotalsAtTop(bool value = true)
     {
         SubtotalsAtTop = value;
         return this;
     }
 
-    public IXLPivotField SetRepeatItemLabels(bool value)
+    public IXLPivotField SetRepeatItemLabels(bool value = true)
     {
         RepeatItemLabels = value;
         return this;
     }
 
-    public IXLPivotField SetInsertBlankLines(bool value)
+    public IXLPivotField SetInsertBlankLines(bool value = true)
     {
         InsertBlankLines = value;
         return this;
     }
 
-    public IXLPivotField SetShowBlankItems(bool value)
+    public IXLPivotField SetShowBlankItems(bool value = true)
     {
         ShowBlankItems = value;
         return this;
     }
 
-    public IXLPivotField SetInsertPageBreaks(bool value)
+    public IXLPivotField SetInsertPageBreaks(bool value = true)
     {
         InsertPageBreaks = value;
         return this;
     }
 
-    public IXLPivotField SetCollapsed(bool value)
+    public IXLPivotField SetCollapsed(bool value = true)
     {
         Collapsed = value;
         return this;

--- a/XLibur/Excel/PivotTables/Areas/XLPivotTablePageField.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotTablePageField.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8,176 +8,25 @@ namespace XLibur.Excel;
 /// Fluent API for filter fields of a <see cref="XLPivotTable"/>. This class shouldn't contain any
 /// state, only logic to change state per API.
 /// </summary>
-internal sealed class XLPivotTablePageField : IXLPivotField
+internal sealed class XLPivotTablePageField : XLPivotFieldBase
 {
-    private readonly XLPivotTable _pivotTable;
     private readonly XLPivotPageField _filterField;
 
     internal XLPivotTablePageField(XLPivotTable pivotTable, XLPivotPageField filterField)
+        : base(pivotTable)
     {
-        _pivotTable = pivotTable;
         _filterField = filterField;
     }
 
-    public string SourceName => _pivotTable.PivotCache.FieldNames[_filterField.Field];
+    public override string SourceName => PivotTable.PivotCache.FieldNames[_filterField.Field];
 
-    public string CustomName
+    public override string CustomName
     {
         get => GetField().Name!;
         set => GetField().Name = value;
     }
 
-    public string SubtotalCaption
-    {
-        get => GetField().SubtotalCaption;
-        set => GetField().SubtotalCaption = value;
-    }
-
-    public IReadOnlyCollection<XLSubtotalFunction> Subtotals => GetField().Subtotals;
-
-    public bool IncludeNewItemsInFilter
-    {
-        get => GetField().IncludeNewItemsInFilter;
-        set => GetField().IncludeNewItemsInFilter = value;
-    }
-
-    public bool Outline
-    {
-        get => GetField().Outline;
-        set => GetField().Outline = value;
-    }
-
-    public bool Compact
-    {
-        get => GetField().Compact;
-        set => GetField().Compact = value;
-    }
-
-    public bool? SubtotalsAtTop
-    {
-        get => GetField().SubtotalTop;
-        set => GetField().SubtotalTop = value ?? true;
-    }
-
-    public bool RepeatItemLabels
-    {
-        get => GetField().RepeatItemLabels;
-        set => GetField().RepeatItemLabels = value;
-    }
-
-    public bool InsertBlankLines
-    {
-        get => GetField().InsertBlankRow;
-        set => GetField().InsertBlankRow = value;
-    }
-
-    public bool ShowBlankItems
-    {
-        get => GetField().ShowAll;
-        set => GetField().ShowAll = value;
-    }
-
-    public bool InsertPageBreaks
-    {
-        get => GetField().InsertPageBreak;
-        set => GetField().InsertPageBreak = value;
-    }
-
-    public bool Collapsed
-    {
-        get => GetField().Collapsed;
-        set => GetField().Collapsed = value;
-    }
-
-    public XLPivotSortType SortType
-    {
-        get => GetField().SortType;
-        set => GetField().SortType = value;
-    }
-
-    public IXLPivotField SetCustomName(string value)
-    {
-        CustomName = value;
-        return this;
-    }
-
-    public IXLPivotField SetSubtotalCaption(string value)
-    {
-        SubtotalCaption = value;
-        return this;
-    }
-
-    public IXLPivotField SetSubtotal(XLSubtotalFunction function, bool enabled)
-    {
-        if (enabled)
-            GetField().AddSubtotal(function);
-        else
-            GetField().RemoveSubtotal(function);
-
-        return this;
-    }
-
-    public IXLPivotField AddSubtotal(XLSubtotalFunction value)
-    {
-        GetField().AddSubtotal(value);
-        return this;
-    }
-
-    public IXLPivotField SetIncludeNewItemsInFilter(bool value = true)
-    {
-        IncludeNewItemsInFilter = value;
-        return this;
-    }
-
-    public IXLPivotField SetLayout(XLPivotLayout value)
-    {
-        GetField().SetLayout(value);
-        return this;
-    }
-
-    public IXLPivotField SetSubtotalsAtTop(bool value = true)
-    {
-        SubtotalsAtTop = value;
-        return this;
-    }
-
-    public IXLPivotField SetRepeatItemLabels(bool value = true)
-    {
-        RepeatItemLabels = value;
-        return this;
-    }
-
-    public IXLPivotField SetInsertBlankLines(bool value = true)
-    {
-        InsertBlankLines = value;
-        return this;
-    }
-
-    public IXLPivotField SetShowBlankItems(bool value = true)
-    {
-        ShowBlankItems = value;
-        return this;
-    }
-
-    public IXLPivotField SetInsertPageBreaks(bool value = true)
-    {
-        InsertPageBreaks = value;
-        return this;
-    }
-
-    public IXLPivotField SetCollapsed(bool value = true)
-    {
-        Collapsed = value;
-        return this;
-    }
-
-    public IXLPivotField SetSort(XLPivotSortType value)
-    {
-        SortType = value;
-        return this;
-    }
-
-    public IReadOnlyList<XLCellValue> SelectedValues
+    public override IReadOnlyList<XLCellValue> SelectedValues
     {
         get
         {
@@ -194,7 +43,7 @@ internal sealed class XLPivotTablePageField : IXLPivotField
         }
     }
 
-    public IXLPivotField AddSelectedValue(XLCellValue value)
+    public override IXLPivotField AddSelectedValue(XLCellValue value)
     {
         // Try to keep the original behavior of XLibur - it always allows multiple selected items for added values.
         // But it's complete kludge with no sane semantic that will be nuked ASAP.
@@ -232,7 +81,7 @@ internal sealed class XLPivotTablePageField : IXLPivotField
         }
     }
 
-    public IXLPivotField AddSelectedValues(IEnumerable<XLCellValue> values)
+    public override IXLPivotField AddSelectedValues(IEnumerable<XLCellValue> values)
     {
         foreach (var value in values)
             AddSelectedValue(value);
@@ -240,14 +89,14 @@ internal sealed class XLPivotTablePageField : IXLPivotField
         return this;
     }
 
-    public IXLPivotFieldStyleFormats StyleFormats => throw new NotImplementedException("Styles for filter fields are not yet implemented.");
-    public bool IsOnRowAxis => false;
-    public bool IsOnColumnAxis => false;
-    public bool IsInFilterList => true;
-    public int Offset => _filterField.Field;
+    public override IXLPivotFieldStyleFormats StyleFormats => throw new NotImplementedException("Styles for filter fields are not yet implemented.");
+    public override bool IsOnRowAxis => false;
+    public override bool IsOnColumnAxis => false;
+    public override bool IsInFilterList => true;
+    public override int Offset => _filterField.Field;
 
-    private XLPivotTableField GetField()
+    private protected override XLPivotTableField GetField()
     {
-        return _pivotTable.PivotFields[_filterField.Field];
+        return PivotTable.PivotFields[_filterField.Field];
     }
 }

--- a/XLibur/Excel/PivotTables/XLPivotSourceExternalWorkbook.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceExternalWorkbook.cs
@@ -61,9 +61,9 @@ internal sealed class XLPivotSourceExternalWorkbook : IXLPivotSource
         return false;
     }
 
-    public override bool Equals(object? other)
+    public override bool Equals(object? obj)
     {
-        return other is IXLPivotSource source && Equals(source);
+        return obj is IXLPivotSource source && Equals(source);
     }
 
     public override int GetHashCode()

--- a/XLibur/Excel/Ranges/Index/XLRangeIndex.cs
+++ b/XLibur/Excel/Ranges/Index/XLRangeIndex.cs
@@ -194,7 +194,7 @@ internal sealed class XLRangeIndex<T> : XLRangeIndex, IXLRangeIndex<T>
 
     public int RemoveAll(Predicate<T>? predicate = null)
     {
-        predicate = predicate ?? (_ => true);
+        predicate ??= _ => true;
 
         return base.RemoveAll(r => predicate((T)r));
     }

--- a/XLibur/Excel/Ranges/Index/XLRangeIndex.cs
+++ b/XLibur/Excel/Ranges/Index/XLRangeIndex.cs
@@ -192,7 +192,7 @@ internal sealed class XLRangeIndex<T> : XLRangeIndex, IXLRangeIndex<T>
         return base.Add(range);
     }
 
-    public int RemoveAll(Predicate<T>? predicate)
+    public int RemoveAll(Predicate<T>? predicate = null)
     {
         predicate = predicate ?? (_ => true);
 

--- a/XLibur/Excel/Ranges/XLRange.cs
+++ b/XLibur/Excel/Ranges/XLRange.cs
@@ -279,7 +279,7 @@ internal class XLRange : XLStoredRangeBase, IXLRange
 
     public IXLRange CopyTo(IXLCell target)
     {
-        base.CopyTo((XLCell)target);
+        base.CopyToCell((XLCell)target);
 
         var lastRowNumber = target.Address.RowNumber + RowCount() - 1;
         if (lastRowNumber > XLHelper.MaxRowNumber)

--- a/XLibur/Excel/Ranges/XLRangeBase.cs
+++ b/XLibur/Excel/Ranges/XLRangeBase.cs
@@ -1146,10 +1146,10 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
 
     public virtual void CopyTo(IXLRangeBase target)
     {
-        CopyTo((XLCell)target.FirstCell());
+        CopyToCell((XLCell)target.FirstCell());
     }
 
-    internal void CopyTo(XLCell target)
+    internal void CopyToCell(XLCell target)
     {
         target.CopyFrom(this);
     }

--- a/XLibur/Excel/Ranges/XLRangeColumn.cs
+++ b/XLibur/Excel/Ranges/XLRangeColumn.cs
@@ -27,10 +27,10 @@ internal sealed class XLRangeColumn : XLStoredRangeBase, IXLRangeColumn
 
     IXLCells IXLRangeColumn.Cells(string cellsInColumn) => Cells(cellsInColumn);
 
-    public override XLCells Cells(string cellsInColumn)
+    public override XLCells Cells(string cells)
     {
         var retVal = new XLCells(false, XLCellsUsedOptions.AllContents);
-        var rangePairs = cellsInColumn.Split(',');
+        var rangePairs = cells.Split(',');
         foreach (var pair in rangePairs)
             retVal.Add(Range(pair.Trim()).RangeAddress);
         return retVal;
@@ -97,7 +97,7 @@ internal sealed class XLRangeColumn : XLStoredRangeBase, IXLRangeColumn
 
     public IXLRangeColumn CopyTo(IXLCell target)
     {
-        base.CopyTo((XLCell)target);
+        base.CopyToCell((XLCell)target);
         return BuildCopyResult(target.Worksheet, target.Address.RowNumber, target.Address.ColumnNumber);
     }
 

--- a/XLibur/Excel/Ranges/XLRangeRow.cs
+++ b/XLibur/Excel/Ranges/XLRangeRow.cs
@@ -27,9 +27,9 @@ internal class XLRangeRow : XLStoredRangeBase, IXLRangeRow
         return Cell(1, columnNumber);
     }
 
-    public override XLCell Cell(string columnLetter)
+    public override XLCell Cell(string cellAddressInRange)
     {
-        return Cell(1, columnLetter);
+        return Cell(1, cellAddressInRange);
     }
 
     IXLCell IXLRangeRow.Cell(string columnLetter)
@@ -62,10 +62,10 @@ internal class XLRangeRow : XLStoredRangeBase, IXLRangeRow
         return InsertColumnsBefore(numberOfColumns, expandRange).Cells();
     }
 
-    public override XLCells Cells(string cellsInRow)
+    public override XLCells Cells(string cells)
     {
         var retVal = new XLCells(false, XLCellsUsedOptions.AllContents);
-        var rangePairs = cellsInRow.Split(',');
+        var rangePairs = cells.Split(',');
         foreach (var pair in rangePairs)
             retVal.Add(Range(pair.Trim()).RangeAddress);
         return retVal;
@@ -100,7 +100,7 @@ internal class XLRangeRow : XLStoredRangeBase, IXLRangeRow
 
     public IXLRangeRow CopyTo(IXLCell target)
     {
-        base.CopyTo((XLCell)target);
+        base.CopyToCell((XLCell)target);
 
         var lastRowNumber = target.Address.RowNumber + RowCount() - 1;
         if (lastRowNumber > XLHelper.MaxRowNumber)

--- a/XLibur/Excel/Rows/XLRow.cs
+++ b/XLibur/Excel/Rows/XLRow.cs
@@ -217,9 +217,9 @@ internal sealed class XLRow : XLRangeBase, IXLRow
         return Cell(1, columnNumber);
     }
 
-    public override XLCell Cell(string columnLetter)
+    public override XLCell Cell(string cellAddressInRange)
     {
-        return Cell(1, columnLetter);
+        return Cell(1, cellAddressInRange);
     }
 
     IXLCell IXLRow.Cell(string columnLetter)
@@ -239,10 +239,10 @@ internal sealed class XLRow : XLRangeBase, IXLRow
             : Cells(FirstCellUsed()!.Address.ColumnNumber, LastCellUsed()!.Address.ColumnNumber);
     }
 
-    public override XLCells Cells(string cellsInRow)
+    public override XLCells Cells(string cells)
     {
         var retVal = new XLCells(false, XLCellsUsedOptions.AllContents);
-        var rangePairs = cellsInRow.Split(',');
+        var rangePairs = cells.Split(',');
         foreach (var pair in rangePairs)
             retVal.Add(Range(pair.Trim()).RangeAddress);
         return retVal;

--- a/XLibur/Excel/Tables/XLTable.cs
+++ b/XLibur/Excel/Tables/XLTable.cs
@@ -925,7 +925,7 @@ internal sealed class XLTable : XLRange, IXLTable
 
     #region Append and replace data
 
-    public IXLRange? AppendData(IEnumerable data, bool propagateExtraColumns)
+    public IXLRange? AppendData(IEnumerable data, bool propagateExtraColumns = false)
     {
         return AppendData(data, transpose: false, propagateExtraColumns: propagateExtraColumns);
     }

--- a/XLibur/PublicAPI.Shipped.txt
+++ b/XLibur/PublicAPI.Shipped.txt
@@ -333,7 +333,6 @@ XLibur.Excel.IXLCell.RemoveCellImage() -> void
 XLibur.Excel.IXLCell.Select() -> void
 XLibur.Excel.IXLCell.SetActive(bool value = true) -> XLibur.Excel.IXLCell!
 XLibur.Excel.IXLCell.SetCellImage(System.IO.Stream! imageStream, XLibur.Excel.Drawings.XLPictureFormat format, string! altText = "") -> XLibur.Excel.IXLCell!
-XLibur.Excel.IXLCell.SetDataValidation() -> XLibur.Excel.IXLDataValidation!
 XLibur.Excel.IXLCell.SetDynamicFormulaA1(string! formula) -> XLibur.Excel.IXLCell!
 XLibur.Excel.IXLCell.SetFormulaA1(string! formula) -> XLibur.Excel.IXLCell!
 XLibur.Excel.IXLCell.SetFormulaR1C1(string! formula) -> XLibur.Excel.IXLCell!


### PR DESCRIPTION
## Summary
- **S927**: Rename 9 parameters to match base class declarations (e.g. `other`→`obj`, `cellsInColumn`→`cells`)
- **S4019**: Rename internal `CopyTo(XLCell)` to `CopyToCell` in `XLRangeBase` to stop hiding the base method in `XLRange`, `XLRangeColumn`, `XLRangeRow`
- **S1006**: Fix 19 default parameter value mismatches with overridden methods across `XLPivotTableAxisField`, `XLPivotTablePageField`, `XLTable`, `XLConditionalFormat`, and others
- **RS0017**: Remove stale `IXLCell.SetDataValidation()` entry from `PublicAPI.Shipped.txt`

## Test plan
- [x] All 5,929 tests pass on both net8.0 and net10.0
- [x] Zero build warnings/errors
- [ ] CI build and test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added mutation testing instructions (duplicated in two README sections) and expanded developer guidelines with formatting command and spec links.

* **Breaking Changes**
  * Removed SetDataValidation() from public API; several methods now require explicit parameters (defaults removed); added new public enums for cell/table data types.

* **Refactor**
  * Consolidated pivot-field base and streamlined pivot field implementations; broad stylistic and API-surface cleanups.

* **Tests**
  * Added comprehensive range/row copy tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->