### PR TITLE
fix: resolve SonarQube medium severity code smells (batch 2)

### DIFF
--- a/XLibur.Examples/Misc/Collections.cs
+++ b/XLibur.Examples/Misc/Collections.cs
@@ -80,7 +80,7 @@ public class Collections : IXLExample
     }
 
     // Private
-    private DataTable GetTable()
+    private static DataTable GetTable()
     {
         DataTable table = new DataTable();
         table.Columns.Add("Dosage", typeof(int));

--- a/XLibur.Examples/Misc/InsertingData.cs
+++ b/XLibur.Examples/Misc/InsertingData.cs
@@ -92,7 +92,7 @@ public class InsertingData : IXLExample
     }
 
     // Private
-    private DataTable GetTable()
+    private static DataTable GetTable()
     {
         var table = new DataTable();
         table.Columns.Add("Dosage", typeof(int));

--- a/XLibur.Examples/Sparklines/SampleSparklines.cs
+++ b/XLibur.Examples/Sparklines/SampleSparklines.cs
@@ -82,7 +82,7 @@ public class SampleSparklines : IXLExample
         workbook.SaveAs(filePath);
     }
 
-    private void FillSampleData(IXLWorksheet ws)
+    private static void FillSampleData(IXLWorksheet ws)
     {
         ws.Column(1).Style.Alignment.SetWrapText(true);
         ws.Column(1).Width = 30;

--- a/XLibur.Examples/Tables/InsertingTables.cs
+++ b/XLibur.Examples/Tables/InsertingTables.cs
@@ -87,7 +87,7 @@ public class InsertingTables : IXLExample
     }
 
     // Private
-    private DataTable GetTable()
+    private static DataTable GetTable()
     {
         var table = new DataTable();
         table.Columns.Add("Dosage", typeof(int));

--- a/XLibur.Tests/Examples/ColumnsTests.cs
+++ b/XLibur.Tests/Examples/ColumnsTests.cs
@@ -32,7 +32,7 @@ public class ColumnsTests
     }
 
     //[Test] // Not working yet
-    public void InsertColumns()
+    public static void InsertColumns()
     {
         TestHelper.RunTestExample<InsertColumns>(@"Columns\InsertColumns.xlsx");
     }

--- a/XLibur.Tests/Examples/RowsTests.cs
+++ b/XLibur.Tests/Examples/RowsTests.cs
@@ -26,7 +26,7 @@ public class RowsTests
     }
 
     //[Test] // Not working yet
-    public void InsertRows()
+    public static void InsertRows()
     {
         TestHelper.RunTestExample<InsertRows>(@"Rows\InsertRows.xlsx");
     }

--- a/XLibur.Tests/Excel/CalcEngine/LogicalTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LogicalTests.cs
@@ -7,6 +7,10 @@ namespace XLibur.Tests.Excel.CalcEngine;
 [TestFixture]
 public class LogicalTests
 {
+    private static readonly int[] IfTestDataA = [1, 2, 3];
+    private static readonly int[] IfTestDataB = [4, 5, 6];
+    private static readonly bool[] IfTestDataC = [true, false, true];
+
     [Test]
     public void And_IsLogicalConjunction()
     {
@@ -141,9 +145,9 @@ public class LogicalTests
     {
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet();
-        ws.Cell("A1").InsertData(new[] { 1, 2, 3 });
-        ws.Cell("B1").InsertData(new[] { 4, 5, 6 });
-        ws.Cell("C1").InsertData(new[] { true, false, true });
+        ws.Cell("A1").InsertData(IfTestDataA);
+        ws.Cell("B1").InsertData(IfTestDataB);
+        ws.Cell("C1").InsertData(IfTestDataC);
         for (var row = 1; row <= 4; ++row)
             ws.Cell(row, 4).FormulaA1 = "SUM(IF(C1:C3, A1:A3, B1:B3))";
 

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -26,7 +26,7 @@ public class LookupTests
         ws = SetupWorkbook();
     }
 
-    private IXLWorksheet SetupWorkbook()
+    private static IXLWorksheet SetupWorkbook()
     {
         var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Data");

--- a/XLibur.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -14,6 +14,9 @@ public class MathTrigTests
 {
     private const double tolerance = 1e-10;
 
+    private static readonly int[] MultinomialDataB2 = [2, 0, 5];
+    private static readonly int[] MultinomialDataA5 = [3, 6];
+
     [Theory]
     public void Abs_ReturnsItselfOnPositiveNumbers([Range(0, 10, 0.1)] double input)
     {
@@ -1594,8 +1597,8 @@ public class MathTrigTests
     {
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet();
-        ws.Cell("B2").InsertData(new[] { 2, 0, 5 });
-        ws.Cell("A5").InsertData(new[] { 3, 6 });
+        ws.Cell("B2").InsertData(MultinomialDataB2);
+        ws.Cell("A5").InsertData(MultinomialDataA5);
 
         Assert.AreEqual(3087564480d, ws.Evaluate("MULTINOMIAL(B:XFD, 2, A5:A6)"));
     }

--- a/XLibur.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -1271,7 +1271,7 @@ public class StatisticalTests
         Assert.AreEqual(XLError.IncompatibleValue, value);
     }
 
-    private XLWorkbook SetupWorkbook()
+    private static XLWorkbook SetupWorkbook()
     {
         var wb = new XLWorkbook();
         var ws1 = wb.AddWorksheet("Data");

--- a/XLibur.Tests/Excel/Cells/XLCellTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellTests.cs
@@ -31,6 +31,8 @@ public class XLCellTests
         (decimal)11.875m
     ];
 
+    private static readonly string[] InsertDataStrings = ["a", "b", "c"];
+
     [Test]
     public void CellsUsed()
     {
@@ -99,7 +101,7 @@ public class XLCellTests
     public void InsertData1()
     {
         IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-        IXLRange range = ws.Cell(2, 2).InsertData(new[] { "a", "b", "c" });
+        IXLRange range = ws.Cell(2, 2).InsertData(InsertDataStrings);
         Assert.AreEqual("Sheet1!B2:B4", range.ToString());
     }
 
@@ -107,7 +109,7 @@ public class XLCellTests
     public void InsertData_DoesntTransposeDataOnFalseFlag()
     {
         IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-        IXLRange range = ws.Cell(2, 2).InsertData(new[] { "a", "b", "c" }, false);
+        IXLRange range = ws.Cell(2, 2).InsertData(InsertDataStrings, false);
         Assert.AreEqual("Sheet1!B2:B4", range.ToString());
     }
 
@@ -115,7 +117,7 @@ public class XLCellTests
     public void InsertData_TransposesDataOnTrueFlag()
     {
         IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-        IXLRange range = ws.Cell(2, 2).InsertData(new[] { "a", "b", "c" }, true);
+        IXLRange range = ws.Cell(2, 2).InsertData(InsertDataStrings, true);
         Assert.AreEqual("Sheet1!B2:D2", range.ToString());
     }
 

--- a/XLibur.Tests/Excel/Clearing/ClearingTests.cs
+++ b/XLibur.Tests/Excel/Clearing/ClearingTests.cs
@@ -12,7 +12,7 @@ public class ClearingTests
     private static readonly XLColor BackgroundColor = XLColor.LightBlue;
     private static readonly XLColor ForegroundColor = XLColor.DarkBrown;
 
-    private IXLWorkbook SetupWorkbook()
+    private static IXLWorkbook SetupWorkbook()
     {
         var wb = new XLWorkbook();
         var ws = wb.Worksheets.Add("Sheet1");

--- a/XLibur.Tests/Excel/Coordinates/XLAddressTests.cs
+++ b/XLibur.Tests/Excel/Coordinates/XLAddressTests.cs
@@ -161,7 +161,7 @@ public class XLAddressTests
 
     #region Private Methods
 
-    private IXLAddress ProduceInvalidAddress()
+    private static IXLAddress ProduceInvalidAddress()
     {
         IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet 1");
         var range = ws.Range("A1:B2");
@@ -170,7 +170,7 @@ public class XLAddressTests
         return range.RangeAddress.FirstAddress;
     }
 
-    private IXLAddress ProduceAddressOnDeletedWorksheet()
+    private static IXLAddress ProduceAddressOnDeletedWorksheet()
     {
         IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet 1");
         var address = ws.Cell("A1").Address;

--- a/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
@@ -90,7 +90,7 @@ public class PictureTests
         }
     }
 
-    private void verifyAddImageFromFile(string filePath)
+    private static void verifyAddImageFromFile(string filePath)
     {
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");

--- a/XLibur.Tests/Excel/InsertData/ArrayTypeReaderTests.cs
+++ b/XLibur.Tests/Excel/InsertData/ArrayTypeReaderTests.cs
@@ -17,28 +17,28 @@ public class ArrayTypeReaderTests
     [Test]
     public void GetPropertyNameReturnsNull()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.IsNull(reader.GetPropertyName(0));
     }
 
     [Test]
     public void CanGetPropertiesCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual(3, reader.GetPropertiesCount());
     }
 
     [Test]
     public void CanGetRecordsCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual(2, reader.GetRecords().Count());
     }
 
     [Test]
     public void CanReadValues()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         var result = reader.GetRecords();
         var enumerable = result as IEnumerable<XLCellValue>[] ?? result.ToArray();
 

--- a/XLibur.Tests/Excel/InsertData/DataRecordReaderTests.cs
+++ b/XLibur.Tests/Excel/InsertData/DataRecordReaderTests.cs
@@ -41,7 +41,7 @@ public class DataRecordReaderTests
     [Test]
     public void CanGetPropertyName()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
+        var reader = InsertDataReaderFactory.CreateReader(GetData());
         Assert.AreEqual("StringValue", reader.GetPropertyName(0));
         Assert.AreEqual("NumericValue", reader.GetPropertyName(1));
     }
@@ -49,21 +49,21 @@ public class DataRecordReaderTests
     [Test]
     public void CanGetPropertiesCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
+        var reader = InsertDataReaderFactory.CreateReader(GetData());
         Assert.AreEqual(2, reader.GetPropertiesCount());
     }
 
     [Test]
     public void CanGetRecordsCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
+        var reader = InsertDataReaderFactory.CreateReader(GetData());
         Assert.AreEqual(3, reader.GetRecords().Count());
     }
 
     [Test]
     public void CanGetData()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
