### PR TITLE
feat: implement INDIRECT function

### DIFF
--- a/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -304,7 +304,7 @@ public class FormulaParserTests
 
     [TestCase("=INDEX(A1:B2,1,2)", "Lemons")]
     //[TestCase("=OFFSET(C4,-1,-2)", "Pears")] Not implemented
-    //[TestCase("=INDIRECT(\"A2\")", "Bananas")] Not implemented
+    [TestCase("=INDIRECT(\"A2\")", "Bananas")]
     public void Ref_function_name_can_be_excel_ref_function(string formula, object expectedValue)
     {
         using var wb = new XLWorkbook();

--- a/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
@@ -630,4 +630,29 @@ public class InformationTests
         ws.Cell("C1").FormulaA1 = "TYPE((A1,A1))";
         Assert.AreEqual(16.0, ws.Cell("C1").Value);
     }
+
+    [Test]
+    public void IsBlank_EmptyString_ReturnsFalse()
+    {
+        // ISBLANK("") should be false — an empty string is a text value, not blank.
+        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(\"\")"));
+    }
+
+    [Test]
+    public void IsBlank_BlankCell_ReturnsTrue()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+
+        // A1 is never set, so it is blank.
+        Assert.AreEqual(true, ws.Evaluate("ISBLANK(A1)"));
+    }
+
+    [Test]
+    public void IsBlank_NonBlankValues_ReturnsFalse()
+    {
+        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(0)"));
+        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(FALSE)"));
+        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(\"hello\")"));
+    }
 }

--- a/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
@@ -630,29 +630,4 @@ public class InformationTests
         ws.Cell("C1").FormulaA1 = "TYPE((A1,A1))";
         Assert.AreEqual(16.0, ws.Cell("C1").Value);
     }
-
-    [Test]
-    public void IsBlank_EmptyString_ReturnsFalse()
-    {
-        // ISBLANK("") should be false — an empty string is a text value, not blank.
-        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(\"\")"));
-    }
-
-    [Test]
-    public void IsBlank_BlankCell_ReturnsTrue()
-    {
-        using var wb = new XLWorkbook();
-        var ws = wb.AddWorksheet();
-
-        // A1 is never set, so it is blank.
-        Assert.AreEqual(true, ws.Evaluate("ISBLANK(A1)"));
-    }
-
-    [Test]
-    public void IsBlank_NonBlankValues_ReturnsFalse()
-    {
-        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(0)"));
-        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(FALSE)"));
-        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(\"hello\")"));
-    }
 }

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -1054,6 +1054,17 @@ public class LookupTests
     }
 
     [Test]
+    public void Indirect_SheetScopedDefinedName()
+    {
+        using var wb = new XLWorkbook();
+        var sheet1 = wb.AddWorksheet("Sheet1");
+        var sheet2 = wb.AddWorksheet("Sheet2");
+        sheet2.Cell("B2").Value = 55;
+        sheet2.DefinedNames.Add("LocalName", "Sheet2!$B$2");
+        Assert.AreEqual(55, sheet1.Evaluate("INDIRECT(\"Sheet2!LocalName\")"));
+    }
+
+    [Test]
     public void Indirect_A1FlagTrue_SameAsDefault()
     {
         using var wb = new XLWorkbook();

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -1072,6 +1072,27 @@ public class LookupTests
     }
 
     [Test]
+    public void Indirect_QuotedSheetNameWithApostrophe()
+    {
+        using var wb = new XLWorkbook();
+        var sheet1 = wb.AddWorksheet("Main");
+        var sheet2 = wb.AddWorksheet("Bob's");
+        sheet2.Cell("A1").Value = 42;
+        Assert.AreEqual(42, sheet1.Evaluate("INDIRECT(\"'Bob''s'!A1\")"));
+    }
+
+    [Test]
+    public void Indirect_R1C1Range()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 1;
+        sheet.Cell("A2").Value = 2;
+        sheet.Cell("C3").Value = 10;
+        Assert.AreEqual(13.0, sheet.Evaluate("SUM(INDIRECT(\"R1C1:R3C3\", FALSE))"));
+    }
+
+    [Test]
     public void Indirect_NonExistentSheet_ReturnsCellReferenceError()
     {
         using var wb = new XLWorkbook();

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -986,4 +986,108 @@ public class LookupTests
 
         Assert.AreEqual(XLError.NoValueAvailable, sheet.Evaluate(@"HLOOKUP(""Z*"",A1:A2,2,FALSE)"));
     }
