### PR TITLE
feat: implement INDIRECT function

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,14 +3,20 @@ language: en-US
 reviews:
   request_changes_workflow: false
   high_level_summary: true
+  collapse_walkthrough: true
   poem: false
   review_status: true
+  sequence_diagrams: true
   auto_review:
     enabled: true
     drafts: false
   path_filters:
     - '!**/*.trx'
     - '!**/BenchmarkDotNet.Artifacts/**'
+    - '!**/obj/**'
+    - '!**/bin/**'
+    - '!**/PublicAPI.Shipped.txt'
+    - '!**/PublicAPI.Unshipped.txt'
   path_instructions:
     - path: 'XLibur/**/*.cs'
       instructions: |
@@ -25,6 +31,12 @@ reviews:
         - Proper assertions (prefer Assert.That constraint model)
         - Test isolation and determinism
         - Missing edge case coverage
+    - path: 'XLibur.Benchmarks/**/*.cs'
+      instructions: |
+        These are BenchmarkDotNet performance benchmarks. Focus on:
+        - Correct benchmark methodology (no side-effect elimination)
+        - Appropriate [Benchmark] and [GlobalSetup] usage
+        - Do not flag allocations or style in harness code
 
 chat:
   auto_reply: true

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 end_of_line = crlf
 insert_final_newline = true
 trim_trailing_whitespace = true
+charset = utf-8-bom
 max_line_length = 120
 
 # 4 space indentation
@@ -11,3 +12,19 @@ max_line_length = 120
 indent_style = space
 indent_size = 4
 
+# 2 space indentation for project/build files
+[*.{csproj,props,targets,slnx,nuspec}]
+indent_style = space
+indent_size = 2
+
+# 2 space indentation for config files
+[*.{json,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.xml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf
+*.slnx text eol=crlf
 *.csproj text eol=crlf
 
 # Denote all files that are truly binary and should not be modified.
@@ -17,5 +18,3 @@
 *.gif binary
 *.ico binary
 *.xlsx binary
-
-core.autocrlf=true

--- a/XLibur.Benchmarks/ClosedXmlReadBenchmarks.cs
+++ b/XLibur.Benchmarks/ClosedXmlReadBenchmarks.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Attributes;

--- a/XLibur.Benchmarks/ClosedXmlWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/ClosedXmlWorkbookBenchmarks.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using BenchmarkDotNet.Attributes;
 using ClosedXML.Excel;

--- a/XLibur.Benchmarks/EpPlusReadBenchmarks.cs
+++ b/XLibur.Benchmarks/EpPlusReadBenchmarks.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Attributes;

--- a/XLibur.Benchmarks/EpPlusWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/EpPlusWorkbookBenchmarks.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.IO;
 using BenchmarkDotNet.Attributes;

--- a/XLibur.Benchmarks/MemoryProfile.cs
+++ b/XLibur.Benchmarks/MemoryProfile.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;

--- a/XLibur.Benchmarks/Program.cs
+++ b/XLibur.Benchmarks/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using BenchmarkDotNet.Running;
 using XLibur.Benchmarks;
 

--- a/XLibur.Benchmarks/StyleKeyHashCodeBenchmarks.cs
+++ b/XLibur.Benchmarks/StyleKeyHashCodeBenchmarks.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;

--- a/XLibur.Benchmarks/XLiburReadBenchmarks.cs
+++ b/XLibur.Benchmarks/XLiburReadBenchmarks.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Attributes;

--- a/XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnostics.dotTrace;

--- a/XLibur.Examples/AutoFilters/CustomAutoFilter.cs
+++ b/XLibur.Examples/AutoFilters/CustomAutoFilter.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.AutoFilters;

--- a/XLibur.Examples/AutoFilters/DynamicAutoFilter.cs
+++ b/XLibur.Examples/AutoFilters/DynamicAutoFilter.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.AutoFilters;

--- a/XLibur.Examples/AutoFilters/RegularAutoFilter.cs
+++ b/XLibur.Examples/AutoFilters/RegularAutoFilter.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.AutoFilters;

--- a/XLibur.Examples/AutoFilters/TopBottomAutoFilter.cs
+++ b/XLibur.Examples/AutoFilters/TopBottomAutoFilter.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.AutoFilters;

--- a/XLibur.Examples/BasicTable.cs
+++ b/XLibur.Examples/BasicTable.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using System;
 
 namespace XLibur.Examples;

--- a/XLibur.Examples/Charts/ChartExamples.cs
+++ b/XLibur.Examples/Charts/ChartExamples.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Charts;
 

--- a/XLibur.Examples/Columns/ColumnCells.cs
+++ b/XLibur.Examples/Columns/ColumnCells.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Columns;
 

--- a/XLibur.Examples/Columns/ColumnCollections.cs
+++ b/XLibur.Examples/Columns/ColumnCollections.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Columns;
 

--- a/XLibur.Examples/Columns/ColumnSettings.cs
+++ b/XLibur.Examples/Columns/ColumnSettings.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Columns;
 

--- a/XLibur.Examples/Columns/DeletingColumns.cs
+++ b/XLibur.Examples/Columns/DeletingColumns.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Columns;
 

--- a/XLibur.Examples/Columns/InsertColumns.cs
+++ b/XLibur.Examples/Columns/InsertColumns.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using System.Linq;
 
 namespace XLibur.Examples.Columns;

--- a/XLibur.Examples/Comments/AddingComments.cs
+++ b/XLibur.Examples/Comments/AddingComments.cs
@@ -1,4 +1,4 @@
-using MoreLinq;
+﻿using MoreLinq;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Comments;

--- a/XLibur.Examples/ConditionalFormatting/ConditionalFormatting.cs
+++ b/XLibur.Examples/ConditionalFormatting/ConditionalFormatting.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.ConditionalFormatting;
 

--- a/XLibur.Examples/Creating/CreateFiles.cs
+++ b/XLibur.Examples/Creating/CreateFiles.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Examples.Charts;
 using XLibur.Examples.Columns;
 using XLibur.Examples.Comments;

--- a/XLibur.Examples/Delete/DeleteFewWorksheets.cs
+++ b/XLibur.Examples/Delete/DeleteFewWorksheets.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Delete;

--- a/XLibur.Examples/Delete/DeleteRows.cs
+++ b/XLibur.Examples/Delete/DeleteRows.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Delete;

--- a/XLibur.Examples/ExampleHelper.cs
+++ b/XLibur.Examples/ExampleHelper.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 
 namespace XLibur.Examples;
 

--- a/XLibur.Examples/HelloWorld.cs
+++ b/XLibur.Examples/HelloWorld.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples;
 

--- a/XLibur.Examples/IXLExample.cs
+++ b/XLibur.Examples/IXLExample.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Examples;
+﻿namespace XLibur.Examples;
 
 public interface IXLExample
 {

--- a/XLibur.Examples/ImageHandling/ImageAnchors.cs
+++ b/XLibur.Examples/ImageHandling/ImageAnchors.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 using XLibur.Excel;
 using XLibur.Excel.Drawings;

--- a/XLibur.Examples/ImageHandling/ImageFormats.cs
+++ b/XLibur.Examples/ImageHandling/ImageFormats.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using XLibur.Excel;
 using XLibur.Excel.Drawings;
 

--- a/XLibur.Examples/Loading/ChangingBasicTable.cs
+++ b/XLibur.Examples/Loading/ChangingBasicTable.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Loading;

--- a/XLibur.Examples/Loading/LoadFiles.cs
+++ b/XLibur.Examples/Loading/LoadFiles.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Loading;

--- a/XLibur.Examples/Misc/AddingDataSet.cs
+++ b/XLibur.Examples/Misc/AddingDataSet.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using System;
 using System.Data;
 

--- a/XLibur.Examples/Misc/AddingDataTableAsWorksheet.cs
+++ b/XLibur.Examples/Misc/AddingDataTableAsWorksheet.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Linq;
 using XLibur.Excel;

--- a/XLibur.Examples/Misc/AdjustToContents.cs
+++ b/XLibur.Examples/Misc/AdjustToContents.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using System;
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/AdjustToContentsWithAutoFilter.cs
+++ b/XLibur.Examples/Misc/AdjustToContentsWithAutoFilter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;
 

--- a/XLibur.Examples/Misc/AutoFilter.cs
+++ b/XLibur.Examples/Misc/AutoFilter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/BlankCells.cs
+++ b/XLibur.Examples/Misc/BlankCells.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/CellValues.cs
+++ b/XLibur.Examples/Misc/CellValues.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using System;
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/Collections.cs
+++ b/XLibur.Examples/Misc/Collections.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;

--- a/XLibur.Examples/Misc/CopyingRowsAndColumns.cs
+++ b/XLibur.Examples/Misc/CopyingRowsAndColumns.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;
 

--- a/XLibur.Examples/Misc/CopyingWorksheets.cs
+++ b/XLibur.Examples/Misc/CopyingWorksheets.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using XLibur.Examples.Tables;
 using System.IO;
 

--- a/XLibur.Examples/Misc/DataTypes.cs
+++ b/XLibur.Examples/Misc/DataTypes.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/DataValidation.cs
+++ b/XLibur.Examples/Misc/DataValidation.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel;
 
 

--- a/XLibur.Examples/Misc/DataValidationDate.cs
+++ b/XLibur.Examples/Misc/DataValidationDate.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using System;
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/DataValidationDecimal.cs
+++ b/XLibur.Examples/Misc/DataValidationDecimal.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;
 

--- a/XLibur.Examples/Misc/DataValidationTextLength.cs
+++ b/XLibur.Examples/Misc/DataValidationTextLength.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;
 

--- a/XLibur.Examples/Misc/DataValidationTime.cs
+++ b/XLibur.Examples/Misc/DataValidationTime.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using System;
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/DataValidationWholeNumber.cs
+++ b/XLibur.Examples/Misc/DataValidationWholeNumber.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;
 

--- a/XLibur.Examples/Misc/Formulas.cs
+++ b/XLibur.Examples/Misc/Formulas.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;
 

--- a/XLibur.Examples/Misc/FreezePanes.cs
+++ b/XLibur.Examples/Misc/FreezePanes.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;
 

--- a/XLibur.Examples/Misc/HideSheets.cs
+++ b/XLibur.Examples/Misc/HideSheets.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/HideUnhide.cs
+++ b/XLibur.Examples/Misc/HideUnhide.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/Hyperlinks.cs
+++ b/XLibur.Examples/Misc/Hyperlinks.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel;
 
 

--- a/XLibur.Examples/Misc/InsertingData.cs
+++ b/XLibur.Examples/Misc/InsertingData.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/XLibur.Examples/Misc/LambdaExpressions.cs
+++ b/XLibur.Examples/Misc/LambdaExpressions.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using MoreLinq;
 using XLibur.Excel;

--- a/XLibur.Examples/Misc/MergeCells.cs
+++ b/XLibur.Examples/Misc/MergeCells.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/MergeMoves.cs
+++ b/XLibur.Examples/Misc/MergeMoves.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 

--- a/XLibur.Examples/Misc/MultipleSheets.cs
+++ b/XLibur.Examples/Misc/MultipleSheets.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/Outline.cs
+++ b/XLibur.Examples/Misc/Outline.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/RightToLeft.cs
+++ b/XLibur.Examples/Misc/RightToLeft.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;
 

--- a/XLibur.Examples/Misc/SheetProtection.cs
+++ b/XLibur.Examples/Misc/SheetProtection.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;
 

--- a/XLibur.Examples/Misc/SheetViews.cs
+++ b/XLibur.Examples/Misc/SheetViews.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;
 

--- a/XLibur.Examples/Misc/ShiftingFormulas.cs
+++ b/XLibur.Examples/Misc/ShiftingFormulas.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 
 

--- a/XLibur.Examples/Misc/ShowCase.cs
+++ b/XLibur.Examples/Misc/ShowCase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/TabColors.cs
+++ b/XLibur.Examples/Misc/TabColors.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/Misc/WorkbookProperties.cs
+++ b/XLibur.Examples/Misc/WorkbookProperties.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Misc;

--- a/XLibur.Examples/ModifyFiles.cs
+++ b/XLibur.Examples/ModifyFiles.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples.Delete;
+﻿using XLibur.Examples.Delete;
 using System.IO;
 
 namespace XLibur.Examples;

--- a/XLibur.Examples/PageSetup/HeaderFooters.cs
+++ b/XLibur.Examples/PageSetup/HeaderFooters.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.PageSetup;

--- a/XLibur.Examples/PageSetup/Margins.cs
+++ b/XLibur.Examples/PageSetup/Margins.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.PageSetup;

--- a/XLibur.Examples/PageSetup/Page.cs
+++ b/XLibur.Examples/PageSetup/Page.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.PageSetup;

--- a/XLibur.Examples/PageSetup/SheetTab.cs
+++ b/XLibur.Examples/PageSetup/SheetTab.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.PageSetup;

--- a/XLibur.Examples/PageSetup/Sheets.cs
+++ b/XLibur.Examples/PageSetup/Sheets.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.PageSetup;

--- a/XLibur.Examples/PageSetup/TwoPages.cs
+++ b/XLibur.Examples/PageSetup/TwoPages.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 
 

--- a/XLibur.Examples/PivotTables/PivotTables.cs
+++ b/XLibur.Examples/PivotTables/PivotTables.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using XLibur.Excel;
 

--- a/XLibur.Examples/Program.cs
+++ b/XLibur.Examples/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using XLibur.Examples.Creating;
 using XLibur.Examples.Loading;

--- a/XLibur.Examples/Ranges/AddingRowToTables.cs
+++ b/XLibur.Examples/Ranges/AddingRowToTables.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using System.IO;
 using System.Linq;
 

--- a/XLibur.Examples/Ranges/ClearingRanges.cs
+++ b/XLibur.Examples/Ranges/ClearingRanges.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 
 

--- a/XLibur.Examples/Ranges/CopyingRanges.cs
+++ b/XLibur.Examples/Ranges/CopyingRanges.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Ranges/CurrentRowColumn.cs
+++ b/XLibur.Examples/Ranges/CurrentRowColumn.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Ranges/DefinedNames.cs
+++ b/XLibur.Examples/Ranges/DefinedNames.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Ranges;
 

--- a/XLibur.Examples/Ranges/DefiningRanges.cs
+++ b/XLibur.Examples/Ranges/DefiningRanges.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Ranges/DeletingRanges.cs
+++ b/XLibur.Examples/Ranges/DeletingRanges.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Ranges/InsertingDeletingColumns.cs
+++ b/XLibur.Examples/Ranges/InsertingDeletingColumns.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Ranges;
 

--- a/XLibur.Examples/Ranges/InsertingDeletingRows.cs
+++ b/XLibur.Examples/Ranges/InsertingDeletingRows.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Ranges;
 

--- a/XLibur.Examples/Ranges/MultipleRanges.cs
+++ b/XLibur.Examples/Ranges/MultipleRanges.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Ranges;
 

--- a/XLibur.Examples/Ranges/SelectingRanges.cs
+++ b/XLibur.Examples/Ranges/SelectingRanges.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Ranges/ShiftingRanges.cs
+++ b/XLibur.Examples/Ranges/ShiftingRanges.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Ranges/SortExample.cs
+++ b/XLibur.Examples/Ranges/SortExample.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Ranges/Sorting.cs
+++ b/XLibur.Examples/Ranges/Sorting.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Ranges/TransposeRanges.cs
+++ b/XLibur.Examples/Ranges/TransposeRanges.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Ranges/TransposeRangesPlus.cs
+++ b/XLibur.Examples/Ranges/TransposeRangesPlus.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Ranges/WalkingRanges.cs
+++ b/XLibur.Examples/Ranges/WalkingRanges.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Ranges;

--- a/XLibur.Examples/Rows/InsertRows.cs
+++ b/XLibur.Examples/Rows/InsertRows.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 
 

--- a/XLibur.Examples/Rows/RowCells.cs
+++ b/XLibur.Examples/Rows/RowCells.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Rows;
 

--- a/XLibur.Examples/Rows/RowCollection.cs
+++ b/XLibur.Examples/Rows/RowCollection.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Rows;

--- a/XLibur.Examples/Rows/RowSettings.cs
+++ b/XLibur.Examples/Rows/RowSettings.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Rows;
 

--- a/XLibur.Examples/StyleExamples.cs
+++ b/XLibur.Examples/StyleExamples.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples.Styles;
+﻿using XLibur.Examples.Styles;
 using System.IO;
 
 namespace XLibur.Examples;

--- a/XLibur.Examples/Styles/DefaultStyles.cs
+++ b/XLibur.Examples/Styles/DefaultStyles.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Styles;
 

--- a/XLibur.Examples/Styles/PurpleWorksheet.cs
+++ b/XLibur.Examples/Styles/PurpleWorksheet.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Styles;
 

--- a/XLibur.Examples/Styles/StyleAlignment.cs
+++ b/XLibur.Examples/Styles/StyleAlignment.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Styles;
 

--- a/XLibur.Examples/Styles/StyleBorder.cs
+++ b/XLibur.Examples/Styles/StyleBorder.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Styles;
 

--- a/XLibur.Examples/Styles/StyleFill.cs
+++ b/XLibur.Examples/Styles/StyleFill.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Styles;
 

--- a/XLibur.Examples/Styles/StyleNumberFormat.cs
+++ b/XLibur.Examples/Styles/StyleNumberFormat.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Styles;
 

--- a/XLibur.Examples/Styles/StyleRowsColumns.cs
+++ b/XLibur.Examples/Styles/StyleRowsColumns.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Styles;

--- a/XLibur.Examples/Styles/StyleWorksheet.cs
+++ b/XLibur.Examples/Styles/StyleWorksheet.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 
 namespace XLibur.Examples.Styles;

--- a/XLibur.Examples/Styles/UsingColors.cs
+++ b/XLibur.Examples/Styles/UsingColors.cs
@@ -1,4 +1,4 @@
-using System.Drawing;
+﻿using System.Drawing;
 using XLibur.Excel;
 
 

--- a/XLibur.Examples/Styles/UsingPhonetics.cs
+++ b/XLibur.Examples/Styles/UsingPhonetics.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Styles;
 

--- a/XLibur.Examples/Styles/UsingRichText.cs
+++ b/XLibur.Examples/Styles/UsingRichText.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Examples.Styles;
 

--- a/XLibur.Examples/Tables/InsertingTables.cs
+++ b/XLibur.Examples/Tables/InsertingTables.cs
@@ -1,4 +1,4 @@
-using XLibur.Attributes;
+﻿using XLibur.Attributes;
 using XLibur.Excel;
 using System;
 using System.Collections.Generic;

--- a/XLibur.Examples/Tables/UsingTables.cs
+++ b/XLibur.Examples/Tables/UsingTables.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using System.IO;
 
 namespace XLibur.Examples.Tables;

--- a/XLibur.Tests/Examples/AutoFilterTests.cs
+++ b/XLibur.Tests/Examples/AutoFilterTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples;
+﻿using XLibur.Examples;
 using NUnit.Framework;
 using XLibur.Examples.AutoFilters;
 

--- a/XLibur.Tests/Examples/ColumnsTests.cs
+++ b/XLibur.Tests/Examples/ColumnsTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples;
+﻿using XLibur.Examples;
 using XLibur.Examples.Columns;
 using NUnit.Framework;
 

--- a/XLibur.Tests/Examples/CommentsTests.cs
+++ b/XLibur.Tests/Examples/CommentsTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using XLibur.Examples.Comments;
 
 namespace XLibur.Tests.Examples;

--- a/XLibur.Tests/Examples/ConditionalFormattingTests.cs
+++ b/XLibur.Tests/Examples/ConditionalFormattingTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples;
+﻿using XLibur.Examples;
 using NUnit.Framework;
 using XLibur.Examples.ConditionalFormatting;
 

--- a/XLibur.Tests/Examples/DeleteTests.cs
+++ b/XLibur.Tests/Examples/DeleteTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples.Delete;
+﻿using XLibur.Examples.Delete;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Examples;

--- a/XLibur.Tests/Examples/ImageHandlingTests.cs
+++ b/XLibur.Tests/Examples/ImageHandlingTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples;
+﻿using XLibur.Examples;
 using NUnit.Framework;
 using XLibur.Examples.ImageHandling;
 

--- a/XLibur.Tests/Examples/LoadingTests.cs
+++ b/XLibur.Tests/Examples/LoadingTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples;
+﻿using XLibur.Examples;
 using NUnit.Framework;
 using XLibur.Examples.Loading;
 

--- a/XLibur.Tests/Examples/MiscTests.cs
+++ b/XLibur.Tests/Examples/MiscTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples;
+﻿using XLibur.Examples;
 using XLibur.Examples.Misc;
 using NUnit.Framework;
 

--- a/XLibur.Tests/Examples/PageSetupTests.cs
+++ b/XLibur.Tests/Examples/PageSetupTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples.PageSetup;
+﻿using XLibur.Examples.PageSetup;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Examples;

--- a/XLibur.Tests/Examples/RangesTests.cs
+++ b/XLibur.Tests/Examples/RangesTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples;
+﻿using XLibur.Examples;
 using XLibur.Examples.Misc;
 using XLibur.Examples.Ranges;
 using NUnit.Framework;

--- a/XLibur.Tests/Examples/RowsTests.cs
+++ b/XLibur.Tests/Examples/RowsTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples;
+﻿using XLibur.Examples;
 using XLibur.Examples.Rows;
 using NUnit.Framework;
 

--- a/XLibur.Tests/Examples/StylesTests.cs
+++ b/XLibur.Tests/Examples/StylesTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples.Styles;
+﻿using XLibur.Examples.Styles;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Examples;

--- a/XLibur.Tests/Excel/AutoFilters/AutoFilterTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/AutoFilterTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/XLibur.Tests/Excel/AutoFilters/ColorFilterTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/ColorFilterTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using NUnit.Framework;
 using XLibur.Excel;
 

--- a/XLibur.Tests/Excel/Caching/SampleRepositoryTests.cs
+++ b/XLibur.Tests/Excel/Caching/SampleRepositoryTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Caching;
+﻿using XLibur.Excel.Caching;
 using NUnit.Framework;
 using System.Linq;
 using System.Threading.Tasks;

--- a/XLibur.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 using System;
 using XLibur.Extensions;

--- a/XLibur.Tests/Excel/CalcEngine/EngineeringTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/EngineeringTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Excel.CalcEngine;

--- a/XLibur.Tests/Excel/CalcEngine/FinancialTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FinancialTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Excel.CalcEngine;

--- a/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -304,7 +304,7 @@ public class FormulaParserTests
 
     [TestCase("=INDEX(A1:B2,1,2)", "Lemons")]
     //[TestCase("=OFFSET(C4,-1,-2)", "Pears")] Not implemented
-    //[TestCase("=INDIRECT(\"A2\")", "Bananas")] Not implemented
+    [TestCase("=INDIRECT(\"A2\")", "Bananas")]
     public void Ref_function_name_can_be_excel_ref_function(string formula, object expectedValue)
     {
         using var wb = new XLWorkbook();

--- a/XLibur.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 using System;
 

--- a/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
@@ -630,4 +630,29 @@ public class InformationTests
         ws.Cell("C1").FormulaA1 = "TYPE((A1,A1))";
         Assert.AreEqual(16.0, ws.Cell("C1").Value);
     }
+
+    [Test]
+    public void IsBlank_EmptyString_ReturnsFalse()
+    {
+        // ISBLANK("") should be false — an empty string is a text value, not blank.
+        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(\"\")"));
+    }
+
+    [Test]
+    public void IsBlank_BlankCell_ReturnsTrue()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+
+        // A1 is never set, so it is blank.
+        Assert.AreEqual(true, ws.Evaluate("ISBLANK(A1)"));
+    }
+
+    [Test]
+    public void IsBlank_NonBlankValues_ReturnsFalse()
+    {
+        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(0)"));
+        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(FALSE)"));
+        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(\"hello\")"));
+    }
 }