+        var reader = InsertDataReaderFactory.CreateReader(GetData());
         var result = reader.GetRecords().ToArray();
 
         Assert.AreEqual("Value 1", result.First().First());

--- a/XLibur.Tests/Excel/InsertData/DataRowReaderTests.cs
+++ b/XLibur.Tests/Excel/InsertData/DataRowReaderTests.cs
@@ -23,7 +23,7 @@ public class DataRowReaderTests
     [Test]
     public void CanGetPropertyName()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual("Last name", reader.GetPropertyName(0));
         Assert.AreEqual("First name", reader.GetPropertyName(1));
         Assert.AreEqual("Age", reader.GetPropertyName(2));
@@ -32,21 +32,21 @@ public class DataRowReaderTests
     [Test]
     public void CanGetPropertiesCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual(3, reader.GetPropertiesCount());
     }
 
     [Test]
     public void CanGetRecordsCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual(2, reader.GetRecords().Count());
     }
 
     [Test]
     public void CanReadValue()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         var result = reader.GetRecords();
 
         var enumerable = result.ToList();

--- a/XLibur.Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
+++ b/XLibur.Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
@@ -22,7 +22,7 @@ public class InsertDataReaderFactoryTests
     [TestCaseSource(nameof(SimpleSources))]
     public void CanCreateSimpleReader(IEnumerable data)
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
 
         Assert.IsInstanceOf<SimpleTypeReader>(reader);
     }
@@ -42,7 +42,7 @@ public class InsertDataReaderFactoryTests
     [TestCaseSource(nameof(SimpleNullableSources))]
     public void CanCreateSimpleNullableReader(IEnumerable data)
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
 
         Assert.IsInstanceOf<SimpleNullableTypeReader>(reader);
     }
@@ -61,7 +61,7 @@ public class InsertDataReaderFactoryTests
     [TestCaseSource(nameof(ArraySources))]
     public void CanCreateArrayReader<T>(IEnumerable<T> data)
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
 
         Assert.IsInstanceOf<ArrayReader>(reader);
     }
@@ -109,7 +109,7 @@ public class InsertDataReaderFactoryTests
             SourceArray.AsEnumerable(),
             SourceArray0.AsEnumerable(),
         };
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
 
         Assert.IsInstanceOf<ArrayReader>(reader);
     }
@@ -122,7 +122,7 @@ public class InsertDataReaderFactoryTests
             "String 1",
             "String 2",
         };
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
 
         Assert.IsInstanceOf<SimpleTypeReader>(reader);
     }
@@ -131,7 +131,7 @@ public class InsertDataReaderFactoryTests
     public void CanCreateDataTableReader()
     {
         var dt = new DataTable();
-        var reader = InsertDataReaderFactory.Instance.CreateReader(dt);
+        var reader = InsertDataReaderFactory.CreateReader(dt);
 
         Assert.IsInstanceOf<XLibur.Excel.InsertData.DataTableReader>(reader);
     }
@@ -140,7 +140,7 @@ public class InsertDataReaderFactoryTests
     public void CanCreateDataRecordReader()
     {
         var dataRecords = Array.Empty<IDataRecord>();
-        var reader = InsertDataReaderFactory.Instance.CreateReader(dataRecords);
+        var reader = InsertDataReaderFactory.CreateReader(dataRecords);
         Assert.IsInstanceOf<DataRecordReader>(reader);
     }
 
@@ -148,7 +148,7 @@ public class InsertDataReaderFactoryTests
     public void CanCreateObjectReader()
     {
         var entities = Array.Empty<TestEntity>();
-        var reader = InsertDataReaderFactory.Instance.CreateReader(entities);
+        var reader = InsertDataReaderFactory.CreateReader(entities);
         Assert.IsInstanceOf<ObjectReader>(reader);
     }
 
@@ -156,7 +156,7 @@ public class InsertDataReaderFactoryTests
     public void CanCreateObjectReaderForStruct()
     {
         var entities = Array.Empty<TestStruct>();
-        var reader = InsertDataReaderFactory.Instance.CreateReader(entities);
+        var reader = InsertDataReaderFactory.CreateReader(entities);
         Assert.IsInstanceOf<ObjectReader>(reader);
     }
 
@@ -168,7 +168,7 @@ public class InsertDataReaderFactoryTests
             new TestEntity(),
             "123",
         });
-        var reader = InsertDataReaderFactory.Instance.CreateReader(entities);
+        var reader = InsertDataReaderFactory.CreateReader(entities);
         Assert.IsInstanceOf<UntypedObjectReader>(reader);
     }
 

--- a/XLibur.Tests/Excel/InsertData/ObjectReaderTests.cs
+++ b/XLibur.Tests/Excel/InsertData/ObjectReaderTests.cs
@@ -68,7 +68,7 @@ public class ObjectReaderTests
     [TestCaseSource(nameof(ObjectSourceNames))]
     public string CanGetPropertyName<T>(IEnumerable<T> data, int propertyIndex)
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
         return reader.GetPropertyName(propertyIndex);
     }
 
@@ -101,7 +101,7 @@ public class ObjectReaderTests
     [TestCaseSource(nameof(PropertyCounts))]
     public int CanGetPropertiesCount(IEnumerable data)
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
         return reader.GetPropertiesCount();
     }
 
@@ -126,14 +126,14 @@ public class ObjectReaderTests
     [Test]
     public void CanGetRecordsCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(ObjectWithAttributes);
+        var reader = InsertDataReaderFactory.CreateReader(ObjectWithAttributes);
         Assert.AreEqual(2, reader.GetRecords().Count());
     }
 
     [Test]
     public void CanReadValues_FromObject()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(ObjectWithAttributes);
+        var reader = InsertDataReaderFactory.CreateReader(ObjectWithAttributes);
         var result = reader.GetRecords();
 
         var enumerable = result.ToList();
@@ -154,7 +154,7 @@ public class ObjectReaderTests
     [Test]
     public void CanReadValues_FromStruct()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(Structs);
+        var reader = InsertDataReaderFactory.CreateReader(Structs);
         var result = reader.GetRecords();
 
         var enumerable = result.ToList();
@@ -173,7 +173,7 @@ public class ObjectReaderTests
     [Test]
     public void CanReadValues_FromNullableStruct()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(NullableStructs);
+        var reader = InsertDataReaderFactory.CreateReader(NullableStructs);
         var result = reader.GetRecords();
 
         var enumerable = result.ToList();
@@ -193,7 +193,7 @@ public class ObjectReaderTests
     public void IgnoresIndexers()
     {
         var data = new[] { new TestClassWithIndexer() };
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
 
         Assert.AreEqual(1, reader.GetPropertiesCount());
         Assert.AreEqual(nameof(TestClassWithIndexer.Value), reader.GetPropertyName(0));
@@ -201,7 +201,7 @@ public class ObjectReaderTests
 
     private record TestClassWithIndexer
     {
-        public int Value => 0;
+        public static int Value => 0;
     }
 
     private struct TestPoint

--- a/XLibur.Tests/Excel/InsertData/SimpleNullableTypeReaderTests.cs
+++ b/XLibur.Tests/Excel/InsertData/SimpleNullableTypeReaderTests.cs
@@ -14,7 +14,7 @@ public class SimpleNullableTypeReaderTests
     [TestCaseSource(nameof(SimpleNullableSourceNames))]
     public string CanGetPropertyName<T>(IEnumerable<T> data)
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
         return reader.GetPropertyName(0);
     }
 
