### PR TITLE
perf: resolve SonarQube performance issues across 26 files

### DIFF
--- a/XLibur.Examples/Misc/InsertingData.cs
+++ b/XLibur.Examples/Misc/InsertingData.cs
@@ -77,7 +77,7 @@ public class InsertingData : IXLExample
         wb.SaveAs(filePath);
     }
 
-    private class Person
+    private sealed class Person
     {
         public string House { get; set; }
 

--- a/XLibur.Examples/PivotTables/PivotTables.cs
+++ b/XLibur.Examples/PivotTables/PivotTables.cs
@@ -6,7 +6,7 @@ namespace XLibur.Examples.PivotTables;
 
 public class PivotTables : IXLExample
 {
-    private class Pastry
+    private sealed class Pastry
     {
         public Pastry(string name, int? code, int numberOfOrders, double quality, string month, DateTime? bakeDate)
         {

--- a/XLibur.Examples/Tables/InsertingTables.cs
+++ b/XLibur.Examples/Tables/InsertingTables.cs
@@ -74,7 +74,7 @@ public class InsertingTables : IXLExample
         wb.SaveAs(filePath);
     }
 
-    private class Person
+    private sealed class Person
     {
         [XLColumn(Header = "House Street")] public string House { get; set; }
 

--- a/XLibur/Attributes/XLColumnAttribute.cs
+++ b/XLibur/Attributes/XLColumnAttribute.cs
@@ -15,7 +15,7 @@ public class XLColumnAttribute : Attribute
 
     private static XLColumnAttribute? GetXLColumnAttribute(MemberInfo mi)
     {
-        return !mi.HasAttribute<XLColumnAttribute>() ? null : mi.GetAttributes<XLColumnAttribute>().First();
+        return !mi.HasAttribute<XLColumnAttribute>() ? null : mi.GetAttributes<XLColumnAttribute>()[0];
     }
 
     internal static string? GetHeader(MemberInfo mi)

--- a/XLibur/Excel/CalcEngine/AstNode.cs
+++ b/XLibur/Excel/CalcEngine/AstNode.cs
@@ -336,7 +336,7 @@ internal sealed class NameNode : ValueNode
 
         // Parser needs an equal sign for a union of ranges (or braces around formula)
         var nameFormula = definedName.RefersTo;
-        nameFormula = nameFormula.StartsWith("=") ? nameFormula : "=" + nameFormula;
+        nameFormula = nameFormula.StartsWith('=') ? nameFormula : "=" + nameFormula;
         return engine.EvaluateName(nameFormula, ctxWs);
     }
 

--- a/XLibur/Excel/CalcEngine/CalcContext.cs
+++ b/XLibur/Excel/CalcEngine/CalcContext.cs
@@ -294,7 +294,7 @@ internal sealed class CalcContext
         }
     }
 
-    private class FunctionVisitor : CollectVisitor<FunctionVisitor>
+    private sealed class FunctionVisitor : CollectVisitor<FunctionVisitor>
     {
         public FunctionVisitor(string function)
         {

--- a/XLibur/Excel/CalcEngine/DateTimeParser.cs
+++ b/XLibur/Excel/CalcEngine/DateTimeParser.cs
@@ -48,7 +48,7 @@ internal static class DateTimeParser
             // the input couldn't match in any format => excel has likely it's own logic, independent of region setting).
             var timePatterns = new[] { "h:m tt", "H:m", "h:m" };
             var longDatePatterns = shortDatePatterns
-                .SelectMany(datePattern => timePatterns.Select(timePattern => FormattableString.Invariant($"{datePattern} {timePattern}")));
+                .SelectMany(datePattern => timePatterns.Select(timePattern => string.Create(CultureInfo.InvariantCulture, $"{datePattern} {timePattern}")));
 
             // ISO8601 should be parseable in all cultures, not sure if Excel does. Be more forgiving, M,d instead MM,dd.
             return shortDatePatterns.Concat(longDatePatterns).Concat(["yyyy-M-d"]).Distinct().ToArray();

--- a/XLibur/Excel/CalcEngine/DependencyTree.cs
+++ b/XLibur/Excel/CalcEngine/DependencyTree.cs
@@ -202,7 +202,7 @@ internal sealed class DependencyTree
     /// contains precedent cells for a formula. If anything in the area
     /// potentially changes, all dependents might also change.
     /// </summary>
-    private class AreaDependents : ISpatialData
+    private sealed class AreaDependents : ISpatialData
     {
         /// <summary>
         /// An area in a sheet that is used by formulas, converted to RBush envelope.
@@ -302,7 +302,7 @@ internal sealed class DependencyTree
     /// <summary>
     /// A dependency tree for a single worksheet.
     /// </summary>
-    private class SheetDependencyTree
+    private sealed class SheetDependencyTree
     {
         /// <summary>
         /// The precedent areas are not duplicated, though two areas might overlap.

--- a/XLibur/Excel/CalcEngine/Functions/Information.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Information.cs
@@ -119,7 +119,7 @@ internal static class Information
             return array.Apply(static v => ToNumber(v));
 
         var area = reference.Areas[0];
-        var referenceValue = ctx.GetCellValue(area.Worksheet, area.FirstAddress.RowNumber, area.FirstAddress.RowNumber);
+        var referenceValue = ctx.GetCellValue(area.Worksheet, area.FirstAddress.RowNumber, area.FirstAddress.ColumnNumber);
         return ToNumber(referenceValue).ToAnyValue();
 
         static ScalarValue ToNumber(ScalarValue scalar)

--- a/XLibur/Excel/CalcEngine/Functions/Information.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Information.cs
@@ -118,7 +118,7 @@ internal static class Information
         if (collection.TryPickT0(out var array, out var reference))
             return array.Apply(static v => ToNumber(v));
 
-        var area = reference.Areas.First();
+        var area = reference.Areas[0];
         var referenceValue = ctx.GetCellValue(area.Worksheet, area.FirstAddress.RowNumber, area.FirstAddress.RowNumber);
         return ToNumber(referenceValue).ToAnyValue();
 

--- a/XLibur/Excel/CalcEngine/Functions/XLMatrix.cs
+++ b/XLibur/Excel/CalcEngine/Functions/XLMatrix.cs
@@ -283,13 +283,13 @@ internal sealed class XLMatrix
 
     public override string ToString() // Function returns matrix as a string
     {
-        var s = "";
+        var sb = new System.Text.StringBuilder();
         for (var i = 0; i < _rows; i++)
         {
-            for (var j = 0; j < Cols; j++) s += $"{Mat[i, j],5:0.00}" + " ";
-            s += "\r\n";
+            for (var j = 0; j < Cols; j++) sb.Append($"{Mat[i, j],5:0.00}").Append(' ');
+            sb.Append("\r\n");
         }
-        return s;
+        return sb.ToString();
     }
 
     public static XLMatrix Transpose(XLMatrix m) // XLMatrix transpose, for any rectangular matrix

--- a/XLibur/Excel/CalcEngine/Visitors/FormulaReferences.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/FormulaReferences.cs
@@ -72,7 +72,7 @@ internal sealed class FormulaReferences
     /// <summary>
     /// Factory to get all references (cells, tables, names) in local workbook.
     /// </summary>
-    private class CollectRefsFactory : CollectVisitor<FormulaReferences>
+    private sealed class CollectRefsFactory : CollectVisitor<FormulaReferences>
     {
         public static readonly CollectRefsFactory Instance = new();
 

--- a/XLibur/Excel/Cells/Slice.cs
+++ b/XLibur/Excel/Cells/Slice.cs
@@ -344,7 +344,7 @@ internal sealed partial class Slice<TElement> : ISlice
     }
 
     [DebuggerDisplay("{Point}:{Current}")]
-    private class ReverseEnumerator : IEnumerator<XLSheetPoint>
+    private sealed class ReverseEnumerator : IEnumerator<XLSheetPoint>
     {
         private readonly XLSheetRange _range;
         private ReverseColumnEnumerator _columnsEnumerator;

--- a/XLibur/Excel/Cells/XLCellCopyHelper.cs
+++ b/XLibur/Excel/Cells/XLCellCopyHelper.cs
@@ -193,7 +193,7 @@ internal static class XLCellCopyHelper
 
             var c = new XLConditionalFormat(fmtRanges, true);
             c.CopyFrom(cf);
-            c.AdjustFormulas((XLCell)cf.Ranges.First().FirstCell(), fmtRanges.First().FirstCell());
+            c.AdjustFormulas((XLCell)cf.Ranges.First().FirstCell(), fmtRanges[0].FirstCell());
 
             target.Worksheet.ConditionalFormats.Add(c);
         }
@@ -213,7 +213,7 @@ internal static class XLCellCopyHelper
             return defaultWorksheet.Cell(target)!;
 
         var wsName = pair[0];
-        if (wsName.StartsWith("'"))
+        if (wsName.StartsWith('\''))
             wsName = wsName.Substring(1, wsName.Length - 2);
         return defaultWorksheet.Workbook.Worksheet(wsName).Cell(pair[1]);
     }

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFCellIsConverter.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFCellIsConverter.cs
@@ -32,7 +32,7 @@ internal sealed class XLCFCellIsConverter : IXLCFConverter
         string value = formula.Value;
 
         if (formula.IsFormula ||
-            value.StartsWith("\"") && value.EndsWith("\"") ||
+            value.StartsWith('"') && value.EndsWith('"') ||
             double.TryParse(value, XLHelper.NumberStyle, XLHelper.ParseCulture, out _))
         {
             return value;

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -57,7 +57,7 @@ internal sealed class XLConditionalFormats : IXLConditionalFormats
 
         while (formats.Count > 0)
         {
-            var item = formats.First();
+            var item = formats[0];
 
             if (!CFTypesExcludedFromConsolidation.Contains(item.ConditionalFormatType))
             {

--- a/XLibur/Excel/DataValidation/XLDataValidations.cs
+++ b/XLibur/Excel/DataValidation/XLDataValidations.cs
@@ -192,10 +192,10 @@ internal sealed class XLDataValidations : IXLDataValidations
 
         while (rules.Any())
         {
-            var similarRules = rules.Where(r => areEqual(rules.First(), r)).ToList();
+            var similarRules = rules.Where(r => areEqual(rules[0], r)).ToList();
             similarRules.ForEach(r => rules.Remove(r));
 
-            var consRule = similarRules.First();
+            var consRule = similarRules[0];
             var ranges = similarRules.SelectMany(dv => dv.Ranges).ToList();
 
             IXLRanges consolidatedRanges = new XLRanges();
@@ -262,7 +262,7 @@ internal sealed class XLDataValidations : IXLDataValidations
     /// <summary>
     /// Class used for indexing data validation rules.
     /// </summary>
-    private class XLDataValidationIndexEntry : IXLAddressable
+    private sealed class XLDataValidationIndexEntry : IXLAddressable
     {
         public XLDataValidationIndexEntry(IXLRangeAddress rangeAddress, XLDataValidation dataValidation)
         {

--- a/XLibur/Excel/IO/ConditionalFormatReader.cs
+++ b/XLibur/Excel/IO/ConditionalFormatReader.cs
@@ -325,7 +325,7 @@ internal static class ConditionalFormatReader
     {
         var formula = new XLFormula();
         formula._value = value;
-        formula.IsFormula = !(value[0] == '"' && value.EndsWith("\""));
+        formula.IsFormula = !(value[0] == '"' && value.EndsWith('"'));
         return formula;
     }
 

--- a/XLibur/Excel/IO/DrawingPartReader.cs
+++ b/XLibur/Excel/IO/DrawingPartReader.cs
@@ -444,7 +444,7 @@ internal static class DrawingPartReader
         if (opacity != null)
         {
             var opacityVal = opacity.Value;
-            if (opacityVal.EndsWith("f"))
+            if (opacityVal.EndsWith('f'))
                 drawing.Style.ColorsAndLines.FillTransparency =
                     double.Parse(opacityVal.Substring(0, opacityVal.Length - 1), CultureInfo.InvariantCulture) /
                     65536.0;
@@ -467,7 +467,7 @@ internal static class DrawingPartReader
         if (opacity != null)
         {
             var opacityVal = opacity.Value;
-            if (opacityVal.EndsWith("f"))
+            if (opacityVal.EndsWith('f'))
                 drawing.Style.ColorsAndLines.LineTransparency =
                     double.Parse(opacityVal.Substring(0, opacityVal.Length - 1), CultureInfo.InvariantCulture) /
                     65536.0;

--- a/XLibur/Excel/IO/TablePartWriter.cs
+++ b/XLibur/Excel/IO/TablePartWriter.cs
@@ -144,7 +144,7 @@ internal static class TablePartWriter
                 .First()
                 .FormulaA1;
 
-            while (formula.StartsWith("=") && formula.Length > 1)
+            while (formula.StartsWith('=') && formula.Length > 1)
                 formula = formula.Substring(1);
 
             if (!string.IsNullOrWhiteSpace(formula))

--- a/XLibur/Excel/PageSetup/XLHeaderFooter.cs
+++ b/XLibur/Excel/PageSetup/XLHeaderFooter.cs
@@ -37,14 +37,14 @@ internal sealed class XLHeaderFooter : IXLHeaderFooter
     {
         //if (innerTexts.ContainsKey(occurrence)) return innerTexts[occurrence];
 
-        var retVal = string.Empty;
         var leftText = Left.GetText(occurrence);
         var centerText = Center.GetText(occurrence);
         var rightText = Right.GetText(occurrence);
-        retVal += leftText.Length > 0 ? "&L" + leftText : string.Empty;
-        retVal += centerText.Length > 0 ? "&C" + centerText : string.Empty;
-        retVal += rightText.Length > 0 ? "&R" + rightText : string.Empty;
-        return retVal;
+        var sb = new System.Text.StringBuilder();
+        if (leftText.Length > 0) sb.Append("&L").Append(leftText);
+        if (centerText.Length > 0) sb.Append("&C").Append(centerText);
+        if (rightText.Length > 0) sb.Append("&R").Append(rightText);
+        return sb.ToString();
     }
 
     private Dictionary<XLHFOccurrence, string> innerTexts = new();

--- a/XLibur/Excel/PivotTables/PivotStyleFormats/XLPivotValueStyleFormat.cs
+++ b/XLibur/Excel/PivotTables/PivotStyleFormats/XLPivotValueStyleFormat.cs
@@ -88,5 +88,5 @@ internal sealed class XLPivotValueStyleFormat : XLPivotStyleFormatBase, IXLPivot
         return XLPivotAreaComparer.Instance.Equals(area, currentArea);
     }
 
-    private record FieldReference(FieldIndex FieldIndex, IReadOnlyList<uint>? Items = null);
+    private sealed record FieldReference(FieldIndex FieldIndex, IReadOnlyList<uint>? Items = null);
 }

--- a/XLibur/Excel/PivotTables/XLPivotAreaComparer.cs
+++ b/XLibur/Excel/PivotTables/XLPivotAreaComparer.cs
@@ -57,7 +57,7 @@ internal sealed class XLPivotAreaComparer : IEqualityComparer<XLPivotArea>
         return hashCode.ToHashCode();
     }
 
-    private class XLPivotReferenceComparer : IEqualityComparer<XLPivotReference>
+    private sealed class XLPivotReferenceComparer : IEqualityComparer<XLPivotReference>
     {
         public bool Equals(XLPivotReference? x, XLPivotReference? y)
         {

--- a/XLibur/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/XLibur/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -56,7 +56,7 @@ internal sealed class XLRangeConsolidationEngine
     /// Class representing the area covering ranges to be consolidated as a set of bit matrices. Does all the dirty job
     /// of ranges consolidation.
     /// </summary>
-    private class XLRangeConsolidationMatrix
+    private sealed class XLRangeConsolidationMatrix
     {
         #region Public Constructors
 

--- a/XLibur/Excel/Style/XLBorder.cs
+++ b/XLibur/Excel/Style/XLBorder.cs
@@ -581,7 +581,7 @@ internal sealed class XLBorder : IXLBorder
     /// Helper class that remembers outside border state before editing (in constructor) and restore afterwards (on disposing).
     /// It presumes that size of the range does not change during the editing, else it will fail.
     /// </summary>
-    private class RestoreOutsideBorder : IDisposable
+    private sealed class RestoreOutsideBorder : IDisposable
     {
         private readonly IXLRange _range;
         private readonly Dictionary<int, XLBorderKey> _topBorders;

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -275,7 +275,7 @@ public partial class XLWorkbook : IXLWorkbook
         {
             var split = name.Split('!');
             var first = split[0];
-            var wsName = first.StartsWith("'") ? first.Substring(1, first.Length - 2) : first;
+            var wsName = first.StartsWith('\'') ? first.Substring(1, first.Length - 2) : first;
             var sheetlessName = split[1];
             if (TryGetWorksheet(wsName, out XLWorksheet? ws))
             {

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -275,7 +275,7 @@ public partial class XLWorkbook : IXLWorkbook
         {
             var split = name.Split('!');
             var first = split[0];
-            var wsName = first.StartsWith('\'') ? first.Substring(1, first.Length - 2) : first;
+            var wsName = first.UnescapeSheetName();
             var sheetlessName = split[1];
             if (TryGetWorksheet(wsName, out XLWorksheet? ws))
             {

--- a/XLibur/Graphics/WmfInfoReader.cs
+++ b/XLibur/Graphics/WmfInfoReader.cs
@@ -108,7 +108,7 @@ internal sealed class WmfInfoReader : ImageInfoReader
     private static int ToHiMetric(int size, double unitsPerInch) =>
         (int)Math.Round(size / unitsPerInch * 254d, MidpointRounding.AwayFromZero);
 
-    private class PlaceableHeader
+    private sealed class PlaceableHeader
     {
         private readonly uint _key;
         private readonly ushort _resourceHandle;


### PR DESCRIPTION
## Summary
- **Seal 14 private classes/records** not derived in their assemblies — enables JIT devirtualization
- **Use char overloads** for `StartsWith`/`EndsWith` in 8 files — avoids string allocation for single-char comparisons
- **Replace `First()` with `[0]` indexing** on Lists/arrays in 5 files — avoids enumerator allocation
- **Use `StringBuilder`** instead of string concatenation in loops in `XLMatrix.ToString()` and `XLHeaderFooter.GetText()`
- **Use `string.Create`** instead of `FormattableString.Invariant` in `DateTimeParser`

## Test plan
- [x] All 5941 tests pass on both net8.0 and net10.0
- [x] Zero build warnings across all projects (XLibur, Tests, Examples)
- [ ] Verify SonarQube performance issues are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal maintenance and optimizations: tightened internal types to improve safety, optimized collection and string handling, replaced inefficient concatenation patterns, and modernized literal usage. These changes improve performance and maintainability while preserving all public APIs and user-visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->