+
+    #region INDIRECT
+
+    [Test]
+    public void Indirect_BasicA1Reference()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 42;
+        Assert.AreEqual(42, sheet.Evaluate("INDIRECT(\"A1\")"));
+    }
+
+    [Test]
+    public void Indirect_AbsoluteReference()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("B2").Value = "Hello";
+        Assert.AreEqual("Hello", sheet.Evaluate("INDIRECT(\"$B$2\")"));
+    }
+
+    [Test]
+    public void Indirect_RangeReference_ReturnsReferenceUsableByOtherFunctions()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 1;
+        sheet.Cell("A2").Value = 2;
+        sheet.Cell("B1").Value = 3;
+        sheet.Cell("B2").Value = 4;
+        Assert.AreEqual(10.0, sheet.Evaluate("SUM(INDIRECT(\"A1:B2\"))"));
+    }
+
+    [Test]
+    public void Indirect_EmptyString_ReturnsCellReferenceError()
+    {
+        Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("INDIRECT(\"\")"));
+    }
+
+    [Test]
+    public void Indirect_SheetPrefix()
+    {
+        using var wb = new XLWorkbook();
+        var sheet1 = wb.AddWorksheet("Sheet1");
+        var sheet2 = wb.AddWorksheet("Sheet2");
+        sheet2.Cell("A1").Value = 99;
+        Assert.AreEqual(99, sheet1.Evaluate("INDIRECT(\"Sheet2!A1\")"));
+    }
+
+    [Test]
+    public void Indirect_InvalidReference_ReturnsCellReferenceError()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        Assert.AreEqual(XLError.CellReference, sheet.Evaluate("INDIRECT(\"XYZ\")"));
+    }
+
+    [Test]
+    public void Indirect_DefinedName()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("C3").Value = 77;
+        wb.DefinedNames.Add("MyRange", "Sheet1!$C$3");
+        Assert.AreEqual(77, sheet.Evaluate("INDIRECT(\"MyRange\")"));
+    }
+
+    [Test]
+    public void Indirect_A1FlagTrue_SameAsDefault()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 5;
+        Assert.AreEqual(5, sheet.Evaluate("INDIRECT(\"A1\", TRUE)"));
+    }
+
+    [Test]
+    public void Indirect_R1C1Style()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 123;
+        Assert.AreEqual(123, sheet.Evaluate("INDIRECT(\"R1C1\", FALSE)"));
+    }
+
+    [Test]
+    public void Indirect_NonExistentSheet_ReturnsCellReferenceError()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        Assert.AreEqual(XLError.CellReference, sheet.Evaluate("INDIRECT(\"NoSuchSheet!A1\")"));
+    }
+
+    [Test]
+    public void Indirect_DynamicReference()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "B2";
+        sheet.Cell("B2").Value = 100;
+        Assert.AreEqual(100, sheet.Evaluate("INDIRECT(A1)"));
+    }
+
+    #endregion
 }

--- a/XLibur/Excel/CalcEngine/DependenciesVisitor.cs
+++ b/XLibur/Excel/CalcEngine/DependenciesVisitor.cs
@@ -177,6 +177,14 @@ internal sealed class DependenciesVisitor : IFormulaVisitor<DependenciesContext,
         if (XLHelper.FunctionComparer.Equals(node.Name, "CHOOSE"))
             return VisitChooseFunction(context, node);
 
+        if (XLHelper.FunctionComparer.Equals(node.Name, "INDIRECT"))
+        {
+            // INDIRECT references are dynamic — can't determine at parse time.
+            // The Volatile flag ensures recalculation. Accept args for their dependencies.
+            AcceptAndAddAllParameters(context, node);
+            return null;
+        }
+
         // All other functions can have references as arguments, but not as an output value.
         AcceptAndAddAllParameters(context, node);
         return null;

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -754,8 +754,9 @@ internal static class Lookup
         if (!firstMatch.Success)
             return XLError.CellReference;
 