@@ -33,21 +33,21 @@ public class SimpleNullableTypeReaderTests
     [Test]
     public void CanGetPropertiesCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual(1, reader.GetPropertiesCount());
     }
 
     [Test]
     public void CanGetRecordsCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual(3, reader.GetRecords().Count());
     }
 
     [Test]
     public void CanReadValues()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         var result = reader.GetRecords();
 
         var enumerable = result.ToList();

--- a/XLibur.Tests/Excel/InsertData/SimpleTypeReaderTests.cs
+++ b/XLibur.Tests/Excel/InsertData/SimpleTypeReaderTests.cs
@@ -20,7 +20,7 @@ public class SimpleTypeReaderTests
     [TestCaseSource(nameof(SimpleSourceNames))]
     public string CanGetPropertyName<T>(IEnumerable<T> data)
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
         return reader.GetPropertyName(0);
     }
 
@@ -40,21 +40,21 @@ public class SimpleTypeReaderTests
     [Test]
     public void CanGetPropertiesCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual(1, reader.GetPropertiesCount());
     }
 
     [Test]
     public void CanGetRecordsCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual(3, reader.GetRecords().Count());
     }
 
     [Test]
     public void CanReadValues()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         var result = reader.GetRecords();
 
         var enumerable = result.ToList();

--- a/XLibur.Tests/Excel/InsertData/UntypedObjectReaderTests.cs
+++ b/XLibur.Tests/Excel/InsertData/UntypedObjectReaderTests.cs
@@ -39,7 +39,7 @@ public class UntypedObjectReaderTests
     [TestCase(3, "UnOrderedColumn")]
     public void CanGetPropertyName(int propertyIndex, string expectedPropertyName)
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         var actualPropertyName = reader.GetPropertyName(propertyIndex);
         Assert.AreEqual(expectedPropertyName, actualPropertyName);
     }
@@ -47,21 +47,21 @@ public class UntypedObjectReaderTests
     [Test]
     public void CanGetPropertiesCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual(4, reader.GetPropertiesCount());
     }
 
     [Test]
     public void CanGetRecordsCount()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
         Assert.AreEqual(9, reader.GetRecords().Count());
     }
 
     [Test]
     public void CanGetData()
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+        var reader = InsertDataReaderFactory.CreateReader(_data);
 
         var result = reader.GetRecords().ToArray();
 

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
@@ -6,17 +6,21 @@ namespace XLibur.Tests.Excel.PivotTables;
 [TestFixture]
 public class XLPivotCacheTests
 {
+    private static readonly string[] PivotCacheFieldNamePie = ["Name", "Pie"];
+    private static readonly string[] PivotCacheFieldNameOnly = ["Name"];
+    private static readonly string[] PivotCacheFieldPastry = ["Pastry"];
+
     [Test]
     public void FieldNames_KeepNamesEvenWhenSourceChange()
     {
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet();
-        var range = ws.FirstCell().InsertData(new[] { "Name", "Pie" });
+        var range = ws.FirstCell().InsertData(PivotCacheFieldNamePie);
 
         var pivotCache = wb.PivotCaches.Add(range);
         ws.Cell("A1").Value = "Pastry";
 
-        Assert.AreEqual(new[] { "Name" }, pivotCache.FieldNames);
+        Assert.AreEqual(PivotCacheFieldNameOnly, pivotCache.FieldNames);
     }
 
     [Test]
@@ -24,13 +28,13 @@ public class XLPivotCacheTests
     {
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet();
-        var range = ws.FirstCell().InsertData(new[] { "Name", "Pie" });
+        var range = ws.FirstCell().InsertData(PivotCacheFieldNamePie);
 
         var pivotCache = wb.PivotCaches.Add(range);
         ws.Cell("A1").Value = "Pastry";
         pivotCache.Refresh();
 
-        Assert.AreEqual(new[] { "Pastry" }, pivotCache.FieldNames);
+        Assert.AreEqual(PivotCacheFieldPastry, pivotCache.FieldNames);
     }
 
     [Test]
@@ -38,7 +42,7 @@ public class XLPivotCacheTests
     {
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet();
-        var range = ws.FirstCell().InsertData(new[] { "Name", "Pie" });
+        var range = ws.FirstCell().InsertData(PivotCacheFieldNamePie);
 
         var pivotCache = wb.PivotCaches.Add(range);
 

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -303,7 +303,7 @@ public class XLPivotTableTests
         AssertPivotTablesAreEqual(pt1, pt1.CopyTo(wb2.AddWorksheet("pvt").FirstCell()) as XLPivotTable, compareName: true);
     }
 
-    private void AssertPivotTablesAreEqual(XLPivotTable original, XLPivotTable copy, Boolean compareName)
+    private static void AssertPivotTablesAreEqual(XLPivotTable original, XLPivotTable copy, Boolean compareName)
     {
         Assert.AreEqual(compareName, original.Name.Equals(copy.Name));
 

--- a/XLibur.Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeIndexTest.cs
@@ -243,7 +243,7 @@ public class RangeIndexTest
         Assert.AreEqual(0, ranges.Count);
     }
 
-    private IXLRangeIndex CreateRangeIndex(IXLWorksheet worksheet)
+    private static IXLRangeIndex CreateRangeIndex(IXLWorksheet worksheet)
     {
         return new XLRangeIndex<IXLRangeBase>((XLWorksheet)worksheet);
     }

--- a/XLibur.Tests/Excel/Ranges/RangeShiftingTests.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeShiftingTests.cs
@@ -116,14 +116,14 @@ public class RangeShiftingTests
         Assert.AreEqual(deletedRangeAddress, mergedRange.RangeAddress.ToString());
     }
 
-    private void SetContent(IXLCell cell)
+    private static void SetContent(IXLCell cell)
     {
         cell.FormulaA1 = $"\"Formula \" & \"{cell.Address}\"";
         cell.Style.Fill.SetBackgroundColor(XLColor.Green);
         cell.CreateComment().AddText("Some comment " + cell.Address);
     }
 
