### PR TITLE
fix: resolve miscellaneous SonarQube and Roslyn code smells

### DIFF
--- a/XLibur.Tests/Excel/Comments/CommentsTests.cs
+++ b/XLibur.Tests/Excel/Comments/CommentsTests.cs
@@ -5,12 +5,13 @@ using System;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using XLibur.Extensions;
 
 namespace XLibur.Tests.Excel.Comments;
 
-public class CommentsTests
+public partial class CommentsTests
 {
     [Test]
     public void CanConvertVmlPaletteEntriesToColors()
@@ -245,7 +246,7 @@ public class CommentsTests
         // Verify that the height was auto-sized to be larger than default 59.25pt.
         // The lorem ipsum text at Tahoma 9pt in 144pt-wide box wraps to 5 lines,
         // requiring more height than the default 59.25pt.
-        var heightMatch = System.Text.RegularExpressions.Regex.Match(vmlStr, @"height:(\d+\.?\d*)pt");
+        var heightMatch = HeightPattern().Match(vmlStr);
         Assert.That(heightMatch.Success, Is.True);
         var height = double.Parse(heightMatch.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
         Assert.That(height, Is.GreaterThan(59.25));
@@ -291,4 +292,7 @@ public class CommentsTests
             Assert.That(ws.Cell("A1").HasComment, Is.True);
         });
     }
+
+    [GeneratedRegex(@"height:(\d+\.?\d*)pt")]
+    private static partial Regex HeightPattern();
 }

--- a/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
+++ b/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
@@ -15,14 +15,14 @@ public class SparklinesTests
     [Test]
     public void CannotCreateSparklineGroupsWithoutWorksheet()
     {
-        TestDelegate action = () => new XLSparklineGroups(null);
+        TestDelegate action = () => _ = new XLSparklineGroups(null);
         Assert.Throws<ArgumentNullException>(action);
     }
 
     [Test]
     public void CannotCreateSparklineGroupWithoutWorksheet()
     {
-        TestDelegate action = () => new XLSparklineGroup(null);
+        TestDelegate action = () => _ = new XLSparklineGroup(null);
         Assert.Throws<ArgumentNullException>(action);
     }
 
@@ -30,7 +30,7 @@ public class SparklinesTests
     public void CannotCreateSparklineWithoutGroup()
     {
         var ws = new XLWorkbook().AddWorksheet("Sheet1");
-        TestDelegate action = () => new XLSparkline(null, ws.Cell("A1"), ws.Range("A2:A5"));
+        TestDelegate action = () => _ = new XLSparkline(null, ws.Cell("A1"), ws.Range("A2:A5"));
         Assert.Throws<ArgumentNullException>(action);
     }
 
@@ -39,7 +39,7 @@ public class SparklinesTests
     {
         var ws = new XLWorkbook().AddWorksheet("Sheet1");
         var group = new XLSparklineGroup(ws);
-        TestDelegate action = () => new XLSparkline(group, null, ws.Range("A2:A5"));
+        TestDelegate action = () => _ = new XLSparkline(group, null, ws.Range("A2:A5"));
         Assert.Throws<ArgumentNullException>(action);
     }
 