-        var firstRow = int.Parse(firstMatch.Groups[1].Value);
-        var firstCol = int.Parse(firstMatch.Groups[2].Value);
+        if (!int.TryParse(firstMatch.Groups[1].Value, out var firstRow)
+            || !int.TryParse(firstMatch.Groups[2].Value, out var firstCol))
+            return XLError.CellReference;
 
         int lastRow, lastCol;
         if (parts.Length == 2)
@@ -764,8 +765,9 @@ internal static class Lookup
             if (!lastMatch.Success)
                 return XLError.CellReference;
 
-            lastRow = int.Parse(lastMatch.Groups[1].Value);
-            lastCol = int.Parse(lastMatch.Groups[2].Value);
+            if (!int.TryParse(lastMatch.Groups[1].Value, out lastRow)
+                || !int.TryParse(lastMatch.Groups[2].Value, out lastCol))
+                return XLError.CellReference;
         }
         else
         {

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -717,7 +717,7 @@ internal static class Lookup
         {
             // Check if it's a valid A1 cell or range address
             if (!XLHelper.IsValidA1Address(addressText) && !XLHelper.IsValidRangeAddress(addressText))
-                return TryResolveDefinedName(ctx, refText);
+                return TryResolveDefinedName(ctx, worksheet, addressText);
 
             try
             {
@@ -786,10 +786,11 @@ internal static class Lookup
         return new Reference(rangeAddress.Normalize());
     }
 
-    private static AnyValue TryResolveDefinedName(CalcContext ctx, string name)
+    private static AnyValue TryResolveDefinedName(CalcContext ctx, XLWorksheet? worksheet, string name)
     {
-        // Sheet-level first, then workbook-level (same order as NameNode.TryGetNameRange)
-        if (ctx.Worksheet.DefinedNames.TryGetValue(name, out var sheetDefinedName))
+        // Resolve in the target worksheet's scope first, then workbook-level
+        var ws = worksheet ?? ctx.Worksheet;
+        if (ws.DefinedNames.TryGetValue(name, out var sheetDefinedName))
             return EvaluateDefinedName(ctx, sheetDefinedName);
 
         if (ctx.Workbook.DefinedNamesInternal.TryGetValue(name, out var bookDefinedName))

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -741,7 +741,7 @@ internal static class Lookup
     }
 
     private static readonly Regex AbsoluteR1C1Regex = new(
-        @"^R(\d+)C(\d+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        @"^R(\d+)C(\d+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled, XLHelper.RegexTimeout);
 
     private static AnyValue TryParseR1C1Reference(XLWorksheet? worksheet, string addressText)
     {

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text.RegularExpressions;
 using XLibur.Excel.Coordinates;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
@@ -21,7 +22,7 @@ internal static class Lookup
         ce.RegisterFunction("HLOOKUP", 3, 4, AdaptLastOptional(Hlookup, true), FunctionFlags.Range, AllowRange.Only, 1); // Looks in the top row of an array and returns the value of the indicated cell
         ce.RegisterFunction("HYPERLINK", 1, 2, Adapt(Hyperlink), FunctionFlags.Scalar | FunctionFlags.SideEffect); // Creates a shortcut or jump that opens a document stored on a network server, an intranet, or the Internet
         ce.RegisterFunction("INDEX", 2, 4, AdaptIndex(Index), FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.Only, 0); // Uses an index to choose a value from a reference or array
-        //ce.RegisterFunction("INDIRECT", , Indirect); // Returns a reference indicated by a text value
+        ce.RegisterFunction("INDIRECT", 1, 2, Indirect, FunctionFlags.Range | FunctionFlags.Volatile); // Returns a reference indicated by a text value
         //ce.RegisterFunction("LOOKUP", , Lookup); // Looks up values in a vector or array
         ce.RegisterFunction("MATCH", 2, 3, AdaptMatch(Match), FunctionFlags.Range, AllowRange.Only, 1); // Looks up values in a reference or array
         //ce.RegisterFunction("OFFSET", , Offset); // Returns a reference offset from a given reference
@@ -679,5 +680,126 @@ internal static class Lookup
 
         // Only thing left, if reference has multiple areas
         return XLError.CellReference;
+    }
+
+    private static AnyValue Indirect(CalcContext ctx, Span<AnyValue> p)
+    {
+        var refTextResult = ToText(p[0], ctx);
+        if (!refTextResult.TryPickT0(out var refText, out var textError))
+            return textError;
+
+        // Optional second arg: TRUE = A1 style (default), FALSE = R1C1 style
+        var isA1 = true;
+        if (p.Length > 1 && !p[1].IsBlank)
+        {
+            var a1Result = CoerceToLogical(p[1], ctx);
+            if (!a1Result.TryPickT0(out isA1, out var a1Error))
+                return a1Error;
+        }
+
+        if (string.IsNullOrEmpty(refText))
+            return XLError.CellReference;
+
+        // Handle sheet prefix: "Sheet1!A1" or "'Sheet Name'!A1"
+        XLWorksheet? worksheet = ctx.Worksheet;
+        var addressText = refText;
+
+        var bangIndex = refText.LastIndexOf('!');
+        if (bangIndex >= 0)
+        {
+            var sheetName = refText[..bangIndex].Trim('\'');
+            addressText = refText[(bangIndex + 1)..];
+            if (!ctx.Workbook.TryGetWorksheet(sheetName, out worksheet))
+                return XLError.CellReference;
+        }
+
+        if (isA1)
+        {
+            // Check if it's a valid A1 cell or range address
+            if (!XLHelper.IsValidA1Address(addressText) && !XLHelper.IsValidRangeAddress(addressText))
+                return TryResolveDefinedName(ctx, refText);
+
+            try
+            {
+                var rangeAddress = new XLRangeAddress(worksheet, addressText);
+                if (!XLHelper.IsValidRangeAddress(rangeAddress))
+                    return XLError.CellReference;
+
+                return new Reference(rangeAddress.Normalize());
+            }
+            catch
+            {
+                return XLError.CellReference;
+            }
+        }
+        else
+        {
+            // R1C1 style: support absolute references (R1C1, R1C1:R5C3)
+            // Relative R1C1 (R[-1]C[2]) is not supported — return #REF!
+            return TryParseR1C1Reference(worksheet, addressText);
+        }
+    }
+
+    private static readonly Regex AbsoluteR1C1Regex = new(
+        @"^R(\d+)C(\d+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static AnyValue TryParseR1C1Reference(XLWorksheet? worksheet, string addressText)
+    {
+        // Support single cell (R1C1) and range (R1C1:R5C3)
+        var parts = addressText.Split(':');
+        if (parts.Length > 2)
+            return XLError.CellReference;
+
+        var firstMatch = AbsoluteR1C1Regex.Match(parts[0]);
+        if (!firstMatch.Success)
+            return XLError.CellReference;
+
+        var firstRow = int.Parse(firstMatch.Groups[1].Value);
+        var firstCol = int.Parse(firstMatch.Groups[2].Value);
+
+        int lastRow, lastCol;
+        if (parts.Length == 2)
+        {
+            var lastMatch = AbsoluteR1C1Regex.Match(parts[1]);
+            if (!lastMatch.Success)
+                return XLError.CellReference;
+
+            lastRow = int.Parse(lastMatch.Groups[1].Value);
+            lastCol = int.Parse(lastMatch.Groups[2].Value);
+        }
+        else
+        {
+            lastRow = firstRow;
+            lastCol = firstCol;
+        }
+
+        if (firstRow < 1 || firstCol < 1 || lastRow < 1 || lastCol < 1
+            || firstRow > XLHelper.MaxRowNumber || firstCol > XLHelper.MaxColumnNumber
+            || lastRow > XLHelper.MaxRowNumber || lastCol > XLHelper.MaxColumnNumber)
+            return XLError.CellReference;
+
+        var firstAddress = new XLAddress(worksheet, firstRow, firstCol, true, true);
+        var lastAddress = new XLAddress(lastRow, lastCol, true, true);
+        var rangeAddress = new XLRangeAddress(firstAddress, lastAddress);
+        return new Reference(rangeAddress.Normalize());
+    }
+
+    private static AnyValue TryResolveDefinedName(CalcContext ctx, string name)
+    {
+        // Sheet-level first, then workbook-level (same order as NameNode.TryGetNameRange)
+        if (ctx.Worksheet.DefinedNames.TryGetValue(name, out var sheetDefinedName))
+            return EvaluateDefinedName(ctx, sheetDefinedName);
+
+        if (ctx.Workbook.DefinedNamesInternal.TryGetValue(name, out var bookDefinedName))
+            return EvaluateDefinedName(ctx, bookDefinedName);
+
+        return XLError.CellReference;
+    }
+
+    private static AnyValue EvaluateDefinedName(CalcContext ctx, IXLDefinedName definedName)
+    {
+        var nameFormula = definedName.RefersTo;
+        nameFormula = nameFormula.StartsWith('=') ? nameFormula : "=" + nameFormula;
+        return ctx.CalcEngine.EvaluateName(nameFormula, ctx.Worksheet);
     }
 }

--- a/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -889,7 +889,7 @@ internal static class SignatureAdapter
     // Each method is named ToSomething and it converts an argument into a desired type (e.g. for ToSomething it should be type Something).
     // Return value is always OneOf<Something, Error>, if there is an error, return it as an error.
 
-    private static OneOf<bool, XLError> CoerceToLogical(in AnyValue value, CalcContext ctx)
+    internal static OneOf<bool, XLError> CoerceToLogical(in AnyValue value, CalcContext ctx)
     {
         if (!ToScalarValue(in value, ctx).TryPickT0(out var scalar, out var scalarError))
             return scalarError;
@@ -917,7 +917,7 @@ internal static class SignatureAdapter
         throw new NotImplementedException("Array formulas not implemented.");
     }
 
-    private static OneOf<string, XLError> ToText(in AnyValue value, CalcContext ctx)
+    internal static OneOf<string, XLError> ToText(in AnyValue value, CalcContext ctx)
     {
         if (value.TryPickScalar(out var scalar, out var collection))
             return scalar.ToText(ctx.Culture);

--- a/XLibur/XLHelper.cs
+++ b/XLibur/XLHelper.cs
@@ -61,7 +61,7 @@ public static partial class XLHelper
     /// </summary>
     internal static readonly StringComparer FunctionComparer = StringComparer.OrdinalIgnoreCase;
 
-    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(150);
+    internal static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(150);
 
     internal static readonly Regex RCSimpleRegex = new(
         @"^(r(((-\d)?\d*)|\[(-\d)?\d*\]))?(c(((-\d)?\d*)|\[(-\d)?\d*\]))?$"


### PR DESCRIPTION
## Summary
- Implement the `INDIRECT(ref_text, [a1])` Excel function that converts text strings into cell references at evaluation time
- Supports A1 style (default), absolute R1C1 (`R1C1`, `R1C1:R5C3`), sheet prefixes (`Sheet2!A1`), range references, and defined name resolution
- Registered as volatile (`FunctionFlags.Volatile`) to ensure recalculation, with dynamic dependency handling in `DependenciesVisitor`

## Changes
- **`Lookup.cs`** — Added `Indirect`, `TryParseR1C1Reference`, `TryResolveDefinedName`, `EvaluateDefinedName` methods; registered function
- **`SignatureAdapter.cs`** — Changed `ToText` and `CoerceToLogical` from `private` to `internal` for reuse by raw Span-based functions
- **`DependenciesVisitor.cs`** — Added INDIRECT case (dynamic refs can't be statically resolved; volatile flag handles recalc)
- **`FormulaParserTests.cs`** — Uncommented existing `INDIRECT("A2")` test case
- **`LookupTests.cs`** — Added 11 tests covering basic A1, absolute refs, ranges, empty string, sheet prefix, invalid ref, defined names, A1 flag, R1C1, nonexistent sheet, dynamic reference

## Test plan
- [x] All 11 new INDIRECT tests pass on net8.0 and net10.0
- [x] Uncommented `Ref_function` parser test passes
- [x] Full test suite (6007 tests) passes with zero regressions on both TFMs
- [ ] Verify R1C1 range references work (e.g., `INDIRECT("R1C1:R5C3", FALSE)`)
- [ ] Verify edge cases with quoted sheet names (e.g., `'My Sheet'!A1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * INDIREC T support added: resolves text references to cells/ranges with A1 and R1C1 styles, absolute/range and sheet-qualified references, and defined-name resolution; treated as volatile with dependency tracking.

* **Tests**
  * Re-enabled and expanded unit tests exercising INDIRECT across many formats and edge cases (including invalid or missing references).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->