-    private void AssertContent(IXLCell cell, string originalAddress)
+    private static void AssertContent(IXLCell cell, string originalAddress)
     {
         Assert.AreEqual($"\"Formula \" & \"{originalAddress}\"", cell.FormulaA1);
         Assert.AreEqual(XLColor.Green, cell.Style.Fill.BackgroundColor);

--- a/XLibur.Tests/Excel/Ranges/SortTests.cs
+++ b/XLibur.Tests/Excel/Ranges/SortTests.cs
@@ -104,9 +104,9 @@ public class SortTests
         var ws = wb.AddWorksheet();
         ws.FirstCell().InsertData(new object[]
         {
-            new[] { 1, 2 },
-            new[] { 2, 2 },
-            new[] { 1, 1 },
+            SortRow1,
+            SortRow2,
+            SortRow3,
         });
 
         ws.Range("A1:B4").Sort("2 ASC, 1 DESC");
@@ -121,6 +121,9 @@ public class SortTests
 
     private static readonly int[] Data = [2, 2, 1];
     private static readonly int[] DataArray = [1, 2, 1];
+    private static readonly int[] SortRow1 = [1, 2];
+    private static readonly int[] SortRow2 = [2, 2];
+    private static readonly int[] SortRow3 = [1, 1];
 
     [Test]
     public void Sort_columns_in_range_by_rows()

--- a/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -317,7 +317,7 @@ public class XLRangeAddressTests
 
     #region Private Methods
 
-    private IXLRangeAddress ProduceInvalidAddress()
+    private static IXLRangeAddress ProduceInvalidAddress()
     {
         var ws = new XLWorkbook().Worksheets.Add("Sheet 1");
         var range = ws.Range("A1:B2");
@@ -326,7 +326,7 @@ public class XLRangeAddressTests
         return range.RangeAddress;
     }
 
-    private IXLRangeAddress ProduceAddressOnDeletedWorksheet()
+    private static IXLRangeAddress ProduceAddressOnDeletedWorksheet()
     {
         var ws = new XLWorkbook().Worksheets.Add("Sheet 1");
         var address = ws.Range("A1:B2").RangeAddress;

--- a/XLibur.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
+++ b/XLibur.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
@@ -32,7 +32,7 @@ public class AppendingAndReplacingTableDataTests
         public bool IsActive;
     }
 
-    private XLWorkbook PrepareWorkbook()
+    private static XLWorkbook PrepareWorkbook()
     {
         var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Tables");
@@ -83,7 +83,7 @@ public class AppendingAndReplacingTableDataTests
         return wb;
     }
 
-    private Person[] NewData =>
+    private static Person[] NewData =>
     [
         new()
         {

--- a/XLibur.Tests/Excel/Tables/TablesTests.cs
+++ b/XLibur.Tests/Excel/Tables/TablesTests.cs
@@ -1179,7 +1179,7 @@ public class TablesTests
         Assert.AreEqual("Table2", t2.Name);
     }
 
-    private void AssertTablesAreEqual(IXLTable table1, IXLTable table2)
+    private static void AssertTablesAreEqual(IXLTable table1, IXLTable table2)
     {
         Assert.AreEqual(table1.RangeAddress.ToString(XLReferenceStyle.A1, false),
             table2.RangeAddress.ToString(XLReferenceStyle.A1, false));

--- a/XLibur.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/XLibur.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -11,6 +11,9 @@ namespace XLibur.Tests.Extensions;
 
 public class EnumerableExtensionsTests
 {
+    private static readonly int[] SkipLastSingle = [1];
+    private static readonly int[] SkipLastTwo = [1, 2];
+
     [Test]
     public void CanGetItemType()
     {
@@ -54,10 +57,10 @@ public class EnumerableExtensionsTests
         var empty = Array.Empty<int>().SkipLast();
         Assert.That(empty, Is.Empty);
 
-        var oneElement = new[] { 1 }.SkipLast();
+        var oneElement = SkipLastSingle.SkipLast();
         Assert.That(oneElement, Is.Empty);
 
-        var twoElements = new[] { 1, 2 }.SkipLast();
+        var twoElements = SkipLastTwo.SkipLast();
         Assert.That(twoElements, Is.EqualTo([1]));
     }
 

--- a/XLibur/Excel/AutoFilters/XLFilter.cs
+++ b/XLibur/Excel/AutoFilters/XLFilter.cs
@@ -162,12 +162,9 @@ internal sealed class XLFilter
         if (cellValue.IsBlank || filterValue.IsBlank)
             return false;
 
-        if (cellValue.Type != filterValue.Type)
-        {
-            // Types are different, but could still be unified numbers and thus comparable.
-            if (!(cellValue.IsUnifiedNumber && filterValue.IsUnifiedNumber))
-                return false;
-        }
+        // Types are different, but could still be unified numbers and thus comparable.
+        if (cellValue.Type != filterValue.Type && !(cellValue.IsUnifiedNumber && filterValue.IsUnifiedNumber))
+            return false;
 
         // Note that custom filter even error values, basically everything as a number.
         var comparison = cellValue.Type switch

--- a/XLibur/Excel/CalcEngine/AnyValue.cs
+++ b/XLibur/Excel/CalcEngine/AnyValue.cs
@@ -53,7 +53,7 @@ internal readonly struct AnyValue
     public static AnyValue From(string text)
     {
         return text is null
-            ? throw new ArgumentNullException()
+            ? throw new ArgumentNullException(nameof(text))
             : new AnyValue(TextValue, false, 0, text, default, null, null);
     }
 
@@ -62,7 +62,7 @@ internal readonly struct AnyValue
     public static AnyValue From(Array array)
     {
         if (array is null)
-            throw new ArgumentNullException();
+            throw new ArgumentNullException(nameof(array));
 
         return new(ArrayValue, false, 0, null, default, array, null);
     }
@@ -70,7 +70,7 @@ internal readonly struct AnyValue
     public static AnyValue From(Reference reference)
     {
         if (reference is null)
-            throw new ArgumentNullException();
+            throw new ArgumentNullException(nameof(reference));
 
         return new(ReferenceValue, false, 0, null, default, null, reference);
     }

--- a/XLibur/Excel/CalcEngine/Array.cs
+++ b/XLibur/Excel/CalcEngine/Array.cs
@@ -372,6 +372,8 @@ internal sealed class SlicedArray : Array
     /// <param name="cols">The number of columns in the sliced array.</param>
     public SlicedArray(Array original, int rowOfs, int rows, int colOfs, int cols)
     {
+        ArgumentNullException.ThrowIfNull(original);
+
         if (rowOfs < 0 || rows < 1 || colOfs < 0 || cols < 1 ||
             rowOfs + rows > original.Height ||
             colOfs + cols > original.Width)

--- a/XLibur/Excel/CalcEngine/Array.cs
+++ b/XLibur/Excel/CalcEngine/Array.cs
@@ -375,7 +375,7 @@ internal sealed class SlicedArray : Array
         if (rowOfs < 0 || rows < 1 || colOfs < 0 || cols < 1 ||
             rowOfs + rows > original.Height ||
             colOfs + cols > original.Width)
-            throw new ArgumentOutOfRangeException();
+            throw new ArgumentOutOfRangeException(nameof(original), "Slice dimensions exceed the bounds of the original array.");
 
         _original = original;
         _rowOfs = rowOfs;

--- a/XLibur/Excel/CalcEngine/CalcContext.cs
+++ b/XLibur/Excel/CalcEngine/CalcContext.cs
@@ -57,7 +57,7 @@ internal sealed class CalcContext
     /// Excel 2016 and earlier doesn't support dynamic array formulas (it used an array formulas instead). As a consequence,
     /// all arguments for scalar functions where passed through implicit intersection before calling the function.
     /// </summary>
-    public bool UseImplicitIntersection => true;
+    public static bool UseImplicitIntersection => true;
 
     /// <summary>
     /// Should functions be calculated per item of multi-values argument in the scalar parameters.

--- a/XLibur/Excel/CalcEngine/DateTimeParser.cs
+++ b/XLibur/Excel/CalcEngine/DateTimeParser.cs
@@ -24,6 +24,8 @@ internal static class DateTimeParser
 
     private static readonly string[] TimeOfDayPatterns = ["h:m tt", "h:m t", "h:m:s tt", "h:m:s t"];
 
+    private static readonly string[] TimePatterns = ["h:m tt", "H:m", "h:m"];
+
     public static bool TryParseCultureDate(string s, CultureInfo culture, out DateTime date)
     {
         var datePatterns = CultureSpecificPatterns.GetOrAdd(culture, static ci =>
@@ -46,7 +48,7 @@ internal static class DateTimeParser
             // isn't a pattern to just use. Example: for en-US, Excel type coercion can transform "aug 10, 2022 14:10",
             // but every single format from CultureInfo.DateTimeFormat requires AM/PM. and two digits for minutes (thus
             // the input couldn't match in any format => excel has likely it's own logic, independent of region setting).
-            var timePatterns = new[] { "h:m tt", "H:m", "h:m" };
+            var timePatterns = TimePatterns;
             var longDatePatterns = shortDatePatterns
                 .SelectMany(datePattern => timePatterns.Select(timePattern => FormattableString.Invariant($"{datePattern} {timePattern}")));
 

--- a/XLibur/Excel/CalcEngine/FunctionDefinition.cs
+++ b/XLibur/Excel/CalcEngine/FunctionDefinition.cs
@@ -24,7 +24,7 @@ internal sealed class FunctionDefinition
     public FunctionDefinition(int minParams, int maxParams, CalcEngineFunction function, FunctionFlags flags, AllowRange allowRanges, IReadOnlyCollection<int> markedParams)
     {
         if (allowRanges == AllowRange.None && markedParams.Count > 0)
-            throw new ArgumentException(nameof(markedParams));
+            throw new ArgumentException("Marked params must be empty when AllowRange is None.", nameof(markedParams));
 
         MinParams = minParams;
         MaxParams = maxParams;
@@ -40,7 +40,7 @@ internal sealed class FunctionDefinition
 
     public AnyValue CallFunction(CalcContext ctx, Span<AnyValue> args)
     {
-        if (ctx.UseImplicitIntersection)
+        if (CalcContext.UseImplicitIntersection)
             IntersectArguments(ctx, args);
 
         return _function(ctx, args);

--- a/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -63,11 +63,8 @@ internal static class DateAndTime
         // subtract the number of bank holidays during the time interval
         foreach (var holidayDate in distinctHolidays)
         {
-            if (firstDay <= holidayDate && holidayDate <= lastDay)
-            {
-                if (!IsWeekend(holidayDate))
-                    --workDays;
-            }
+            if (firstDay <= holidayDate && holidayDate <= lastDay && !IsWeekend(holidayDate))
+                --workDays;
         }
 
         return workDays;
@@ -439,12 +436,9 @@ internal static class DateAndTime
             return dateError;
 
         var flagValue = 1d;
-        if (!flag.IsBlank)
-        {
-            // Caller provided a value for optional parameter
-            if (!flag.ToNumber(ctx.Culture).TryPickT0(out flagValue, out var flagError))
-                return flagError;
-        }
+        // Caller provided a value for optional parameter
+        if (!flag.IsBlank && !flag.ToNumber(ctx.Culture).TryPickT0(out flagValue, out var flagError))
+            return flagError;
 
         var result = Weekday(serialDate, (int)Math.Truncate(flagValue));
 

--- a/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
@@ -20,6 +20,7 @@ internal static class MathTrig
     /// </summary>
     private const double MaxDoubleInt = 9007199254740991;
 
+    private static readonly int[] SumIfsAllowedRangeParams = new[] { 0 }.Concat(Enumerable.Range(0, 128).Select(x => x * 2 + 1)).ToArray();
 
     /// <summary>
     /// Key: roman form. Value: A collection of subtract symbols and subtract value.
@@ -107,7 +108,7 @@ internal static class MathTrig
         ce.RegisterFunction("SUBTOTAL", 2, 255, Adapt(Subtotal), FunctionFlags.Range, AllowRange.Except, 0);
         ce.RegisterFunction("SUM", 1, int.MaxValue, Sum, FunctionFlags.Range, AllowRange.All);
         ce.RegisterFunction("SUMIF", 2, 3, AdaptLastOptional(SumIf), FunctionFlags.Range, AllowRange.Only, 0, 2);
-        ce.RegisterFunction("SUMIFS", 3, 255, AdaptIfs(SumIfs), FunctionFlags.Range, AllowRange.Only, new[] { 0 }.Concat(Enumerable.Range(0, 128).Select(x => x * 2 + 1)).ToArray());
+        ce.RegisterFunction("SUMIFS", 3, 255, AdaptIfs(SumIfs), FunctionFlags.Range, AllowRange.Only, SumIfsAllowedRangeParams);
         ce.RegisterFunction("SUMPRODUCT", 1, 30, Adapt(SumProduct), FunctionFlags.Range, AllowRange.All);
         ce.RegisterFunction("SUMSQ", 1, 255, SumSq, FunctionFlags.Range, AllowRange.All);
         //ce.RegisterFunction("SUMX2MY2", SumX2MY2, 1);

--- a/XLibur/Excel/CalcEngine/Functions/TallyCriteria.cs
+++ b/XLibur/Excel/CalcEngine/Functions/TallyCriteria.cs
@@ -146,11 +146,8 @@ internal sealed class TallyCriteria : ITally
         for (var i = 0; i < enumerables.Count; ++i)
         {
             var currentOfs = GetOffset(enumerables, enumerators, i);
-            if (currentOfs.CompareTo(minOfs) <= 0)
-            {
-                if (!enumerators[i].MoveNext())
-                    return false;
-            }
+            if (currentOfs.CompareTo(minOfs) <= 0 && !enumerators[i].MoveNext())
+                return false;
         }
 
         return true;

--- a/XLibur/Excel/CalcEngine/Reference.cs
+++ b/XLibur/Excel/CalcEngine/Reference.cs
@@ -23,6 +23,8 @@ namespace XLibur.Excel.CalcEngine
         /// </summary>
         public Reference(List<XLRangeAddress> areas)
         {
+            ArgumentNullException.ThrowIfNull(areas);
+
             if (areas.Count < 1)
                 throw new ArgumentException("Reference must contain at least one area.", nameof(areas));
 
@@ -31,6 +33,8 @@ namespace XLibur.Excel.CalcEngine
 
         public Reference(IXLRanges ranges)
         {
+            ArgumentNullException.ThrowIfNull(ranges);
+
             if (ranges.Count < 1)
                 throw new ArgumentException("Reference must contain at least one range.", nameof(ranges));
 

--- a/XLibur/Excel/CalcEngine/Reference.cs
+++ b/XLibur/Excel/CalcEngine/Reference.cs
@@ -13,7 +13,7 @@ namespace XLibur.Excel.CalcEngine
         public Reference(XLRangeAddress area)
         {
             if (!area.IsNormalized)
-                throw new ArgumentException();
+                throw new ArgumentException("Range address must be normalized.", nameof(area));
 
             Areas = new List<XLRangeAddress>(1) { area };
         }
@@ -24,7 +24,7 @@ namespace XLibur.Excel.CalcEngine
         public Reference(List<XLRangeAddress> areas)
         {
             if (areas.Count < 1)
-                throw new ArgumentException();
+                throw new ArgumentException("Reference must contain at least one area.", nameof(areas));
 
             Areas = areas;
         }
@@ -32,7 +32,7 @@ namespace XLibur.Excel.CalcEngine
         public Reference(IXLRanges ranges)
         {
             if (ranges.Count < 1)
-                throw new ArgumentException();
+                throw new ArgumentException("Reference must contain at least one range.", nameof(ranges));
 
             var areas = new List<XLRangeAddress>(ranges.Count);
             foreach (var range in ranges)
@@ -101,11 +101,8 @@ namespace XLibur.Excel.CalcEngine
 
             var rhsWorksheet = rhsWorksheets.SingleOrDefault();
 
-            if (rhsWorksheet is not null)
-            {
-                if ((lhsWorksheet ?? contextWorksheet) != rhsWorksheet)
-                    return XLError.IncompatibleValue;
-            }
+            if (rhsWorksheet is not null && (lhsWorksheet ?? contextWorksheet) != rhsWorksheet)
+                return XLError.IncompatibleValue;
 
             var minCol = XLHelper.MaxColumnNumber;
             var maxCol = 1;

--- a/XLibur/Excel/CalcEngine/ScalarValue.cs
+++ b/XLibur/Excel/CalcEngine/ScalarValue.cs
@@ -63,7 +63,7 @@ internal readonly struct ScalarValue
     public static ScalarValue From(string text)
     {
         if (text is null)
-            throw new ArgumentNullException();
+            throw new ArgumentNullException(nameof(text));
 
         return new ScalarValue(TextValue, default, default, text, default);
     }

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -352,7 +352,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
             RecalculateSheetId = recalculateSheetId
         };
         var result = EvaluateFormula(expression, ctx);
-        if (ctx.UseImplicitIntersection)
+        if (CalcContext.UseImplicitIntersection)
         {
             result = result.Match(
                 () => AnyValue.Blank,
@@ -396,7 +396,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
     }
 
     // build/get static keyword table
-    private FunctionRegistry GetFunctionTable()
+    private static FunctionRegistry GetFunctionTable()
     {
         var fr = new FunctionRegistry();
 

--- a/XLibur/Excel/Cells/ValueSlice.cs
+++ b/XLibur/Excel/Cells/ValueSlice.cs
@@ -95,7 +95,7 @@ internal sealed class ValueSlice : ISlice
             XLDataType.Error => (XLError)value,
             XLDataType.DateTime => XLCellValue.FromSerialDateTime(value),
             XLDataType.TimeSpan => XLCellValue.FromSerialTimeSpan(value),
-            _ => throw new ArgumentOutOfRangeException()
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unexpected data type.")
         };
     }
 

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -422,7 +422,7 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
     public IXLTable InsertTable<T>(IEnumerable<T> data, string? tableName, bool createTable, bool addHeadings,
         bool transpose)
     {
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
         return Worksheet.InsertTable(SheetPoint, reader, tableName, createTable, addHeadings, transpose);
     }
 
@@ -449,7 +449,7 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         if (createTable && Worksheet.Tables.Any<XLTable>(t => t.Contains(this)))
             throw new InvalidOperationException($"This cell '{Address}' is already part of a table.");
 
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
         return Worksheet.InsertTable(SheetPoint, reader, tableName, createTable, addHeadings: true, transpose: false);
     }
 
@@ -474,7 +474,7 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         if (data is null or string)
             return null;
 
-        var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+        var reader = InsertDataReaderFactory.CreateReader(data);
         return Worksheet.InsertData(SheetPoint, reader, addHeadings: false, transpose: transpose);
     }
 
@@ -483,7 +483,7 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         if (dataTable == null)
             return null;
 
-        var reader = InsertDataReaderFactory.Instance.CreateReader(dataTable);
+        var reader = InsertDataReaderFactory.CreateReader(dataTable);
         return Worksheet.InsertData(SheetPoint, reader, addHeadings: false, transpose: false);
     }
 

--- a/XLibur/Excel/Cells/XLCells.cs
+++ b/XLibur/Excel/Cells/XLCells.cs
@@ -50,7 +50,7 @@ internal sealed class XLCells : XLStylizedBase, IXLCells, IXLStylized, IEnumerab
         }
     }
 
-    private IEnumerable<XLSheetPoint> GetAllCellsInRange(IXLRangeAddress rangeAddress)
+    private static IEnumerable<XLSheetPoint> GetAllCellsInRange(IXLRangeAddress rangeAddress)
     {
         if (!rangeAddress.IsValid)
             yield break;

--- a/XLibur/Excel/Cells/XLCellsCollection.cs
+++ b/XLibur/Excel/Cells/XLCellsCollection.cs
@@ -437,14 +437,11 @@ internal sealed class XLCellsCollection : IWorkbookListener
             for (var i = _count - 1; i >= 0; --i)
             {
                 var enumerator = _enumerators[i];
-                if (enumerator.Current == current)
+                if (enumerator.Current == current && !enumerator.MoveNext())
                 {
-                    if (!enumerator.MoveNext())
-                    {
-                        _count--;
-                        if (i < _count)
-                            _enumerators[i] = _enumerators[_count];
-                    }
+                    _count--;
+                    if (i < _count)
+                        _enumerators[i] = _enumerators[_count];
                 }
             }
         }

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFCellIsConverter.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFCellIsConverter.cs
@@ -27,7 +27,7 @@ internal sealed class XLCFCellIsConverter : IXLCFConverter
         return conditionalFormattingRule;
     }
 
-    private string GetQuoted(XLFormula formula)
+    private static string GetQuoted(XLFormula formula)
     {
         string value = formula.Value;
 

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFDataBarConverter.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFDataBarConverter.cs
@@ -43,7 +43,7 @@ internal sealed class XLCFDataBarConverter : IXLCFConverter
         return conditionalFormattingRule;
     }
 
-    private ConditionalFormattingRuleExtension BuildRuleExtension(IXLConditionalFormat cf)
+    private static ConditionalFormattingRuleExtension BuildRuleExtension(IXLConditionalFormat cf)
     {
         var conditionalFormattingRuleExtension = new ConditionalFormattingRuleExtension { Uri = "{B025F937-C7B1-47D3-B67F-A62EFF666E3E}" };
         conditionalFormattingRuleExtension.AddNamespaceDeclaration("x14", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main");
@@ -56,7 +56,7 @@ internal sealed class XLCFDataBarConverter : IXLCFConverter
         return conditionalFormattingRuleExtension;
     }
 
-    private ConditionalFormatValueObject GetConditionalFormatValueObjectByIndex(IXLConditionalFormat cf, int index, ConditionalFormatValueObjectValues defaultType)
+    private static ConditionalFormatValueObject GetConditionalFormatValueObjectByIndex(IXLConditionalFormat cf, int index, ConditionalFormatValueObjectValues defaultType)
     {
         var conditionalFormatValueObject = new ConditionalFormatValueObject();
 

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -266,7 +266,7 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
         CopyDictionary(IconSetOperators, other.IconSetOperators);
     }
 
-    private void CopyDictionary<T>(XLDictionary<T> target, XLDictionary<T> source) where T : notnull
+    private static void CopyDictionary<T>(XLDictionary<T> target, XLDictionary<T> source) where T : notnull
     {
         target.Clear();
         source.ForEach(kp => target.Add(kp.Key, kp.Value));

--- a/XLibur/Excel/Coordinates/Emu.cs
+++ b/XLibur/Excel/Coordinates/Emu.cs
@@ -50,7 +50,7 @@ internal readonly record struct Emu
             AbsLengthUnit.Point => PerPt,
             AbsLengthUnit.Pica => PerPc,
             AbsLengthUnit.Emu => 1,
-            _ => throw new ArgumentOutOfRangeException(),
+            _ => throw new ArgumentOutOfRangeException(nameof(srcUnit), srcUnit, "Unsupported length unit."),
         };
     }
 

--- a/XLibur/Excel/Coordinates/XLAddress.cs
+++ b/XLibur/Excel/Coordinates/XLAddress.cs
@@ -334,7 +334,7 @@ internal struct XLAddress : IXLAddress, IEquatable<XLAddress>
         return x == y;
     }
 
-    public new bool Equals(object? x, object? y)
+    public static new bool Equals(object? x, object? y)
     {
         return x == y;
     }

--- a/XLibur/Excel/Coordinates/XLBookArea.cs
+++ b/XLibur/Excel/Coordinates/XLBookArea.cs
@@ -20,7 +20,7 @@ internal readonly struct XLBookArea : IEquatable<XLBookArea>
     public XLBookArea(string name, XLSheetRange area)
     {
         if (string.IsNullOrEmpty(name))
-            throw new ArgumentException(nameof(name));
+            throw new ArgumentException("Name must not be null or empty.", nameof(name));
 
         Name = name;
         Area = area;

--- a/XLibur/Excel/Coordinates/XLName.cs
+++ b/XLibur/Excel/Coordinates/XLName.cs
@@ -23,7 +23,7 @@ internal readonly struct XLName : IEquatable<XLName>
     public XLName(string sheetName, string name)
     {
         if (string.IsNullOrEmpty(sheetName))
-            throw new ArgumentException(nameof(sheetName));
+            throw new ArgumentException("Sheet name must not be null or empty.", nameof(sheetName));
 
         if (name.Any(char.IsWhiteSpace))
             throw new ArgumentException("Name can't contain whitespace.");

--- a/XLibur/Excel/Coordinates/XLSheetRange.cs
+++ b/XLibur/Excel/Coordinates/XLSheetRange.cs
@@ -244,8 +244,7 @@ internal readonly struct XLSheetRange : IEquatable<XLSheetRange>, IEnumerable<XL
     /// <param name="rows">How many rows to take, must be at least one.</param>
     public XLSheetRange SliceFromBottom(int rows)
     {
-        if (rows < 1)
-            throw new ArgumentOutOfRangeException();
+        ArgumentOutOfRangeException.ThrowIfLessThan(rows, 1);
 
         return new XLSheetRange(new XLSheetPoint(BottomRow - rows + 1, FirstPoint.Column), LastPoint);
     }
@@ -256,8 +255,7 @@ internal readonly struct XLSheetRange : IEquatable<XLSheetRange>, IEnumerable<XL
     /// <param name="rows">How many rows to take, must be at least one.</param>
     public XLSheetRange SliceFromTop(int rows)
     {
-        if (rows < 1)
-            throw new ArgumentOutOfRangeException();
+        ArgumentOutOfRangeException.ThrowIfLessThan(rows, 1);
 
         return new XLSheetRange(FirstPoint, new XLSheetPoint(TopRow + rows - 1, LastPoint.Column));
     }
@@ -268,8 +266,7 @@ internal readonly struct XLSheetRange : IEquatable<XLSheetRange>, IEnumerable<XL
     /// <param name="columns">How many columns to take, must be at least one.</param>
     public XLSheetRange SliceFromLeft(int columns)
     {
-        if (columns < 1)
-            throw new ArgumentOutOfRangeException();
+        ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
 
         return new XLSheetRange(FirstPoint, new XLSheetPoint(FirstPoint.Row, LeftColumn + columns - 1));
     }
@@ -280,8 +277,7 @@ internal readonly struct XLSheetRange : IEquatable<XLSheetRange>, IEnumerable<XL
     /// <param name="columns">How many columns to take, must be at least one.</param>
     public XLSheetRange SliceFromRight(int columns)
     {
-        if (columns < 1)
-            throw new ArgumentOutOfRangeException();
+        ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
 
         return new XLSheetRange(new XLSheetPoint(FirstPoint.Row, RightColumn - columns + 1), LastPoint);
     }

--- a/XLibur/Excel/DefinedNames/XLDefinedName.cs
+++ b/XLibur/Excel/DefinedNames/XLDefinedName.cs
@@ -21,11 +21,8 @@ internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
     {
         // Excel accepts invalid names per grammar (e.g. `[Foo]Bar`) as a valid name and they can
         // encountered in existing workbooks. We shouldn't throw exception on load.
-        if (validateName)
-        {
-            if (!XLHelper.ValidateName("named range", name, out var error))
-                throw new ArgumentException(error, nameof(name));
-        }
+        if (validateName && !XLHelper.ValidateName("named range", name, out var error))
+            throw new ArgumentException(error, nameof(name));
 
         _container = container;
         _name = name;
@@ -70,7 +67,7 @@ internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
         set
         {
             if (value is null)
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(value));
 
             var formula = value.TrimFormulaEqual();
             var references = FormulaReferences.ForFormula(formula);

--- a/XLibur/Excel/EnumConverter.cs
+++ b/XLibur/Excel/EnumConverter.cs
@@ -80,7 +80,7 @@ internal static class EnumConverter
                 XLFontScheme.None => FontSchemeValues.None,
                 XLFontScheme.Major => FontSchemeValues.Major,
                 XLFontScheme.Minor => FontSchemeValues.Minor,
-                _ => throw new ArgumentOutOfRangeException()
+                _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unsupported font scheme value.")
             };
         }
     }

--- a/XLibur/Excel/IO/PictureWriter.cs
+++ b/XLibur/Excel/IO/PictureWriter.cs
@@ -297,7 +297,7 @@ internal sealed class PictureWriter
                 AttachAnchor(oneCellAnchor, existingAnchor);
                 break;
             default:
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(pic.Placement), pic.Placement, "Unsupported picture placement.");
         }
 
         return;

--- a/XLibur/Excel/IO/VmlDrawingPartWriter.cs
+++ b/XLibur/Excel/IO/VmlDrawingPartWriter.cs
@@ -242,7 +242,7 @@ internal static class VmlDrawingPartWriter
 
         sb.Append("visibility:");
         sb.Append(c.Visible ? "visible" : "hidden");
-        sb.Append(";");
+        sb.Append(';');
 
         sb.Append("width:");
         sb.Append(Math.Round(widthInColumns * 7.5, 2).ToInvariantString());

--- a/XLibur/Excel/InsertData/InsertDataReaderFactory.cs
+++ b/XLibur/Excel/InsertData/InsertDataReaderFactory.cs
@@ -13,7 +13,7 @@ internal sealed class InsertDataReaderFactory
 
     public static InsertDataReaderFactory Instance => _instance.Value;
 
-    public IInsertDataReader CreateReader(IEnumerable data)
+    public static IInsertDataReader CreateReader(IEnumerable data)
     {
         ArgumentNullException.ThrowIfNull(data);
 
@@ -35,12 +35,12 @@ internal sealed class InsertDataReaderFactory
         return new ObjectReader(data);
     }
 
-    public IInsertDataReader CreateReader<T>(IEnumerable<T[]> data)
+    public static IInsertDataReader CreateReader<T>(IEnumerable<T[]> data)
     {
         return data == null ? throw new ArgumentNullException(nameof(data)) : new ArrayReader(data);
     }
 
-    public IInsertDataReader CreateReader(IEnumerable<IEnumerable> data)
+    public static IInsertDataReader CreateReader(IEnumerable<IEnumerable> data)
     {
         ArgumentNullException.ThrowIfNull(data);
 
@@ -50,7 +50,7 @@ internal sealed class InsertDataReaderFactory
         return new ArrayReader(data);
     }
 
-    public IInsertDataReader CreateReader(DataTable dataTable)
+    public static IInsertDataReader CreateReader(DataTable dataTable)
     {
         return dataTable == null ? throw new ArgumentNullException(nameof(dataTable)) : new DataTableReader(dataTable);
     }

--- a/XLibur/Excel/InsertData/UntypedObjectReader.cs
+++ b/XLibur/Excel/InsertData/UntypedObjectReader.cs
@@ -49,7 +49,7 @@ internal sealed class UntypedObjectReader : IInsertDataReader
             var items = Array.CreateInstance(itemType, itemsOfSameType.Count);
             Array.Copy(itemsOfSameType.ToArray(), items, items.Length);
 
-            return InsertDataReaderFactory.Instance.CreateReader(items);
+            return InsertDataReaderFactory.CreateReader(items);
         }
     }
 

