### PR TITLE
feat: add wildcard support to HLOOKUP and VLOOKUP

### DIFF
--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -859,6 +859,25 @@ public class LookupTests
     }
 
     [Test]
+    public void Vlookup_Wildcard_IsCaseInsensitive()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "Apple";
+        sheet.Cell("A2").Value = "Banana";
+        sheet.Cell("B1").Value = 1;
+        sheet.Cell("B2").Value = 2;
+
+        // Lowercase pattern against uppercase cell value
+        Assert.AreEqual(1, sheet.Evaluate(@"VLOOKUP(""a*"",A1:B2,2,FALSE)"));
+        Assert.AreEqual(1, sheet.Evaluate(@"VLOOKUP(""*pple"",A1:B2,2,FALSE)"));
+
+        // Uppercase pattern against mixed-case cell value
+        Assert.AreEqual(1, sheet.Evaluate(@"VLOOKUP(""*PPLE"",A1:B2,2,FALSE)"));
+        Assert.AreEqual(2, sheet.Evaluate(@"VLOOKUP(""BANANA"",A1:B2,2,FALSE)"));
+    }
+
+    [Test]
     public void Vlookup_Wildcard_QuestionMarkMatchesSingleCharacter()
     {
         using var wb = new XLWorkbook();

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -840,4 +840,131 @@ public class LookupTests
     {
         Assert.AreEqual(2, XLWorkbook.EvaluateExpr("VLOOKUP(4, {1,2; 3,2; 5,3; 7,4}, 2)"));
     }
+
+    [Test]
+    public void Vlookup_Wildcard_AsteriskMatchesAnyCharacters()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "Apple";
+        sheet.Cell("A2").Value = "Banana";
+        sheet.Cell("A3").Value = "Avocado";
+        sheet.Cell("B1").Value = 1;
+        sheet.Cell("B2").Value = 2;
+        sheet.Cell("B3").Value = 3;
+
+        Assert.AreEqual(1, sheet.Evaluate(@"VLOOKUP(""A*"",A1:B3,2,FALSE)"));
+        Assert.AreEqual(2, sheet.Evaluate(@"VLOOKUP(""B*"",A1:B3,2,FALSE)"));
+        Assert.AreEqual(1, sheet.Evaluate(@"VLOOKUP(""*pple"",A1:B3,2,FALSE)"));
+    }
+
+    [Test]
+    public void Vlookup_Wildcard_QuestionMarkMatchesSingleCharacter()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "Ab";
+        sheet.Cell("A2").Value = "Abc";
+        sheet.Cell("A3").Value = "Abcd";
+        sheet.Cell("B1").Value = 1;
+        sheet.Cell("B2").Value = 2;
+        sheet.Cell("B3").Value = 3;
+
+        // A? matches exactly two characters starting with A
+        Assert.AreEqual(1, sheet.Evaluate(@"VLOOKUP(""A?"",A1:B3,2,FALSE)"));
+
+        // A?? matches exactly three characters starting with A
+        Assert.AreEqual(2, sheet.Evaluate(@"VLOOKUP(""A??"",A1:B3,2,FALSE)"));
+    }
+
+    [Test]
+    public void Vlookup_Wildcard_EscapedWildcardMatchesLiteral()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "A*B";
+        sheet.Cell("A2").Value = "AXB";
+        sheet.Cell("B1").Value = 1;
+        sheet.Cell("B2").Value = 2;
+
+        // ~* matches literal asterisk
+        Assert.AreEqual(1, sheet.Evaluate(@"VLOOKUP(""A~*B"",A1:B2,2,FALSE)"));
+    }
+
+    [Test]
+    public void Vlookup_Wildcard_NoMatch_ReturnsNA()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "Apple";
+        sheet.Cell("B1").Value = 1;
+
+        Assert.AreEqual(XLError.NoValueAvailable, sheet.Evaluate(@"VLOOKUP(""Z*"",A1:B1,2,FALSE)"));
+    }
+
+    [Test]
+    public void Vlookup_Wildcard_NonTextLookupStillWorks()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 10;
+        sheet.Cell("A2").Value = 20;
+        sheet.Cell("B1").Value = "ten";
+        sheet.Cell("B2").Value = "twenty";
+
+        Assert.AreEqual("ten", sheet.Evaluate("VLOOKUP(10,A1:B2,2,FALSE)"));
+    }
+
+    [Test]
+    public void Hlookup_Wildcard_AsteriskMatchesAnyCharacters()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "Apple";
+        sheet.Cell("B1").Value = "Banana";
+        sheet.Cell("C1").Value = "Avocado";
+        sheet.Cell("A2").Value = 1;
+        sheet.Cell("B2").Value = 2;
+        sheet.Cell("C2").Value = 3;
+
+        Assert.AreEqual(1, sheet.Evaluate(@"HLOOKUP(""A*"",A1:C2,2,FALSE)"));
+        Assert.AreEqual(2, sheet.Evaluate(@"HLOOKUP(""B*"",A1:C2,2,FALSE)"));
+    }
+
+    [Test]
+    public void Hlookup_Wildcard_QuestionMarkMatchesSingleCharacter()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "Ab";
+        sheet.Cell("B1").Value = "Abc";
+        sheet.Cell("A2").Value = 1;
+        sheet.Cell("B2").Value = 2;
+
+        Assert.AreEqual(1, sheet.Evaluate(@"HLOOKUP(""A?"",A1:B2,2,FALSE)"));
+    }
+
+    [Test]
+    public void Hlookup_Wildcard_EscapedWildcardMatchesLiteral()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "A*B";
+        sheet.Cell("B1").Value = "AXB";
+        sheet.Cell("A2").Value = 1;
+        sheet.Cell("B2").Value = 2;
+
+        Assert.AreEqual(1, sheet.Evaluate(@"HLOOKUP(""A~*B"",A1:B2,2,FALSE)"));
+    }
+
+    [Test]
+    public void Hlookup_Wildcard_NoMatch_ReturnsNA()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "Apple";
+        sheet.Cell("A2").Value = 1;
+
+        Assert.AreEqual(XLError.NoValueAvailable, sheet.Evaluate(@"HLOOKUP(""Z*"",A1:A2,2,FALSE)"));
+    }
 }

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -82,7 +82,6 @@ internal static class Lookup
             return array[rowIndex, foundColumn].ToAnyValue();
         }
 
