### PR TITLE
fix: resolve SonarQube S3881/S3928 IDisposable and exception type issues

### DIFF
--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
@@ -182,8 +182,8 @@ internal class XLPivotTableAxisTests
         pt.ColumnLabels.Add("Color");
 
         Assert.AreEqual("ID", pt.RowLabels.Get(0).SourceName);
-        Assert.Throws<IndexOutOfRangeException>(() => pt.RowLabels.Get(-2));
-        Assert.Throws<IndexOutOfRangeException>(() => pt.RowLabels.Get(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => pt.RowLabels.Get(-2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => pt.RowLabels.Get(1));
     }
 
     #endregion

--- a/XLibur.Tests/Excel/RichText/XLRichStringTests.cs
+++ b/XLibur.Tests/Excel/RichText/XLRichStringTests.cs
@@ -596,7 +596,7 @@ public class XLRichStringTests
 
         richString.AddText("Hello");
 
-        Assert.That(() => richString.Substring(50), Throws.TypeOf<IndexOutOfRangeException>());
+        Assert.That(() => richString.Substring(50), Throws.TypeOf<ArgumentOutOfRangeException>());
     }
 
     [Test]
@@ -608,7 +608,7 @@ public class XLRichStringTests
         richString.AddText("Hello");
         richString.AddText("World");
 
-        Assert.That(() => richString.Substring(50), Throws.TypeOf<IndexOutOfRangeException>());
+        Assert.That(() => richString.Substring(50), Throws.TypeOf<ArgumentOutOfRangeException>());
     }
 
     [Test]
@@ -619,7 +619,7 @@ public class XLRichStringTests
 
         richString.AddText("Hello");
 
-        Assert.That(() => richString.Substring(1, 10), Throws.TypeOf<IndexOutOfRangeException>());
+        Assert.That(() => richString.Substring(1, 10), Throws.TypeOf<ArgumentOutOfRangeException>());
     }
 
     [Test]
@@ -631,7 +631,7 @@ public class XLRichStringTests
         richString.AddText("Hello");
         richString.AddText("World");
 
-        Assert.That(() => richString.Substring(5, 20), Throws.TypeOf<IndexOutOfRangeException>());
+        Assert.That(() => richString.Substring(5, 20), Throws.TypeOf<ArgumentOutOfRangeException>());
     }
 
     [Test]