--- a/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
@@ -630,29 +630,4 @@ public class InformationTests
         ws.Cell("C1").FormulaA1 = "TYPE((A1,A1))";
         Assert.AreEqual(16.0, ws.Cell("C1").Value);
     }
-
-    [Test]
-    public void IsBlank_EmptyString_ReturnsFalse()
-    {
-        // ISBLANK("") should be false — an empty string is a text value, not blank.
-        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(\"\")"));
-    }
-
-    [Test]
-    public void IsBlank_BlankCell_ReturnsTrue()
-    {
-        using var wb = new XLWorkbook();
-        var ws = wb.AddWorksheet();
-
-        // A1 is never set, so it is blank.
-        Assert.AreEqual(true, ws.Evaluate("ISBLANK(A1)"));
-    }
-
-    [Test]
-    public void IsBlank_NonBlankValues_ReturnsFalse()
-    {
-        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(0)"));
-        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(FALSE)"));
-        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("ISBLANK(\"hello\")"));
-    }
 }

--- a/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 using System;
 using XLibur.Extensions;

--- a/XLibur.Tests/Excel/CalcEngine/LogicalTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LogicalTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 using System;
 

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -1054,6 +1054,17 @@ public class LookupTests
     }
 
     [Test]
+    public void Indirect_SheetScopedDefinedName()
+    {
+        using var wb = new XLWorkbook();
+        var sheet1 = wb.AddWorksheet("Sheet1");
+        var sheet2 = wb.AddWorksheet("Sheet2");
+        sheet2.Cell("B2").Value = 55;
+        sheet2.DefinedNames.Add("LocalName", "Sheet2!$B$2");
+        Assert.AreEqual(55, sheet1.Evaluate("INDIRECT(\"Sheet2!LocalName\")"));
+    }
+
+    [Test]
     public void Indirect_A1FlagTrue_SameAsDefault()
     {
         using var wb = new XLWorkbook();

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -1072,6 +1072,27 @@ public class LookupTests
     }
 
     [Test]
+    public void Indirect_QuotedSheetNameWithApostrophe()
+    {
+        using var wb = new XLWorkbook();
+        var sheet1 = wb.AddWorksheet("Main");
+        var sheet2 = wb.AddWorksheet("Bob's");
+        sheet2.Cell("A1").Value = 42;
+        Assert.AreEqual(42, sheet1.Evaluate("INDIRECT(\"'Bob''s'!A1\")"));
+    }
+
+    [Test]
+    public void Indirect_R1C1Range()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 1;
+        sheet.Cell("A2").Value = 2;
+        sheet.Cell("C3").Value = 10;
+        Assert.AreEqual(13.0, sheet.Evaluate("SUM(INDIRECT(\"R1C1:R3C3\", FALSE))"));
+    }
+
+    [Test]
     public void Indirect_NonExistentSheet_ReturnsCellReferenceError()
     {
         using var wb = new XLWorkbook();

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -986,4 +986,108 @@ public class LookupTests
 
         Assert.AreEqual(XLError.NoValueAvailable, sheet.Evaluate(@"HLOOKUP(""Z*"",A1:A2,2,FALSE)"));
     }
