### PR TITLE
fix: load and write alignment in pivot table DXF formats

### DIFF
--- a/XLibur.Tests/Excel/PivotTables/Style/XLPivotTableStyleFormatsTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/Style/XLPivotTableStyleFormatsTests.cs
@@ -1,4 +1,6 @@
-﻿using XLibur.Excel;
+﻿using System.IO;
+using System.Linq;
+using XLibur.Excel;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Excel.PivotTables.Style;
@@ -38,6 +40,59 @@ internal class XLPivotTableStyleFormatsTests
                 .ForElement(XLPivotStyleFormatElement.Data).Style
                 .Font.SetFontColor(XLColor.Red);
         }, @"Other\PivotTable\Style\Add_grand_row_total_styles.xlsx");
+    }
+
+    [Test]
+    public void Alignment_in_pivot_format_survives_round_trip()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var dataSheet = wb.AddWorksheet();
+            var dataRange = dataSheet.Cell("A1").InsertData(new object[]
+            {
+                ("Name", "Price"),
+                ("Cake", 9),
+                ("Pie", 7),
+                ("Cake", 3),
+            });
+
+            var ptSheet = wb.AddWorksheet().SetTabActive();
+            var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+            pt.RowLabels.Add("Name");
+            pt.Values.Add("Price");
+
+            // Set various alignment properties on the grand total format
+            pt.StyleFormats.RowGrandTotalFormats
+                .ForElement(XLPivotStyleFormatElement.All).Style
+                .Alignment.SetHorizontal(XLAlignmentHorizontalValues.Center)
+                .Alignment.SetVertical(XLAlignmentVerticalValues.Top)
+                .Alignment.SetWrapText(true)
+                .Alignment.SetTextRotation(45);
+
+            wb.SaveAs(ms);
+        }
+
+        ms.Seek(0, SeekOrigin.Begin);
+
+        using (var wb = new XLWorkbook(ms))
+        {
+            var pt = (XLPivotTable)wb.Worksheet(2).PivotTables.First();
+
+            // Check DxfStyleValue on the loaded format — the internal representation
+            // that proves alignment round-tripped through the DXF record.
+            var format = pt.Formats.First();
+            var alignment = format.DxfStyleValue.Alignment;
+            Assert.AreEqual(XLAlignmentHorizontalValues.Center, alignment.Horizontal);
+            Assert.AreEqual(XLAlignmentVerticalValues.Top, alignment.Vertical);
+            Assert.AreEqual(true, alignment.WrapText);
+            Assert.AreEqual(45, alignment.TextRotation);
+
+            // Non-set properties remain at defaults
+            Assert.AreEqual(0, alignment.Indent);
+            Assert.AreEqual(false, alignment.ShrinkToFit);
+            Assert.AreEqual(XLAlignmentReadingOrderValues.ContextDependent, alignment.ReadingOrder);
+        }
     }
 
     [Test]

--- a/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -171,12 +171,12 @@ internal static class PivotTableDefinitionPartReader
             var dxfStyle = XLStyle.Default;
             if (format.FormatId is not null)
             {
-                // TODO: What about alignment?
                 var df = differentialFormats[checked((int)format.FormatId.Value)];
                 OpenXmlHelper.LoadFont(df.Font, dxfStyle.Font);
                 OpenXmlHelper.LoadFill(df.Fill, dxfStyle.Fill, differentialFillFormat: true);
                 OpenXmlHelper.LoadBorder(df.Border, dxfStyle.Border);
                 OpenXmlHelper.LoadNumberFormat(df.NumberingFormat, dxfStyle.NumberFormat);
+                OpenXmlHelper.LoadAlignment(df.Alignment, dxfStyle.Alignment);
             }
 
             var pivotArea = format.PivotArea ?? throw PartStructureException.ExpectedElementNotFound();

--- a/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
@@ -483,6 +483,10 @@ internal static class WorkbookStylesPartWriter
         if (diffBorder?.HasChildren ?? false)
             differentialFormat.Append(diffBorder);
 
+        var diffAlignment = GetNewDifferentialAlignment(style.Alignment);
+        if (diffAlignment is not null)
+            differentialFormat.Append(diffAlignment);
+
         differentialFormats.Append(differentialFormat);
 
         context.DifferentialFormats.Add(style, differentialFormats.ChildElements.Count - 1);
@@ -723,6 +727,48 @@ internal static class WorkbookStylesPartWriter
         }
 
         return border;
