### PR TITLE
fix: resolve SonarQube medium severity code smells

### DIFF
--- a/XLibur.Tests/Excel/PageSetup/HeaderFooterImageTests.cs
+++ b/XLibur.Tests/Excel/PageSetup/HeaderFooterImageTests.cs
@@ -12,6 +12,11 @@ namespace XLibur.Tests.Excel.PageSetup;
 [TestFixture]
 public class HeaderFooterImageTests
 {
+    private static readonly string[] ShapeIdsLH = ["LH"];
+    private static readonly string[] ShapeIdsCH = ["CH"];
+    private static readonly string[] ShapeIdsRH = ["RH"];
+    private static readonly string[] ShapeIdsLF = ["LF"];
+
     private string _pngPath = null!;
     private string _jpegPath = null!;
     private string _tempDir = null!;
@@ -47,7 +52,7 @@ public class HeaderFooterImageTests
         wb.SaveAs(ms, true);
 
         ms.Position = 0;
-        AssertPackageContainsHFImage(ms, expectedShapeIds: new[] { "LH" }, expectedHeaderText: "&L&G");
+        AssertPackageContainsHFImage(ms, expectedShapeIds: ShapeIdsLH, expectedHeaderText: "&L&G");
     }
 
     [Test]
@@ -61,7 +66,7 @@ public class HeaderFooterImageTests
         wb.SaveAs(ms, true);
 
         ms.Position = 0;
-        AssertPackageContainsHFImage(ms, expectedShapeIds: new[] { "CH" }, expectedHeaderText: "&C&G");
+        AssertPackageContainsHFImage(ms, expectedShapeIds: ShapeIdsCH, expectedHeaderText: "&C&G");
     }
 
     [Test]
@@ -75,7 +80,7 @@ public class HeaderFooterImageTests
         wb.SaveAs(ms, true);
 
         ms.Position = 0;
-        AssertPackageContainsHFImage(ms, expectedShapeIds: new[] { "RH" }, expectedHeaderText: "&R&G");
+        AssertPackageContainsHFImage(ms, expectedShapeIds: ShapeIdsRH, expectedHeaderText: "&R&G");
     }
 
     [Test]
@@ -89,7 +94,7 @@ public class HeaderFooterImageTests
         wb.SaveAs(ms, true);
 
         ms.Position = 0;
-        AssertPackageContainsHFImage(ms, expectedShapeIds: new[] { "LF" }, expectedFooterText: "&L&G");
+        AssertPackageContainsHFImage(ms, expectedShapeIds: ShapeIdsLF, expectedFooterText: "&L&G");
     }
 
     [Test]
@@ -105,7 +110,7 @@ public class HeaderFooterImageTests
         wb.SaveAs(ms, true);
 
         ms.Position = 0;
-        AssertPackageContainsHFImage(ms, expectedShapeIds: new[] { "LH" }, expectedHeaderText: "&LBefore:&G:After");
+        AssertPackageContainsHFImage(ms, expectedShapeIds: ShapeIdsLH, expectedHeaderText: "&LBefore:&G:After");
     }
 
     [Test]
@@ -452,7 +457,7 @@ public class HeaderFooterImageTests
         var vNs = XNamespace.Get("urn:schemas-microsoft-com:vml");
         return doc.Descendants(vNs + "shape")
             .Select(s => s.Attribute("id")?.Value ?? "")
-            .Where(id => !string.IsNullOrEmpty(id) && !id.StartsWith("_"))
+            .Where(id => !string.IsNullOrEmpty(id) && !id.StartsWith('_'))
             .ToArray();
     }
 

