### PR TITLE
fix: replace Any() with Count/Length checks per CA1860

### DIFF
--- a/XLibur.Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/XLibur.Tests/Excel/Misc/XLWorkbookTests.cs
@@ -156,7 +156,7 @@ public class XLWorkbookTests
         var r = wb.Ranges(rangesAddress);
 
         Assert.NotNull(r);
-        Assert.False(r.Any());
+        Assert.That(r.Count, Is.EqualTo(0));
     }
 
     [Test]

--- a/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -456,7 +456,7 @@ public class NamedRangesTests
         Assert.AreEqual("Named range 4", wb.DefinedNames.ElementAt(1).Name);
         Assert.AreEqual(XLNamedRangeScope.Workbook, wb.DefinedNames.ElementAt(1).Scope);
         Assert.AreEqual("#REF!", wb.DefinedNames.ElementAt(1).RefersTo);
-        Assert.IsFalse(wb.DefinedNames.ElementAt(1).Ranges.Any());
+        Assert.That(wb.DefinedNames.ElementAt(1).Ranges.Count, Is.EqualTo(0));
 
         Assert.AreEqual("Named range 5", wb.DefinedNames.ElementAt(2).Name);
         Assert.AreEqual(XLNamedRangeScope.Workbook, wb.DefinedNames.ElementAt(2).Scope);
@@ -574,7 +574,7 @@ public class NamedRangesTests
             Assert.AreEqual("Named range 4", wb.DefinedNames.ElementAt(1).Name);
             Assert.AreEqual(XLNamedRangeScope.Workbook, wb.DefinedNames.ElementAt(1).Scope);
             Assert.AreEqual("#REF!", wb.DefinedNames.ElementAt(1).RefersTo);
-            Assert.IsFalse(wb.DefinedNames.ElementAt(1).Ranges.Any());
+            Assert.That(wb.DefinedNames.ElementAt(1).Ranges.Count, Is.EqualTo(0));
 
             Assert.AreEqual("Named range 5", wb.DefinedNames.ElementAt(2).Name);
             Assert.AreEqual(XLNamedRangeScope.Workbook, wb.DefinedNames.ElementAt(2).Scope);

--- a/XLibur/Excel/CalcEngine/FunctionDefinition.cs
+++ b/XLibur/Excel/CalcEngine/FunctionDefinition.cs
@@ -23,7 +23,7 @@ internal sealed class FunctionDefinition
 
     public FunctionDefinition(int minParams, int maxParams, CalcEngineFunction function, FunctionFlags flags, AllowRange allowRanges, IReadOnlyCollection<int> markedParams)
     {
-        if (allowRanges == AllowRange.None && markedParams.Any())
+        if (allowRanges == AllowRange.None && markedParams.Count > 0)
             throw new ArgumentException(nameof(markedParams));
 
         MinParams = minParams;

--- a/XLibur/Excel/CalcEngine/Reference.cs
+++ b/XLibur/Excel/CalcEngine/Reference.cs
@@ -155,7 +155,7 @@ namespace XLibur.Excel.CalcEngine
                     intersections.Add(intersectedArea);
             }
 
-            return intersections.Any() ? new Reference(intersections) : XLError.NullValue;
+            return intersections.Count > 0 ? new Reference(intersections) : XLError.NullValue;
         }
 
         /// <summary>