-        // TODO: Implement wildcard search
         var exactColumn = ExactSearchColumn(array, lookupValue);
         if (exactColumn == -1)
             return XLError.NoValueAvailable;
@@ -379,7 +378,6 @@ internal static class Lookup
             return array[foundRow, columnIdx].ToAnyValue();
         }
 
-        // TODO: Implement wildcard search
         var exactRow = ExactSearchRow(array, lookupValue);
         if (exactRow == -1)
             return XLError.NoValueAvailable;
@@ -427,9 +425,23 @@ internal static class Lookup
 
     /// <summary>
     /// Linear exact search across the first row of an array. Returns the column index or -1.
+    /// Supports wildcards (<c>*</c>, <c>?</c>, <c>~</c>) when the lookup value is text.
     /// </summary>
     private static int ExactSearchColumn(Array array, ScalarValue lookupValue)
     {
+        if (lookupValue.TryPickText(out var lookupText, out _) && ContainsWildcardChars(lookupText!))
+        {
+            var wildcard = new Wildcard(lookupText!);
+            for (var columnIndex = 0; columnIndex < array.Width; columnIndex++)
+            {
+                var currentValue = array[0, columnIndex];
+                if (currentValue.TryPickText(out var cellText, out _) && wildcard.Matches(cellText!.AsSpan()))
+                    return columnIndex;
+            }
+
+            return -1;
+        }
+
         for (var columnIndex = 0; columnIndex < array.Width; columnIndex++)
         {
             var currentValue = array[0, columnIndex];
@@ -443,9 +455,23 @@ internal static class Lookup
 
     /// <summary>
     /// Linear exact search down the first column of an array. Returns the row index or -1.
+    /// Supports wildcards (<c>*</c>, <c>?</c>, <c>~</c>) when the lookup value is text.
     /// </summary>
     private static int ExactSearchRow(Array array, ScalarValue lookupValue)
     {
+        if (lookupValue.TryPickText(out var lookupText, out _) && ContainsWildcardChars(lookupText!))
+        {
+            var wildcard = new Wildcard(lookupText!);
+            for (var rowIndex = 0; rowIndex < array.Height; rowIndex++)
+            {
+                var currentValue = array[rowIndex, 0];
+                if (currentValue.TryPickText(out var cellText, out _) && wildcard.Matches(cellText!.AsSpan()))
+                    return rowIndex;
+            }
+
+            return -1;
+        }
+
         for (var rowIndex = 0; rowIndex < array.Height; rowIndex++)
         {
             var currentValue = array[rowIndex, 0];
@@ -455,6 +481,24 @@ internal static class Lookup
         }
 
         return -1;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the text contains wildcard syntax: unescaped <c>*</c> or <c>?</c>,
+    /// or <c>~</c> escape sequences (<c>~*</c>, <c>~?</c>, <c>~~</c>).
+    /// </summary>
+    private static bool ContainsWildcardChars(string text)
+    {
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (c == '*' || c == '?')
+                return true;
+            if (c == '~')
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -494,8 +494,12 @@ internal static class Lookup
             var c = text[i];
             if (c == '*' || c == '?')
                 return true;
-            if (c == '~')
-                return true;
+            if (c == '~' && i + 1 < text.Length)
+            {
+                var next = text[i + 1];
+                if (next == '*' || next == '?' || next == '~')
+                    return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
## Summary
- Implements wildcard matching (`*`, `?`, `~` escape) for HLOOKUP and VLOOKUP exact match mode (`range_lookup=FALSE`), matching Excel behavior
- Uses the existing `Wildcard` struct for pattern matching; non-text lookups (numbers, booleans) are unaffected
- Adds 8 new tests covering asterisk, question mark, escaped wildcards, no-match, and non-text lookup scenarios

## Test plan
- [x] All 30 HLOOKUP/VLOOKUP tests pass on net8.0 and net10.0
- [x] Build succeeds with zero warnings (`TreatWarningsAsErrors=true`)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VLOOKUP and HLOOKUP now support wildcard-aware exact matching: * matches any characters, ? matches a single character, and ~ escapes wildcards for literal matches.

* **Tests**
  * Added comprehensive unit tests covering wildcard cases, escaped literals, no-match behavior, and non-text lookup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->