### PR TITLE
feat: resolve named ranges as pivot cache source

### DIFF
--- a/XLibur.Tests/Excel/PivotTables/XLPivotSourceTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotSourceTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
+using XLibur.Excel;
+using XLibur.Excel.Coordinates;
 
 namespace XLibur.Tests.Excel.PivotTables;
 
@@ -31,4 +33,115 @@ internal class XLPivotSourceTests
             @"Other\PivotTable\Sources\PivotTable-AllSources-input.xlsx",
             @"Other\PivotTable\Sources\PivotTable-AllSources-output.xlsx");
     }
+
+    #region TryGetSource - named range resolution
+
+    [Test]
+    public void TryGetSource_resolves_workbook_scoped_named_range()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = "Name";
+        ws.Cell("B1").Value = "Value";
+        ws.Cell("A2").Value = "Alpha";
+        ws.Cell("B2").Value = 1;
+
+        wb.DefinedNames.Add("PivotData", "Data!$A$1:$B$2");
+
+        var source = new XLPivotSourceReference("PivotData");
+        var result = source.TryGetSource(wb, out var sheet, out var sheetArea);
+
+        Assert.That(result, Is.True);
+        Assert.That(sheet!.Name, Is.EqualTo("Data"));
+        Assert.That(sheetArea, Is.EqualTo(new XLSheetRange(1, 1, 2, 2)));
+    }
+
+    [Test]
+    public void TryGetSource_prefers_table_over_named_range_with_same_name()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = "Name";
+        ws.Cell("A2").Value = "Alpha";
+
+        // Create a table named "Source"
+        ws.Range("A1:A2").CreateTable("Source");
+
+        // Create a defined name with the same identifier pointing to a different area
+        wb.DefinedNames.Add("Source", "Data!$B$1:$B$5");
+
+        var source = new XLPivotSourceReference("Source");
+        var result = source.TryGetSource(wb, out var sheet, out var sheetArea);
+
+        Assert.That(result, Is.True);
+        Assert.That(sheet!.Name, Is.EqualTo("Data"));
+        // Should resolve to table area (A1:A2), not defined name area (B1:B5)
+        Assert.That(sheetArea!.Value.LeftColumn, Is.EqualTo(1));
+        Assert.That(sheetArea!.Value.RightColumn, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TryGetSource_returns_false_for_nonexistent_name()
+    {
+        using var wb = new XLWorkbook();
+        wb.AddWorksheet("Data");
+
+        var source = new XLPivotSourceReference("NoSuchName");
+        var result = source.TryGetSource(wb, out var sheet, out var sheetArea);
+
+        Assert.That(result, Is.False);
+        Assert.That(sheet, Is.Null);
+        Assert.That(sheetArea, Is.Null);
+    }
+
+    [Test]
+    public void TryGetSource_returns_false_for_named_range_referencing_deleted_sheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = "Name";
+        wb.DefinedNames.Add("PivotData", "Data!$A$1:$B$2");
+
+        // Delete the sheet that the named range points to
+        wb.Worksheets.Delete("Data");
+
+        var source = new XLPivotSourceReference("PivotData");
+        var result = source.TryGetSource(wb, out var sheet, out var sheetArea);
+
+        Assert.That(result, Is.False);
+        Assert.That(sheet, Is.Null);
+    }
+
+    [Test]
+    public void TryGetSource_resolves_area_based_source()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = "Header";
+
+        var area = new XLBookArea("Sheet1", new XLSheetRange(1, 1, 5, 3));
+        var source = new XLPivotSourceReference(area);
+        var result = source.TryGetSource(wb, out var sheet, out var sheetArea);
+
+        Assert.That(result, Is.True);
+        Assert.That(sheet!.Name, Is.EqualTo("Sheet1"));
+        Assert.That(sheetArea, Is.EqualTo(new XLSheetRange(1, 1, 5, 3)));
+    }
+
+    [Test]
+    public void TryGetSource_area_returns_false_for_nonexistent_sheet()
+    {
+        using var wb = new XLWorkbook();
+        wb.AddWorksheet("Sheet1");
+
+        var area = new XLBookArea("NonExistent", new XLSheetRange(1, 1, 5, 3));
+        var source = new XLPivotSourceReference(area);
+        var result = source.TryGetSource(wb, out var sheet, out var sheetArea);
+
+        Assert.That(result, Is.False);
+        Assert.That(sheet, Is.Null);
+        Assert.That(sheetArea, Is.Null);
+    }
+
+    #endregion
 }