+
+    #region INDIRECT
+
+    [Test]
+    public void Indirect_BasicA1Reference()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 42;
+        Assert.AreEqual(42, sheet.Evaluate("INDIRECT(\"A1\")"));
+    }
+
+    [Test]
+    public void Indirect_AbsoluteReference()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("B2").Value = "Hello";
+        Assert.AreEqual("Hello", sheet.Evaluate("INDIRECT(\"$B$2\")"));
+    }
+
+    [Test]
+    public void Indirect_RangeReference_ReturnsReferenceUsableByOtherFunctions()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 1;
+        sheet.Cell("A2").Value = 2;
+        sheet.Cell("B1").Value = 3;
+        sheet.Cell("B2").Value = 4;
+        Assert.AreEqual(10.0, sheet.Evaluate("SUM(INDIRECT(\"A1:B2\"))"));
+    }
+
+    [Test]
+    public void Indirect_EmptyString_ReturnsCellReferenceError()
+    {
+        Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("INDIRECT(\"\")"));
+    }
+
+    [Test]
+    public void Indirect_SheetPrefix()
+    {
+        using var wb = new XLWorkbook();
+        var sheet1 = wb.AddWorksheet("Sheet1");
+        var sheet2 = wb.AddWorksheet("Sheet2");
+        sheet2.Cell("A1").Value = 99;
+        Assert.AreEqual(99, sheet1.Evaluate("INDIRECT(\"Sheet2!A1\")"));
+    }
+
+    [Test]
+    public void Indirect_InvalidReference_ReturnsCellReferenceError()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        Assert.AreEqual(XLError.CellReference, sheet.Evaluate("INDIRECT(\"XYZ\")"));
+    }
+
+    [Test]
+    public void Indirect_DefinedName()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("C3").Value = 77;
+        wb.DefinedNames.Add("MyRange", "Sheet1!$C$3");
+        Assert.AreEqual(77, sheet.Evaluate("INDIRECT(\"MyRange\")"));
+    }
+
+    [Test]
+    public void Indirect_A1FlagTrue_SameAsDefault()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 5;
+        Assert.AreEqual(5, sheet.Evaluate("INDIRECT(\"A1\", TRUE)"));
+    }
+
+    [Test]
+    public void Indirect_R1C1Style()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = 123;
+        Assert.AreEqual(123, sheet.Evaluate("INDIRECT(\"R1C1\", FALSE)"));
+    }
+
+    [Test]
+    public void Indirect_NonExistentSheet_ReturnsCellReferenceError()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        Assert.AreEqual(XLError.CellReference, sheet.Evaluate("INDIRECT(\"NoSuchSheet!A1\")"));
+    }
+
+    [Test]
+    public void Indirect_DynamicReference()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        sheet.Cell("A1").Value = "B2";
+        sheet.Cell("B2").Value = 100;
+        Assert.AreEqual(100, sheet.Evaluate("INDIRECT(A1)"));
+    }
+
+    #endregion
 }

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -1,4 +1,4 @@
-
+﻿
 using XLibur.Excel;
 using NUnit.Framework;
 using System;

--- a/XLibur.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -1,4 +1,4 @@
-
+﻿
 using XLibur.Excel;
 using NUnit.Framework;
 using System;

--- a/XLibur.Tests/Excel/CalcEngine/StructuredReferenceColonTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/StructuredReferenceColonTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using XLibur.Excel;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/CalcEngine/TextTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/TextTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 using System;
 using System.Globalization;

--- a/XLibur.Tests/Excel/CalcEngine/XLMathTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/XLMathTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.CalcEngine.Functions;
+﻿using XLibur.Excel.CalcEngine.Functions;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Excel.CalcEngine;

--- a/XLibur.Tests/Excel/Cells/XLCellFormulaTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellFormulaTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;

--- a/XLibur.Tests/Excel/Cells/XLCellImageTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellImageTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using XLibur.Excel;

--- a/XLibur.Tests/Excel/Cells/XLCellTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;

--- a/XLibur.Tests/Excel/Charts/ChartTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartTests.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml.Drawing.Charts;
+﻿using DocumentFormat.OpenXml.Drawing.Charts;
 using DocumentFormat.OpenXml.Packaging;
 using NUnit.Framework;
 using System.IO;

--- a/XLibur.Tests/Excel/Columns/ColumnTests.cs
+++ b/XLibur.Tests/Excel/Columns/ColumnTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 using XLibur.Extensions;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/Coordinates/XLAddressTests.cs
+++ b/XLibur.Tests/Excel/Coordinates/XLAddressTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 
 namespace XLibur.Tests;

--- a/XLibur.Tests/Excel/CustomProperties/XLCustomPropertyTests.cs
+++ b/XLibur.Tests/Excel/CustomProperties/XLCustomPropertyTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using XLibur.Excel;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;

--- a/XLibur.Tests/Excel/Drawings/PictureTests.cs
+++ b/XLibur.Tests/Excel/Drawings/PictureTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Reflection;
 using DocumentFormat.OpenXml;

--- a/XLibur.Tests/Excel/Hyperlinks/XLHyperlinksTests.cs
+++ b/XLibur.Tests/Excel/Hyperlinks/XLHyperlinksTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel;

--- a/XLibur.Tests/Excel/IO/WorksheetSheetDataReaderTests.cs
+++ b/XLibur.Tests/Excel/IO/WorksheetSheetDataReaderTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;

--- a/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.IO;
 using System.Linq;

--- a/XLibur.Tests/Excel/Loading/LoadingTests.cs
+++ b/XLibur.Tests/Excel/Loading/LoadingTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;

--- a/XLibur.Tests/Excel/Misc/CopyContentsTests.cs
+++ b/XLibur.Tests/Excel/Misc/CopyContentsTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel;
 using NUnit.Framework;
 using System.Linq;

--- a/XLibur.Tests/Excel/Misc/FormulaTests.cs
+++ b/XLibur.Tests/Excel/Misc/FormulaTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using XLibur.Excel;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/Misc/StylesTests.cs
+++ b/XLibur.Tests/Excel/Misc/StylesTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 using XLibur.Extensions;
 

--- a/XLibur.Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/XLibur.Tests/Excel/Misc/XLWorkbookTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using XLibur.Excel;

--- a/XLibur.Tests/Excel/Misc/XlHelperTests.cs
+++ b/XLibur.Tests/Excel/Misc/XlHelperTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using XLibur.Excel;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/Misc/XmlEncoderTests.cs
+++ b/XLibur.Tests/Excel/Misc/XmlEncoderTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 using XLibur.Utils;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/NamedRanges/NamedRangeInsertionTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangeInsertionTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using XLibur.Excel;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/XLibur.Tests/Excel/PageSetup/HeaderFooterImageTests.cs
+++ b/XLibur.Tests/Excel/PageSetup/HeaderFooterImageTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;

--- a/XLibur.Tests/Excel/PageSetup/HeaderFooterTests.cs
+++ b/XLibur.Tests/Excel/PageSetup/HeaderFooterTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using XLibur.Excel;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/PageSetup/PageBreaksTests.cs
+++ b/XLibur.Tests/Excel/PageSetup/PageBreaksTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Excel.PageSetup;

--- a/XLibur.Tests/Excel/PivotTables/XLPivotSourceTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotSourceTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using XLibur.Excel;
 using XLibur.Excel.Coordinates;
 

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;

--- a/XLibur.Tests/Excel/Ranges/CopyingRangesTests.cs
+++ b/XLibur.Tests/Excel/Ranges/CopyingRangesTests.cs
@@ -1,4 +1,4 @@
-using System.Drawing;
+﻿using System.Drawing;
 using System.Linq;
 using XLibur.Excel;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/Ranges/InsertingRangesTests.cs
+++ b/XLibur.Tests/Excel/Ranges/InsertingRangesTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using XLibur.Excel;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/Ranges/MergedRangesTests.cs
+++ b/XLibur.Tests/Excel/Ranges/MergedRangesTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 using NUnit.Framework;
 using XLibur.Extensions;

--- a/XLibur.Tests/Excel/Ranges/RangeRowCopyToTests.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeRowCopyToTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.Ranges;

--- a/XLibur.Tests/Excel/Ranges/RangeShiftingTests.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeShiftingTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Excel.Ranges;

--- a/XLibur.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/XLibur.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 using System.Linq;
 

--- a/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel;
 using NUnit.Framework;
 using XLibur.Excel.Coordinates;

--- a/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/Rows/RowTests.cs
+++ b/XLibur.Tests/Excel/Rows/RowTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using XLibur.Excel;

--- a/XLibur.Tests/Excel/Saving/SavingTests.cs
+++ b/XLibur.Tests/Excel/Saving/SavingTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using XLibur.Excel.Drawings;
 using XLibur.Tests.Utils;
 using DocumentFormat.OpenXml;

--- a/XLibur.Tests/Excel/Styles/BatchStyleTests.cs
+++ b/XLibur.Tests/Excel/Styles/BatchStyleTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Excel.Styles;

--- a/XLibur.Tests/Excel/Styles/ColorTests.cs
+++ b/XLibur.Tests/Excel/Styles/ColorTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Threading;
 using XLibur.Excel;
 using XLibur.Utils;

--- a/XLibur.Tests/Excel/Styles/NumberFormatTests.cs
+++ b/XLibur.Tests/Excel/Styles/NumberFormatTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Globalization;
 using System.IO;

--- a/XLibur.Tests/Excel/Styles/XLFillTests.cs
+++ b/XLibur.Tests/Excel/Styles/XLFillTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using XLibur.Excel;
 using NUnit.Framework;
 

--- a/XLibur.Tests/Excel/Tables/TableNameValidationTests.cs
+++ b/XLibur.Tests/Excel/Tables/TableNameValidationTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Linq;
 using XLibur.Excel;

--- a/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/XLibur.Tests/ExcelDocsComparerTests.cs
+++ b/XLibur.Tests/ExcelDocsComparerTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples;
+﻿using XLibur.Examples;
 using NUnit.Framework;
 using System.IO;
 using XLibur.Tests.Utils;

--- a/XLibur.Tests/Extensions/ReflectionExtensionTests.cs
+++ b/XLibur.Tests/Extensions/ReflectionExtensionTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Extensions;
+﻿using XLibur.Extensions;
 using NUnit.Framework;
 using System;
 using System.Linq;

--- a/XLibur.Tests/Graphics/FontTests.cs
+++ b/XLibur.Tests/Graphics/FontTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel;
 using XLibur.Graphics;
 using NUnit.Framework;

--- a/XLibur.Tests/OpenXmlTests.cs
+++ b/XLibur.Tests/OpenXmlTests.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml.Packaging;
+﻿using DocumentFormat.OpenXml.Packaging;
 using NUnit.Framework;
 using System.IO;
 

--- a/XLibur.Tests/TestHelper.cs
+++ b/XLibur.Tests/TestHelper.cs
@@ -1,4 +1,4 @@
-using XLibur.Examples;
+﻿using XLibur.Examples;
 using XLibur.Excel;
 using NUnit.Framework;
 using System;

--- a/XLibur.Tests/Utils/ExcelDocsComparer.cs
+++ b/XLibur.Tests/Utils/ExcelDocsComparer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.IO.Packaging;
 

--- a/XLibur.Tests/Utils/PackageHelper.cs
+++ b/XLibur.Tests/Utils/PackageHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/XLibur.Tests/Utils/ResourceFileExtractor.cs
+++ b/XLibur.Tests/Utils/ResourceFileExtractor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;

--- a/XLibur.Tests/Utils/StreamHelper.cs
+++ b/XLibur.Tests/Utils/StreamHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/XLibur.Tests/XLHelperTests.cs
+++ b/XLibur.Tests/XLHelperTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using NUnit.Framework;
 using System;
 

--- a/XLibur/Attributes/XLColumnAttribute.cs
+++ b/XLibur/Attributes/XLColumnAttribute.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 

