### PR TITLE
fix: trigger release drafter only on PR merge to main

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,10 +1,9 @@
 name: Release Drafter
 
 on:
-  push:
-    branches: [main]
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: read
@@ -12,6 +11,7 @@ permissions:
 
 jobs:
   update-release-draft:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Replace `push` + `pull_request_target[opened, reopened, synchronize]` triggers with `pull_request_target[closed]` on main
- Add `merged == true` condition so closed-but-not-merged PRs are skipped

## Test plan
- [ ] Merge a PR and verify release draft updates
- [ ] Close a PR without merging and verify release draft is not updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)