--- a/XLibur/Excel/PageSetup/XLPageSetup.cs
+++ b/XLibur/Excel/PageSetup/XLPageSetup.cs
@@ -76,8 +76,8 @@ internal sealed class XLPageSetup : IXLPageSetup
     }
     public void SetRowsToRepeatAtTop(int firstRowToRepeatAtTop, int lastRowToRepeatAtTop)
     {
-        if (firstRowToRepeatAtTop <= 0) throw new ArgumentOutOfRangeException("The first row has to be greater than zero.");
-        if (firstRowToRepeatAtTop > lastRowToRepeatAtTop) throw new ArgumentOutOfRangeException("The first row has to be less than the second row.");
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(firstRowToRepeatAtTop);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(firstRowToRepeatAtTop, lastRowToRepeatAtTop);
 
         FirstRowToRepeatAtTop = firstRowToRepeatAtTop;
         LastRowToRepeatAtTop = lastRowToRepeatAtTop;
@@ -98,8 +98,8 @@ internal sealed class XLPageSetup : IXLPageSetup
     }
     public void SetColumnsToRepeatAtLeft(int firstColumnToRepeatAtLeft, int lastColumnToRepeatAtLeft)
     {
-        if (firstColumnToRepeatAtLeft <= 0) throw new ArgumentOutOfRangeException("The first column has to be greater than zero.");
-        if (firstColumnToRepeatAtLeft > lastColumnToRepeatAtLeft) throw new ArgumentOutOfRangeException("The first column has to be less than the second column.");
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(firstColumnToRepeatAtLeft);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(firstColumnToRepeatAtLeft, lastColumnToRepeatAtLeft);
 
         FirstColumnToRepeatAtLeft = firstColumnToRepeatAtLeft;
         LastColumnToRepeatAtLeft = lastColumnToRepeatAtLeft;

--- a/XLibur/Excel/Patterns/Quadrant.cs
+++ b/XLibur/Excel/Patterns/Quadrant.cs
@@ -229,11 +229,8 @@ internal class Quadrant
             }
         }
 