--- a/XLibur.Tests/Excel/PivotTables/XLPivotSourceTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotSourceTests.cs
@@ -110,6 +110,7 @@ internal class XLPivotSourceTests
 
         Assert.That(result, Is.False);
         Assert.That(sheet, Is.Null);
+        Assert.That(sheetArea, Is.Null);
     }
 
     [Test]

--- a/XLibur/Excel/Coordinates/XLReference.cs
+++ b/XLibur/Excel/Coordinates/XLReference.cs
@@ -26,6 +26,11 @@ internal readonly record struct XLReference
         return _reference.GetDisplayStringA1();
     }
 
+    internal XLSheetRange ToSheetRange(XLSheetPoint anchor)
+    {
+        return _reference.ToSheetRange(anchor);
+    }
+
     internal XLRangeAddress ToRangeAddress(XLWorksheet? sheet, XLSheetPoint anchor)
     {
         var area = _reference.ToSheetRange(anchor);

--- a/XLibur/Excel/DefinedNames/XLDefinedName.cs
+++ b/XLibur/Excel/DefinedNames/XLDefinedName.cs
@@ -95,6 +95,27 @@ internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
     /// </summary>
     internal IReadOnlyList<string> GetSheetReferencesList() => _references.SheetReferences.Select(x => x.GetA1()).ToList();
 
+    /// <summary>
+    /// Try to resolve the first sheet reference in the formula to a worksheet and area.
+    /// Avoids materializing <see cref="XLRange"/> or <see cref="XLRanges"/> objects.
+    /// </summary>
+    internal bool TryGetFirstSheetArea(XLWorkbook workbook, out XLWorksheet? sheet, out XLSheetRange sheetArea)
+    {
+        var anchor = new XLSheetPoint(1, 1);
+        foreach (var reference in _references.SheetReferences)
+        {
+            if (workbook.TryGetWorksheet(reference.Sheet, out sheet))
+            {
+                sheetArea = reference.Reference.ToSheetRange(anchor);
+                return true;
+            }
+        }
+
+        sheet = null;
+        sheetArea = default;
+        return false;
+    }
+
     internal XLDefinedName CopyTo(XLWorksheet targetSheet)
     {
         var sheet = _container.Worksheet;

--- a/XLibur/Excel/PivotTables/XLPivotSourceReference.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceReference.cs
@@ -74,11 +74,18 @@ internal sealed class XLPivotSourceReference : IXLPivotSource
     {
         if (Name is not null)
         {
-            // TODO: Named ranges are currently unusable, so only check tables.
             if (workbook.TryGetTable(Name, out var table))
             {
                 sheet = table.Worksheet;
                 sheetArea = table.Area;
+                return true;
+            }
+
+            if (workbook.DefinedNamesInternal.TryGetScopedValue(Name, out var definedName)
+                && definedName.IsValid
+                && definedName.TryGetFirstSheetArea(workbook, out sheet, out var area))
+            {
+                sheetArea = area;
                 return true;
             }
 


### PR DESCRIPTION
## Summary

- Add named range (defined name) resolution to `XLPivotSourceReference.TryGetSource`, which previously only supported tables
- Add zero-allocation `XLDefinedName.TryGetFirstSheetArea` that resolves the first sheet reference without materializing `XLRange`/`XLRanges` objects
- Add `XLReference.ToSheetRange` for lightweight conversion to `XLSheetRange` bypassing `XLRangeAddress` allocation
- Tables still take priority over defined names with the same identifier (matching Excel behavior)

## Test plan

- [x] Named range resolves to correct worksheet and sheet area
- [x] Table takes priority over named range with same name
- [x] Nonexistent name returns false
- [x] Named range referencing deleted sheet returns false
- [x] Area-based source still works correctly
- [x] Area-based source with nonexistent sheet returns false
- [x] Existing load/save roundtrip test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pivot tables can use workbook-scoped named ranges as data sources; if a table and a named range share a name, the table is preferred.
* **Bug Fixes**
  * Improved validation and resolution for named-range sources, including handling deleted or non-existent sheets and invalid names.
* **Tests**
  * Added unit tests for named-range and area-based pivot source resolution and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->