--- a/XLibur/Excel/CalcEngine/Array.cs
+++ b/XLibur/Excel/CalcEngine/Array.cs
@@ -227,7 +227,7 @@ internal sealed class RepeatedColumnArray : Array
         get
         {
             if (row >= Height || column >= Width)
-                throw new IndexOutOfRangeException();
+                throw new ArgumentOutOfRangeException();
 
             if (row >= _columnArray.Height)
                 return XLError.NoValueAvailable;
@@ -258,7 +258,7 @@ internal sealed class RepeatedRowArray : Array
         get
         {
             if (row >= Height || column >= Width)
-                throw new IndexOutOfRangeException();
+                throw new ArgumentOutOfRangeException();
 
             if (column >= _rowArray.Width)
                 return XLError.NoValueAvailable;
@@ -291,7 +291,7 @@ internal sealed class ResizedArray : Array
         get
         {
             if (y >= Height || x >= Width)
-                throw new IndexOutOfRangeException();
+                throw new ArgumentOutOfRangeException();
 
             return y < _original.Height && x < _original.Width
                 ? _original[y, x]
@@ -325,7 +325,7 @@ internal sealed class ScalarArray : Array
         get
         {
             if (x < 0 || x >= Width || y < 0 || y >= Height)
-                throw new IndexOutOfRangeException();
+                throw new ArgumentOutOfRangeException();
 
             return _value;
         }

--- a/XLibur/Excel/Cells/SharedStringTable.cs
+++ b/XLibur/Excel/Cells/SharedStringTable.cs
@@ -34,7 +34,7 @@ internal sealed class SharedStringTable
 
     /// <summary>
     /// Release all entries so the memory can be reclaimed by GC.
-    /// Called from <see cref="XLWorkbook.Dispose"/>.
+    /// Called from <see cref="XLWorkbook.Dispose()"/>.
     /// </summary>
     internal void Clear()
     {

--- a/XLibur/Excel/Cells/Slice.cs
+++ b/XLibur/Excel/Cells/Slice.cs
@@ -384,6 +384,9 @@ internal sealed partial class Slice<TElement> : ISlice
 
         object IEnumerator.Current => Point;
 
-        public void Dispose() { }
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/XLibur/Excel/PivotTables/Areas/XLPivotTableAxis.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotTableAxis.cs
@@ -70,7 +70,7 @@ internal sealed class XLPivotTableAxis : IXLPivotFields
     IXLPivotField IXLPivotFields.Get(int index)
     {
         if (index < 0 || index >= _fields.Count)
-            throw new IndexOutOfRangeException();
+            throw new ArgumentOutOfRangeException(nameof(index));
 
         return new XLPivotTableAxisField(_pivotTable, _fields[index]);
     }

--- a/XLibur/Excel/PivotTables/Areas/XLPivotTableFilters.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotTableFilters.cs
@@ -64,7 +64,7 @@ internal sealed class XLPivotTableFilters : IXLPivotFields
     public IXLPivotField Get(int index)
     {
         if (index < 0 || index >= _fields.Count)
-            throw new IndexOutOfRangeException();
+            throw new ArgumentOutOfRangeException(nameof(index));
 
         return new XLPivotTablePageField(_pivotTable, _fields[index]);
     }

--- a/XLibur/Excel/RichText/XLFormattedText.cs
+++ b/XLibur/Excel/RichText/XLFormattedText.cs
@@ -107,7 +107,7 @@ internal class XLFormattedText<T> : IXLFormattedText<T>
     public IXLFormattedText<T> Substring(int index, int length)
     {
         if (index + 1 > Length || Length - index + 1 < length || length <= 0)
-            throw new IndexOutOfRangeException("Index and length must refer to a location within the string.");
+            throw new ArgumentOutOfRangeException(nameof(index), "Index and length must refer to a location within the string.");
 
         var newRichTexts = new List<XLRichString>();
         var retVal = new XLFormattedText<T>(_defaultFont);

--- a/XLibur/Excel/Style/XLBorder.cs
+++ b/XLibur/Excel/Style/XLBorder.cs
@@ -636,6 +636,7 @@ internal sealed class XLBorder : IXLBorder
                     RightBorder = kp.Value.RightBorder,
                     RightBorderColor = kp.Value.RightBorderColor,
                 }));
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/XLibur/Excel/XLInCellImageStore.cs
+++ b/XLibur/Excel/XLInCellImageStore.cs
@@ -21,7 +21,7 @@ internal sealed class XLInCellImageStore : IDisposable
 
     /// <summary>
     /// Dispose all held <see cref="MemoryStream"/>s and release collections.
-    /// Called from <see cref="XLWorkbook.Dispose"/>.
+    /// Called from <see cref="XLWorkbook.Dispose()"/>.
     /// </summary>
     public void Dispose()
     {

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -812,6 +812,15 @@ public partial class XLWorkbook : IXLWorkbook
 
     public void Dispose()
     {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing)
+            return;
+
         Worksheets.ForEach(w => ((XLWorksheet)w).Cleanup());
 
         // Release calc engine and its heavy structures (DependencyTree,

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -38,7 +38,7 @@ public partial class XLWorkbook
 
         if (!errors.Any()) return;
         var message = string.Join("\r\n", errors.Select(e => $"Part {e.Part?.Uri}, Path {e.Path?.XPath}: {e.Description}").ToArray());
-        throw new ApplicationException(message);
+        throw new InvalidOperationException(message);
     }
 
     private void CreatePackage(string filePath, SpreadsheetDocumentType spreadsheetDocumentType, SaveOptions options)

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
 static XLibur.Excel.IO.PartStructureException.IncorrectElementFormat(string! elementName) -> XLibur.Excel.IO.PartStructureException!
 static XLibur.Excel.IO.PartStructureException.RequiredElementIsMissing() -> XLibur.Excel.IO.PartStructureException!
+virtual XLibur.Excel.XLWorkbook.Dispose(bool disposing) -> void
 XLibur.Excel.IO.PartStructureException


### PR DESCRIPTION
## Summary
- **S3881**: Fix IDisposable pattern conformance in 3 classes:
  - `XLWorkbook`: implement proper `Dispose(bool disposing)` pattern for unsealed public class
  - `Slice.ReverseEnumerator`: add `GC.SuppressFinalize` to sealed class Dispose
  - `XLBorder.RestoreOutsideBorder`: add `GC.SuppressFinalize` to sealed class Dispose
- **S3928**: Replace reserved exception types that should not be thrown by user code:
  - `IndexOutOfRangeException` → `ArgumentOutOfRangeException` in Array.cs, XLPivotTableAxis, XLPivotTableFilters, XLFormattedText
  - `ApplicationException` → `InvalidOperationException` in XLWorkbook_Save
- Update 6 test assertions to expect `ArgumentOutOfRangeException`

## Test plan
- [x] All 5941 tests pass on both net8.0 and net10.0
- [x] Zero build warnings
- [ ] Verify SonarQube S3881/S3928 issues are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling throughout the library by using more precise error types for invalid parameter values.
  * Enhanced resource cleanup and disposal pattern for more deterministic resource management and finalization.

* **Tests**
  * Updated test cases to reflect corrected exception types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->