-        if (!coveredByChild)
-        {
-            if (_ranges?.Remove(rangeAddress) == true)
-                res = true;
-        }
+        if (!coveredByChild && _ranges?.Remove(rangeAddress) == true)
+            res = true;
 
         return res;
     }

--- a/XLibur/Excel/PivotTables/Areas/FieldIndex.cs
+++ b/XLibur/Excel/PivotTables/Areas/FieldIndex.cs
@@ -13,7 +13,7 @@ internal readonly record struct FieldIndex
     internal FieldIndex(int value)
     {
         if (value < 0 && value != -2)
-            throw new ArgumentOutOfRangeException();
+            throw new ArgumentOutOfRangeException(nameof(value), value, "Field index must be non-negative or -2 for data field.");
 
         Value = value;
     }

--- a/XLibur/Excel/PivotTables/Areas/XLPivotTableFilters.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotTableFilters.cs
@@ -112,7 +112,7 @@ internal sealed class XLPivotTableFilters : IXLPivotFields
     internal XLPivotTablePageField Add(string sourceName, string customName)
     {
         if (sourceName == XLConstants.PivotTable.ValuesSentinalLabel)
-            throw new ArgumentException(nameof(sourceName), $"The column '{sourceName}' does not appear in the source range.");
+            throw new ArgumentException($"The column '{sourceName}' does not appear in the source range.", nameof(sourceName));
 
         var heightDifference = GetHeightDifference(1);
         var movedArea = _pivotTable.Area.ShiftRows(heightDifference);

--- a/XLibur/Excel/PivotTables/XLPivotCacheValue.cs
+++ b/XLibur/Excel/PivotTables/XLPivotCacheValue.cs
@@ -35,7 +35,7 @@ internal readonly struct XLPivotCacheValue
     internal static XLPivotCacheValue ForNumber(double number)
     {
         if (double.IsNaN(number) || double.IsInfinity(number))
-            throw new ArgumentOutOfRangeException();
+            throw new ArgumentOutOfRangeException(nameof(number), number, "Value must be a finite number.");
 
         return new XLPivotCacheValue(XLPivotCacheValueType.Number, number);
     }

--- a/XLibur/Excel/PivotTables/XLPivotPageField.cs
+++ b/XLibur/Excel/PivotTables/XLPivotPageField.cs
@@ -9,8 +9,7 @@ internal sealed class XLPivotPageField
 {
     internal XLPivotPageField(int field)
     {
-        if (field < 0)
-            throw new ArgumentOutOfRangeException();
+        ArgumentOutOfRangeException.ThrowIfNegative(field);
 
         Field = field;
     }

--- a/XLibur/Excel/PivotTables/XLPivotTable.cs
+++ b/XLibur/Excel/PivotTables/XLPivotTable.cs
@@ -1064,8 +1064,7 @@ internal sealed class XLPivotTable : IXLPivotTable
         get => _filterFieldsPageWrap;
         set
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException();
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             _filterFieldsPageWrap = value;
         }

--- a/XLibur/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/XLibur/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -138,7 +138,7 @@ internal sealed class XLRangeConsolidationEngine
             }
         }
 