--- a/XLibur/Excel/Caching/XLWorkbookElementRepositoryBase.cs
+++ b/XLibur/Excel/Caching/XLWorkbookElementRepositoryBase.cs
@@ -12,12 +12,12 @@ internal abstract class XLWorkbookElementRepositoryBase<Tkey, Tvalue> : XLReposi
 {
     public XLWorkbook Workbook { get; private set; }
 
-    public XLWorkbookElementRepositoryBase(XLWorkbook workbook, Func<Tkey, Tvalue> createNew)
+    protected XLWorkbookElementRepositoryBase(XLWorkbook workbook, Func<Tkey, Tvalue> createNew)
         : this(workbook, createNew, EqualityComparer<Tkey>.Default)
     {
     }
 
-    public XLWorkbookElementRepositoryBase(XLWorkbook workbook, Func<Tkey, Tvalue> createNew, IEqualityComparer<Tkey> comparer)
+    protected XLWorkbookElementRepositoryBase(XLWorkbook workbook, Func<Tkey, Tvalue> createNew, IEqualityComparer<Tkey> comparer)
         : base(createNew, comparer)
     {
         Workbook = workbook;

--- a/XLibur/Excel/CalcEngine/Functions/Text.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Text.cs
@@ -709,7 +709,7 @@ internal static class Text
             return error;
 
         const string percentSign = "%";
-        var isPercent = text!.IndexOf(percentSign, StringComparison.Ordinal) >= 0;
+        var isPercent = text!.Contains(percentSign, StringComparison.Ordinal);
         var textWithoutPercent = isPercent ? text.Replace(percentSign, string.Empty) : text;
         if (double.TryParse(textWithoutPercent, NumberStyles.Any, ctx.Culture, out var parsedNumber))
             return isPercent ? parsedNumber / 100d : parsedNumber;

--- a/XLibur/Excel/CalcEngine/ScalarValue.cs
+++ b/XLibur/Excel/CalcEngine/ScalarValue.cs
@@ -448,6 +448,7 @@ internal readonly struct ScalarValue
         switch (_index)
         {
             case BlankValue:
+            case TextValue when (StringComparer.OrdinalIgnoreCase.Equals(_text!, "FALSE")):
                 value = false;
                 error = default;
                 return true;
@@ -461,10 +462,6 @@ internal readonly struct ScalarValue
                 return true;
             case TextValue when (StringComparer.OrdinalIgnoreCase.Equals(_text!, "TRUE")):
                 value = true;
-                error = default;
-                return true;
-            case TextValue when (StringComparer.OrdinalIgnoreCase.Equals(_text!, "FALSE")):
-                value = false;
                 error = default;
                 return true;
             case ErrorValue:

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -120,7 +120,7 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
 
     #region Constructors
 
-    private XLConditionalFormat(XLStyleValue style)
+    private XLConditionalFormat()
         : base(XLStyle.Default.Value)
     {
         Id = Guid.NewGuid();
@@ -132,7 +132,7 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
     }
 
     public XLConditionalFormat(XLRange range, bool copyDefaultModify = false)
-        : this(XLStyle.Default.Value)
+        : this()
     {
         if (range != null)
             Ranges.Add(range);
@@ -140,7 +140,7 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
     }
 
     public XLConditionalFormat(IEnumerable<XLRange> ranges, bool copyDefaultModify = false)
-        : this(XLStyle.Default.Value)
+        : this()
     {
         ranges?.ForEach(range => Ranges.Add(range));
         CopyDefaultModify = copyDefaultModify;
@@ -152,7 +152,7 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
     }
 
     public XLConditionalFormat(XLConditionalFormat conditionalFormat, IEnumerable<IXLRange> targetRanges)
-        : this(conditionalFormat.StyleValue)
+        : this()
     {
         targetRanges?.ForEach(range => Ranges.Add(range));
         CopyFrom(conditionalFormat);

--- a/XLibur/Excel/Coordinates/XLSheetPoint.cs
+++ b/XLibur/Excel/Coordinates/XLSheetPoint.cs
@@ -132,8 +132,9 @@ internal readonly struct XLSheetPoint : IEquatable<XLSheetPoint>, IComparable<XL
             return false;
 
         var columnIndex = c - 'A' + 1;
-        while (i < input.Length && IsLetter(c = input[i]))
+        while (i < input.Length && IsLetter(input[i]))
         {
+            c = input[i];
             columnIndex = columnIndex * 26 + c - 'A' + 1;
             i++;
         }
@@ -152,8 +153,9 @@ internal readonly struct XLSheetPoint : IEquatable<XLSheetPoint>, IComparable<XL
             return false;
 
         var rowIndex = c - '0';
-        while (i < input.Length && IsDigit(c = input[i]))
+        while (i < input.Length && IsDigit(input[i]))
         {
+            c = input[i];
             rowIndex = rowIndex * 10 + c - '0';
             i++;
         }

--- a/XLibur/Excel/DefinedNames/XLDefinedNames.cs
+++ b/XLibur/Excel/DefinedNames/XLDefinedNames.cs
@@ -34,7 +34,7 @@ internal sealed class XLDefinedNames : IXLDefinedNames, IEnumerable<XLDefinedNam
 
     #region IXLNamedRanges Members
 
-    [Obsolete]
+    [Obsolete("Use DefinedName instead.")]
     IXLDefinedName IXLDefinedNames.NamedRange(string name) => DefinedName(name);
 
     IXLDefinedName IXLDefinedNames.DefinedName(string name) => DefinedName(name);
@@ -105,7 +105,7 @@ internal sealed class XLDefinedNames : IXLDefinedNames, IEnumerable<XLDefinedNam
                 "The range address '{0}' for the named range '{1}' is not a valid range.", rangeAddress,
                 name));
 
-        if (Scope == XLNamedRangeScope.Workbook && !XLHelper.NamedRangeReferenceRegex.Match(range.ToString()!).Success)
+        if (Scope == XLNamedRangeScope.Workbook && !XLHelper.NamedRangeReferenceRegex.IsMatch(range.ToString()!))
             throw new ArgumentException(
                 "For named ranges in the workbook scope, specify the sheet name in the reference.");
 

--- a/XLibur/Excel/Drawings/XLMarker.cs
+++ b/XLibur/Excel/Drawings/XLMarker.cs
@@ -4,7 +4,7 @@ using System.Drawing;
 
 namespace XLibur.Excel.Drawings;
 
-[DebuggerDisplay("{Address} {Offset}")]
+[DebuggerDisplay("R{RowNumber}C{ColumnNumber} {Offset}")]
 internal sealed class XLMarker
 {
     // Using a range to store the location so that it gets added to the range repository

--- a/XLibur/Excel/IO/DefinedNameReader.cs
+++ b/XLibur/Excel/IO/DefinedNameReader.cs
@@ -108,7 +108,7 @@ internal static class DefinedNameReader
         var fixedNames = ValidateDefinedNames(definedName.Text.Split(','));
         foreach (var area in fixedNames)
         {
-            if (area.Contains("["))
+            if (area.Contains('['))
             {
                 var ws = xlWorkbook.WorksheetsInternal.FirstOrDefault<XLWorksheet>(w => w.SheetId == (localSheetId + 1));
                 if (ws != null)

--- a/XLibur/Excel/IO/DrawingPartReader.cs
+++ b/XLibur/Excel/IO/DrawingPartReader.cs
@@ -67,7 +67,7 @@ internal static class DrawingPartReader
                 if (!drawingsPart.TryGetPartById(imgId, out var imagePart))
                     continue;
 
-                var picture = LoadPictureFromAnchor(drawingsPart, anchor, imgId, imagePart, ws);
+                var picture = LoadPictureFromAnchor(anchor, imgId, imagePart, ws);
                 if (picture is null)
                     continue;
 
@@ -253,12 +253,12 @@ internal static class DrawingPartReader
         var sizeWithCellsElement = clientData.Elements().FirstOrDefault(e => e.Name.LocalName == "SizeWithCells");
         var moveWithCells = !(moveWithCellsElement != null && moveWithCellsElement.Value.ToLower() == "true");
         var sizeWithCells = !(sizeWithCellsElement != null && sizeWithCellsElement.Value.ToLower() == "true");
-        if (moveWithCells && !sizeWithCells)
-            drawing.Style.Properties.Positioning = XLDrawingAnchor.MoveWithCells;
-        else if (moveWithCells && sizeWithCells)
+        if (!moveWithCells)
+            drawing.Style.Properties.Positioning = XLDrawingAnchor.Absolute;
+        else if (sizeWithCells)
             drawing.Style.Properties.Positioning = XLDrawingAnchor.MoveAndSizeWithCells;
         else
-            drawing.Style.Properties.Positioning = XLDrawingAnchor.Absolute;
+            drawing.Style.Properties.Positioning = XLDrawingAnchor.MoveWithCells;
     }
 
     internal static void LoadClientDataAnchor<T>(IXLDrawing<T> drawing, XElement anchor)
@@ -338,7 +338,7 @@ internal static class DrawingPartReader
         return name.Replace("_x000a_", Environment.NewLine).Replace("_x005f_x000a_", "_x000a_");
     }
 
-    private static XLPicture? LoadPictureFromAnchor(DrawingsPart drawingsPart,
+    private static XLPicture? LoadPictureFromAnchor(
         DocumentFormat.OpenXml.OpenXmlElement anchor, string imgId,
         DocumentFormat.OpenXml.Packaging.OpenXmlPart imagePart, XLWorksheet ws)
     {

--- a/XLibur/Excel/IO/RichDataReader.cs
+++ b/XLibur/Excel/IO/RichDataReader.cs
@@ -255,7 +255,7 @@ internal static class RichDataReader
             if (rc?.TypeIndex?.Value == richValueTypeIndex)
             {
                 var fmIndex = (int)(rc.Val?.Value ?? 0);
-                var rvIndex = FindRvIndexFromFutureMetadata(metadata, richValueTypeIndex.Value, fmIndex);
+                var rvIndex = FindRvIndexFromFutureMetadata(metadata, fmIndex);
                 result[vmIndex] = rvIndex;
             }
 
@@ -268,7 +268,7 @@ internal static class RichDataReader
     /// <summary>
     /// Find the rv index from futureMetadata block at the given index for XLRICHVALUE type.
     /// </summary>
-    private static int FindRvIndexFromFutureMetadata(Metadata metadata, uint typeIndex, int blockIndex)
+    private static int FindRvIndexFromFutureMetadata(Metadata metadata, int blockIndex)
     {
         // Find the futureMetadata element with name "XLRICHVALUE"
         foreach (var fm in metadata.Elements<FutureMetadata>())

--- a/XLibur/Excel/IO/VmlDrawingPartWriter.cs
+++ b/XLibur/Excel/IO/VmlDrawingPartWriter.cs
@@ -95,7 +95,7 @@ internal static class VmlDrawingPartWriter
         // Unique per cell (workbook?), e.g.: "_x0000_s1026"
         var anchor = GetAnchor(c, effectiveWidth, effectiveHeight);
         var textBox = GetTextBox(comment.Style);
-        var fill = new Vml.Fill { Color2 = "#" + comment.Style.ColorsAndLines.FillColor.Color.ToHex().Substring(2) };
+        var fill = new Vml.Fill { Color2 = string.Concat("#", comment.Style.ColorsAndLines.FillColor.Color.ToHex().AsSpan(2)) };
         if (comment.Style.ColorsAndLines.FillTransparency < 1)
             fill.Opacity =
                 Math.Round(Convert.ToDouble(comment.Style.ColorsAndLines.FillTransparency), 2).ToInvariantString();

--- a/XLibur/Excel/Ranges/IXLBaseCollection.cs
+++ b/XLibur/Excel/Ranges/IXLBaseCollection.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace XLibur.Excel;
 
-public interface IXLBaseCollection<TSingle, TMultiple> : IEnumerable<TSingle>
+public interface IXLBaseCollection<out TSingle, TMultiple> : IEnumerable<TSingle>
 {
     int Count { get; }
 

--- a/XLibur/Excel/Ranges/Index/XLRangeIndex.cs
+++ b/XLibur/Excel/Ranges/Index/XLRangeIndex.cs
@@ -13,7 +13,7 @@ internal abstract class XLRangeIndex : IXLRangeIndex
 {
     #region Public Constructors
 
-    public XLRangeIndex(IXLWorksheet worksheet)
+    protected XLRangeIndex(IXLWorksheet worksheet)
     {
         _worksheet = worksheet;
         _rangeList = [];

--- a/XLibur/Excel/Style/Colors/XLColor_Public.cs
+++ b/XLibur/Excel/Style/Colors/XLColor_Public.cs
@@ -28,7 +28,7 @@ public enum XLThemeColor
     FollowedHyperlink
 }
 
-public partial class XLColor : IEquatable<XLColor>
+public sealed partial class XLColor : IEquatable<XLColor>
 {
     public bool HasValue { get; private set; }
 

--- a/XLibur/Excel/Style/Colors/XLColor_Static.cs
+++ b/XLibur/Excel/Style/Colors/XLColor_Static.cs
@@ -153,10 +153,10 @@ public partial class XLColor
         // ST_ColorType can have an *optional* index to a palette (*system* palette, not indexed colors),
         // but it only brings trouble because VML is used pretty much only for unusual features like notes,
         // form controls ect. Ignore the palette entry completely, it is a legacy feature from times of 256 colors.
-        var paletteIndexStart = colorType.IndexOf("[", StringComparison.Ordinal);
+        var paletteIndexStart = colorType.IndexOf('[', StringComparison.Ordinal);
         var hasPaletteEntry = paletteIndexStart >= 0;
         colorType = hasPaletteEntry ? colorType.Substring(0, paletteIndexStart).Trim() : colorType;
-        if (colorType.StartsWith("#", StringComparison.Ordinal))
+        if (colorType.StartsWith('#'))
             return FromHtml(colorType);
 
         if (_paletteEntries.Value.TryGetValue(colorType, out var xlColor))

--- a/XLibur/Excel/Style/IXLFont.cs
+++ b/XLibur/Excel/Style/IXLFont.cs
@@ -63,7 +63,8 @@ public enum XLFontCharSet
     /// <summary>
     /// Another common spelling of the Korean character set.
     /// </summary>
-    Hangeul = 129,
+    [Obsolete("Use Hangul instead.")]
+    Hangeul = Hangul,
 
     /// <summary>
     /// Korean character set.

--- a/XLibur/Excel/Style/XLBorder.cs
+++ b/XLibur/Excel/Style/XLBorder.cs
@@ -548,7 +548,7 @@ internal sealed class XLBorder : IXLBorder
         sb.Append('-');
         sb.Append(DiagonalBorderColor);
         sb.Append('-');
-        sb.Append(DiagonalUp.ToString());
+        sb.Append(DiagonalUp);
         sb.Append('-');
         sb.Append(DiagonalDown);
         return sb.ToString();

--- a/XLibur/Excel/XLCellValue.cs
+++ b/XLibur/Excel/XLCellValue.cs
@@ -462,6 +462,10 @@ public readonly struct XLCellValue : IEquatable<XLCellValue>, IEquatable<Blank>,
         }
     }
 
+    public static bool operator ==(XLCellValue left, XLCellValue right) => left.Equals(right);
+
+    public static bool operator !=(XLCellValue left, XLCellValue right) => !left.Equals(right);
+
     /// <summary>
     /// Get a value, if it is a <see cref="XLDataType.Text"/>.
     /// </summary>

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -823,6 +823,8 @@ public partial class XLWorkbook : IXLWorkbook
 
         // Dispose in-cell image MemoryStreams and release collections.
         InCellImages.Dispose();
+
+        GC.SuppressFinalize(this);
     }
 
 

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -1334,7 +1334,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
             return Range(new XLRangeAddress(Worksheet, rangeAddressStr));
 
         if (rangeAddressStr.Contains('['))
-            return Table(rangeAddressStr[..rangeAddressStr.IndexOf("[", StringComparison.Ordinal)]) as XLRange;
+            return Table(rangeAddressStr[..rangeAddressStr.IndexOf('[', StringComparison.Ordinal)]) as XLRange;
 
         if (DefinedNames.TryGetValue(rangeAddressStr, out var sheetDefinedName))
             return sheetDefinedName.Ranges.First().CastTo<XLRange>();

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
 static XLibur.Excel.IO.PartStructureException.IncorrectElementFormat(string! elementName) -> XLibur.Excel.IO.PartStructureException!
 static XLibur.Excel.IO.PartStructureException.RequiredElementIsMissing() -> XLibur.Excel.IO.PartStructureException!
+static XLibur.Excel.XLCellValue.operator ==(XLibur.Excel.XLCellValue left, XLibur.Excel.XLCellValue right) -> bool
+static XLibur.Excel.XLCellValue.operator !=(XLibur.Excel.XLCellValue left, XLibur.Excel.XLCellValue right) -> bool
 XLibur.Excel.IO.PartStructureException

--- a/XLibur/Utils/CryptographicAlgorithms.cs
+++ b/XLibur/Utils/CryptographicAlgorithms.cs
@@ -113,19 +113,15 @@ internal static class CryptographicAlgorithms
         var passwordBytes = Encoding.Unicode.GetBytes(password);
         var bytes = saltBytes.Concat(passwordBytes).ToArray();
 
-        byte[] hashedBytes;
-        using (var hash = SHA512.Create())
-        {
-            hashedBytes = hash.ComputeHash(bytes);
+        var hashedBytes = SHA512.HashData(bytes);
 
-            bytes = new byte[hashedBytes.Length + sizeof(uint)];
-            for (uint i = 0; i < spinCount; i++)
-            {
-                var le = BitConverter.GetBytes(i);
-                Array.Copy(hashedBytes, bytes, hashedBytes.Length);
-                Array.Copy(le, 0, bytes, hashedBytes.Length, le.Length);
-                hashedBytes = hash.ComputeHash(bytes);
-            }
+        bytes = new byte[hashedBytes.Length + sizeof(uint)];
+        for (uint i = 0; i < spinCount; i++)
+        {
+            var le = BitConverter.GetBytes(i);
+            Array.Copy(hashedBytes, bytes, hashedBytes.Length);
+            Array.Copy(le, 0, bytes, hashedBytes.Length, le.Length);
+            hashedBytes = SHA512.HashData(bytes);
         }
 
         return Convert.ToBase64String(hashedBytes);


### PR DESCRIPTION
## Summary
- Fix 21 code quality issues across 23 files from SonarQube and Roslyn analyzers
- Covers CA1806, CA1816, CA1830, CA1845, CA1847, CA1850, CA1865, CA1869, CA1874, CA2231, CA2249, S1121, S1123, S1172, S1871, S2589, S3246, S3442, S4035, S4545, SYSLIB1045
- Key changes: seal XLColor, add `==`/`!=` operators to XLCellValue, use static SHA512.HashData, add GC.SuppressFinalize to XLWorkbook.Dispose, make IXLBaseCollection TSingle covariant

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors (all 3 projects)
- [x] `dotnet test` — 5941 passed, 0 failed on both net8.0 and net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added equality operators (==, !=) for cell values.

* **Bug Fixes / Behavior**
  * Adjusted drawing/image positioning behavior.
  * Minor disposal/finalizer handling updated.

* **Deprecated**
  * The Hangeul enum member is now deprecated; use Hangul instead.

* **Performance**
  * Optimized cryptographic hashing for better efficiency.

* **Refactor**
  * Sealed color class, tightened some internal constructor/index visibility, and added interface variance tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->