--- a/XLibur/Excel/AutoFilters/IXLAutoFilter.cs
+++ b/XLibur/Excel/AutoFilters/IXLAutoFilter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/AutoFilters/IXLCustomFilteredColumn.cs
+++ b/XLibur/Excel/AutoFilters/IXLCustomFilteredColumn.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLCustomFilteredColumn
 {

--- a/XLibur/Excel/AutoFilters/IXLFilterColumn.cs
+++ b/XLibur/Excel/AutoFilters/IXLFilterColumn.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/AutoFilters/IXLFilterConnector.cs
+++ b/XLibur/Excel/AutoFilters/IXLFilterConnector.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLFilterConnector
 {

--- a/XLibur/Excel/AutoFilters/IXLFilteredColumn.cs
+++ b/XLibur/Excel/AutoFilters/IXLFilteredColumn.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Caching/IXLRepository.cs
+++ b/XLibur/Excel/Caching/IXLRepository.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel.Caching;

--- a/XLibur/Excel/Caching/XLRepositoryBase.cs
+++ b/XLibur/Excel/Caching/XLRepositoryBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/XLibur/Excel/Caching/XLWorkbookElementRepositoryBase.cs
+++ b/XLibur/Excel/Caching/XLWorkbookElementRepositoryBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel.Caching;

--- a/XLibur/Excel/CalcEngine/AnyValue.cs
+++ b/XLibur/Excel/CalcEngine/AnyValue.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Linq;
 using XLibur.Extensions;

--- a/XLibur/Excel/CalcEngine/Blank.cs
+++ b/XLibur/Excel/CalcEngine/Blank.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// A blank value. Used as a value of blank cells or as an optional argument for function calls.

--- a/XLibur/Excel/CalcEngine/DateTimeParser.cs
+++ b/XLibur/Excel/CalcEngine/DateTimeParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Linq;

--- a/XLibur/Excel/CalcEngine/DependenciesVisitor.cs
+++ b/XLibur/Excel/CalcEngine/DependenciesVisitor.cs
@@ -177,6 +177,14 @@ internal sealed class DependenciesVisitor : IFormulaVisitor<DependenciesContext,
         if (XLHelper.FunctionComparer.Equals(node.Name, "CHOOSE"))
             return VisitChooseFunction(context, node);
 
+        if (XLHelper.FunctionComparer.Equals(node.Name, "INDIRECT"))
+        {
+            // INDIRECT references are dynamic — can't determine at parse time.
+            // The Volatile flag ensures recalculation. Accept args for their dependencies.
+            AcceptAndAddAllParameters(context, node);
+            return null;
+        }
+
         // All other functions can have references as arguments, but not as an output value.
         AcceptAndAddAllParameters(context, node);
         return null;

--- a/XLibur/Excel/CalcEngine/ExpressionCache.cs
+++ b/XLibur/Excel/CalcEngine/ExpressionCache.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace XLibur.Excel.CalcEngine;
 

--- a/XLibur/Excel/CalcEngine/ExpressionParseException.cs
+++ b/XLibur/Excel/CalcEngine/ExpressionParseException.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel.CalcEngine;
 

--- a/XLibur/Excel/CalcEngine/FormulaVisitor.cs
+++ b/XLibur/Excel/CalcEngine/FormulaVisitor.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel.CalcEngine;
+﻿namespace XLibur.Excel.CalcEngine;
 
 internal interface IFormulaVisitor<in TContext, out TResult>
 {

--- a/XLibur/Excel/CalcEngine/FractionParser.cs
+++ b/XLibur/Excel/CalcEngine/FractionParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 

--- a/XLibur/Excel/CalcEngine/FunctionFlags.cs
+++ b/XLibur/Excel/CalcEngine/FunctionFlags.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel.CalcEngine;
 

--- a/XLibur/Excel/CalcEngine/FunctionRegistry.cs
+++ b/XLibur/Excel/CalcEngine/FunctionRegistry.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 
 namespace XLibur.Excel.CalcEngine;
 
-/// <summary>Which parameters of a function allow ranges. That is important for implicit intersection.</summary>
+/// <summary>Which parameters of a function allow ranges? That is important for implicit intersection.</summary>
 internal enum AllowRange
 {
-    /// <summary>None of parameters allow ranges.</summary>
+    /// <summary>None of the parameters allow ranges.</summary>
     None,
 
     /// <summary>All parameters allow ranges.</summary>
@@ -34,11 +34,12 @@ internal sealed class FunctionRegistry
     /// <param name="functionName">Name of function in formulas.</param>
     /// <param name="minParams">Minimum number of parameters.</param>
     /// <param name="maxParams">Maximum number of parameters.</param>
-    /// <param name="fn">A delegate of a function that will be called when function is supposed to be evaluated.</param>
-    /// <param name="flags">Flags that indicate some additional info about function.</param>
-    /// <param name="allowRanges">Which parameters allow ranges to be argument. Useful for array formulas.</param>
+    /// <param name="fn">A delegate of a function that will be called when the function is supposed to be evaluated.</param>
+    /// <param name="flags">Flags that indicate some additional info about a function.</param>
+    /// <param name="allowRanges">Which parameters allow ranges to be argument? Useful for array formulas.</param>
     /// <param name="markedParams">Index of parameter that is marked, start from 0</param>
-    public void RegisterFunction(string functionName, int minParams, int maxParams, CalcEngineFunction fn, FunctionFlags flags, AllowRange allowRanges = AllowRange.None, params int[] markedParams)
+    public void RegisterFunction(string functionName, int minParams, int maxParams, CalcEngineFunction fn,
+        FunctionFlags flags, AllowRange allowRanges = AllowRange.None, params int[] markedParams)
     {
         _func.Add(functionName, new FunctionDefinition(minParams, maxParams, fn, flags, allowRanges, markedParams));
     }

--- a/XLibur/Excel/CalcEngine/Functions/ArgumentsExtensions.cs
+++ b/XLibur/Excel/CalcEngine/Functions/ArgumentsExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel.CalcEngine.Functions;
 

--- a/XLibur/Excel/CalcEngine/Functions/Database.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Database.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel.CalcEngine.Functions;
+﻿namespace XLibur.Excel.CalcEngine.Functions;
 
 internal static class Database
 {

--- a/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using XLibur.Extensions;

--- a/XLibur/Excel/CalcEngine/Functions/Engineering.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Engineering.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 

--- a/XLibur/Excel/CalcEngine/Functions/Financial.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Financial.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
 #pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility

--- a/XLibur/Excel/CalcEngine/Functions/ITally.cs
+++ b/XLibur/Excel/CalcEngine/Functions/ITally.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel.CalcEngine.Functions;
 

--- a/XLibur/Excel/CalcEngine/Functions/Information.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Information.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Linq;
+﻿using System;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
 #pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility

--- a/XLibur/Excel/CalcEngine/Functions/Logical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Logical.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel.CalcEngine.Functions;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -754,8 +754,9 @@ internal static class Lookup
         if (!firstMatch.Success)
             return XLError.CellReference;
 
-        var firstRow = int.Parse(firstMatch.Groups[1].Value);
-        var firstCol = int.Parse(firstMatch.Groups[2].Value);
+        if (!int.TryParse(firstMatch.Groups[1].Value, out var firstRow)
+            || !int.TryParse(firstMatch.Groups[2].Value, out var firstCol))
+            return XLError.CellReference;
 
         int lastRow, lastCol;
         if (parts.Length == 2)
@@ -764,8 +765,9 @@ internal static class Lookup
             if (!lastMatch.Success)
                 return XLError.CellReference;
 
-            lastRow = int.Parse(lastMatch.Groups[1].Value);
-            lastCol = int.Parse(lastMatch.Groups[2].Value);
+            if (!int.TryParse(lastMatch.Groups[1].Value, out lastRow)
+                || !int.TryParse(lastMatch.Groups[2].Value, out lastCol))
+                return XLError.CellReference;
         }
         else
         {

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -717,7 +717,7 @@ internal static class Lookup
         {
             // Check if it's a valid A1 cell or range address
             if (!XLHelper.IsValidA1Address(addressText) && !XLHelper.IsValidRangeAddress(addressText))
-                return TryResolveDefinedName(ctx, refText);
+                return TryResolveDefinedName(ctx, worksheet, addressText);
 
             try
             {
@@ -786,10 +786,11 @@ internal static class Lookup
         return new Reference(rangeAddress.Normalize());
     }
 
-    private static AnyValue TryResolveDefinedName(CalcContext ctx, string name)
+    private static AnyValue TryResolveDefinedName(CalcContext ctx, XLWorksheet? worksheet, string name)
     {
-        // Sheet-level first, then workbook-level (same order as NameNode.TryGetNameRange)
-        if (ctx.Worksheet.DefinedNames.TryGetValue(name, out var sheetDefinedName))
+        // Resolve in the target worksheet's scope first, then workbook-level
+        var ws = worksheet ?? ctx.Worksheet;
+        if (ws.DefinedNames.TryGetValue(name, out var sheetDefinedName))
             return EvaluateDefinedName(ctx, sheetDefinedName);
 
         if (ctx.Workbook.DefinedNamesInternal.TryGetValue(name, out var bookDefinedName))

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -741,7 +741,7 @@ internal static class Lookup
     }
 
     private static readonly Regex AbsoluteR1C1Regex = new(
-        @"^R(\d+)C(\d+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        @"^R(\d+)C(\d+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled, XLHelper.RegexTimeout);
 
     private static AnyValue TryParseR1C1Reference(XLWorksheet? worksheet, string addressText)
     {

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text.RegularExpressions;
 using XLibur.Excel.Coordinates;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
@@ -21,7 +22,7 @@ internal static class Lookup
         ce.RegisterFunction("HLOOKUP", 3, 4, AdaptLastOptional(Hlookup, true), FunctionFlags.Range, AllowRange.Only, 1); // Looks in the top row of an array and returns the value of the indicated cell
         ce.RegisterFunction("HYPERLINK", 1, 2, Adapt(Hyperlink), FunctionFlags.Scalar | FunctionFlags.SideEffect); // Creates a shortcut or jump that opens a document stored on a network server, an intranet, or the Internet
         ce.RegisterFunction("INDEX", 2, 4, AdaptIndex(Index), FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.Only, 0); // Uses an index to choose a value from a reference or array
-        //ce.RegisterFunction("INDIRECT", , Indirect); // Returns a reference indicated by a text value
+        ce.RegisterFunction("INDIRECT", 1, 2, Indirect, FunctionFlags.Range | FunctionFlags.Volatile); // Returns a reference indicated by a text value
         //ce.RegisterFunction("LOOKUP", , Lookup); // Looks up values in a vector or array
         ce.RegisterFunction("MATCH", 2, 3, AdaptMatch(Match), FunctionFlags.Range, AllowRange.Only, 1); // Looks up values in a reference or array
         //ce.RegisterFunction("OFFSET", , Offset); // Returns a reference offset from a given reference
@@ -679,5 +680,126 @@ internal static class Lookup
 
         // Only thing left, if reference has multiple areas
         return XLError.CellReference;
+    }
+
+    private static AnyValue Indirect(CalcContext ctx, Span<AnyValue> p)
+    {
+        var refTextResult = ToText(p[0], ctx);
+        if (!refTextResult.TryPickT0(out var refText, out var textError))
+            return textError;
+
+        // Optional second arg: TRUE = A1 style (default), FALSE = R1C1 style
+        var isA1 = true;
+        if (p.Length > 1 && !p[1].IsBlank)
+        {
+            var a1Result = CoerceToLogical(p[1], ctx);
+            if (!a1Result.TryPickT0(out isA1, out var a1Error))
+                return a1Error;
+        }
+
+        if (string.IsNullOrEmpty(refText))
+            return XLError.CellReference;
+
+        // Handle sheet prefix: "Sheet1!A1" or "'Sheet Name'!A1"
+        XLWorksheet? worksheet = ctx.Worksheet;
+        var addressText = refText;
+
+        var bangIndex = refText.LastIndexOf('!');
+        if (bangIndex >= 0)
+        {
+            var sheetName = refText[..bangIndex].Trim('\'');
+            addressText = refText[(bangIndex + 1)..];
+            if (!ctx.Workbook.TryGetWorksheet(sheetName, out worksheet))
+                return XLError.CellReference;
+        }
+
+        if (isA1)
+        {
+            // Check if it's a valid A1 cell or range address
+            if (!XLHelper.IsValidA1Address(addressText) && !XLHelper.IsValidRangeAddress(addressText))
+                return TryResolveDefinedName(ctx, refText);
+
+            try
+            {
+                var rangeAddress = new XLRangeAddress(worksheet, addressText);
+                if (!XLHelper.IsValidRangeAddress(rangeAddress))
+                    return XLError.CellReference;
+
+                return new Reference(rangeAddress.Normalize());
+            }
+            catch
+            {
+                return XLError.CellReference;
+            }
+        }
+        else
+        {
+            // R1C1 style: support absolute references (R1C1, R1C1:R5C3)
+            // Relative R1C1 (R[-1]C[2]) is not supported — return #REF!
+            return TryParseR1C1Reference(worksheet, addressText);
+        }
+    }
+
+    private static readonly Regex AbsoluteR1C1Regex = new(
+        @"^R(\d+)C(\d+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static AnyValue TryParseR1C1Reference(XLWorksheet? worksheet, string addressText)
+    {
+        // Support single cell (R1C1) and range (R1C1:R5C3)
+        var parts = addressText.Split(':');
+        if (parts.Length > 2)
+            return XLError.CellReference;
+
+        var firstMatch = AbsoluteR1C1Regex.Match(parts[0]);
+        if (!firstMatch.Success)
+            return XLError.CellReference;
+
+        var firstRow = int.Parse(firstMatch.Groups[1].Value);
+        var firstCol = int.Parse(firstMatch.Groups[2].Value);
+
+        int lastRow, lastCol;
+        if (parts.Length == 2)
+        {
+            var lastMatch = AbsoluteR1C1Regex.Match(parts[1]);
+            if (!lastMatch.Success)
+                return XLError.CellReference;
+
+            lastRow = int.Parse(lastMatch.Groups[1].Value);
+            lastCol = int.Parse(lastMatch.Groups[2].Value);
+        }
+        else
+        {
+            lastRow = firstRow;
+            lastCol = firstCol;
+        }
+
+        if (firstRow < 1 || firstCol < 1 || lastRow < 1 || lastCol < 1
+            || firstRow > XLHelper.MaxRowNumber || firstCol > XLHelper.MaxColumnNumber
+            || lastRow > XLHelper.MaxRowNumber || lastCol > XLHelper.MaxColumnNumber)
+            return XLError.CellReference;
+
+        var firstAddress = new XLAddress(worksheet, firstRow, firstCol, true, true);
+        var lastAddress = new XLAddress(lastRow, lastCol, true, true);
+        var rangeAddress = new XLRangeAddress(firstAddress, lastAddress);
+        return new Reference(rangeAddress.Normalize());
+    }
+
+    private static AnyValue TryResolveDefinedName(CalcContext ctx, string name)
+    {
+        // Sheet-level first, then workbook-level (same order as NameNode.TryGetNameRange)
+        if (ctx.Worksheet.DefinedNames.TryGetValue(name, out var sheetDefinedName))
+            return EvaluateDefinedName(ctx, sheetDefinedName);
+
+        if (ctx.Workbook.DefinedNamesInternal.TryGetValue(name, out var bookDefinedName))
+            return EvaluateDefinedName(ctx, bookDefinedName);
+
+        return XLError.CellReference;
+    }
+
+    private static AnyValue EvaluateDefinedName(CalcContext ctx, IXLDefinedName definedName)
+    {
+        var nameFormula = definedName.RefersTo;
+        nameFormula = nameFormula.StartsWith('=') ? nameFormula : "=" + nameFormula;
+        return ctx.CalcEngine.EvaluateName(nameFormula, ctx.Worksheet);
     }
 }

--- a/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
@@ -1,4 +1,4 @@
-
+﻿
 using XLibur.Excel.CalcEngine.Functions;
 using System;
 using System.Collections.Generic;

--- a/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel.CalcEngine.Functions;
@@ -10,8 +10,8 @@ internal static class SignatureAdapter
 {
     #region Signature adapters
     // Each method converts a more specific signature of a function into a generic formula function type.
-    // We have many functions with same signature and the adapters should be reusable. Convert parameters
-    // through value converters below. We can hopefully generate them at a later date, so try to keep them similar.
+    // We have many functions with the same signature, and the adapters should be reusable. Convert parameters
+    // through the value converters below. We can hopefully generate them at a later date, so try to keep them similar.
 
     public static CalcEngineFunction Adapt(Func<ScalarValue> f)
     {
@@ -816,7 +816,7 @@ internal static class SignatureAdapter
             if (!arg1Converted.TryPickT0(out var arg1, out var err1))
                 return err1;
 
-            // AnyValue to bool has different semantic than AnyValue to number, e.g. "0" is not valid for bool coercion
+            // AnyValue to bool has a different semantic than AnyValue to number, e.g. "0" is not valid for bool coercion
             var arg2Converted = args.Length > 2 ? args[2] : defaultValue2;
             if (!CoerceToLogical(arg2Converted, ctx).TryPickT0(out var arg2, out var err2))
                 return err2;
@@ -886,7 +886,8 @@ internal static class SignatureAdapter
     #endregion
 
     #region Value converters
-    // Each method is named ToSomething and it converts an argument into a desired type (e.g. for ToSomething it should be type Something).
+    // Each method is named ToSomething, and it converts an argument into a desired type
+    // (e.g., for ToSomething it should be type Something).
     // Return value is always OneOf<Something, Error>, if there is an error, return it as an error.
 
     internal static OneOf<bool, XLError> CoerceToLogical(in AnyValue value, CalcContext ctx)
@@ -1007,8 +1008,8 @@ internal static class SignatureAdapter
             var rangeArgIndex = 2 * i;
             var range = args[rangeArgIndex];
 
-            // Excel grammar requires even number of arguments. We can't
-            // do that, so use blank for missing pair value.
+            // Excel grammar requires an even number of arguments. We can't
+            // do that, so use blank for the missing pair value.
             var criteriaArgIndex = rangeArgIndex + 1;
             var criteriaArgConverted = criteriaArgIndex < args.Length
                 ? ToScalarValue(args[criteriaArgIndex], ctx)

--- a/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -889,7 +889,7 @@ internal static class SignatureAdapter
     // Each method is named ToSomething and it converts an argument into a desired type (e.g. for ToSomething it should be type Something).
     // Return value is always OneOf<Something, Error>, if there is an error, return it as an error.
 
-    private static OneOf<bool, XLError> CoerceToLogical(in AnyValue value, CalcContext ctx)
+    internal static OneOf<bool, XLError> CoerceToLogical(in AnyValue value, CalcContext ctx)
     {
         if (!ToScalarValue(in value, ctx).TryPickT0(out var scalar, out var scalarError))
             return scalarError;
@@ -917,7 +917,7 @@ internal static class SignatureAdapter
         throw new NotImplementedException("Array formulas not implemented.");
     }
 
-    private static OneOf<string, XLError> ToText(in AnyValue value, CalcContext ctx)
+    internal static OneOf<string, XLError> ToText(in AnyValue value, CalcContext ctx)
     {
         if (value.TryPickScalar(out var scalar, out var collection))
             return scalar.ToText(ctx.Culture);

--- a/XLibur/Excel/CalcEngine/Functions/Statistical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Statistical.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel.CalcEngine.Functions;

--- a/XLibur/Excel/CalcEngine/Functions/Text.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Text.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/XLibur/Excel/CalcEngine/Functions/XLMath.cs
+++ b/XLibur/Excel/CalcEngine/Functions/XLMath.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 #pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility
 

--- a/XLibur/Excel/CalcEngine/OneOf.cs
+++ b/XLibur/Excel/CalcEngine/OneOf.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace XLibur.Excel.CalcEngine;

--- a/XLibur/Excel/CalcEngine/ScalarValue.cs
+++ b/XLibur/Excel/CalcEngine/ScalarValue.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using XLibur.Extensions;
 

--- a/XLibur/Excel/CalcEngine/TimeSpanParser.cs
+++ b/XLibur/Excel/CalcEngine/TimeSpanParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 
 namespace XLibur.Excel.CalcEngine;

--- a/XLibur/Excel/CalcEngine/Visitors/CollectVisitor.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/CollectVisitor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using ClosedXML.Parser;
 

--- a/XLibur/Excel/CalcEngine/Wildcard.cs
+++ b/XLibur/Excel/CalcEngine/Wildcard.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel.CalcEngine;
 

--- a/XLibur/Excel/CalcEngine/XLError.cs
+++ b/XLibur/Excel/CalcEngine/XLError.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// A formula error.

--- a/XLibur/Excel/Cells/IXLCell.cs
+++ b/XLibur/Excel/Cells/IXLCell.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;

--- a/XLibur/Excel/Cells/IXLCells.cs
+++ b/XLibur/Excel/Cells/IXLCells.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.InsertData;
+﻿using XLibur.Excel.InsertData;
 using XLibur.Extensions;
 using System;
 using System.Collections;

--- a/XLibur/Excel/Cells/XLCellCopyHelper.cs
+++ b/XLibur/Excel/Cells/XLCellCopyHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using XLibur.Excel.ConditionalFormats;
 using XLibur.Excel.Rows;

--- a/XLibur/Excel/Cells/XLCellCopyOptions.cs
+++ b/XLibur/Excel/Cells/XLCellCopyOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Cells/XLCellFormula.cs
+++ b/XLibur/Excel/Cells/XLCellFormula.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using XLibur.Excel.CalcEngine;

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -1,4 +1,4 @@
-using XLibur.Extensions;
+﻿using XLibur.Extensions;
 using System;
 using System.Linq;
 using System.Text;

--- a/XLibur/Excel/Cells/XLCellGlyphHelper.cs
+++ b/XLibur/Excel/Cells/XLCellGlyphHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using XLibur.Extensions;

--- a/XLibur/Excel/Cells/XLCellImage.cs
+++ b/XLibur/Excel/Cells/XLCellImage.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// Represents an in-cell image ("Place in Cell" feature in Excel 365+).

--- a/XLibur/Excel/Cells/XLCellRegionHelper.cs
+++ b/XLibur/Excel/Cells/XLCellRegionHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel.Coordinates;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Cells/XLCellValueConverter.cs
+++ b/XLibur/Excel/Cells/XLCellValueConverter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Linq;
 using System.Text;

--- a/XLibur/Excel/Charts/IXLChart.cs
+++ b/XLibur/Excel/Charts/IXLChart.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLChartType
 {

--- a/XLibur/Excel/Charts/IXLChartSeries.cs
+++ b/XLibur/Excel/Charts/IXLChartSeries.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// Represents a single data series within a chart.

--- a/XLibur/Excel/Charts/IXLChartSeriesCollection.cs
+++ b/XLibur/Excel/Charts/IXLChartSeriesCollection.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Charts/IXLCharts.cs
+++ b/XLibur/Excel/Charts/IXLCharts.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Charts/XLChartSeries.cs
+++ b/XLibur/Excel/Charts/XLChartSeries.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 internal sealed class XLChartSeries : IXLChartSeries
 {

--- a/XLibur/Excel/Charts/XLChartSeriesCollection.cs
+++ b/XLibur/Excel/Charts/XLChartSeriesCollection.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Charts/XLCharts.cs
+++ b/XLibur/Excel/Charts/XLCharts.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Columns/IXLColumn.cs
+++ b/XLibur/Excel/Columns/IXLColumn.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLColumn : IXLRangeBase
 {

--- a/XLibur/Excel/Columns/IXLColumns.cs
+++ b/XLibur/Excel/Columns/IXLColumns.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Comments/IXLComment.cs
+++ b/XLibur/Excel/Comments/IXLComment.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLComment : IXLFormattedText<IXLComment>, IXLDrawing<IXLComment>
 {

--- a/XLibur/Excel/ConditionalFormats/IXLCFColorScaleMax.cs
+++ b/XLibur/Excel/ConditionalFormats/IXLCFColorScaleMax.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLCFColorScaleMax
 {

--- a/XLibur/Excel/ConditionalFormats/IXLCFColorScaleMid.cs
+++ b/XLibur/Excel/ConditionalFormats/IXLCFColorScaleMid.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLCFColorScaleMid
 {

--- a/XLibur/Excel/ConditionalFormats/IXLCFColorScaleMin.cs
+++ b/XLibur/Excel/ConditionalFormats/IXLCFColorScaleMin.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLCFContentType { Number, Percent, Formula, Percentile, Minimum, Maximum }
 public interface IXLCFColorScaleMin

--- a/XLibur/Excel/ConditionalFormats/IXLCFDataBarMax.cs
+++ b/XLibur/Excel/ConditionalFormats/IXLCFDataBarMax.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLCFDataBarMax
 {

--- a/XLibur/Excel/ConditionalFormats/IXLCFDataBarMin.cs
+++ b/XLibur/Excel/ConditionalFormats/IXLCFDataBarMin.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLCFDataBarMin
 {

--- a/XLibur/Excel/ConditionalFormats/IXLCFIconSet.cs
+++ b/XLibur/Excel/ConditionalFormats/IXLCFIconSet.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLCFIconSetOperator { GreaterThan, EqualOrGreaterThan }
 public interface IXLCFIconSet

--- a/XLibur/Excel/ConditionalFormats/IXLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/IXLConditionalFormat.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLTimePeriod
 {

--- a/XLibur/Excel/ConditionalFormats/IXLConditionalFormats.cs
+++ b/XLibur/Excel/ConditionalFormats/IXLConditionalFormats.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/ConditionalFormats/Save/IXLCFConverter.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/IXLCFConverter.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml.Spreadsheet;
+﻿using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/ConditionalFormats/Save/IXLCFConverterExtension.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/IXLCFConverterExtension.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml.Office2010.Excel;
+﻿using DocumentFormat.OpenXml.Office2010.Excel;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFBaseConverter.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFBaseConverter.cs
@@ -1,4 +1,4 @@
-using XLibur.Utils;
+﻿using XLibur.Utils;
 using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel.Coordinates;

--- a/XLibur/Excel/ContentManagers/XLBaseContentManager.cs
+++ b/XLibur/Excel/ContentManagers/XLBaseContentManager.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml;
+﻿using DocumentFormat.OpenXml;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/XLibur/Excel/Coordinates/IXLAddress.cs
+++ b/XLibur/Excel/Coordinates/IXLAddress.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Coordinates/XLAddress.cs
+++ b/XLibur/Excel/Coordinates/XLAddress.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using XLibur.Extensions;

--- a/XLibur/Excel/Coordinates/XLBookPoint.cs
+++ b/XLibur/Excel/Coordinates/XLBookPoint.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 

--- a/XLibur/Excel/Coordinates/XLSheetOffset.cs
+++ b/XLibur/Excel/Coordinates/XLSheetOffset.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel.Coordinates;
 

--- a/XLibur/Excel/Coordinates/XLSheetPoint.cs
+++ b/XLibur/Excel/Coordinates/XLSheetPoint.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 

--- a/XLibur/Excel/CustomProperties/IXLCustomProperties.cs
+++ b/XLibur/Excel/CustomProperties/IXLCustomProperties.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/CustomProperties/IXLCustomProperty.cs
+++ b/XLibur/Excel/CustomProperties/IXLCustomProperty.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLCustomPropertyType { Text, Number, Date, Boolean }
 public interface IXLCustomProperty

--- a/XLibur/Excel/DataValidation/IXLDataValidation.cs
+++ b/XLibur/Excel/DataValidation/IXLDataValidation.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/DataValidation/IXLDataValidations.cs
+++ b/XLibur/Excel/DataValidation/IXLDataValidations.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/DataValidation/IXLValidationCriteria.cs
+++ b/XLibur/Excel/DataValidation/IXLValidationCriteria.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 public interface IXLValidationCriteria

--- a/XLibur/Excel/DataValidation/XLDateCriteria.cs
+++ b/XLibur/Excel/DataValidation/XLDateCriteria.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/DataValidation/XLDecimalCriteria.cs
+++ b/XLibur/Excel/DataValidation/XLDecimalCriteria.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 public class XLDecimalCriteria : XLValidationCriteria

--- a/XLibur/Excel/DataValidation/XLTextLengthCriteria.cs
+++ b/XLibur/Excel/DataValidation/XLTextLengthCriteria.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 public class XLTextLengthCriteria : XLWholeNumberCriteriaBase

--- a/XLibur/Excel/DataValidation/XLTimeCriteria.cs
+++ b/XLibur/Excel/DataValidation/XLTimeCriteria.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/DataValidation/XLValidationCriteria.cs
+++ b/XLibur/Excel/DataValidation/XLValidationCriteria.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 public abstract class XLValidationCriteria : IXLValidationCriteria

--- a/XLibur/Excel/DataValidation/XLWholeNumberCriteria.cs
+++ b/XLibur/Excel/DataValidation/XLWholeNumberCriteria.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 public class XLWholeNumberCriteria : XLWholeNumberCriteriaBase

--- a/XLibur/Excel/DataValidation/XLWholeNumberCriteriaBase.cs
+++ b/XLibur/Excel/DataValidation/XLWholeNumberCriteriaBase.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 public abstract class XLWholeNumberCriteriaBase : XLValidationCriteria

--- a/XLibur/Excel/DefinedNames/IXLDefinedName.cs
+++ b/XLibur/Excel/DefinedNames/IXLDefinedName.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/DefinedNames/IXLDefinedNames.cs
+++ b/XLibur/Excel/DefinedNames/IXLDefinedNames.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 

--- a/XLibur/Excel/Drawings/IXLDrawing.cs
+++ b/XLibur/Excel/Drawings/IXLDrawing.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLDrawingAnchor { MoveAndSizeWithCells, MoveWithCells, Absolute }
 public interface IXLDrawing<out T>

--- a/XLibur/Excel/Drawings/IXLDrawingPosition.cs
+++ b/XLibur/Excel/Drawings/IXLDrawingPosition.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLDrawingPosition
 {

--- a/XLibur/Excel/Drawings/IXLPicture.cs
+++ b/XLibur/Excel/Drawings/IXLPicture.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.IO;
 

--- a/XLibur/Excel/Drawings/IXLPictures.cs
+++ b/XLibur/Excel/Drawings/IXLPictures.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 
 namespace XLibur.Excel.Drawings;

--- a/XLibur/Excel/Drawings/PictureEnums.cs
+++ b/XLibur/Excel/Drawings/PictureEnums.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel.Drawings;
+﻿namespace XLibur.Excel.Drawings;
 
 public enum XLMarkerPosition
 {

--- a/XLibur/Excel/Drawings/Style/IXLDrawingAlignment.cs
+++ b/XLibur/Excel/Drawings/Style/IXLDrawingAlignment.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLDrawingTextDirection
 {

--- a/XLibur/Excel/Drawings/Style/IXLDrawingColorsAndLines.cs
+++ b/XLibur/Excel/Drawings/Style/IXLDrawingColorsAndLines.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLDashStyle
 {

--- a/XLibur/Excel/Drawings/Style/IXLDrawingFont.cs
+++ b/XLibur/Excel/Drawings/Style/IXLDrawingFont.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLDrawingFont : IXLFontBase
 {

--- a/XLibur/Excel/Drawings/Style/IXLDrawingMargins.cs
+++ b/XLibur/Excel/Drawings/Style/IXLDrawingMargins.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLDrawingMargins
 {

--- a/XLibur/Excel/Drawings/Style/IXLDrawingProperties.cs
+++ b/XLibur/Excel/Drawings/Style/IXLDrawingProperties.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLDrawingProperties
 {

--- a/XLibur/Excel/Drawings/Style/IXLDrawingProtection.cs
+++ b/XLibur/Excel/Drawings/Style/IXLDrawingProtection.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLDrawingProtection
 {

--- a/XLibur/Excel/Drawings/Style/IXLDrawingSize.cs
+++ b/XLibur/Excel/Drawings/Style/IXLDrawingSize.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLDrawingSize
 {

--- a/XLibur/Excel/Drawings/Style/IXLDrawingStyle.cs
+++ b/XLibur/Excel/Drawings/Style/IXLDrawingStyle.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLDrawingStyle
 {

--- a/XLibur/Excel/Drawings/Style/IXLDrawingWeb.cs
+++ b/XLibur/Excel/Drawings/Style/IXLDrawingWeb.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLDrawingWeb
 {

--- a/XLibur/Excel/Drawings/XLDrawing.cs
+++ b/XLibur/Excel/Drawings/XLDrawing.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 internal class XLDrawing<T> : IXLDrawing<T>
 {

--- a/XLibur/Excel/EnumConverter.cs
+++ b/XLibur/Excel/EnumConverter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Drawings;
+﻿using XLibur.Excel.Drawings;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;

--- a/XLibur/Excel/Exceptions/ClosedXMLException.cs
+++ b/XLibur/Excel/Exceptions/ClosedXMLException.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel.Exceptions;
 

--- a/XLibur/Excel/Exceptions/EmptyTableException.cs
+++ b/XLibur/Excel/Exceptions/EmptyTableException.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel.Exceptions;
 

--- a/XLibur/Excel/Hyperlinks/IXLHyperlinks.cs
+++ b/XLibur/Excel/Hyperlinks/IXLHyperlinks.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Hyperlinks/XLHyperlink_Internal.cs
+++ b/XLibur/Excel/Hyperlinks/XLHyperlink_Internal.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Hyperlinks/XLHyperlink_public.cs
+++ b/XLibur/Excel/Hyperlinks/XLHyperlink_public.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Extensions;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/IO/AutoFilterWriter.cs
+++ b/XLibur/Excel/IO/AutoFilterWriter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.AutoFilters;
+﻿using XLibur.Excel.AutoFilters;
 using XLibur.Excel.ContentManagers;
 using XLibur.Utils;
 using DocumentFormat.OpenXml.Spreadsheet;

--- a/XLibur/Excel/IO/CalculationChainPartWriter.cs
+++ b/XLibur/Excel/IO/CalculationChainPartWriter.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml.Packaging;
+﻿using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Linq;
 using static XLibur.Excel.XLWorkbook;

--- a/XLibur/Excel/IO/ChartReader.cs
+++ b/XLibur/Excel/IO/ChartReader.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml;
+﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing.Charts;
 using DocumentFormat.OpenXml.Packaging;
 using System.Linq;

--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml;
+﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing.Charts;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;

--- a/XLibur/Excel/IO/ColumnWriter.cs
+++ b/XLibur/Excel/IO/ColumnWriter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.ContentManagers;
+﻿using XLibur.Excel.ContentManagers;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;

--- a/XLibur/Excel/IO/ConditionalFormatReader.cs
+++ b/XLibur/Excel/IO/ConditionalFormatReader.cs
@@ -1,4 +1,4 @@
-using XLibur.Extensions;
+﻿using XLibur.Extensions;
 using XLibur.Utils;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;

--- a/XLibur/Excel/IO/ConditionalFormattingWriter.cs
+++ b/XLibur/Excel/IO/ConditionalFormattingWriter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.ContentManagers;
+﻿using XLibur.Excel.ContentManagers;
 using XLibur.Extensions;
 using XLibur.Utils;
 using DocumentFormat.OpenXml;

--- a/XLibur/Excel/IO/DataValidationWriter.cs
+++ b/XLibur/Excel/IO/DataValidationWriter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.ContentManagers;
+﻿using XLibur.Excel.ContentManagers;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;

--- a/XLibur/Excel/IO/DefinedNameReader.cs
+++ b/XLibur/Excel/IO/DefinedNameReader.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml;
+﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;

--- a/XLibur/Excel/IO/DrawingPartReader.cs
+++ b/XLibur/Excel/IO/DrawingPartReader.cs
@@ -1,4 +1,4 @@
-using XLibur.Extensions;
+﻿using XLibur.Extensions;
 using DocumentFormat.OpenXml.Packaging;
 using System;
 using System.Collections.Generic;

--- a/XLibur/Excel/IO/ExtendedFilePropertiesPartWriter.cs
+++ b/XLibur/Excel/IO/ExtendedFilePropertiesPartWriter.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml.ExtendedProperties;
+﻿using DocumentFormat.OpenXml.ExtendedProperties;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.VariantTypes;
 using DocumentFormat.OpenXml;

--- a/XLibur/Excel/IO/HeaderFooterImageWriter.cs
+++ b/XLibur/Excel/IO/HeaderFooterImageWriter.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/XLibur/Excel/IO/OpenXmlConst.cs
+++ b/XLibur/Excel/IO/OpenXmlConst.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel.IO;
+﻿namespace XLibur.Excel.IO;
 
 /// <summary>
 /// Constants used across writers.

--- a/XLibur/Excel/IO/PageSetupWriter.cs
+++ b/XLibur/Excel/IO/PageSetupWriter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.ContentManagers;
+﻿using XLibur.Excel.ContentManagers;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;

--- a/XLibur/Excel/IO/PictureWriter.cs
+++ b/XLibur/Excel/IO/PictureWriter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.ContentManagers;
+﻿using XLibur.Excel.ContentManagers;
 using XLibur.Extensions;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing;

--- a/XLibur/Excel/IO/RichDataReader.cs
+++ b/XLibur/Excel/IO/RichDataReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/XLibur/Excel/IO/RichDataWriter.cs
+++ b/XLibur/Excel/IO/RichDataWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;

--- a/XLibur/Excel/IO/SharedStringReader.cs
+++ b/XLibur/Excel/IO/SharedStringReader.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml.Packaging;
+﻿using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Collections.Generic;
 using System.Linq;

--- a/XLibur/Excel/IO/SheetDataWriter.cs
+++ b/XLibur/Excel/IO/SheetDataWriter.cs
@@ -1,4 +1,4 @@
-using XLibur.Extensions;
+﻿using XLibur.Extensions;
 using DocumentFormat.OpenXml;
 using System;
 using System.Collections.Generic;

--- a/XLibur/Excel/IO/SheetProtectionWriter.cs
+++ b/XLibur/Excel/IO/SheetProtectionWriter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.ContentManagers;
+﻿using XLibur.Excel.ContentManagers;
 using XLibur.Utils;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Linq;

--- a/XLibur/Excel/IO/SheetViewWriter.cs
+++ b/XLibur/Excel/IO/SheetViewWriter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.ContentManagers;
+﻿using XLibur.Excel.ContentManagers;
 using XLibur.Utils;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;

--- a/XLibur/Excel/IO/VmlDrawingPartWriter.cs
+++ b/XLibur/Excel/IO/VmlDrawingPartWriter.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml.Packaging;
+﻿using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Vml.Office;
 using DocumentFormat.OpenXml.Vml.Spreadsheet;
 using DocumentFormat.OpenXml;

--- a/XLibur/Excel/IO/WorkbookPartWriter.cs
+++ b/XLibur/Excel/IO/WorkbookPartWriter.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using XLibur.Utils;
 using DocumentFormat.OpenXml;

--- a/XLibur/Excel/IO/WorksheetElementReader.cs
+++ b/XLibur/Excel/IO/WorksheetElementReader.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.AutoFilters;
+﻿using XLibur.Excel.AutoFilters;
 using XLibur.Utils;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;

--- a/XLibur/Excel/IO/WorksheetPartWriter.cs
+++ b/XLibur/Excel/IO/WorksheetPartWriter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.ContentManagers;
+﻿using XLibur.Excel.ContentManagers;
 using XLibur.Excel.Exceptions;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -1,4 +1,4 @@
-using XLibur.Extensions;
+﻿using XLibur.Extensions;
 using XLibur.Excel.CalcEngine.Visitors;
 using XLibur.Utils;
 using DocumentFormat.OpenXml;

--- a/XLibur/Excel/IXLFileSharing.cs
+++ b/XLibur/Excel/IXLFileSharing.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 public interface IXLFileSharing

--- a/XLibur/Excel/IXLOutline.cs
+++ b/XLibur/Excel/IXLOutline.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLOutlineSummaryVLocation
 {

--- a/XLibur/Excel/IXLSheetView.cs
+++ b/XLibur/Excel/IXLSheetView.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLSheetViewOptions { Normal, PageBreakPreview, PageLayout }
 

--- a/XLibur/Excel/IXLTheme.cs
+++ b/XLibur/Excel/IXLTheme.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLTheme
 {

--- a/XLibur/Excel/IXLWorkbook.cs
+++ b/XLibur/Excel/IXLWorkbook.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/XLibur/Excel/IXLWorksheet.cs
+++ b/XLibur/Excel/IXLWorksheet.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.CalcEngine.Exceptions;
+﻿using XLibur.Excel.CalcEngine.Exceptions;
 using XLibur.Excel.Drawings;
 using System;
 using System.IO;

--- a/XLibur/Excel/IXLWorksheets.cs
+++ b/XLibur/Excel/IXLWorksheets.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
 

--- a/XLibur/Excel/InsertData/IInsertDataReader.cs
+++ b/XLibur/Excel/InsertData/IInsertDataReader.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System.Collections.Generic;
 
 namespace XLibur.Excel.InsertData;

--- a/XLibur/Excel/LoadOptions.cs
+++ b/XLibur/Excel/LoadOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using XLibur.Graphics;
 

--- a/XLibur/Excel/Misc/XLDictionary.cs
+++ b/XLibur/Excel/Misc/XLDictionary.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using XLibur.Extensions;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Misc/XLFormula.cs
+++ b/XLibur/Excel/Misc/XLFormula.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public class XLFormula
 {

--- a/XLibur/Excel/PageSetup/IXLHFItem.cs
+++ b/XLibur/Excel/PageSetup/IXLHFItem.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLHFPredefinedText
 {

--- a/XLibur/Excel/PageSetup/IXLHeaderFooter.cs
+++ b/XLibur/Excel/PageSetup/IXLHeaderFooter.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLHFMode { OddPagesOnly, OddAndEvenPages, Odd }
 public interface IXLHeaderFooter

--- a/XLibur/Excel/PageSetup/IXLMargins.cs
+++ b/XLibur/Excel/PageSetup/IXLMargins.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLMargins
 {

--- a/XLibur/Excel/PageSetup/IXLPageSetup.cs
+++ b/XLibur/Excel/PageSetup/IXLPageSetup.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/PageSetup/IXLPrintAreas.cs
+++ b/XLibur/Excel/PageSetup/IXLPrintAreas.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/PageSetup/XLHFImage.cs
+++ b/XLibur/Excel/PageSetup/XLHFImage.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.IO;
 using XLibur.Excel.Drawings;

--- a/XLibur/Excel/PageSetup/XLHFItem.cs
+++ b/XLibur/Excel/PageSetup/XLHFItem.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using XLibur.Excel.RichText;

--- a/XLibur/Excel/PivotTables/Areas/FieldIndex.cs
+++ b/XLibur/Excel/PivotTables/Areas/FieldIndex.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/PivotTables/Areas/IXLPivotField.cs
+++ b/XLibur/Excel/PivotTables/Areas/IXLPivotField.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/PivotTables/Areas/IXLPivotFields.cs
+++ b/XLibur/Excel/PivotTables/Areas/IXLPivotFields.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Collections.Generic;
 

--- a/XLibur/Excel/PivotTables/Areas/XLPivotAxis.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotAxis.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// Describes an axis of a pivot table. Used to determine which areas should be styled through

--- a/XLibur/Excel/PivotTables/Areas/XLPivotFieldBase.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotFieldBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/PivotTables/Areas/XLPivotTableAxisField.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotTableAxisField.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/XLibur/Excel/PivotTables/Areas/XLPivotTablePageField.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotTablePageField.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/XLibur/Excel/PivotTables/IXLPivotTable.cs
+++ b/XLibur/Excel/PivotTables/IXLPivotTable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/PivotTables/IXLPivotTables.cs
+++ b/XLibur/Excel/PivotTables/IXLPivotTables.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/PivotTables/PivotStyleFormats/IXLPivotFieldStyleFormats.cs
+++ b/XLibur/Excel/PivotTables/PivotStyleFormats/IXLPivotFieldStyleFormats.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 /// <summary>

--- a/XLibur/Excel/PivotTables/PivotStyleFormats/IXLPivotStyleFormat.cs
+++ b/XLibur/Excel/PivotTables/PivotStyleFormats/IXLPivotStyleFormat.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 /// <summary>

--- a/XLibur/Excel/PivotTables/PivotStyleFormats/IXLPivotStyleFormats.cs
+++ b/XLibur/Excel/PivotTables/PivotStyleFormats/IXLPivotStyleFormats.cs
@@ -1,4 +1,4 @@
-
+﻿
 
 using System;
 using System.Collections.Generic;

--- a/XLibur/Excel/PivotTables/PivotStyleFormats/IXLPivotTableStyleFormats.cs
+++ b/XLibur/Excel/PivotTables/PivotStyleFormats/IXLPivotTableStyleFormats.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 /// <summary>

--- a/XLibur/Excel/PivotTables/PivotStyleFormats/IXLPivotValueStyleFormat.cs
+++ b/XLibur/Excel/PivotTables/PivotStyleFormats/IXLPivotValueStyleFormat.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormatBase.cs
+++ b/XLibur/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormatBase.cs
@@ -1,4 +1,4 @@
-
+﻿
 
 using System;
 using System.Collections.Generic;

--- a/XLibur/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormatEnums.cs
+++ b/XLibur/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormatEnums.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/PivotTables/PivotValues/IXLPivotValue.cs
+++ b/XLibur/Excel/PivotTables/PivotValues/IXLPivotValue.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// Enum describing how is a pivot field values (i.e. in data area) displayed.

--- a/XLibur/Excel/PivotTables/PivotValues/IXLPivotValueCombination.cs
+++ b/XLibur/Excel/PivotTables/PivotValues/IXLPivotValueCombination.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// An interface for fluent configuration of how to show <see cref="IXLPivotValue"/>,

--- a/XLibur/Excel/PivotTables/PivotValues/IXLPivotValueFormat.cs
+++ b/XLibur/Excel/PivotTables/PivotValues/IXLPivotValueFormat.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// An API for manipulating a <see cref="IXLPivotValue.NumberFormat">format</see> of one

--- a/XLibur/Excel/PivotTables/PivotValues/IXLPivotValues.cs
+++ b/XLibur/Excel/PivotTables/PivotValues/IXLPivotValues.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/PivotTables/XLPivotAreaType.cs
+++ b/XLibur/Excel/PivotTables/XLPivotAreaType.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// An area of aspect of pivot table that is part of the <see cref="XLPivotArea.Type"/>.

--- a/XLibur/Excel/PivotTables/XLPivotCacheValue.cs
+++ b/XLibur/Excel/PivotTables/XLPivotCacheValue.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 #pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility

--- a/XLibur/Excel/PivotTables/XLPivotCacheValueType.cs
+++ b/XLibur/Excel/PivotTables/XLPivotCacheValueType.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// An enum that represents types of values in pivot cache records. It represents

--- a/XLibur/Excel/PivotTables/XLPivotCacheValuesStats.cs
+++ b/XLibur/Excel/PivotTables/XLPivotCacheValuesStats.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/PivotTables/XLPivotCfScope.cs
+++ b/XLibur/Excel/PivotTables/XLPivotCfScope.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// Defines a scope of conditional formatting applied to <see cref="XLPivotTable"/>. The scope is

--- a/XLibur/Excel/PivotTables/XLPivotFormatAction.cs
+++ b/XLibur/Excel/PivotTables/XLPivotFormatAction.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// An enum describing if <see cref="XLPivotFormat"/> applies formatting to the cells of pivot

--- a/XLibur/Excel/PivotTables/XLPivotItemType.cs
+++ b/XLibur/Excel/PivotTables/XLPivotItemType.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// A categorization of <see cref="XLPivotFieldItem"/> or <see cref="XLPivotFieldAxisItem"/>.

--- a/XLibur/Excel/Protection/IXLElementProtection.cs
+++ b/XLibur/Excel/Protection/IXLElementProtection.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using static XLibur.Excel.XLProtectionAlgorithm;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Protection/IXLProtectable.cs
+++ b/XLibur/Excel/Protection/IXLProtectable.cs
@@ -1,4 +1,4 @@
-using static XLibur.Excel.XLProtectionAlgorithm;
+﻿using static XLibur.Excel.XLProtectionAlgorithm;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Protection/IXLSheetProtection.cs
+++ b/XLibur/Excel/Protection/IXLSheetProtection.cs
@@ -1,4 +1,4 @@
-using static XLibur.Excel.XLProtectionAlgorithm;
+﻿using static XLibur.Excel.XLProtectionAlgorithm;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Protection/IXLWorkbookProtection.cs
+++ b/XLibur/Excel/Protection/IXLWorkbookProtection.cs
@@ -1,4 +1,4 @@
-using static XLibur.Excel.XLProtectionAlgorithm;
+﻿using static XLibur.Excel.XLProtectionAlgorithm;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Protection/XLProtectionAlgorithm.cs
+++ b/XLibur/Excel/Protection/XLProtectionAlgorithm.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Protection/XLSheetProtectionElements.cs
+++ b/XLibur/Excel/Protection/XLSheetProtectionElements.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Protection/XLWorkbookProtectionElements.cs
+++ b/XLibur/Excel/Protection/XLWorkbookProtectionElements.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Ranges/IXLAddressable.cs
+++ b/XLibur/Excel/Ranges/IXLAddressable.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// A very lightweight interface for entities that have an address as

--- a/XLibur/Excel/Ranges/IXLBaseCollection.cs
+++ b/XLibur/Excel/Ranges/IXLBaseCollection.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Ranges/IXLRange.cs
+++ b/XLibur/Excel/Ranges/IXLRange.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Ranges/IXLRangeAddress.cs
+++ b/XLibur/Excel/Ranges/IXLRangeAddress.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace XLibur.Excel;
 
 public interface IXLRangeAddress

--- a/XLibur/Excel/Ranges/IXLRangeBase.cs
+++ b/XLibur/Excel/Ranges/IXLRangeBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Ranges/IXLRangeColumn.cs
+++ b/XLibur/Excel/Ranges/IXLRangeColumn.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLRangeColumn : IXLRangeBase
 {

--- a/XLibur/Excel/Ranges/IXLRangeColumns.cs
+++ b/XLibur/Excel/Ranges/IXLRangeColumns.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Ranges/IXLRangeRow.cs
+++ b/XLibur/Excel/Ranges/IXLRangeRow.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLRangeRow : IXLRangeBase
 {

--- a/XLibur/Excel/Ranges/IXLRangeRows.cs
+++ b/XLibur/Excel/Ranges/IXLRangeRows.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Ranges/IXLRanges.cs
+++ b/XLibur/Excel/Ranges/IXLRanges.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Ranges/Index/IXLRangeIndex.cs
+++ b/XLibur/Excel/Ranges/Index/IXLRangeIndex.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using XLibur.Excel.Coordinates;
 

--- a/XLibur/Excel/Ranges/Sort/IXLSortElement.cs
+++ b/XLibur/Excel/Ranges/Sort/IXLSortElement.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLSortOrder { Ascending, Descending }
 public enum XLSortOrientation { TopToBottom, LeftToRight }

--- a/XLibur/Excel/Ranges/Sort/IXLSortElements.cs
+++ b/XLibur/Excel/Ranges/Sort/IXLSortElements.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Ranges/Sort/XLSortElement.cs
+++ b/XLibur/Excel/Ranges/Sort/XLSortElement.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 internal record XLSortElement(
     int ElementNumber,

--- a/XLibur/Excel/Ranges/XLCellComparer.cs
+++ b/XLibur/Excel/Ranges/XLCellComparer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel.Ranges;
 

--- a/XLibur/Excel/Ranges/XLRange.cs
+++ b/XLibur/Excel/Ranges/XLRange.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/XLibur/Excel/Ranges/XLRangeAddress.cs
+++ b/XLibur/Excel/Ranges/XLRangeAddress.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using XLibur.Excel.Coordinates;

--- a/XLibur/Excel/Ranges/XLRangeBase.cs
+++ b/XLibur/Excel/Ranges/XLRangeBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/XLibur/Excel/Ranges/XLRangeCellsHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeCellsHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/XLibur/Excel/Ranges/XLRangeConditionalFormatHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeConditionalFormatHelper.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel.Coordinates;
 using XLibur.Extensions;
 

--- a/XLibur/Excel/Ranges/XLRangeInsertHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeInsertHelper.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel.Coordinates;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Ranges/XLRangeKey.cs
+++ b/XLibur/Excel/Ranges/XLRangeKey.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Ranges/XLRangeRow.cs
+++ b/XLibur/Excel/Ranges/XLRangeRow.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Ranges;
+﻿using XLibur.Excel.Ranges;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Ranges/XLRangeSetOperationsHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeSetOperationsHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel.Coordinates;

--- a/XLibur/Excel/Ranges/XLRangeShiftHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeShiftHelper.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Coordinates;
+﻿using XLibur.Excel.Coordinates;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Ranges/XLRangeSortHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeSortHelper.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using XLibur.Excel.Coordinates;

--- a/XLibur/Excel/Ranges/XLRangeType.cs
+++ b/XLibur/Excel/Ranges/XLRangeType.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 internal enum XLRangeType : byte
 {

--- a/XLibur/Excel/Ranges/XLStoredRangeBase.cs
+++ b/XLibur/Excel/Ranges/XLStoredRangeBase.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Rows;
+﻿using XLibur.Excel.Rows;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/RichText/IXLFormattedText.cs
+++ b/XLibur/Excel/RichText/IXLFormattedText.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/RichText/IXLPhonetic.cs
+++ b/XLibur/Excel/RichText/IXLPhonetic.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/RichText/IXLPhonetics.cs
+++ b/XLibur/Excel/RichText/IXLPhonetics.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/RichText/IXLRichString.cs
+++ b/XLibur/Excel/RichText/IXLRichString.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/RichText/IXLRichText.cs
+++ b/XLibur/Excel/RichText/IXLRichText.cs
@@ -1,3 +1,3 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLRichText : IXLFormattedText<IXLRichText>;

--- a/XLibur/Excel/RichText/XLFormattedText.cs
+++ b/XLibur/Excel/RichText/XLFormattedText.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/XLibur/Excel/Rows/IXLRow.cs
+++ b/XLibur/Excel/Rows/IXLRow.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLRow : IXLRangeBase
 {

--- a/XLibur/Excel/Rows/IXLRows.cs
+++ b/XLibur/Excel/Rows/IXLRows.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Rows/XLRow.cs
+++ b/XLibur/Excel/Rows/XLRow.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using XLibur.Extensions;

--- a/XLibur/Excel/SaveOptions.cs
+++ b/XLibur/Excel/SaveOptions.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public class SaveOptions
 {

--- a/XLibur/Excel/Sparkline/IXLSparkLineGroup.cs
+++ b/XLibur/Excel/Sparkline/IXLSparkLineGroup.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Sparkline/IXLSparkLineGroups.cs
+++ b/XLibur/Excel/Sparkline/IXLSparkLineGroups.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Sparkline/IXLSparkline.cs
+++ b/XLibur/Excel/Sparkline/IXLSparkline.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLSparkline
 {

--- a/XLibur/Excel/Sparkline/IXLSparklineHorizontalAxis.cs
+++ b/XLibur/Excel/Sparkline/IXLSparklineHorizontalAxis.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLSparklineHorizontalAxis
 {

--- a/XLibur/Excel/Sparkline/IXLSparklineStyle.cs
+++ b/XLibur/Excel/Sparkline/IXLSparklineStyle.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLSparklineStyle
 {

--- a/XLibur/Excel/Sparkline/IXLSparklineVerticalAxis.cs
+++ b/XLibur/Excel/Sparkline/IXLSparklineVerticalAxis.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLSparklineVerticalAxis
 {

--- a/XLibur/Excel/Sparkline/XLSparklineTheme.cs
+++ b/XLibur/Excel/Sparkline/XLSparklineTheme.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public static class XLSparklineTheme
 {

--- a/XLibur/Excel/Style/Colors/XLColor_Internal.cs
+++ b/XLibur/Excel/Style/Colors/XLColor_Internal.cs
@@ -1,4 +1,4 @@
-using System.Drawing;
+﻿using System.Drawing;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/Colors/XLColor_Public.cs
+++ b/XLibur/Excel/Style/Colors/XLColor_Public.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.Globalization;
 using XLibur.Extensions;

--- a/XLibur/Excel/Style/Colors/XLColor_Static.cs
+++ b/XLibur/Excel/Style/Colors/XLColor_Static.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Caching;
+﻿using XLibur.Excel.Caching;
 using XLibur.Utils;
 using System;
 using System.Collections.Generic;

--- a/XLibur/Excel/Style/IXLAlignment.cs
+++ b/XLibur/Excel/Style/IXLAlignment.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/IXLBorder.cs
+++ b/XLibur/Excel/Style/IXLBorder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/IXLFill.cs
+++ b/XLibur/Excel/Style/IXLFill.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/IXLFont.cs
+++ b/XLibur/Excel/Style/IXLFont.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/IXLFontBase.cs
+++ b/XLibur/Excel/Style/IXLFontBase.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLFontBase
 {

--- a/XLibur/Excel/Style/IXLNumberFormat.cs
+++ b/XLibur/Excel/Style/IXLNumberFormat.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/IXLNumberFormatBase.cs
+++ b/XLibur/Excel/Style/IXLNumberFormatBase.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLNumberFormatBase
 {

--- a/XLibur/Excel/Style/IXLProtection.cs
+++ b/XLibur/Excel/Style/IXLProtection.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/IXLStyle.cs
+++ b/XLibur/Excel/Style/IXLStyle.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/IXLStylized.cs
+++ b/XLibur/Excel/Style/IXLStylized.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel.Rows;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Style/XLAlignmentKey.cs
+++ b/XLibur/Excel/Style/XLAlignmentKey.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public readonly record struct XLAlignmentKey
 {

--- a/XLibur/Excel/Style/XLAlignmentValue.cs
+++ b/XLibur/Excel/Style/XLAlignmentValue.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Caching;
+﻿using XLibur.Excel.Caching;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLBorderKey.cs
+++ b/XLibur/Excel/Style/XLBorderKey.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 internal readonly record struct XLBorderKey
 {

--- a/XLibur/Excel/Style/XLColorKey.cs
+++ b/XLibur/Excel/Style/XLColorKey.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLDeferredAlignment.cs
+++ b/XLibur/Excel/Style/XLDeferredAlignment.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLDeferredBorder.cs
+++ b/XLibur/Excel/Style/XLDeferredBorder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLDeferredFill.cs
+++ b/XLibur/Excel/Style/XLDeferredFill.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLDeferredFont.cs
+++ b/XLibur/Excel/Style/XLDeferredFont.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLDeferredNumberFormat.cs
+++ b/XLibur/Excel/Style/XLDeferredNumberFormat.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// Lightweight <see cref="IXLNumberFormat"/> that accumulates property changes into an <see cref="XLNumberFormatKey"/>

--- a/XLibur/Excel/Style/XLDeferredProtection.cs
+++ b/XLibur/Excel/Style/XLDeferredProtection.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 /// <summary>
 /// Lightweight <see cref="IXLProtection"/> that accumulates property changes into an <see cref="XLProtectionKey"/>

--- a/XLibur/Excel/Style/XLDeferredStyle.cs
+++ b/XLibur/Excel/Style/XLDeferredStyle.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLFillKey.cs
+++ b/XLibur/Excel/Style/XLFillKey.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 internal readonly record struct XLFillKey
 {

--- a/XLibur/Excel/Style/XLFillValue.cs
+++ b/XLibur/Excel/Style/XLFillValue.cs
@@ -1,4 +1,4 @@
-
+﻿
 using XLibur.Excel.Caching;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Style/XLFontKey.cs
+++ b/XLibur/Excel/Style/XLFontKey.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLFontValue.cs
+++ b/XLibur/Excel/Style/XLFontValue.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Caching;
+﻿using XLibur.Excel.Caching;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Style/XLNumberFormatKey.cs
+++ b/XLibur/Excel/Style/XLNumberFormatKey.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLNumberFormatValue.cs
+++ b/XLibur/Excel/Style/XLNumberFormatValue.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Caching;
+﻿using XLibur.Excel.Caching;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLPredefinedFormat.cs
+++ b/XLibur/Excel/Style/XLPredefinedFormat.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLProtectionKey.cs
+++ b/XLibur/Excel/Style/XLProtectionKey.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 internal readonly record struct XLProtectionKey
 {

--- a/XLibur/Excel/Style/XLProtectionValue.cs
+++ b/XLibur/Excel/Style/XLProtectionValue.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Caching;
+﻿using XLibur.Excel.Caching;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Style/XLStyleKey.cs
+++ b/XLibur/Excel/Style/XLStyleKey.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 internal readonly record struct XLStyleKey
 {

--- a/XLibur/Excel/Style/XLStyleValue.cs
+++ b/XLibur/Excel/Style/XLStyleValue.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Caching;
+﻿using XLibur.Excel.Caching;
 using System;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/Style/XLStylizedBase.cs
+++ b/XLibur/Excel/Style/XLStylizedBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/XLibur/Excel/Tables/IXLTable.cs
+++ b/XLibur/Excel/Tables/IXLTable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;

--- a/XLibur/Excel/Tables/IXLTableField.cs
+++ b/XLibur/Excel/Tables/IXLTableField.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public enum XLTotalsRowFunction
 {

--- a/XLibur/Excel/Tables/IXLTableRange.cs
+++ b/XLibur/Excel/Tables/IXLTableRange.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Tables/IXLTableRow.cs
+++ b/XLibur/Excel/Tables/IXLTableRow.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel;
+﻿namespace XLibur.Excel;
 
 public interface IXLTableRow : IXLRangeRow
 {

--- a/XLibur/Excel/Tables/IXLTableRows.cs
+++ b/XLibur/Excel/Tables/IXLTableRows.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Tables/IXLTables.cs
+++ b/XLibur/Excel/Tables/IXLTables.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/Tables/TableNameValidator.cs
+++ b/XLibur/Excel/Tables/TableNameValidator.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 
 namespace XLibur.Excel.Tables;
 

--- a/XLibur/Excel/Tables/XLTableTheme.cs
+++ b/XLibur/Excel/Tables/XLTableTheme.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 

--- a/XLibur/Excel/XLCellValue.cs
+++ b/XLibur/Excel/XLCellValue.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Globalization;
 using XLibur.Excel.CalcEngine;

--- a/XLibur/Excel/XLCellsUsedOptions.cs
+++ b/XLibur/Excel/XLCellsUsedOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/XLClearOptions.cs
+++ b/XLibur/Excel/XLClearOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/XLConstants.cs
+++ b/XLibur/Excel/XLConstants.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Collections.Generic;
 

--- a/XLibur/Excel/XLInCellImageStore.cs
+++ b/XLibur/Excel/XLInCellImageStore.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;

--- a/XLibur/Excel/XLOutline.cs
+++ b/XLibur/Excel/XLOutline.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/XLOutlineTracker.cs
+++ b/XLibur/Excel/XLOutlineTracker.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace XLibur.Excel;

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.CalcEngine;
+﻿using XLibur.Excel.CalcEngine;
 using XLibur.Graphics;
 using DocumentFormat.OpenXml;
 using System;

--- a/XLibur/Excel/XLWorkbookProperties.cs
+++ b/XLibur/Excel/XLWorkbookProperties.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 

--- a/XLibur/Excel/XLWorkbook_ImageHandling.cs
+++ b/XLibur/Excel/XLWorkbook_ImageHandling.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml;
+﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing.Spreadsheet;
 using DocumentFormat.OpenXml.Packaging;
 using System;

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -1,4 +1,4 @@
-using XLibur.Extensions;
+﻿using XLibur.Extensions;
 using XLibur.Utils;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;

--- a/XLibur/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/XLibur/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml.Packaging;
+﻿using DocumentFormat.OpenXml.Packaging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -1,4 +1,4 @@
-using XLibur.Extensions;
+﻿using XLibur.Extensions;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Caching;
+﻿using XLibur.Excel.Caching;
 using XLibur.Excel.CalcEngine;
 using XLibur.Excel.Drawings;
 using XLibur.Excel.Ranges.Index;

--- a/XLibur/Excel/XLWorksheetDataInserter.cs
+++ b/XLibur/Excel/XLWorksheetDataInserter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.InsertData;
+﻿using XLibur.Excel.InsertData;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/XLibur/Excel/XLWorksheetRangeShifter.cs
+++ b/XLibur/Excel/XLWorksheetRangeShifter.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.CalcEngine;
+﻿using XLibur.Excel.CalcEngine;
 using System;
 using System.Linq;
 using XLibur.Excel.Coordinates;

--- a/XLibur/Extensions/AttributeExtensions.cs
+++ b/XLibur/Extensions/AttributeExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
 

--- a/XLibur/Extensions/ColorExtensions.cs
+++ b/XLibur/Extensions/ColorExtensions.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System.Drawing;
 
 namespace XLibur.Extensions;

--- a/XLibur/Extensions/DateTimeExtensions.cs
+++ b/XLibur/Extensions/DateTimeExtensions.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 
 namespace XLibur.Extensions;

--- a/XLibur/Extensions/DictionaryExtensions.cs
+++ b/XLibur/Extensions/DictionaryExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/XLibur/Extensions/DoubleExtensions.cs
+++ b/XLibur/Extensions/DoubleExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using XLibur.Excel;
 
 namespace XLibur.Extensions;

--- a/XLibur/Extensions/DoubleValueExtensions.cs
+++ b/XLibur/Extensions/DoubleValueExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using DocumentFormat.OpenXml;
 
 namespace XLibur.Extensions;

--- a/XLibur/Extensions/EnumerableExtensions.cs
+++ b/XLibur/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/XLibur/Extensions/FontBaseExtensions.cs
+++ b/XLibur/Extensions/FontBaseExtensions.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 
 namespace XLibur.Extensions;
 

--- a/XLibur/Extensions/FormatExtensions.cs
+++ b/XLibur/Extensions/FormatExtensions.cs
@@ -1,4 +1,4 @@
-
+﻿
 using ExcelNumberFormat;
 using System.Globalization;
 

--- a/XLibur/Extensions/GuidExtensions.cs
+++ b/XLibur/Extensions/GuidExtensions.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 
 namespace XLibur.Extensions;

--- a/XLibur/Extensions/IntegerExtensions.cs
+++ b/XLibur/Extensions/IntegerExtensions.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace XLibur.Extensions;
 

--- a/XLibur/Extensions/ObjectExtensions.cs
+++ b/XLibur/Extensions/ObjectExtensions.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Globalization;
 

--- a/XLibur/Extensions/OpenXmlPartContainerExtensions.cs
+++ b/XLibur/Extensions/OpenXmlPartContainerExtensions.cs
@@ -1,4 +1,4 @@
-using DocumentFormat.OpenXml.Packaging;
+﻿using DocumentFormat.OpenXml.Packaging;
 using System.Linq;
 
 namespace XLibur.Extensions;

--- a/XLibur/Extensions/OpenXmlPartReaderExtensions.cs
+++ b/XLibur/Extensions/OpenXmlPartReaderExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using XLibur.Excel;

--- a/XLibur/Extensions/ReflectionExtensions.cs
+++ b/XLibur/Extensions/ReflectionExtensions.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace XLibur.Extensions;
 

--- a/XLibur/Extensions/StringExtensions.cs
+++ b/XLibur/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/XLibur/Extensions/TimeSpanExtensions.cs
+++ b/XLibur/Extensions/TimeSpanExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Text;
 using XLibur.Excel.CalcEngine;

--- a/XLibur/Extensions/TypeExtensions.cs
+++ b/XLibur/Extensions/TypeExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Extensions;
 

--- a/XLibur/Extensions/XDocumentExtensions.cs
+++ b/XLibur/Extensions/XDocumentExtensions.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Xml;
 using System.Xml.Linq;
 

--- a/XLibur/Extensions/XLErrorExtensions.cs
+++ b/XLibur/Extensions/XLErrorExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using XLibur.Excel;
 

--- a/XLibur/Extensions/XmlWriterExtensions.cs
+++ b/XLibur/Extensions/XmlWriterExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Xml;
 using XLibur.Excel;

--- a/XLibur/Graphics/DefaultGraphicEngine.cs
+++ b/XLibur/Graphics/DefaultGraphicEngine.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;

--- a/XLibur/Graphics/Dpi.cs
+++ b/XLibur/Graphics/Dpi.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Graphics;
+﻿namespace XLibur.Graphics;
 
 /// <summary>
 /// A DPI resolution.

--- a/XLibur/Graphics/GlyphBox.cs
+++ b/XLibur/Graphics/GlyphBox.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 #pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility
 

--- a/XLibur/Graphics/IXLGraphicEngine.cs
+++ b/XLibur/Graphics/IXLGraphicEngine.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.IO;
 using XLibur.Excel;

--- a/XLibur/Graphics/ImageInfoReader.cs
+++ b/XLibur/Graphics/ImageInfoReader.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 
 namespace XLibur.Graphics;
 

--- a/XLibur/Graphics/SvgInfoReader.cs
+++ b/XLibur/Graphics/SvgInfoReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.Globalization;
 using System.IO;

--- a/XLibur/Graphics/XLPictureInfo.cs
+++ b/XLibur/Graphics/XLPictureInfo.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel.Drawings;
+﻿using XLibur.Excel.Drawings;
 using System;
 using System.Drawing;
 

--- a/XLibur/Properties/AssemblyInfo.cs
+++ b/XLibur/Properties/AssemblyInfo.cs
@@ -1,2 +1,2 @@
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("XLibur.Tests")]
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("XLibur.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("XLibur.Benchmarks")]

--- a/XLibur/Utils/ColorStringParser.cs
+++ b/XLibur/Utils/ColorStringParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Color = System.Drawing.Color;
 
 namespace XLibur.Utils;

--- a/XLibur/Utils/CryptographicAlgorithms.cs
+++ b/XLibur/Utils/CryptographicAlgorithms.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;

--- a/XLibur/Utils/DescribedEnumParser.cs
+++ b/XLibur/Utils/DescribedEnumParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/XLibur/Utils/OpenXmlHelper.cs
+++ b/XLibur/Utils/OpenXmlHelper.cs
@@ -1,4 +1,4 @@
-
+﻿
 using XLibur.Excel;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;

--- a/XLibur/Utils/StreamExtensions.cs
+++ b/XLibur/Utils/StreamExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 
 namespace XLibur.Utils;

--- a/XLibur/Utils/XmlEncoder.cs
+++ b/XLibur/Utils/XmlEncoder.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 

--- a/XLibur/XLHelper.cs
+++ b/XLibur/XLHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/XLibur/XLHelper.cs
+++ b/XLibur/XLHelper.cs
@@ -61,7 +61,7 @@ public static partial class XLHelper
     /// </summary>
     internal static readonly StringComparer FunctionComparer = StringComparer.OrdinalIgnoreCase;
 
-    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(150);
+    internal static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(150);
 
     internal static readonly Regex RCSimpleRegex = new(
         @"^(r(((-\d)?\d*)|\[(-\d)?\d*\]))?(c(((-\d)?\d*)|\[(-\d)?\d*\]))?$"

--- a/XLibur/XLHelper_ASF.cs
+++ b/XLibur/XLHelper_ASF.cs
@@ -1,4 +1,4 @@
-/* ====================================================================
+﻿/* ====================================================================
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.


### PR DESCRIPTION
## Summary
- Implement `INDIRECT(ref_text, [a1])` Excel function — converts text strings into cell references at evaluation time
- Supports A1 style (default), absolute R1C1 (`R1C1`, `R1C1:R5C3`), sheet prefixes (`Sheet2!A1`), quoted sheet names with apostrophes (`'Bob''s'!A1`), range references, and defined name resolution (both sheet-scoped and workbook-level)
- Registered as volatile (`FunctionFlags.Volatile`) with dynamic dependency handling in `DependenciesVisitor`
- Clean up `.gitattributes`, `.editorconfig`, and `.coderabbit.yaml` config files

## Changes
- **`Lookup.cs`** — `Indirect`, `TryParseR1C1Reference`, `TryResolveDefinedName`, `EvaluateDefinedName`; uses `int.TryParse` for overflow safety
- **`SignatureAdapter.cs`** — `ToText`/`CoerceToLogical` changed to `internal` for reuse
- **`DependenciesVisitor.cs`** — INDIRECT case (volatile, no static deps)
- **`XLHelper.cs`** — `RegexTimeout` changed to `internal`
- **`.gitattributes`** — removed invalid `core.autocrlf=true`, added `*.slnx`
- **`.editorconfig`** — added `charset`, indent rules for project/config files
- **`.coderabbit.yaml`** — added walkthrough collapse, sequence diagrams, benchmark instructions, generated file filters

## Test plan
- [x] 14 INDIRECT tests pass (basic A1, absolute, ranges, empty string, sheet prefix, quoted sheet names, invalid ref, defined names, sheet-scoped names, A1 flag, R1C1 single cell, R1C1 range, nonexistent sheet, dynamic reference)
- [x] Uncommented `Ref_function` parser test passes
- [x] Full test suite (6007 tests) passes with zero regressions on net8.0 and net10.0
- [x] Removed duplicate ISBLANK tests (already covered by parameterized tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)