-        private void ClearRangeInRow(BitArray rowArray, Tuple<int, int> rangeBoundaries)
+        private static void ClearRangeInRow(BitArray rowArray, Tuple<int, int> rangeBoundaries)
         {
             for (var i = rangeBoundaries.Item1; i <= rangeBoundaries.Item2; i++)
             {
@@ -157,7 +157,7 @@ internal sealed class XLRangeConsolidationEngine
                 _bitMatrix.Values.All(r => !r[0] && !r[^1]));
         }
 
-        private IEnumerable<Tuple<int, int>> GetRangesBoundariesStartingByRow(BitArray rowArray)
+        private static IEnumerable<Tuple<int, int>> GetRangesBoundariesStartingByRow(BitArray rowArray)
         {
             var startIdx = 0;
             for (var i = 1; i < rowArray.Length - 1; i++)
@@ -195,7 +195,7 @@ internal sealed class XLRangeConsolidationEngine
             }
         }
 
-        private bool RowIncludesRange(BitArray rowArray, Tuple<int, int> rangeBoundaries)
+        private static bool RowIncludesRange(BitArray rowArray, Tuple<int, int> rangeBoundaries)
         {
             for (var i = rangeBoundaries.Item1; i <= rangeBoundaries.Item2; i++)
             {

--- a/XLibur/Excel/Sparkline/XLSparkLineGroup.cs
+++ b/XLibur/Excel/Sparkline/XLSparkLineGroup.cs
@@ -254,11 +254,8 @@ internal sealed class XLSparklineGroup : IXLSparklineGroup
 
     public IXLSparklineGroup SetDateRange(IXLRange? value)
     {
-        if (value != null)
-        {
-            if (value.RowCount() != 1 && value.ColumnCount() != 1)
-                throw new ArgumentException("The date range must be either one row high or one column wide");
-        }
+        if (value != null && value.RowCount() != 1 && value.ColumnCount() != 1)
+            throw new ArgumentException("The date range must be either one row high or one column wide");
 
         _dateRange = value;
         return this;

--- a/XLibur/Excel/Style/XLAlignment.cs
+++ b/XLibur/Excel/Style/XLAlignment.cs
@@ -320,23 +320,23 @@ internal sealed class XLAlignment : IXLAlignment
     {
         var sb = new StringBuilder();
         sb.Append(Horizontal);
-        sb.Append("-");
+        sb.Append('-');
         sb.Append(Vertical);
-        sb.Append("-");
+        sb.Append('-');
         sb.Append(Indent);
-        sb.Append("-");
+        sb.Append('-');
         sb.Append(JustifyLastLine);
-        sb.Append("-");
+        sb.Append('-');
         sb.Append(ReadingOrder);
-        sb.Append("-");
+        sb.Append('-');
         sb.Append(RelativeIndent);
-        sb.Append("-");
+        sb.Append('-');
         sb.Append(ShrinkToFit);
-        sb.Append("-");
+        sb.Append('-');
         sb.Append(TextRotation);
-        sb.Append("-");
+        sb.Append('-');
         sb.Append(WrapText);
-        sb.Append("-");
+        sb.Append('-');
         return sb.ToString();
     }
 

--- a/XLibur/Excel/XLSheetView.cs
+++ b/XLibur/Excel/XLSheetView.cs
@@ -76,7 +76,7 @@ internal sealed class XLSheetView : IXLSheetView
                     ZoomScaleSheetLayoutView = value;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException(nameof(View), View, "Unsupported sheet view option.");
             }
         }
     }

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -277,11 +277,8 @@ public partial class XLWorkbook : IXLWorkbook
             var first = split[0];
             var wsName = first.StartsWith("'") ? first.Substring(1, first.Length - 2) : first;
             var sheetlessName = split[1];
