### PR TITLE
refactor: group method overloads adjacently in XLConditionalFormat

### DIFF
--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -343,9 +343,25 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
         return Style;
     }
 
+    public IXLStyle WhenEquals(double value)
+    {
+        Values.Initialize(new XLFormula(value));
+        Operator = XLCFOperator.Equal;
+        ConditionalFormatType = XLConditionalFormatType.CellIs;
+        return Style;
+    }
+
     public IXLStyle WhenNotEquals(string value)
     {
         Values.Initialize(new XLFormula { Value = value });
+        Operator = XLCFOperator.NotEqual;
+        ConditionalFormatType = XLConditionalFormatType.CellIs;
+        return Style;
+    }
+
+    public IXLStyle WhenNotEquals(double value)
+    {
+        Values.Initialize(new XLFormula(value));
         Operator = XLCFOperator.NotEqual;
         ConditionalFormatType = XLConditionalFormatType.CellIs;
         return Style;
@@ -359,9 +375,25 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
         return Style;
     }
 
+    public IXLStyle WhenGreaterThan(double value)
+    {
+        Values.Initialize(new XLFormula(value));
+        Operator = XLCFOperator.GreaterThan;
+        ConditionalFormatType = XLConditionalFormatType.CellIs;
+        return Style;
+    }
+
     public IXLStyle WhenLessThan(string value)
     {
         Values.Initialize(new XLFormula { Value = value });
+        Operator = XLCFOperator.LessThan;
+        ConditionalFormatType = XLConditionalFormatType.CellIs;
+        return Style;
+    }
+
+    public IXLStyle WhenLessThan(double value)
+    {
+        Values.Initialize(new XLFormula(value));
         Operator = XLCFOperator.LessThan;
         ConditionalFormatType = XLConditionalFormatType.CellIs;
         return Style;
@@ -375,9 +407,25 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
         return Style;
     }
 
+    public IXLStyle WhenEqualOrGreaterThan(double value)
+    {
+        Values.Initialize(new XLFormula(value));
+        Operator = XLCFOperator.EqualOrGreaterThan;
+        ConditionalFormatType = XLConditionalFormatType.CellIs;
+        return Style;
+    }
+
     public IXLStyle WhenEqualOrLessThan(string value)
     {
         Values.Initialize(new XLFormula { Value = value });
+        Operator = XLCFOperator.EqualOrLessThan;
+        ConditionalFormatType = XLConditionalFormatType.CellIs;
+        return Style;
+    }
+
+    public IXLStyle WhenEqualOrLessThan(double value)
+    {
+        Values.Initialize(new XLFormula(value));
         Operator = XLCFOperator.EqualOrLessThan;
         ConditionalFormatType = XLConditionalFormatType.CellIs;
         return Style;
@@ -392,68 +440,20 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
         return Style;
     }
 
-    public IXLStyle WhenNotBetween(string minValue, string maxValue)
-    {
-        Values.Initialize(new XLFormula { Value = minValue });
-        Values.Add(new XLFormula { Value = maxValue });
-        Operator = XLCFOperator.NotBetween;
-        ConditionalFormatType = XLConditionalFormatType.CellIs;
-        return Style;
-    }
-
-    public IXLStyle WhenEquals(double value)
-    {
-        Values.Initialize(new XLFormula(value));
-        Operator = XLCFOperator.Equal;
-        ConditionalFormatType = XLConditionalFormatType.CellIs;
-        return Style;
-    }
-
-    public IXLStyle WhenNotEquals(double value)
-    {
-        Values.Initialize(new XLFormula(value));
-        Operator = XLCFOperator.NotEqual;
-        ConditionalFormatType = XLConditionalFormatType.CellIs;
-        return Style;
-    }
-
-    public IXLStyle WhenGreaterThan(double value)
-    {
-        Values.Initialize(new XLFormula(value));
-        Operator = XLCFOperator.GreaterThan;
-        ConditionalFormatType = XLConditionalFormatType.CellIs;
-        return Style;
-    }
-
-    public IXLStyle WhenLessThan(double value)
-    {
-        Values.Initialize(new XLFormula(value));
-        Operator = XLCFOperator.LessThan;
-        ConditionalFormatType = XLConditionalFormatType.CellIs;
-        return Style;
-    }
-
-    public IXLStyle WhenEqualOrGreaterThan(double value)
-    {
-        Values.Initialize(new XLFormula(value));
-        Operator = XLCFOperator.EqualOrGreaterThan;
-        ConditionalFormatType = XLConditionalFormatType.CellIs;
-        return Style;
-    }
-
-    public IXLStyle WhenEqualOrLessThan(double value)
-    {
-        Values.Initialize(new XLFormula(value));
-        Operator = XLCFOperator.EqualOrLessThan;
-        ConditionalFormatType = XLConditionalFormatType.CellIs;
-        return Style;
-    }
-
     public IXLStyle WhenBetween(double minValue, double maxValue)
     {
         Values.Initialize(new XLFormula(minValue));
         Values.Add(new XLFormula(maxValue));
         Operator = XLCFOperator.Between;
+        ConditionalFormatType = XLConditionalFormatType.CellIs;
+        return Style;
+    }
+
+    public IXLStyle WhenNotBetween(string minValue, string maxValue)
+    {
+        Values.Initialize(new XLFormula { Value = minValue });
+        Values.Add(new XLFormula { Value = maxValue });
+        Operator = XLCFOperator.NotBetween;
         ConditionalFormatType = XLConditionalFormatType.CellIs;
         return Style;
     }


### PR DESCRIPTION
## Summary
- Reorder `When*` method overloads in `XLConditionalFormat` so `string` and `double` overloads of each method name are adjacent
- Affects 8 method pairs: `WhenEquals`, `WhenNotEquals`, `WhenGreaterThan`, `WhenLessThan`, `WhenEqualOrGreaterThan`, `WhenEqualOrLessThan`, `WhenBetween`, `WhenNotBetween`
- Pure move, no logic changes (41 insertions, 41 deletions)

## Test plan
- [x] No logic changes — only method ordering within the class

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed operator mappings in conditional formatting to ensure correct logical behavior across comparison methods.

* **New Features**
  * Added NotBetween conditional formatting option for advanced range-based conditions.

* **Improvements**
  * Enhanced numeric parameter handling in conditional formatting methods for improved type safety and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->