### PR TITLE
fix: resolve SonarCloud security hotspots

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Begin SonarCloud analysis
         if: env.SONAR_TOKEN != ''
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >
           dotnet sonarscanner begin
           /k:"XLibur_XLibur"
@@ -84,6 +86,8 @@ jobs:
 
       - name: End SonarCloud analysis
         if: env.SONAR_TOKEN != ''
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"
 
       - name: Upload test results

--- a/XLibur.Benchmarks/ClosedXmlWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/ClosedXmlWorkbookBenchmarks.cs
@@ -21,7 +21,9 @@ public class ClosedXmlWorkbookBenchmarks
         _numbers = new double[RowCount];
         _dates = new DateTime[RowCount];
 
+#pragma warning disable S2245 // Using pseudorandom number generator - deterministic seed is intentional for benchmarks
         var random = new Random(42);
+#pragma warning restore S2245
         var baseDate = new DateTime(2020, 1, 1);
 
         for (var i = 0; i < RowCount; i++)

--- a/XLibur/Excel/CalcEngine/DateTimeParser.cs
+++ b/XLibur/Excel/CalcEngine/DateTimeParser.cs
@@ -20,6 +20,8 @@ internal static class DateTimeParser
     // what patterns Excel uses for which cultures.
     private static readonly ConcurrentDictionary<CultureInfo, string[]> CultureSpecificPatterns = new();
 
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(150);
+
     private static readonly string[] TimeOfDayPatterns = ["h:m tt", "h:m t", "h:m:s tt", "h:m:s t"];
 
     public static bool TryParseCultureDate(string s, CultureInfo culture, out DateTime date)
@@ -35,8 +37,8 @@ internal static class DateTimeParser
             var shortDatePatterns = ci.DateTimeFormat.GetAllDateTimePatterns('d')
                 .Concat(ci.DateTimeFormat.GetAllDateTimePatterns('D'))
                 .Where(pattern => !pattern.Contains("dddd")) // It doesn't seem that Excel parser is capable of parsing day names in any culture
-                .Select(pattern => Regex.Replace(pattern, leadingZeroMonthPattern, "M")) // Recognize months even without leading zero
-                .Select(pattern => Regex.Replace(pattern, leadingZeroDayPattern, "d")) // Recognize days even without leading zero
+                .Select(pattern => Regex.Replace(pattern, leadingZeroMonthPattern, "M", RegexOptions.None, RegexTimeout)) // Recognize months even without leading zero
+                .Select(pattern => Regex.Replace(pattern, leadingZeroDayPattern, "d", RegexOptions.None, RegexTimeout)) // Recognize days even without leading zero
                 .Distinct().ToArray();
 
             // Not sure about this, but reasonably close. Hours pattern is probably generated (e.g. 'as-IN' culture

--- a/XLibur/Excel/CalcEngine/FractionParser.cs
+++ b/XLibur/Excel/CalcEngine/FractionParser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
@@ -8,7 +9,9 @@ namespace XLibur.Excel.CalcEngine;
 /// </summary>
 internal static class FractionParser
 {
-    private static readonly Regex FractionRegex = new(@"^ *([+-]?) *([0-9]+) ([0-9]{1,5})/([0-9]{1,5}) *$", RegexOptions.CultureInvariant);
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(150);
+
+    private static readonly Regex FractionRegex = new(@"^ *([+-]?) *([0-9]+) ([0-9]{1,5})/([0-9]{1,5}) *$", RegexOptions.CultureInvariant, RegexTimeout);
 
     public static bool TryParse(string s, out double result)
     {

--- a/XLibur/Excel/CalcEngine/Functions/XLMatrix.cs
+++ b/XLibur/Excel/CalcEngine/Functions/XLMatrix.cs
@@ -5,6 +5,7 @@ namespace XLibur.Excel.CalcEngine.Functions;
 
 internal sealed class XLMatrix
 {
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(150);
     public XLMatrix? L;
     public XLMatrix? U;
     public int Cols;
@@ -257,7 +258,7 @@ internal sealed class XLMatrix
     public static XLMatrix Parse(string ps) // Function parses the matrix from string
     {
         var s = NormalizeMatrixString(ps);
-        var rows = Regex.Split(s, "\r\n");
+        var rows = Regex.Split(s, "\r\n", RegexOptions.None, RegexTimeout);
         var nums = rows[0].Split(' ');
         var matrix = new XLMatrix(rows.Length, nums.Length);
         try

--- a/XLibur/Excel/CalcEngine/Functions/XLMatrix.cs
+++ b/XLibur/Excel/CalcEngine/Functions/XLMatrix.cs
@@ -258,22 +258,26 @@ internal sealed class XLMatrix
     public static XLMatrix Parse(string ps) // Function parses the matrix from string
     {
         var s = NormalizeMatrixString(ps);
-        var rows = Regex.Split(s, "\r\n", RegexOptions.None, RegexTimeout);
-        var nums = rows[0].Split(' ');
-        var matrix = new XLMatrix(rows.Length, nums.Length);
         try
         {
+            var rows = Regex.Split(s, "\r\n", RegexOptions.None, RegexTimeout);
+            var nums = rows[0].Split(' ');
+            var matrix = new XLMatrix(rows.Length, nums.Length);
             for (var i = 0; i < rows.Length; i++)
             {
                 nums = rows[i].Split(' ');
                 for (var j = 0; j < nums.Length; j++) matrix[i, j] = double.Parse(nums[j]);
             }
+            return matrix;
+        }
+        catch (RegexMatchTimeoutException ex)
+        {
+            throw new FormatException("Wrong input format!", ex);
         }
         catch (FormatException fe)
         {
             throw new FormatException("Wrong input format!", fe);
         }
-        return matrix;
     }
 
     public override string ToString() // Function returns matrix as a string

--- a/XLibur/XLHelper.cs
+++ b/XLibur/XLHelper.cs
@@ -60,9 +60,11 @@ public static partial class XLHelper
     /// </summary>
     internal static readonly StringComparer FunctionComparer = StringComparer.OrdinalIgnoreCase;
 
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(150);
+
     internal static readonly Regex RCSimpleRegex = new(
         @"^(r(((-\d)?\d*)|\[(-\d)?\d*\]))?(c(((-\d)?\d*)|\[(-\d)?\d*\]))?$"
-        , RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        , RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexTimeout);
 
     internal static readonly Regex A1SimpleRegex = new(
         @"\A"
@@ -85,7 +87,7 @@ public static partial class XLHelper
         + ")" // End Range
         + ")" // End Group to pick
         + @"\Z"
-        , RegexOptions.Compiled);
+        , RegexOptions.Compiled, RegexTimeout);
 
     internal static readonly Regex NamedRangeReferenceRegex = NamedRangeReferenceRegexCompiled();
 


### PR DESCRIPTION
## Summary
- Add 150ms regex timeouts to `DateTimeParser`, `FractionParser`, `XLMatrix`, and `XLHelper` to mitigate ReDoS (S4784)
- Pass `SONAR_TOKEN` via step-level `env` instead of expanding secrets in `run` blocks (S6886)
- Suppress S2245 for intentional seeded `Random(42)` usage in benchmark files
- Normalize line endings in `XLibur.csproj`

## Test plan
- [ ] Verify CI build passes
- [ ] Confirm SonarCloud analysis completes successfully with env-based token
- [ ] Verify no regex-related test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to set analysis token per-step for SonarCloud.
  * Introduced timeouts on parsing operations to avoid potential hangs.
* **Bug Fixes**
  * Improved error handling for parsing timeouts, converting stalled regex operations into clear format errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->