--- a/XLibur/Excel/Cells/XLCellCopyHelper.cs
+++ b/XLibur/Excel/Cells/XLCellCopyHelper.cs
@@ -168,7 +168,7 @@ internal static class XLCellCopyHelper
         {
             var fs = srcSheet.ConditionalFormats
                 .SelectMany(cf => cf.Ranges.GetIntersectedRanges(fromRange.RangeAddress)).ToArray();
-            if (fs.Any())
+            if (fs.Length > 0)
             {
                 minRo = fs.Max(r => r.RangeAddress.LastAddress.RowNumber);
                 minCo = fs.Max(r => r.RangeAddress.LastAddress.ColumnNumber);

--- a/XLibur/Excel/IO/ConditionalFormattingWriter.cs
+++ b/XLibur/Excel/IO/ConditionalFormattingWriter.cs
@@ -35,7 +35,7 @@ internal sealed class ConditionalFormattingWriter
         for (var i = 0; i < xlConditionalFormats.Count; ++i)
             xlConditionalFormats[i].Priority = i + 1;
 
-        if (!xlConditionalFormats.Any())
+        if (xlConditionalFormats.Count == 0)
         {
             worksheet.RemoveAllChildren<ConditionalFormatting>();
             cm.SetElement(XLWorksheetContents.ConditionalFormatting, null);
@@ -87,7 +87,7 @@ internal sealed class ConditionalFormattingWriter
     {
         var exlst = xlWorksheet.ConditionalFormats
             .Where(c => c.ConditionalFormatType == XLConditionalFormatType.DataBar).ToArray();
-        if (exlst.Any())
+        if (exlst.Length > 0)
         {
             if (!worksheet.Elements<WorksheetExtensionList>().Any())
             {

--- a/XLibur/Excel/IO/PictureWriter.cs
+++ b/XLibur/Excel/IO/PictureWriter.cs
@@ -41,11 +41,11 @@ internal sealed class PictureWriter
             AddPictureAnchor(worksheetPart, pic, context);
         }
 
-        if (xlWorksheet.Pictures.Any())
+        if (xlWorksheet.Pictures.Count > 0)
             RebaseNonVisualDrawingPropertiesIds(worksheetPart);
 
         var tableParts = worksheet.Elements<TableParts>().First();
-        if (xlWorksheet.Pictures.Any() && !worksheet.OfType<Drawing>().Any())
+        if (xlWorksheet.Pictures.Count > 0 && !worksheet.OfType<Drawing>().Any())
         {
             var worksheetDrawing = new Drawing { Id = worksheetPart.GetIdOfPart(worksheetPart.DrawingsPart!) };
             worksheetDrawing.AddNamespaceDeclaration("r",
@@ -59,7 +59,7 @@ internal sealed class PictureWriter
         if (worksheetPart.DrawingsPart is not null && // There is a drawing part for the sheet that could be deleted
             xlWorksheet
                 .LegacyDrawingId is null && // and sheet doesn't contain any form controls or comments or other shapes
-            !xlWorksheet.Pictures.Any() && // and also no pictures.
+            xlWorksheet.Pictures.Count == 0 && // and also no pictures.
             !hasCharts && // and no charts
                           // Check for non-picture shapes (textboxes, rectangles, etc.) last to avoid
                           // loading the DrawingsPart DOM unnecessarily — DOM loading causes re-serialization

--- a/XLibur/Excel/IO/SheetViewWriter.cs
+++ b/XLibur/Excel/IO/SheetViewWriter.cs
@@ -90,7 +90,7 @@ internal sealed class SheetViewWriter
         sheetView.RemoveAllChildren<Selection>();
         svcm.SetElement(XLSheetViewContents.Selection, null);
 
-        if (xlWorksheet.SelectedRanges.Any() || xlWorksheet.ActiveCell is not null)
+        if (xlWorksheet.SelectedRanges.Count > 0 || xlWorksheet.ActiveCell is not null)
             SetupSelections(sheetView, svcm, xlWorksheet, pane);
 
         SetZoomScales(sheetView, xlWorksheet);

--- a/XLibur/Excel/Ranges/XLRangeCellsHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeCellsHelper.cs
@@ -15,7 +15,7 @@ internal static class XLRangeCellsHelper
     {
         var cellsUsed = CellsUsedInternal(range, options, r => r.FirstCell(), predicate).ToList();
 
-        if (!cellsUsed.Any())
+        if (cellsUsed.Count == 0)
             return null;
 
         var firstRow = cellsUsed.Min(c => c.Address.RowNumber);
@@ -34,7 +34,7 @@ internal static class XLRangeCellsHelper
     {
         var cellsUsed = CellsUsedInternal(range, options, r => r.LastCell(), predicate).ToList();
 
-        if (!cellsUsed.Any())
+        if (cellsUsed.Count == 0)
             return null;
 
         var lastRow = cellsUsed.Max(c => c.Address.RowNumber);

--- a/XLibur/Excel/Ranges/XLRangeConditionalFormatHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeConditionalFormatHelper.cs
@@ -19,7 +19,7 @@ internal static class XLRangeConditionalFormatHelper
         {
             SplitFormatRanges(format, range);
 
-            if (!format.Ranges.Any())
+            if (format.Ranges.Count == 0)
                 range.Worksheet.ConditionalFormats.Remove(x => x == format);
         }
     }

--- a/XLibur/Excel/XLWorksheetRangeShifter.cs
+++ b/XLibur/Excel/XLWorksheetRangeShifter.cs
@@ -143,7 +143,7 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
                     cf.Ranges.Add(newRange);
             }
 
-            if (!cf.Ranges.Any())
+            if (cf.Ranges.Count == 0)
                 worksheet.ConditionalFormats.Remove(f => f == cf);
         }
     }
@@ -170,7 +170,7 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
                     cf.Ranges.Add(newRange);
             }
 
-            if (!cf.Ranges.Any())
+            if (cf.Ranges.Count == 0)
                 worksheet.ConditionalFormats.Remove(f => f == cf);
         }
     }


### PR DESCRIPTION
## Summary
- Resolves all 17 open SonarQube CA1860 violations across 11 files
- Replaces `Any()` with `Count`/`Length` comparisons on collections that expose these properties (List, arrays, IXLRanges, IXLPictures, IReadOnlyCollection)
- Avoids unnecessary enumerator allocation for simple emptiness checks

## Test plan
- [x] All 5941 tests pass on both net8.0 and net10.0
- [x] Zero build warnings
- [ ] Verify SonarQube CA1860 issues are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code refactoring to standardize collection emptiness checks throughout the codebase. No functional changes or visible impact to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->