+    }
+
+    private static Alignment? GetNewDifferentialAlignment(XLAlignmentValue alignment)
+    {
+        var d = XLAlignmentValue.Default;
+        if (alignment.Horizontal == d.Horizontal &&
+            alignment.Vertical == d.Vertical &&
+            alignment.Indent == d.Indent &&
+            alignment.ReadingOrder == d.ReadingOrder &&
+            alignment.WrapText == d.WrapText &&
+            alignment.TextRotation == d.TextRotation &&
+            alignment.ShrinkToFit == d.ShrinkToFit &&
+            alignment.RelativeIndent == d.RelativeIndent &&
+            alignment.JustifyLastLine == d.JustifyLastLine)
+        {
+            return null;
+        }
+
+        var result = new Alignment();
+        if (alignment.Horizontal != d.Horizontal)
+            result.Horizontal = alignment.Horizontal.ToOpenXml();
+        if (alignment.Vertical != d.Vertical)
+            result.Vertical = alignment.Vertical.ToOpenXml();
+        if (alignment.Indent != d.Indent)
+            result.Indent = (uint)alignment.Indent;
+        if (alignment.ReadingOrder != d.ReadingOrder)
+            result.ReadingOrder = alignment.ReadingOrder.ToOpenXml();
+        if (alignment.WrapText != d.WrapText)
+            result.WrapText = alignment.WrapText;
+        if (alignment.TextRotation != d.TextRotation)
+        {
+            var textRotation = alignment.TextRotation;
+            result.TextRotation = (uint)(textRotation >= 0 ? textRotation : 90 - textRotation);
+        }
+        if (alignment.ShrinkToFit != d.ShrinkToFit)
+            result.ShrinkToFit = alignment.ShrinkToFit;
+        if (alignment.RelativeIndent != d.RelativeIndent)
+            result.RelativeIndent = alignment.RelativeIndent;
+        if (alignment.JustifyLastLine != d.JustifyLastLine)
+            result.JustifyLastLine = alignment.JustifyLastLine;
+
+        return result;
     }
 
     private static void AppendBorderSideWithColor<TSide>(Border border,

--- a/XLibur/Utils/OpenXmlHelper.cs
+++ b/XLibur/Utils/OpenXmlHelper.cs
@@ -89,6 +89,30 @@ internal static class OpenXmlHelper
             nf.Format = nfSource.FormatCode.Value!;
     }
 
+    internal static void LoadAlignment(Alignment? alignmentSource, IXLAlignment alignment)
+    {
+        if (alignmentSource is null) return;
+
+        if (alignmentSource.Horizontal?.Value is not null)
+            alignment.Horizontal = alignmentSource.Horizontal.Value.ToXLibur();
+        if (alignmentSource.Vertical?.Value is not null)
+            alignment.Vertical = alignmentSource.Vertical.Value.ToXLibur();
+        if (alignmentSource.Indent?.Value is not null)
+            alignment.Indent = checked((int)alignmentSource.Indent.Value);
+        if (alignmentSource.ReadingOrder?.Value is not null)
+            alignment.ReadingOrder = alignmentSource.ReadingOrder.Value.ToXLibur();
+        if (alignmentSource.WrapText?.Value is not null)
+            alignment.WrapText = alignmentSource.WrapText.Value;
+        if (alignmentSource.TextRotation is not null)
+            alignment.TextRotation = GetXLiburTextRotation(alignmentSource);
+        if (alignmentSource.ShrinkToFit?.Value is not null)
+            alignment.ShrinkToFit = alignmentSource.ShrinkToFit.Value;
+        if (alignmentSource.RelativeIndent?.Value is not null)
+            alignment.RelativeIndent = alignmentSource.RelativeIndent.Value;
+        if (alignmentSource.JustifyLastLine?.Value is not null)
+            alignment.JustifyLastLine = alignmentSource.JustifyLastLine.Value;
+    }
+
     internal static void LoadBorder(Border? borderSource, IXLBorder border)
     {
         if (borderSource == null) return;


### PR DESCRIPTION
## Summary
- Alignment formatting on pivot table formats was silently lost during round-trip (load/save)
- Added `OpenXmlHelper.LoadAlignment()` to read alignment from DXF records, called in `PivotTableDefinitionPartReader.LoadFormats`
- Added `GetNewDifferentialAlignment()` in `WorkbookStylesPartWriter.AddStyleAsDifferentialFormat` to write alignment into DXF records

## Test plan
- [x] New round-trip test `Alignment_in_pivot_format_survives_round_trip` verifies horizontal, vertical, wrapText, and textRotation survive save/load
- [x] All 5944 existing tests pass on net8.0 and net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pivot table alignment properties (horizontal, vertical, text wrapping, and text rotation) to correctly persist when saving and reloading workbooks.

* **Tests**
  * Added test coverage for pivot table alignment round-trip persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->