--- a/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -566,7 +566,7 @@ internal static class DateAndTime
     }
 
     private static OneOf<List<int>, XLError> CollectWorkdayHolidays(
-        CalcContext ctx, AnyValue holidays, int startDate, IComparer<int> comparer)
+        CalcContext ctx, AnyValue holidays, int startDate, Comparer<int> comparer)
     {
         // Use set to skip duplicate values
         var distinctHolidays = new HashSet<int>();
@@ -596,7 +596,7 @@ internal static class DateAndTime
     /// Returns the last date processed and the number of workdays counted so far.
     /// </summary>
     private static (int LastDate, int WorkdaysCounted) SkipHolidaySegments(
-        List<int> orderedHolidays, int startDate, int dayOffset, int oneDay, IComparer<int> cmp)
+        List<int> orderedHolidays, int startDate, int dayOffset, int oneDay, Comparer<int> cmp)
     {
         var lastDateSoFar = startDate;
         var workdaysSoFar = 0;

--- a/XLibur/Excel/CalcEngine/Functions/Engineering.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Engineering.cs
@@ -16,9 +16,6 @@ internal static class Engineering
     private const long OctMin = -536870912;
     private const long HexMax = 549755813887;
     private const long HexMin = -549755813888;
-    private const long TwoP10 = 1L << 10;
-    private const long TwoP30 = 1L << 30;
-    private const long TwoP40 = 1L << 40;
 
     public static void Register(FunctionRegistry ce)
     {

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFConverters.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFConverters.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace XLibur.Excel;
 
-internal sealed class XLCFConverters
+internal static class XLCFConverters
 {
     private static readonly Dictionary<XLConditionalFormatType, IXLCFConverter> Converters;
     static XLCFConverters()

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFConvertersExtension.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFConvertersExtension.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace XLibur.Excel;
 
-internal sealed class XLCFConvertersExtension
+internal static class XLCFConvertersExtension
 {
     private static readonly Dictionary<XLConditionalFormatType, IXLCFConverterExtension> Converters;
 

--- a/XLibur/Excel/EnumConverter.cs
+++ b/XLibur/Excel/EnumConverter.cs
@@ -571,7 +571,7 @@ internal static class EnumConverter
         return OrientationMap[value];
     }
 
-    private static readonly IReadOnlyDictionary<VerticalAlignmentRunValues, XLFontVerticalTextAlignmentValues>
+    private static readonly Dictionary<VerticalAlignmentRunValues, XLFontVerticalTextAlignmentValues>
         VerticalAlignmentRunMap =
             new Dictionary<VerticalAlignmentRunValues, XLFontVerticalTextAlignmentValues>
             {
@@ -639,7 +639,7 @@ internal static class EnumConverter
         return BorderStyleMap[value];
     }
 
-    private static readonly IReadOnlyDictionary<HorizontalAlignmentValues, XLAlignmentHorizontalValues>
+    private static readonly Dictionary<HorizontalAlignmentValues, XLAlignmentHorizontalValues>
         HorizontalAlignmentMap =
             new Dictionary<HorizontalAlignmentValues, XLAlignmentHorizontalValues>
             {
@@ -658,7 +658,7 @@ internal static class EnumConverter
         return HorizontalAlignmentMap[value];
     }
 
-    private static readonly IReadOnlyDictionary<VerticalAlignmentValues, XLAlignmentVerticalValues>
+    private static readonly Dictionary<VerticalAlignmentValues, XLAlignmentVerticalValues>
         VerticalAlignmentMap =
             new Dictionary<VerticalAlignmentValues, XLAlignmentVerticalValues>
             {
@@ -785,7 +785,7 @@ internal static class EnumConverter
         return DataValidationMap[value];
     }
 
-    private static readonly IReadOnlyDictionary<DataValidationErrorStyleValues, XLErrorStyle>
+    private static readonly Dictionary<DataValidationErrorStyleValues, XLErrorStyle>
         DataValidationErrorStyleMap =
             new Dictionary<DataValidationErrorStyleValues, XLErrorStyle>
             {
@@ -859,7 +859,7 @@ internal static class EnumConverter
         return PhoneticMap[value];
     }
 
-    private static readonly IReadOnlyDictionary<DataConsolidateFunctionValues, XLPivotSummary>
+    private static readonly Dictionary<DataConsolidateFunctionValues, XLPivotSummary>
         DataConsolidateFunctionMap =
             new Dictionary<DataConsolidateFunctionValues, XLPivotSummary>
             {
@@ -1002,7 +1002,7 @@ internal static class EnumConverter
         return ConditionalFormatMap[value];
     }
 
-    private static readonly IReadOnlyDictionary<ConditionalFormatValueObjectValues, XLCFContentType>
+    private static readonly Dictionary<ConditionalFormatValueObjectValues, XLCFContentType>
         ConditionalFormatValueObjectMap =
             new Dictionary<ConditionalFormatValueObjectValues, XLCFContentType>
             {
@@ -1019,7 +1019,7 @@ internal static class EnumConverter
         return ConditionalFormatValueObjectMap[value];
     }
 
-    private static readonly IReadOnlyDictionary<ConditionalFormattingOperatorValues, XLCFOperator>
+    private static readonly Dictionary<ConditionalFormattingOperatorValues, XLCFOperator>
         ConditionalFormattingOperatorMap =
             new Dictionary<ConditionalFormattingOperatorValues, XLCFOperator>
             {
@@ -1120,7 +1120,7 @@ internal static class EnumConverter
         return SparklineTypeMap[value];
     }
 
-    private static readonly IReadOnlyDictionary<X14.SparklineAxisMinMaxValues, XLSparklineAxisMinMax>
+    private static readonly Dictionary<X14.SparklineAxisMinMaxValues, XLSparklineAxisMinMax>
         SparklineAxisMinMaxMap =
             new Dictionary<X14.SparklineAxisMinMaxValues, XLSparklineAxisMinMax>
             {

--- a/XLibur/Excel/IO/AutoFilterWriter.cs
+++ b/XLibur/Excel/IO/AutoFilterWriter.cs
@@ -9,7 +9,7 @@ using static XLibur.Excel.XLWorkbook;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class AutoFilterWriter
+internal static class AutoFilterWriter
 {
     internal static void WriteAutoFilter(
         Worksheet worksheet,

--- a/XLibur/Excel/IO/CalculationChainPartWriter.cs
+++ b/XLibur/Excel/IO/CalculationChainPartWriter.cs
@@ -5,7 +5,7 @@ using static XLibur.Excel.XLWorkbook;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class CalculationChainPartWriter
+internal static class CalculationChainPartWriter
 {
     internal static void GenerateContent(WorkbookPart workbookPart, XLWorkbook workbook, SaveContext context)
     {

--- a/XLibur/Excel/IO/ColumnWriter.cs
+++ b/XLibur/Excel/IO/ColumnWriter.cs
@@ -9,7 +9,7 @@ using static XLibur.Excel.XLWorkbook;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class ColumnWriter
+internal static class ColumnWriter
 {
     internal static void WriteColumns(
         Worksheet worksheet,

--- a/XLibur/Excel/IO/CommentPartWriter.cs
+++ b/XLibur/Excel/IO/CommentPartWriter.cs
@@ -8,7 +8,7 @@ using static XLibur.Excel.IO.OpenXmlConst;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class CommentPartWriter
+internal static class CommentPartWriter
 {
     internal static void GenerateWorksheetCommentsPartContent(WorksheetCommentsPart worksheetCommentsPart,
         XLWorksheet xlWorksheet)

--- a/XLibur/Excel/IO/ConditionalFormattingWriter.cs
+++ b/XLibur/Excel/IO/ConditionalFormattingWriter.cs
@@ -13,7 +13,7 @@ using static XLibur.Excel.XLWorkbook;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class ConditionalFormattingWriter
+internal static class ConditionalFormattingWriter
 {
     internal static void WriteConditionalFormatting(
         Worksheet worksheet,

--- a/XLibur/Excel/IO/CustomFilePropertiesPartWriter.cs
+++ b/XLibur/Excel/IO/CustomFilePropertiesPartWriter.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class CustomFilePropertiesPartWriter
+internal static class CustomFilePropertiesPartWriter
 {
     internal static void GenerateContent(CustomFilePropertiesPart customFilePropertiesPart, XLWorkbook workbook)
     {

--- a/XLibur/Excel/IO/ExtendedFilePropertiesPartWriter.cs
+++ b/XLibur/Excel/IO/ExtendedFilePropertiesPartWriter.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class ExtendedFilePropertiesPartWriter
+internal static class ExtendedFilePropertiesPartWriter
 {
     internal static void GenerateContent(ExtendedFilePropertiesPart extendedFilePropertiesPart, XLWorkbook workbook)
     {

--- a/XLibur/Excel/IO/PivotTableCacheDefinitionPartReader.cs
+++ b/XLibur/Excel/IO/PivotTableCacheDefinitionPartReader.cs
@@ -9,7 +9,7 @@ using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class PivotTableCacheDefinitionPartReader
+internal static class PivotTableCacheDefinitionPartReader
 {
     internal static void Load(WorkbookPart workbookPart, XLWorkbook workbook)
     {

--- a/XLibur/Excel/IO/PivotTableCacheDefinitionPartWriter.cs
+++ b/XLibur/Excel/IO/PivotTableCacheDefinitionPartWriter.cs
@@ -10,7 +10,7 @@ using static XLibur.Excel.XLWorkbook;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class PivotTableCacheDefinitionPartWriter
+internal static class PivotTableCacheDefinitionPartWriter
 {
     internal static void GenerateContent(
         PivotTableCacheDefinitionPart pivotTableCacheDefinitionPart,

--- a/XLibur/Excel/IO/PivotTableCacheRecordsPartWriter.cs
+++ b/XLibur/Excel/IO/PivotTableCacheRecordsPartWriter.cs
@@ -7,7 +7,7 @@ using static XLibur.Excel.IO.OpenXmlConst;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class PivotTableCacheRecordsPartWriter
+internal static class PivotTableCacheRecordsPartWriter
 {
     internal static void WriteContent(PivotTableCacheRecordsPart recordsPart, XLPivotCache pivotCache)
     {

--- a/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -8,7 +8,7 @@ using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class PivotTableDefinitionPartReader
+internal static class PivotTableDefinitionPartReader
 {
     /// <summary>
     /// A field displayed as <c>∑Values</c> in a pivot table that contains names of all aggregation

--- a/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -12,7 +12,7 @@ using Array = System.Array;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class PivotTableDefinitionPartWriter2
+internal static class PivotTableDefinitionPartWriter2
 {
     internal static void WriteContent(PivotTablePart pivotTablePart, XLPivotTable pt, SaveContext context)
     {

--- a/XLibur/Excel/IO/RichDataReader.cs
+++ b/XLibur/Excel/IO/RichDataReader.cs
@@ -21,9 +21,6 @@ internal static class RichDataReader
     private const string RichValueRelRelType = "http://schemas.microsoft.com/office/2017/06/relationships/richValueRel";
 
     // XML namespaces
-    private const string RvNs = "http://schemas.microsoft.com/office/spreadsheetml/2017/richdata";
-    private const string RvsNs = "http://schemas.microsoft.com/office/spreadsheetml/2017/richdata2";
-    private const string RvrNs = "http://schemas.microsoft.com/office/spreadsheetml/2022/richvaluerel";
     private const string RNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
     /// <summary>

--- a/XLibur/Excel/IO/RichDataWriter.cs
+++ b/XLibur/Excel/IO/RichDataWriter.cs
@@ -33,9 +33,6 @@ internal static class RichDataWriter
     private const string RvrNs = "http://schemas.microsoft.com/office/spreadsheetml/2022/richvaluerel";
     private const string RNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
-    // Image binary relationship type
-    private const string ImageRelType = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
-
     /// <summary>
     /// Entry for a single rich value (one per cell with in-cell image).
     /// </summary>

--- a/XLibur/Excel/IO/SharedStringTableWriter.cs
+++ b/XLibur/Excel/IO/SharedStringTableWriter.cs
@@ -9,7 +9,7 @@ using static XLibur.Excel.IO.OpenXmlConst;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class SharedStringTableWriter
+internal static class SharedStringTableWriter
 {
     internal static void GenerateSharedStringTablePartContent(XLWorkbook workbook, SharedStringTablePart sharedStringTablePart,
         SaveContext context)

--- a/XLibur/Excel/IO/TablePartWriter.cs
+++ b/XLibur/Excel/IO/TablePartWriter.cs
@@ -12,7 +12,7 @@ namespace XLibur.Excel.IO;
 /// <summary>
 /// A writer for table definition part.
 /// </summary>
-internal sealed class TablePartWriter
+internal static class TablePartWriter
 {
     internal static void SynchronizeTableParts(XLTables tables, WorksheetPart worksheetPart, SaveContext context)
     {

--- a/XLibur/Excel/IO/TextSerializer.cs
+++ b/XLibur/Excel/IO/TextSerializer.cs
@@ -6,7 +6,7 @@ using static XLibur.Excel.IO.OpenXmlConst;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class TextSerializer
+internal static class TextSerializer
 {
     internal static void WriteRichTextElements(XmlWriter w, XLImmutableRichText richText, SaveContext context)
     {

--- a/XLibur/Excel/IO/ThemePartWriter.cs
+++ b/XLibur/Excel/IO/ThemePartWriter.cs
@@ -4,7 +4,7 @@ using XLibur.Extensions;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class ThemePartWriter
+internal static class ThemePartWriter
 {
     internal static void GenerateContent(ThemePart themePart, XLTheme theme)
     {

--- a/XLibur/Excel/IO/VmlDrawingPartWriter.cs
+++ b/XLibur/Excel/IO/VmlDrawingPartWriter.cs
@@ -15,7 +15,7 @@ using XLibur.Graphics;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class VmlDrawingPartWriter
+internal static class VmlDrawingPartWriter
 {
     // Generates content of vmlDrawingPart1.
     internal static bool GenerateContent(VmlDrawingPart vmlDrawingPart, XLWorksheet xlWorksheet)

--- a/XLibur/Excel/IO/WorkbookPartWriter.cs
+++ b/XLibur/Excel/IO/WorkbookPartWriter.cs
@@ -8,7 +8,7 @@ using XLibur.Extensions;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class WorkbookPartWriter
+internal static class WorkbookPartWriter
 {
     internal static void GenerateContent(WorkbookPart workbookPart, XLWorkbook xlWorkbook, SaveOptions options, XLWorkbook.SaveContext context)
     {

--- a/XLibur/Excel/IO/WorksheetPartWriter.cs
+++ b/XLibur/Excel/IO/WorksheetPartWriter.cs
@@ -11,7 +11,7 @@ using static XLibur.Excel.XLWorkbook;
 
 namespace XLibur.Excel.IO;
 
-internal sealed class WorksheetPartWriter
+internal static class WorksheetPartWriter
 {
     internal static void GenerateWorksheetPartContent(
         bool partIsEmpty,

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -420,27 +420,31 @@ internal static class WorksheetSheetDataReader
     internal static XLDataType? GetDataTypeFromFormat(string format)
     {
         var length = format.Length;
-        for (var i = 0; i < length; i++)
+        var i = 0;
+        while (i < length)
         {
             var c = char.ToLowerInvariant(format[i]);
             if (c == '"')
             {
-                i = format.IndexOf('"', i + 1);
-                if (i == -1)
+                var closeIndex = format.IndexOf('"', i + 1);
+                if (closeIndex == -1)
                     return null;
+                i = closeIndex + 1;
             }
             else if (c == '[')
             {
                 // #1742 We need to skip locale prefixes in DateTime formats [...]
-                i = format.IndexOf(']', i + 1);
-                if (i == -1)
+                var closeIndex = format.IndexOf(']', i + 1);
+                if (closeIndex == -1)
                     return null;
+                i = closeIndex + 1;
             }
             else
             {
                 var result = ClassifyFormatChar(c, format, i, length);
                 if (result.HasValue)
                     return result.Value;
+                i++;
             }
         }
 

--- a/XLibur/Excel/Ranges/XLRangeConditionalFormatHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeConditionalFormatHelper.cs
@@ -61,7 +61,7 @@ internal static class XLRangeConditionalFormatHelper
     private static bool TrySplitByWidth(
         IXLConditionalFormat format,
         IXLWorksheet worksheet,
-        IXLAddress mf, IXLAddress ml,
+        XLAddress mf, XLAddress ml,
         IXLAddress f, IXLAddress l)
     {
         if (mf.ColumnNumber > f.ColumnNumber || ml.ColumnNumber < l.ColumnNumber)
@@ -82,7 +82,7 @@ internal static class XLRangeConditionalFormatHelper
     private static bool TrySplitByHeight(
         IXLConditionalFormat format,
         IXLWorksheet worksheet,
-        IXLAddress mf, IXLAddress ml,
+        XLAddress mf, XLAddress ml,
         IXLAddress f, IXLAddress l)
     {
         if (mf.RowNumber > f.RowNumber || ml.RowNumber < l.RowNumber)

--- a/XLibur/Excel/Tables/TableNameValidator.cs
+++ b/XLibur/Excel/Tables/TableNameValidator.cs
@@ -46,7 +46,7 @@ internal static class TableNameValidator
         return true;
     }
 
-    private static bool IsDefinedNameConflict(string tableName, IXLWorkbook workbook)
+    private static bool IsDefinedNameConflict(string tableName, XLWorkbook workbook)
     {
         return workbook.DefinedNames.Contains(tableName) ||
                workbook.Worksheets.Any(ws => ws.DefinedNames.Contains(tableName));

--- a/XLibur/Utils/XmlEncoder.cs
+++ b/XLibur/Utils/XmlEncoder.cs
@@ -21,21 +21,25 @@ internal static partial class XmlEncoder
 
         var sb = new StringBuilder(encodeStr.Length);
         var len = encodeStr.Length;
-        for (var i = 0; i < len; ++i)
+        var i = 0;
+        while (i < len)
         {
             var currentChar = encodeStr[i];
             if (XmlConvert.IsXmlChar(currentChar))
             {
                 sb.Append(currentChar);
+                i++;
             }
             else if (i + 1 < len && XmlConvert.IsXmlSurrogatePair(encodeStr[i + 1], currentChar))
             {
                 sb.Append(currentChar);
-                sb.Append(encodeStr[++i]);
+                sb.Append(encodeStr[i + 1]);
+                i += 2;
             }
             else
             {
                 sb.Append(XmlConvert.EncodeName(currentChar.ToString()));
+                i++;
             }
         }
 
@@ -49,7 +53,8 @@ internal static partial class XmlEncoder
     private static bool NeedsEncoding(string s)
     {
         var len = s.Length;
-        for (var i = 0; i < len; i++)
+        var i = 0;
+        while (i < len)
         {
             var c = s[i];
 
@@ -68,12 +73,14 @@ internal static partial class XmlEncoder
                 // Valid surrogate pair doesn't need encoding.
                 if (i + 1 < len && XmlConvert.IsXmlSurrogatePair(s[i + 1], c))
                 {
-                    i++; // Skip the low surrogate
+                    i += 2; // Skip the surrogate pair
                     continue;
                 }
 
                 return true;
             }
+
+            i++;
         }
 
         return false;


### PR DESCRIPTION
## Summary
- **S1118** (21 files): Mark static-only classes as `static` — IO writers/readers and conditional format converters
- **S1144** (7 issues): Remove unused private fields in `Engineering.cs`, `RichDataReader.cs`, `RichDataWriter.cs`
- **CA1861** (5 issues): Extract inline constant array args to `private static readonly` fields in `HeaderFooterImageTests.cs`
- **CA1866** (2 issues): Use `char` overload for single-char `StartsWith` in `HeaderFooterImageTests.cs`
- **S127** (3 issues): Convert `for`-loops that modify loop variable in body to `while`-loops in `XmlEncoder.cs` and `WorksheetSheetDataReader.cs`

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 5941 passed, 0 failed (net8.0 + net10.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Converted many internal utility types to static to enforce static-only usage.
  * Removed several unused internal constants.
  * Simplified iteration and parsing logic in XML encoding and worksheet data parsing for clarity.
  * Adjusted several internal type and collection declarations for tighter/consistent typing.

* **Tests**
  * Replaced repeated literals with shared test data arrays to reduce duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->