### PR TITLE
Remove dead PivotSourceInfo and PivotTableFieldInfo types

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ dotnet run -c Release --project XLibur.Benchmarks/XLibur.Benchmarks.csproj -- --
 dotnet run -c Release --project XLibur.Benchmarks/XLibur.Benchmarks.csproj -- --filter '*ClosedXmlWorkbookBenchmarks*'
 ```
 
-
-
 ## Developer guidelines
 
 Please read the [full developer guidelines](CONTRIBUTING.md).

--- a/XLibur/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/XLibur/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -25,7 +25,6 @@ public partial class XLWorkbook
             TableId = 0;
             TableNames = [];
             PivotSourceCacheId = 0;
-            PivotSources = new Dictionary<Guid, PivotSourceInfo>();
         }
 
         public Dictionary<XLStyleValue, int> DifferentialFormats { get; private set; }
@@ -48,11 +47,6 @@ public partial class XLWorkbook
         /// cache parts.
         /// </summary>
         public uint PivotSourceCacheId { get; set; }
-
-        /// <summary>
-        /// A dictionary of extra info for pivot during saving. The key is <see cref="XLPivotCache.Guid"/>.
-        /// </summary>
-        public IDictionary<Guid, PivotSourceInfo> PivotSources { get; }
 
         /// <summary>
         /// A map of shared string ids. The index is the actual index from sharedStringId, and
@@ -234,25 +228,4 @@ public partial class XLWorkbook
     }
 
     #endregion Nested type: StyleInfo
-
-    #region Nested type: Pivot tables
-
-    internal struct PivotTableFieldInfo
-    {
-        public bool MixedDataType;
-        public IReadOnlyList<XLCellValue> DistinctValues;
-        public bool IsTotallyBlankField;
-    }
-
-    internal struct PivotSourceInfo
-    {
-        public IDictionary<string, PivotTableFieldInfo> Fields;
-
-        public PivotSourceInfo(IDictionary<string, PivotTableFieldInfo> fields)
-        {
-            Fields = fields;
-        }
-    }
-
-    #endregion Nested type: Pivot tables
 }


### PR DESCRIPTION
## Summary
- Remove unused `PivotSources` dictionary and `PivotSourceInfo`/`PivotTableFieldInfo` nested structs from `SaveContext`
- Fix trailing blank lines in README

## Test plan
- [x] Build succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor formatting adjustments to the README.

* **Chores**
  * Removed internal code structures related to pivot functionality, resulting in cleaner codebase maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->