-            if (TryGetWorksheet(wsName, out XLWorksheet? ws))
-            {
-                if (ws.DefinedNames.TryGetScopedValue(sheetlessName, out var sheetDefinedName))
-                    return sheetDefinedName;
-            }
+            if (TryGetWorksheet(wsName, out XLWorksheet? ws) && ws.DefinedNames.TryGetScopedValue(sheetlessName, out var sheetDefinedName))
+                return sheetDefinedName;
 
             name = sheetlessName;
         }

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -1671,7 +1671,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
             case XLDataType.Error:
                 break;
             default:
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(value), value.Type, "Unexpected data type.");
         }
 
         return null;

--- a/XLibur/Extensions/StringExtensions.cs
+++ b/XLibur/Extensions/StringExtensions.cs
@@ -141,7 +141,7 @@ internal static partial class StringExtensions
     {
         if (magic.Length > 4)
         {
-            throw new ArgumentException();
+            throw new ArgumentException("Magic text must be at most 4 characters.", nameof(magic));
         }
 
         return Encoding.ASCII.GetBytes(magic).Select(x => (uint)x).Aggregate((acc, cur) => acc * 256 + cur);

--- a/XLibur/Extensions/XLErrorExtensions.cs
+++ b/XLibur/Extensions/XLErrorExtensions.cs
@@ -16,7 +16,7 @@ internal static class XLErrorExtensions
             XLError.NoValueAvailable => "#N/A",
             XLError.NullValue => "#NULL!",
             XLError.NumberInvalid => "#NUM!",
-            _ => throw new ArgumentOutOfRangeException()
+            _ => throw new ArgumentOutOfRangeException(nameof(error), error, "Unknown XLError value.")
         };
 }
 

--- a/XLibur/Graphics/DefaultGraphicEngine.cs
+++ b/XLibur/Graphics/DefaultGraphicEngine.cs
@@ -68,7 +68,7 @@ public class DefaultGraphicEngine : IXLGraphicEngine
     public DefaultGraphicEngine(string fallbackFont)
     {
         if (string.IsNullOrWhiteSpace(fallbackFont))
-            throw new ArgumentException(nameof(fallbackFont));
+            throw new ArgumentException("Fallback font name must not be null or whitespace.", nameof(fallbackFont));
 
         var fontCollection = new FontCollection();
         AddEmbeddedFont(fontCollection);
@@ -172,7 +172,7 @@ public class DefaultGraphicEngine : IXLGraphicEngine
         return GetDescent(font, dpiY, metrics);
     }
 
-    private double GetDescent(IXLFontBase font, double dpiY, FontMetrics metrics)
+    private static double GetDescent(IXLFontBase font, double dpiY, FontMetrics metrics)
     {
         return PointsToPixels(-metrics.VerticalMetrics.Descender * font.FontSize / metrics.UnitsPerEm, dpiY);
     }
@@ -272,7 +272,7 @@ public class DefaultGraphicEngine : IXLGraphicEngine
         return fontFamily.CreateFont(FontMetricSize); // Size is irrelevant for metric
     }
 
-    private void AddEmbeddedFont(FontCollection fontCollection)
+    private static void AddEmbeddedFont(FontCollection fontCollection)
     {
         var assembly = Assembly.GetExecutingAssembly();
         const string resourcePath = "XLibur.Graphics.Fonts.CarlitoBare-{0}.ttf";

--- a/XLibur/Graphics/JpegInfoReader.cs
+++ b/XLibur/Graphics/JpegInfoReader.cs
@@ -105,6 +105,9 @@ internal sealed class JpegInfoReader : ImageInfoReader
         if (!stream.TryReadU16BE(out length))
             return false;
 
+        if (length < 2)
+            return false;
+
         length -= 2;
         return true;
     }

--- a/XLibur/Graphics/JpegInfoReader.cs
+++ b/XLibur/Graphics/JpegInfoReader.cs
@@ -92,7 +92,7 @@ internal sealed class JpegInfoReader : ImageInfoReader
         throw new ArgumentException("SOF not found in the JFIF.");
     }
 
-    private bool TryGetMarker(Stream stream, out ushort marker)
+    private static bool TryGetMarker(Stream stream, out ushort marker)
     {
         if (!stream.TryReadU16BE(out marker))
             return false;
@@ -100,7 +100,7 @@ internal sealed class JpegInfoReader : ImageInfoReader
         return marker >> 8 == 0xFF;
     }
 
-    private bool TryGetLength(Stream stream, out ushort length)
+    private static bool TryGetLength(Stream stream, out ushort length)
     {
         if (!stream.TryReadU16BE(out length))
             return false;
@@ -108,7 +108,7 @@ internal sealed class JpegInfoReader : ImageInfoReader
         length -= 2;
         return true;
     }
-    private double ConvertToDpi(int density, byte units)
+    private static double ConvertToDpi(int density, byte units)
     {
         return units switch
         {

--- a/XLibur/XLHelper.cs
+++ b/XLibur/XLHelper.cs
@@ -402,7 +402,7 @@ public static partial class XLHelper
             return false;
         }
 
-        if (new[] { 'C', 'R' }.Any(c => newName.ToUpper().Equals(c.ToString())))
+        if (newName.Equals("C", StringComparison.OrdinalIgnoreCase) || newName.Equals("R", StringComparison.OrdinalIgnoreCase))
         {
             message = $"The {objectType} name '{newName}' is invalid";
             return false;


### PR DESCRIPTION
## Summary
- **CA1822** (42 issues): Mark methods that don't access instance data as `static`, including call-site updates for `InsertDataReaderFactory` and `CalcContext`
- **CA2208 + S3928** (33 issues): Add `paramName` and descriptive messages to `ArgumentNullException`, `ArgumentOutOfRangeException`, and `ArgumentException` constructors; fix swapped paramName/message arguments
- **CA1861** (21 issues): Extract inline constant array arguments to `private static readonly` fields; replace `new[] { 'C', 'R' }.Any(...)` with direct string comparison in `XLHelper`
- **S1066** (10 issues): Merge nested `if` statements with enclosing ones using `&&`
- **CA1512** (10 issues): Replace manual throw patterns with .NET 8+ `ThrowIfLessThan`, `ThrowIfNegative`, `ThrowIfNegativeOrZero`, `ThrowIfGreaterThan`
- **CA1834** (10 issues): Use `StringBuilder.Append(char)` instead of `Append(string)` for single-character constants

## Test plan
- [x] All 5,941 tests pass on both net8.0 and net10.0
- [x] Build succeeds with 0 warnings, 0 errors across all projects (XLibur, XLibur.Tests, XLibur.Examples)
- [ ] CI build and test pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting with clearer exception messages and parameter details for more actionable diagnostics.
  * Tightened input validation to fail earlier with descriptive errors.

* **Refactor**
  * Consolidated internal conditionals and simplified helper usage for clearer, more maintainable code.
  * Standardized internal factory and helper access patterns to reduce redundancy without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->