### PR TITLE
perf: optimize load/save hot paths and improve benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ _ReSharper*/
 *.DotSettings.user
 BenchmarkDotNet.Artifacts/
 /results/*
+/temp/*

--- a/XLibur.Benchmarks/ClosedXmlWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/ClosedXmlWorkbookBenchmarks.cs
@@ -6,6 +6,7 @@ using ClosedXML.Excel;
 namespace XLibur.Benchmarks;
 
 [MemoryDiagnoser]
+[Config(typeof(JoinSummaryConfig))]
 public class ClosedXmlWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
@@ -51,6 +52,10 @@ public class ClosedXmlWorkbookBenchmarks
             worksheet.Cell(row, 2).Value = _numbers[i];
             worksheet.Cell(row, 3).Value = _dates[i];
         }
+
+        var sumRow = RowCount + 2;
+        worksheet.Cell(sumRow, 1).Value = "Total";
+        worksheet.Cell(sumRow, 2).FormulaA1 = $"SUM(B2:B{RowCount + 1})";
 
         using var stream = new MemoryStream();
         workbook.SaveAs(stream);

--- a/XLibur.Benchmarks/EpPlusWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/EpPlusWorkbookBenchmarks.cs
@@ -8,6 +8,7 @@ using OfficeOpenXml.Style;
 namespace XLibur.Benchmarks;
 
 [MemoryDiagnoser]
+[Config(typeof(JoinSummaryConfig))]
 public class EpPlusWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
@@ -55,6 +56,10 @@ public class EpPlusWorkbookBenchmarks
             worksheet.Cells[row, 2].Value = _numbers[i];
             worksheet.Cells[row, 3].Value = _dates[i];
         }
+
+        var sumRow = RowCount + 2;
+        worksheet.Cells[sumRow, 1].Value = "Total";
+        worksheet.Cells[sumRow, 2].Formula = $"SUM(B2:B{RowCount + 1})";
 
         using var stream = new MemoryStream();
         package.SaveAs(stream);

--- a/XLibur.Benchmarks/JoinSummaryConfig.cs
+++ b/XLibur.Benchmarks/JoinSummaryConfig.cs
@@ -1,4 +1,4 @@
-using BenchmarkDotNet.Columns;
+﻿using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;

--- a/XLibur.Benchmarks/JoinSummaryConfig.cs
+++ b/XLibur.Benchmarks/JoinSummaryConfig.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+
+namespace XLibur.Benchmarks;
+
+public class JoinSummaryConfig : ManualConfig
+{
+    public JoinSummaryConfig()
+    {
+        WithOption(ConfigOptions.JoinSummary, true);
+        AddColumn(new LibraryNameColumn());
+    }
+}
+
+public class LibraryNameColumn : IColumn
+{
+    public string Id => "Library";
+    public string ColumnName => "Library";
+    public bool IsDefault(Summary summary, BenchmarkCase b) => false;
+
+    public string GetValue(Summary summary, BenchmarkCase b)
+    {
+        var typeName = b.Descriptor.Type.Name;
+        return typeName switch
+        {
+            var n when n.Contains("ClosedXml") => "ClosedXML",
+            var n when n.Contains("EpPlus") => "EPPlus",
+            var n when n.Contains("XLibur") => "XLibur",
+            _ => typeName
+        };
+    }
+
+    public string GetValue(Summary s, BenchmarkCase b, SummaryStyle style) => GetValue(s, b);
+    public bool IsAvailable(Summary s) => true;
+    public bool AlwaysShow => true;
+    public ColumnCategory Category => ColumnCategory.Job;
+    public int PriorityInCategory => -10;
+    public bool IsNumeric => false;
+    public UnitType UnitType => UnitType.Dimensionless;
+    public string Legend => "Library under test";
+}

--- a/XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs
@@ -9,6 +9,7 @@ namespace XLibur.Benchmarks;
 [MemoryDiagnoser]
 //[DotMemoryDiagnoser]
 [DotTraceDiagnoser]
+[Config(typeof(JoinSummaryConfig))]
 public class XLiburWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
@@ -54,6 +55,10 @@ public class XLiburWorkbookBenchmarks
             worksheet.Cell(row, 2).Value = _numbers[i];
             worksheet.Cell(row, 3).Value = _dates[i];
         }
+
+        var sumRow = RowCount + 2;
+        worksheet.Cell(sumRow, 1).Value = "Total";
+        worksheet.Cell(sumRow, 2).FormulaA1 = $"SUM(B2:B{RowCount + 1})";
 
         using var stream = new MemoryStream();
         workbook.SaveAs(stream);

--- a/XLibur/Excel/Cells/FormulaSlice.cs
+++ b/XLibur/Excel/Cells/FormulaSlice.cs
@@ -98,6 +98,17 @@ internal sealed class FormulaSlice : ISlice
     }
 
     /// <summary>
+    /// Fast path for initial worksheet loading. The caller guarantees that the cell
+    /// has no existing formula (original is null) and that the calc engine's dependency
+    /// tree/chain are not yet initialized, so we skip the original-value lookup,
+    /// ReferenceEquals check, and calc engine registration.
+    /// </summary>
+    internal void SetDuringLoad(XLSheetPoint point, XLCellFormula formula)
+    {
+        _formulas.SetNonDefault(point, formula);
+    }
+
+    /// <summary>
     /// Set all cells in a <paramref name="range"/> to the array formula.
     /// </summary>
     /// <remarks>

--- a/XLibur/Excel/Cells/Slice.Lut.cs
+++ b/XLibur/Excel/Cells/Slice.Lut.cs
@@ -94,7 +94,7 @@ internal sealed partial class Slice<TElement>
             if (_buckets[topIdx].Bitmap == 0)
                 _buckets[topIdx] = new LutBucket(null, 0);
 
-            RecalculateMaxIndex(index);
+            RecalculateMaxIndex(index, valueIsDefault);
         }
 
         /// <summary>
@@ -170,10 +170,20 @@ internal sealed partial class Slice<TElement>
         private void ClearBitmap(int topIdx, int bottomIdx)
             => _buckets[topIdx] = new LutBucket(_buckets[topIdx].Nodes, _buckets[topIdx].Bitmap & ~((uint)1 << bottomIdx));
 
-        private void RecalculateMaxIndex(int index)
+        private void RecalculateMaxIndex(int index, bool valueIsDefault)
         {
-            if (MaxUsedIndex <= index)
-                MaxUsedIndex = CalculateMaxIndex();
+            if (!valueIsDefault)
+            {
+                // Setting a non-default value — max can only increase or stay the same.
+                if (index > MaxUsedIndex)
+                    MaxUsedIndex = index;
+            }
+            else
+            {
+                // Clearing a value — max may need to decrease if we cleared the current max.
+                if (index >= MaxUsedIndex)
+                    MaxUsedIndex = CalculateMaxIndex();
+            }
         }
 
         private int CalculateMaxIndex()

--- a/XLibur/Excel/Cells/Slice.Lut.cs
+++ b/XLibur/Excel/Cells/Slice.Lut.cs
@@ -97,6 +97,20 @@ internal sealed partial class Slice<TElement>
             RecalculateMaxIndex(index);
         }
 
+        /// <summary>
+        /// Fast path for setting a value that the caller guarantees is not <c>default</c>.
+        /// Skips the <see cref="EqualityComparer{T}"/> check and always sets the bitmap bit.
+        /// </summary>
+        internal void SetNonDefault(int index, T value)
+        {
+            var (topIdx, bottomIdx) = SplitIndex(index);
+            SetValue(value, topIdx, bottomIdx);
+            SetBitmap(topIdx, bottomIdx);
+
+            if (index > MaxUsedIndex)
+                MaxUsedIndex = index;
+        }
+
         private void SetValue(T value, int topIdx, int bottomIdx)
         {
             var topSize = _buckets.Length;
@@ -432,6 +446,48 @@ internal sealed partial class Slice<TElement>
 
             if (_bitmap == 0)
                 _storage = null;
+        }
+
+        /// <summary>
+        /// Fast path for setting a value that the caller guarantees is not <c>default</c>.
+        /// Skips the <see cref="EqualityComparer{TElement}"/> check and always sets the bitmap bit.
+        /// </summary>
+        internal void SetNonDefault(int columnIndex, TElement value)
+        {
+            if (_storage is Lut<TElement> lut)
+            {
+                lut.SetNonDefault(columnIndex, value);
+                return;
+            }
+
+            if (columnIndex >= 32)
+            {
+                UpgradeToWideAndSet(columnIndex, value);
+                return;
+            }
+
+            // Narrow mode
+            if (_storage is not TElement[] nodes)
+            {
+                var size = 4;
+                while (columnIndex >= size)
+                    size *= 2;
+
+                nodes = new TElement[size];
+                _storage = nodes;
+            }
+            else if (columnIndex >= nodes.Length)
+            {
+                var size = nodes.Length;
+                while (columnIndex >= size)
+                    size *= 2;
+
+                Array.Resize(ref nodes, size);
+                _storage = nodes;
+            }
+
+            nodes[columnIndex] = value;
+            _bitmap |= 1u << columnIndex;
         }
 
         private void UpgradeToWideAndSet(int columnIndex, TElement value)

--- a/XLibur/Excel/Cells/Slice.cs
+++ b/XLibur/Excel/Cells/Slice.cs
@@ -262,6 +262,44 @@ internal sealed partial class Slice<TElement> : ISlice
         }
     }
 
+    /// <summary>
+    /// Fast path for bulk-loading non-default values. The caller guarantees that <paramref name="value"/>
+    /// is not <c>default</c>, so we skip <see cref="EqualityComparer{T}"/> checks and the
+    /// "was-used-now-unused" bookkeeping that cannot happen during a load of non-default data.
+    /// </summary>
+    internal void SetNonDefault(XLSheetPoint point, in TElement value)
+        => SetNonDefault(point.Row, point.Column, in value);
+
+    /// <inheritdoc cref="SetNonDefault(XLSheetPoint, in TElement)"/>
+    internal void SetNonDefault(int row, int column, in TElement value)
+    {
+        ref readonly var existing = ref _data.Get(row - 1);
+        if (existing.IsEmpty)
+        {
+            var rowData = RowData.CreateForSet(column - 1, value);
+            _data.SetNonDefault(row - 1, rowData);
+            IncrementColumnUsage(column);
+            if (column > MaxColumn)
+                MaxColumn = column;
+            return;
+        }
+
+        // Copy the struct so we can mutate it.
+        var rd = existing;
+        var wasUsed = rd.IsUsed(column - 1);
+        rd.SetNonDefault(column - 1, value);
+
+        // Write back — value is non-default so RowData is always non-empty.
+        _data.SetNonDefault(row - 1, rd);
+
+        if (!wasUsed)
+        {
+            IncrementColumnUsage(column);
+            if (column > MaxColumn)
+                MaxColumn = column;
+        }
+    }
+
     private int CalculateMaxColumn()
     {
         var maxColIdx = -1;

--- a/XLibur/Excel/Cells/ValueSlice.cs
+++ b/XLibur/Excel/Cells/ValueSlice.cs
@@ -214,6 +214,29 @@ internal sealed class ValueSlice : ISlice
         _values.Set(point, modified);
     }
 
+    /// <summary>
+    /// Get cell value and share-string flag in a single slice lookup, avoiding a
+    /// second Lut traversal when both are needed (e.g., during save).
+    /// </summary>
+    internal XLCellValue GetCellValueAndShareString(XLSheetPoint point, out bool shareString)
+    {
+        ref readonly var cellValue = ref _values[point];
+        shareString = !cellValue.Inline;
+        var type = cellValue.Type;
+        var value = cellValue.Value;
+        return type switch
+        {
+            XLDataType.Blank => Blank.Value,
+            XLDataType.Boolean => value != 0,
+            XLDataType.Number => value,
+            XLDataType.Text => _sst[(int)value],
+            XLDataType.Error => (XLError)value,
+            XLDataType.DateTime => XLCellValue.FromSerialDateTime(value),
+            XLDataType.TimeSpan => XLCellValue.FromSerialTimeSpan(value),
+            _ => throw new ArgumentOutOfRangeException(nameof(point), type, "Unexpected data type.")
+        };
+    }
+
     internal bool GetShareString(XLSheetPoint point)
     {
         return !_values[point].Inline;

--- a/XLibur/Excel/Cells/ValueSlice.cs
+++ b/XLibur/Excel/Cells/ValueSlice.cs
@@ -144,6 +144,41 @@ internal sealed class ValueSlice : ISlice
         _values.Set(point, in modified);
     }
 
+    /// <summary>
+    /// Fast path for initial worksheet loading. The caller guarantees that the cell at
+    /// <paramref name="point"/> has never been written (original is blank), so we skip
+    /// the original-value lookup, SST dereference, and the default-equality check in the
+    /// underlying slice. The value must be non-blank.
+    /// </summary>
+    internal void SetCellValueDuringLoad(XLSheetPoint point, XLCellValue cellValue)
+    {
+        double value;
+        if (cellValue.Type == XLDataType.Text)
+        {
+            // Fresh cell — no existing text to dereference. Inline defaults to false.
+            value = _sst.IncreaseRef(cellValue.GetText(), inline: false);
+        }
+        else if (cellValue.IsUnifiedNumber)
+        {
+            value = cellValue.GetUnifiedNumber();
+        }
+        else if (cellValue.IsBoolean)
+        {
+            value = cellValue.GetBoolean() ? 1 : 0;
+        }
+        else if (cellValue.IsError)
+        {
+            value = (int)cellValue.GetError();
+        }
+        else
+        {
+            value = 0;
+        }
+
+        var modified = new XLValueSliceContent(value, cellValue.Type, inline: false);
+        _values.SetNonDefault(point, in modified);
+    }
+
     internal XLImmutableRichText? GetRichText(XLSheetPoint point)
     {
         ref readonly var cellValue = ref _values[point];

--- a/XLibur/Excel/Cells/ValueSlice.cs
+++ b/XLibur/Excel/Cells/ValueSlice.cs
@@ -150,13 +150,19 @@ internal sealed class ValueSlice : ISlice
     /// the original-value lookup, SST dereference, and the default-equality check in the
     /// underlying slice. The value must be non-blank.
     /// </summary>
-    internal void SetCellValueDuringLoad(XLSheetPoint point, XLCellValue cellValue)
+    /// <param name="point">Cell address.</param>
+    /// <param name="cellValue">Non-blank value to write.</param>
+    /// <param name="inline">
+    /// <c>true</c> for formula result text (not in the shared string table);
+    /// <c>false</c> (default) for normal data cells.
+    /// </param>
+    internal void SetCellValueDuringLoad(XLSheetPoint point, XLCellValue cellValue, bool inline = false)
     {
         double value;
         if (cellValue.Type == XLDataType.Text)
         {
-            // Fresh cell — no existing text to dereference. Inline defaults to false.
-            value = _sst.IncreaseRef(cellValue.GetText(), inline: false);
+            // Fresh cell — no existing text to dereference.
+            value = _sst.IncreaseRef(cellValue.GetText(), inline);
         }
         else if (cellValue.IsUnifiedNumber)
         {
@@ -175,7 +181,7 @@ internal sealed class ValueSlice : ISlice
             value = 0;
         }
 
-        var modified = new XLValueSliceContent(value, cellValue.Type, inline: false);
+        var modified = new XLValueSliceContent(value, cellValue.Type, inline);
         _values.SetNonDefault(point, in modified);
     }
 

--- a/XLibur/Excel/IO/SharedStringReader.cs
+++ b/XLibur/Excel/IO/SharedStringReader.cs
@@ -1,4 +1,5 @@
-﻿using DocumentFormat.OpenXml.Packaging;
+﻿using System;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,26 +45,54 @@ internal static class SharedStringReader
         if (sst is null)
             return [];
 
-        var entries = new List<SharedStringEntry>();
-
-        foreach (var item in sst.Elements<SharedStringItem>())
+        // Pre-allocate from the SST's UniqueCount (or Count) attribute to avoid
+        // List<T> resize+copy overhead for large shared string tables.
+        var uniqueCount = sst.UniqueCount?.Value ?? sst.Count?.Value;
+        if (uniqueCount is not null and > 0)
         {
-            // Schema: <si> contains either (t, rPh*, phoneticPr?) or (r+, rPh*, phoneticPr?).
-            // Pure plain text: a single <t> child with no runs and no phonetic data.
-            var text = item.Text;
-            if (text is not null && text == item.FirstChild && text == item.LastChild)
+            var entries = new SharedStringEntry[(int)uniqueCount.Value];
+            var idx = 0;
+            foreach (var item in sst.Elements<SharedStringItem>())
             {
-                // Decode _xHHHH_ escapes (e.g. _x0018_ → \u0018) matching the original
-                // SetCellText code path.
-                var decoded = XmlEncoder.DecodeString(text.InnerText);
-                entries.Add(SharedStringEntry.Plain(decoded));
+                var entry = ReadEntry(item);
+                if (idx < entries.Length)
+                    entries[idx++] = entry;
+                else
+                {
+                    // Count attribute was wrong — fall back to growing
+                    Array.Resize(ref entries, entries.Length * 2);
+                    entries[idx++] = entry;
+                }
             }
-            else
-            {
-                entries.Add(SharedStringEntry.Rich(item));
-            }
+
+            // Trim if the declared count was larger than actual entries
+            if (idx < entries.Length)
+                Array.Resize(ref entries, idx);
+
+            return entries;
         }
 
-        return entries.ToArray();
+        // Fallback: no count attribute, use list
+        var list = new List<SharedStringEntry>();
+        foreach (var item in sst.Elements<SharedStringItem>())
+            list.Add(ReadEntry(item));
+
+        return list.ToArray();
+    }
+
+    private static SharedStringEntry ReadEntry(SharedStringItem item)
+    {
+        // Schema: <si> contains either (t, rPh*, phoneticPr?) or (r+, rPh*, phoneticPr?).
+        // Pure plain text: a single <t> child with no runs and no phonetic data.
+        var text = item.Text;
+        if (text is not null && text == item.FirstChild && text == item.LastChild)
+        {
+            // Decode _xHHHH_ escapes (e.g. _x0018_ → \u0018) matching the original
+            // SetCellText code path.
+            var decoded = XmlEncoder.DecodeString(text.InnerText);
+            return SharedStringEntry.Plain(decoded);
+        }
+
+        return SharedStringEntry.Rich(item);
     }
 }

--- a/XLibur/Excel/IO/SharedStringReader.cs
+++ b/XLibur/Excel/IO/SharedStringReader.cs
@@ -45,9 +45,11 @@ internal static class SharedStringReader
         if (sst is null)
             return [];
 
-        // Pre-allocate from the SST's UniqueCount (or Count) attribute to avoid
+        // Pre-allocate from the SST's UniqueCount attribute to avoid
         // List<T> resize+copy overhead for large shared string tables.
-        var uniqueCount = sst.UniqueCount?.Value ?? sst.Count?.Value;
+        // Only use UniqueCount (number of unique <si> entries), not Count
+        // (total reference count including duplicates) which would over-allocate.
+        var uniqueCount = sst.UniqueCount?.Value;
         if (uniqueCount is not null and > 0)
         {
             var entries = new SharedStringEntry[(int)uniqueCount.Value];

--- a/XLibur/Excel/IO/SheetDataWriter.cs
+++ b/XLibur/Excel/IO/SheetDataWriter.cs
@@ -232,10 +232,12 @@ internal static class SheetDataWriter
             return;
         }
 
-        var cellValue = ctx.CellsCollection.ValueSlice.GetCellValue(point);
+        // Single slice lookup for both value and share-string flag, avoiding a
+        // second Lut traversal that GetShareString would require separately.
+        var cellValue = ctx.CellsCollection.ValueSlice.GetCellValueAndShareString(point, out var shareString);
         if (cellValue.Type != XLDataType.Blank)
         {
-            WriteValueOnlyCell(xml, ref ctx, point, cellStyleId, cellValue);
+            WriteValueOnlyCell(xml, ref ctx, point, cellStyleId, cellValue, shareString);
         }
         else if (rowStyleId != cellStyleId)
         {
@@ -244,11 +246,10 @@ internal static class SheetDataWriter
     }
 
     private static void WriteValueOnlyCell(XmlWriter xml, ref CellWriteContext ctx,
-        XLSheetPoint point, uint cellStyleId, XLCellValue cellValue)
+        XLSheetPoint point, uint cellStyleId, XLCellValue cellValue, bool shareString)
     {
         Span<char> cellRefSpan = ctx.CellRef;
         var cellRefLen = point.Format(cellRefSpan);
-        var shareString = ctx.CellsCollection.ValueSlice.GetShareString(point);
         var dataType = GetCellValueTypeDirect(cellValue.Type, shareString);
         ref readonly var misc = ref ctx.CellsCollection.MiscSlice[point];
 

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -230,25 +230,25 @@ internal static class WorksheetSheetDataReader
     {
         var formula = LoadCellFormula(ws, cellAddress, reader, context.SharedFormulasR1C1);
 
+        // Formula results are stored inline (not in the shared string table).
+        var formulaInline = formula is not null;
+
         var cellHasValue = reader.IsStartElement("v");
         if (cellHasValue)
         {
             SetCellValue(dataType, reader.GetText(), cellsCollection, cellAddress, cellStyleValue, ws,
-                context.SharedStrings, hasFormula: formula is not null);
+                context.SharedStrings, formulaInline);
             reader.Skip();
         }
         else if (dataType.Equals(CellValues.SharedString) || dataType.Equals(CellValues.String))
         {
-            if (formula is not null)
-                cellsCollection.ValueSlice.SetCellValue(cellAddress, string.Empty);
-            else
-                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty);
+            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty, formulaInline);
         }
 
         // If the cell doesn't contain a value, invalidate the formula so it recalculates.
         // Formula can be null for slave cells of array formulas.
-        if (formula is not null && !cellHasValue)
-            formula.IsDirty = true;
+        if (formulaInline && !cellHasValue)
+            formula!.IsDirty = true;
 
         if (reader.IsStartElement("is"))
             LoadInlineString(dataType, cellsCollection, cellAddress, ws, reader);
@@ -279,7 +279,6 @@ internal static class WorksheetSheetDataReader
     {
         var attributes = reader.Attributes;
         var formulaSlice = ws.Internals.CellsCollection.FormulaSlice;
-        var valueSlice = ws.Internals.CellsCollection.ValueSlice;
 
         // bx attribute of cell formula is not ever used, per MS-OI29500 2.1.620
         var formulaText = reader.GetText();
@@ -293,14 +292,14 @@ internal static class WorksheetSheetDataReader
             _ => throw new NotSupportedException("Unknown formula type.")
         };
 
-        // Always set the shareString flag to `false`, because the text result of
-        // the formula is stored directly in the sheet, not the shared string table.
+        // The inline flag (shareString=false) for formula results is now set directly
+        // by SetCellValueDuringLoad with inline=true in LoadCellContent, eliminating
+        // separate SetShareString calls and their per-cell slice lookups.
         XLCellFormula? formula = null;
         if (formulaType == CellFormulaValues.Normal)
         {
             formula = XLCellFormula.NormalA1(formulaText);
             formulaSlice.Set(cellAddress, formula);
-            valueSlice.SetShareString(cellAddress, false);
         }
         else if (formulaType == CellFormulaValues.Array && attributes.GetRefAttribute("ref") is
         {
@@ -312,24 +311,14 @@ internal static class WorksheetSheetDataReader
             // a formula yet. Also, Excel doesn't allow change of array data, only through the parent formula.
             formula = XLCellFormula.Array(formulaText, arrayArea, aca);
             formulaSlice.SetArray(arrayArea, formula);
-
-            for (var col = arrayArea.FirstPoint.Column; col <= arrayArea.LastPoint.Column; ++col)
-            {
-                for (var row = arrayArea.FirstPoint.Row; row <= arrayArea.LastPoint.Row; ++row)
-                {
-                    valueSlice.SetShareString(cellAddress, false);
-                }
-            }
         }
         else if (formulaType == CellFormulaValues.Shared && attributes.GetUintAttribute("si") is { } sharedIndex)
         {
             formula = LoadSharedFormula(formulaText, cellAddress, sharedIndex, sharedFormulasR1C1, formulaSlice);
-            valueSlice.SetShareString(cellAddress, false);
         }
         else if (formulaType == CellFormulaValues.DataTable && attributes.GetRefAttribute("ref") is { } dataTableArea)
         {
             formula = LoadDataTableFormula(attributes, cellAddress, dataTableArea, formulaSlice);
-            valueSlice.SetShareString(cellAddress, false);
         }
 
         // Go from the start of the 'f' element to the end of the 'f' element.
@@ -342,44 +331,31 @@ internal static class WorksheetSheetDataReader
     /// Write cell value directly to <see cref="ValueSlice"/> during loading,
     /// bypassing <see cref="XLCell"/> allocation and <c>CalcEngine.MarkDirty</c>.
     /// An <see cref="XLCell"/> is only created for the rare rich-text shared-string path.
-    /// When <paramref name="hasFormula"/> is <c>false</c> (the common case for data cells),
-    /// uses the faster <c>SetCellValueDuringLoad</c> path that skips equality checks.
     /// </summary>
     internal static void SetCellValue(CellValues dataType, string? cellValue,
         XLCellsCollection cellsCollection, XLSheetPoint cellAddress, XLStyleValue cellStyleValue,
-        XLWorksheet ws, SharedStringEntry[]? sharedStrings, bool hasFormula)
+        XLWorksheet ws, SharedStringEntry[]? sharedStrings, bool inline)
     {
         // Only String writes an empty value when v is null.
         if (cellValue is null)
         {
             if (dataType == CellValues.String)
-            {
-                if (hasFormula)
-                    cellsCollection.ValueSlice.SetCellValue(cellAddress, string.Empty);
-                else
-                    cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty);
-            }
-
+                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty, inline);
             return;
         }
 
         if (dataType == CellValues.Number)
-            SetNumberCellValue(cellValue, cellsCollection, cellAddress, cellStyleValue, hasFormula);
+            SetNumberCellValue(cellValue, cellsCollection, cellAddress, cellStyleValue, inline);
         else if (dataType == CellValues.SharedString)
-            SetSharedStringCellValue(cellValue, cellsCollection, cellAddress, ws, sharedStrings, hasFormula);
+            SetSharedStringCellValue(cellValue, cellsCollection, cellAddress, ws, sharedStrings, inline);
         else if (dataType == CellValues.String)
-        {
-            if (hasFormula)
-                cellsCollection.ValueSlice.SetCellValue(cellAddress, cellValue);
-            else
-                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, cellValue);
-        }
+            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, cellValue, inline);
         else if (dataType == CellValues.Boolean)
-            SetBooleanCellValue(cellValue, cellsCollection, cellAddress, hasFormula);
+            SetBooleanCellValue(cellValue, cellsCollection, cellAddress, inline);
         else if (dataType == CellValues.Error)
-            SetErrorCellValue(cellValue, cellsCollection, cellAddress, hasFormula);
+            SetErrorCellValue(cellValue, cellsCollection, cellAddress, inline);
         else if (dataType == CellValues.Date)
-            SetDateCellValue(cellValue, cellsCollection, cellAddress, hasFormula);
+            SetDateCellValue(cellValue, cellsCollection, cellAddress, inline);
     }
 
     /// <summary>
@@ -793,7 +769,7 @@ internal static class WorksheetSheetDataReader
     }
 
     private static void SetNumberCellValue(string cellValue, XLCellsCollection cellsCollection,
-        XLSheetPoint cellAddress, XLStyleValue cellStyleValue, bool hasFormula)
+        XLSheetPoint cellAddress, XLStyleValue cellStyleValue, bool inline)
     {
         if (!TryParseOoxmlDouble(cellValue, out var number)) return;
         var numberDataType = GetNumberDataType(cellStyleValue.NumberFormat);
@@ -803,15 +779,11 @@ internal static class WorksheetSheetDataReader
             XLDataType.TimeSpan => XLCellValue.FromSerialTimeSpan(number),
             _ => number
         };
-
-        if (hasFormula)
-            cellsCollection.ValueSlice.SetCellValue(cellAddress, cellNumber);
-        else
-            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, cellNumber);
+        cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, cellNumber, inline);
     }
 
     private static void SetSharedStringCellValue(string cellValue, XLCellsCollection cellsCollection,
-        XLSheetPoint cellAddress, XLWorksheet ws, SharedStringEntry[]? sharedStrings, bool hasFormula)
+        XLSheetPoint cellAddress, XLWorksheet ws, SharedStringEntry[]? sharedStrings, bool inline)
     {
         if (TryParseOoxmlNonNegativeInt(cellValue, out var sharedStringId)
             && sharedStrings is not null && sharedStringId < sharedStrings.Length)
@@ -822,52 +794,35 @@ internal static class WorksheetSheetDataReader
                 var xlCell = new XLCell(ws, cellAddress);
                 SetCellText(xlCell, entry.RichText);
             }
-            else if (hasFormula)
-                cellsCollection.ValueSlice.SetCellValue(cellAddress, entry.PlainText);
             else
-                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, entry.PlainText);
+                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, entry.PlainText, inline);
         }
-        else if (hasFormula)
-            cellsCollection.ValueSlice.SetCellValue(cellAddress, string.Empty);
         else
-            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty);
+            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty, inline);
     }
 
     private static void SetBooleanCellValue(string cellValue, XLCellsCollection cellsCollection,
-        XLSheetPoint cellAddress, bool hasFormula)
+        XLSheetPoint cellAddress, bool inline)
     {
         var isTrue = string.Equals(cellValue, "1", StringComparison.Ordinal) ||
                      string.Equals(cellValue, "TRUE", StringComparison.OrdinalIgnoreCase);
-
-        if (hasFormula)
-            cellsCollection.ValueSlice.SetCellValue(cellAddress, isTrue);
-        else
-            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, isTrue);
+        cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, isTrue, inline);
     }
 
     private static void SetErrorCellValue(string cellValue, XLCellsCollection cellsCollection,
-        XLSheetPoint cellAddress, bool hasFormula)
+        XLSheetPoint cellAddress, bool inline)
     {
         if (XLErrorParser.TryParseError(cellValue, out var error))
-        {
-            if (hasFormula)
-                cellsCollection.ValueSlice.SetCellValue(cellAddress, error);
-            else
-                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, error);
-        }
+            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, error, inline);
     }
 
     private static void SetDateCellValue(string cellValue, XLCellsCollection cellsCollection,
-        XLSheetPoint cellAddress, bool hasFormula)
+        XLSheetPoint cellAddress, bool inline)
     {
         var date = DateTime.ParseExact(cellValue, DateCellFormats,
             XLHelper.ParseCulture,
             DateTimeStyles.AllowLeadingWhite | DateTimeStyles.AllowTrailingWhite);
-
-        if (hasFormula)
-            cellsCollection.ValueSlice.SetCellValue(cellAddress, date);
-        else
-            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, date);
+        cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, date, inline);
     }
 
     private static void LoadPhonetics(XLCell xlCell, RstType element)

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -41,8 +41,10 @@ internal static class WorksheetSheetDataReader
         /// Whether the worksheet has any custom column styles. When <c>false</c>,
         /// the inherited style for any cell equals the row-level style, avoiding
         /// per-cell column dictionary lookups during loading.
+        /// Evaluated live (not snapshot) because <c>&lt;cols&gt;</c> is parsed
+        /// between context construction and the first <c>&lt;row&gt;</c>.
         /// </summary>
-        public readonly bool HasColumnStyles = worksheet.Internals.ColumnsCollection.Count > 0;
+        public bool HasColumnStyles => Worksheet.Internals.ColumnsCollection.Count > 0;
     }
 
     /// <summary>
@@ -1072,6 +1074,11 @@ internal static class WorksheetSheetDataReader
         var len = s.Length;
         if (len == 0)
             return false;
+
+        // Guard: strings with >9 digits cannot fit in a non-negative int (max 2,147,483,647 = 10 digits).
+        // Fall back to the full parser which handles overflow correctly.
+        if (len > 9)
+            return int.TryParse(s, XLHelper.NumberStyle, XLHelper.ParseCulture, out result);
 
         for (var i = 0; i < len; i++)
         {

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -36,6 +36,13 @@ internal static class WorksheetSheetDataReader
         public readonly Dictionary<uint, string> SharedFormulasR1C1 = sharedFormulasR1C1;
         public readonly Dictionary<int, XLStyleValue> StyleList = styleList;
         public readonly bool Use1904DateSystem = use1904DateSystem;
+
+        /// <summary>
+        /// Whether the worksheet has any custom column styles. When <c>false</c>,
+        /// the inherited style for any cell equals the row-level style, avoiding
+        /// per-cell column dictionary lookups during loading.
+        /// </summary>
+        public readonly bool HasColumnStyles = worksheet.Internals.ColumnsCollection.Count > 0;
     }
 
     /// <summary>
@@ -45,6 +52,13 @@ internal static class WorksheetSheetDataReader
     {
         public int LastRow;
         public int LastColumnNumber;
+
+        /// <summary>
+        /// Cached inherited style for the current row (combines sheet + row styles).
+        /// Recomputed once per row in <see cref="LoadRow"/> to avoid per-cell
+        /// dictionary lookups into <c>RowsCollection</c>.
+        /// </summary>
+        public XLStyleValue? CachedRowInheritedStyle;
     }
 
     /// <summary>
@@ -98,6 +112,15 @@ internal static class WorksheetSheetDataReader
             ApplyRowCustomProps(in rowProps, context.Worksheet, rowIndex, context.Styles);
         }
 
+        // Cache the row-level inherited style (sheet + row) once per row.
+        // This avoids a RowsCollection dictionary lookup for every cell.
+        var ws = context.Worksheet;
+        var sheetStyle = ws.StyleValue;
+        var rowStyle = ws.Internals.RowsCollection.TryGetValue(rowIndex, out var r)
+            ? r.StyleValue
+            : sheetStyle;
+        state.CachedRowInheritedStyle = rowStyle;
+
         state.LastColumnNumber = 0;
 
         // Move from the start element of 'row' forward. We can get cell, extList or end of row.
@@ -105,7 +128,7 @@ internal static class WorksheetSheetDataReader
 
         while (reader.IsStartElement("c"))
         {
-            LoadCell(in context, reader, rowIndex, ref state.LastColumnNumber);
+            LoadCell(in context, reader, rowIndex, ref state);
 
             // Move from an end element of 'cell' either to next cell, extList start or end of row.
             reader.MoveAhead();
@@ -117,14 +140,14 @@ internal static class WorksheetSheetDataReader
     }
 
     private static void LoadCell(in SheetDataReadContext context, OpenXmlPartReader reader, int rowIndex,
-        ref int lastColumnNumber)
+        ref SheetDataReadState state)
     {
         Debug.Assert(reader is { LocalName: "c", IsStartElement: true });
 
         var attributes = reader.Attributes;
         var styleIndex = attributes.GetIntAttribute("s") ?? 0;
-        var cellAddress = attributes.GetCellRefAttribute("r") ?? new XLSheetPoint(rowIndex, lastColumnNumber + 1);
-        lastColumnNumber = cellAddress.Column;
+        var cellAddress = attributes.GetCellRefAttribute("r") ?? new XLSheetPoint(rowIndex, state.LastColumnNumber + 1);
+        state.LastColumnNumber = cellAddress.Column;
         var dataType = ParseCellDataType(attributes.GetAttribute("t"));
 
         var cellStyleValue = ResolveCachedStyleValue(styleIndex, context.Styles, context.StyleList);
@@ -132,12 +155,13 @@ internal static class WorksheetSheetDataReader
         // When the resolved style matches the inherited style AND the cell has data
         // in another slice, we skip the StyleSlice write — avoiding per-row Lut
         // allocation in the style slice for large data sheets.
+        // Use cached row style + column lookup to avoid per-cell RowsCollection lookup.
         var ws = context.Worksheet;
         var cellsCollection = ws.Internals.CellsCollection;
-        var inherited = ws.GetInheritedStyleValue(cellAddress.Row, cellAddress.Column);
+        var inherited = GetInheritedStyleFast(ws, state.CachedRowInheritedStyle!, cellAddress.Column, context.HasColumnStyles);
         var styleMatchesInherited = ReferenceEquals(cellStyleValue, inherited);
         if (!styleMatchesInherited)
-            cellsCollection.StyleSlice.Set(cellAddress.Row, cellAddress.Column, cellStyleValue);
+            cellsCollection.StyleSlice.SetNonDefault(cellAddress.Row, cellAddress.Column, cellStyleValue);
 
         LoadCellMisc(attributes, cellsCollection, cellAddress);
 
@@ -148,6 +172,24 @@ internal static class WorksheetSheetDataReader
 
         if (styleMatchesInherited)
             EnsureStyleForBlankCell(cellsCollection, cellAddress, cellStyleValue);
+    }
+
+    /// <summary>
+    /// Fast inherited style lookup using pre-cached row style. When the worksheet has no
+    /// custom column styles (the common case for data sheets), returns the row style directly,
+    /// avoiding a per-cell dictionary lookup into <c>ColumnsCollection</c>.
+    /// </summary>
+    private static XLStyleValue GetInheritedStyleFast(XLWorksheet ws, XLStyleValue rowStyle, int column, bool hasColumnStyles)
+    {
+        if (!hasColumnStyles)
+            return rowStyle;
+
+        var sheetStyle = ws.StyleValue;
+        var colStyle = ws.Internals.ColumnsCollection.TryGetValue(column, out var c)
+            ? c.StyleValue
+            : sheetStyle;
+
+        return XLStyleValue.Combine(sheetStyle, rowStyle, colStyle);
     }
 
     private static CellValues ParseCellDataType(string? typeAttribute)
@@ -192,12 +234,15 @@ internal static class WorksheetSheetDataReader
         if (cellHasValue)
         {
             SetCellValue(dataType, reader.GetText(), cellsCollection, cellAddress, cellStyleValue, ws,
-                context.SharedStrings);
+                context.SharedStrings, hasFormula: formula is not null);
             reader.Skip();
         }
         else if (dataType.Equals(CellValues.SharedString) || dataType.Equals(CellValues.String))
         {
-            cellsCollection.ValueSlice.SetCellValue(cellAddress, string.Empty);
+            if (formula is not null)
+                cellsCollection.ValueSlice.SetCellValue(cellAddress, string.Empty);
+            else
+                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty);
         }
 
         // If the cell doesn't contain a value, invalidate the formula so it recalculates.
@@ -297,31 +342,44 @@ internal static class WorksheetSheetDataReader
     /// Write cell value directly to <see cref="ValueSlice"/> during loading,
     /// bypassing <see cref="XLCell"/> allocation and <c>CalcEngine.MarkDirty</c>.
     /// An <see cref="XLCell"/> is only created for the rare rich-text shared-string path.
+    /// When <paramref name="hasFormula"/> is <c>false</c> (the common case for data cells),
+    /// uses the faster <c>SetCellValueDuringLoad</c> path that skips equality checks.
     /// </summary>
     internal static void SetCellValue(CellValues dataType, string? cellValue,
         XLCellsCollection cellsCollection, XLSheetPoint cellAddress, XLStyleValue cellStyleValue,
-        XLWorksheet ws, SharedStringEntry[]? sharedStrings)
+        XLWorksheet ws, SharedStringEntry[]? sharedStrings, bool hasFormula)
     {
         // Only String writes an empty value when v is null.
         if (cellValue is null)
         {
             if (dataType == CellValues.String)
-                cellsCollection.ValueSlice.SetCellValue(cellAddress, string.Empty);
+            {
+                if (hasFormula)
+                    cellsCollection.ValueSlice.SetCellValue(cellAddress, string.Empty);
+                else
+                    cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty);
+            }
+
             return;
         }
 
         if (dataType == CellValues.Number)
-            SetNumberCellValue(cellValue, cellsCollection, cellAddress, cellStyleValue);
+            SetNumberCellValue(cellValue, cellsCollection, cellAddress, cellStyleValue, hasFormula);
         else if (dataType == CellValues.SharedString)
-            SetSharedStringCellValue(cellValue, cellsCollection, cellAddress, ws, sharedStrings);
+            SetSharedStringCellValue(cellValue, cellsCollection, cellAddress, ws, sharedStrings, hasFormula);
         else if (dataType == CellValues.String)
-            cellsCollection.ValueSlice.SetCellValue(cellAddress, cellValue);
+        {
+            if (hasFormula)
+                cellsCollection.ValueSlice.SetCellValue(cellAddress, cellValue);
+            else
+                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, cellValue);
+        }
         else if (dataType == CellValues.Boolean)
-            SetBooleanCellValue(cellValue, cellsCollection, cellAddress);
+            SetBooleanCellValue(cellValue, cellsCollection, cellAddress, hasFormula);
         else if (dataType == CellValues.Error)
-            SetErrorCellValue(cellValue, cellsCollection, cellAddress);
+            SetErrorCellValue(cellValue, cellsCollection, cellAddress, hasFormula);
         else if (dataType == CellValues.Date)
-            SetDateCellValue(cellValue, cellsCollection, cellAddress);
+            SetDateCellValue(cellValue, cellsCollection, cellAddress, hasFormula);
     }
 
     /// <summary>
@@ -588,10 +646,42 @@ internal static class WorksheetSheetDataReader
     private static void LoadCellMisc(ReadOnlyCollection<OpenXmlAttribute> attributes,
         XLCellsCollection cellsCollection, XLSheetPoint cellAddress)
     {
-        var showPhonetic = attributes.GetBoolAttribute("ph", false);
-        var cellMetaIndex = attributes.GetUintAttribute("cm");
-        var valueMetaIndex = attributes.GetUintAttribute("vm");
-        if (!showPhonetic && cellMetaIndex is null && valueMetaIndex is null) return;
+        // The misc attributes (ph, cm, vm) are extremely rare on <c> elements. Instead of
+        // 3 separate linear scans through the attribute list, do a single pass that checks
+        // for all three and exits early when none are found.
+        bool showPhonetic = false;
+        uint? cellMetaIndex = null;
+        uint? valueMetaIndex = null;
+        var found = false;
+        var count = attributes.Count;
+        for (var i = 0; i < count; i++)
+        {
+            var attr = attributes[i];
+            if (!string.IsNullOrEmpty(attr.NamespaceUri))
+                continue;
+
+            switch (attr.LocalName)
+            {
+                case "ph":
+                    showPhonetic = attr.Value == "1"
+                        || string.Equals(attr.Value, "true", StringComparison.OrdinalIgnoreCase);
+                    if (showPhonetic)
+                        found = true;
+                    break;
+                case "cm":
+                    cellMetaIndex = uint.Parse(attr.Value!);
+                    found = true;
+                    break;
+                case "vm":
+                    valueMetaIndex = uint.Parse(attr.Value!);
+                    found = true;
+                    break;
+            }
+        }
+
+        if (!found)
+            return;
+
         var misc = new XLMiscSliceContent
         {
             HasPhonetic = showPhonetic,
@@ -652,7 +742,7 @@ internal static class WorksheetSheetDataReader
                            || cellsCollection.MiscSlice.IsUsed(cellAddress);
 
         if (!hasOtherData)
-            cellsCollection.StyleSlice.Set(cellAddress.Row, cellAddress.Column, cellStyleValue);
+            cellsCollection.StyleSlice.SetNonDefault(cellAddress.Row, cellAddress.Column, cellStyleValue);
     }
 
     private static XLCellFormula LoadSharedFormula(string formulaText, XLSheetPoint cellAddress,
@@ -703,9 +793,9 @@ internal static class WorksheetSheetDataReader
     }
 
     private static void SetNumberCellValue(string cellValue, XLCellsCollection cellsCollection,
-        XLSheetPoint cellAddress, XLStyleValue cellStyleValue)
+        XLSheetPoint cellAddress, XLStyleValue cellStyleValue, bool hasFormula)
     {
-        if (!double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out var number)) return;
+        if (!TryParseOoxmlDouble(cellValue, out var number)) return;
         var numberDataType = GetNumberDataType(cellStyleValue.NumberFormat);
         var cellNumber = numberDataType switch
         {
@@ -713,14 +803,18 @@ internal static class WorksheetSheetDataReader
             XLDataType.TimeSpan => XLCellValue.FromSerialTimeSpan(number),
             _ => number
         };
-        cellsCollection.ValueSlice.SetCellValue(cellAddress, cellNumber);
+
+        if (hasFormula)
+            cellsCollection.ValueSlice.SetCellValue(cellAddress, cellNumber);
+        else
+            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, cellNumber);
     }
 
     private static void SetSharedStringCellValue(string cellValue, XLCellsCollection cellsCollection,
-        XLSheetPoint cellAddress, XLWorksheet ws, SharedStringEntry[]? sharedStrings)
+        XLSheetPoint cellAddress, XLWorksheet ws, SharedStringEntry[]? sharedStrings, bool hasFormula)
     {
-        if (int.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out var sharedStringId)
-            && sharedStrings is not null && sharedStringId >= 0 && sharedStringId < sharedStrings.Length)
+        if (TryParseOoxmlNonNegativeInt(cellValue, out var sharedStringId)
+            && sharedStrings is not null && sharedStringId < sharedStrings.Length)
         {
             var entry = sharedStrings[sharedStringId];
             if (entry.IsRichText)
@@ -728,35 +822,52 @@ internal static class WorksheetSheetDataReader
                 var xlCell = new XLCell(ws, cellAddress);
                 SetCellText(xlCell, entry.RichText);
             }
-            else
+            else if (hasFormula)
                 cellsCollection.ValueSlice.SetCellValue(cellAddress, entry.PlainText);
+            else
+                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, entry.PlainText);
         }
-        else
+        else if (hasFormula)
             cellsCollection.ValueSlice.SetCellValue(cellAddress, string.Empty);
+        else
+            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty);
     }
 
     private static void SetBooleanCellValue(string cellValue, XLCellsCollection cellsCollection,
-        XLSheetPoint cellAddress)
+        XLSheetPoint cellAddress, bool hasFormula)
     {
         var isTrue = string.Equals(cellValue, "1", StringComparison.Ordinal) ||
                      string.Equals(cellValue, "TRUE", StringComparison.OrdinalIgnoreCase);
-        cellsCollection.ValueSlice.SetCellValue(cellAddress, isTrue);
+
+        if (hasFormula)
+            cellsCollection.ValueSlice.SetCellValue(cellAddress, isTrue);
+        else
+            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, isTrue);
     }
 
     private static void SetErrorCellValue(string cellValue, XLCellsCollection cellsCollection,
-        XLSheetPoint cellAddress)
+        XLSheetPoint cellAddress, bool hasFormula)
     {
         if (XLErrorParser.TryParseError(cellValue, out var error))
-            cellsCollection.ValueSlice.SetCellValue(cellAddress, error);
+        {
+            if (hasFormula)
+                cellsCollection.ValueSlice.SetCellValue(cellAddress, error);
+            else
+                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, error);
+        }
     }
 
     private static void SetDateCellValue(string cellValue, XLCellsCollection cellsCollection,
-        XLSheetPoint cellAddress)
+        XLSheetPoint cellAddress, bool hasFormula)
     {
         var date = DateTime.ParseExact(cellValue, DateCellFormats,
             XLHelper.ParseCulture,
             DateTimeStyles.AllowLeadingWhite | DateTimeStyles.AllowTrailingWhite);
-        cellsCollection.ValueSlice.SetCellValue(cellAddress, date);
+
+        if (hasFormula)
+            cellsCollection.ValueSlice.SetCellValue(cellAddress, date);
+        else
+            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, date);
     }
 
     private static void LoadPhonetics(XLCell xlCell, RstType element)
@@ -869,6 +980,110 @@ internal static class WorksheetSheetDataReader
             xlNumberFormat = xlNumberFormat with { NumberFormatId = (int)numberFormatId!.Value };
 
         return xlStyle with { NumberFormat = xlNumberFormat };
+    }
+
+    // Exact power-of-10 divisors for up to 18 fraction digits. Using these instead of
+    // Math.Pow(10, -n) ensures bit-exact results matching double.TryParse for simple decimals.
+    private static readonly double[] Pow10 =
+    [
+        1E0, 1E1, 1E2, 1E3, 1E4, 1E5, 1E6, 1E7, 1E8, 1E9,
+        1E10, 1E11, 1E12, 1E13, 1E14, 1E15, 1E16, 1E17, 1E18
+    ];
+
+    /// <summary>
+    /// Fast-path double parser for OOXML numeric cell values. Handles the common forms
+    /// produced by Excel: optional minus, digits with optional decimal point.
+    /// Falls back to <see cref="double.TryParse(string, NumberStyles, IFormatProvider, out double)"/>
+    /// for exponents, leading whitespace, leading '+', overflow, or any non-standard format.
+    /// </summary>
+    private static bool TryParseOoxmlDouble(string s, out double result)
+    {
+        var len = s.Length;
+        if (len == 0)
+        {
+            result = 0;
+            return false;
+        }
+
+        var i = 0;
+        var first = s[0];
+
+        // Leading whitespace, '+', or exponent numbers → fall back (rare in OOXML).
+        if (first == ' ' || first == '+')
+            return double.TryParse(s, XLHelper.NumberStyle, XLHelper.ParseCulture, out result);
+
+        // Optional leading minus.
+        bool negative = false;
+        if (first == '-')
+        {
+            negative = true;
+            i++;
+            if (i >= len) { result = 0; return false; }
+        }
+
+        // Integer part — accumulate in long for exact precision.
+        long mantissa = 0;
+        int totalDigits = 0;
+        while (i < len && (uint)(s[i] - '0') <= 9)
+        {
+            mantissa = mantissa * 10 + (s[i] - '0');
+            totalDigits++;
+            i++;
+        }
+
+        int fractionDigits = 0;
+
+        // Fractional part.
+        if (i < len && s[i] == '.')
+        {
+            i++;
+            while (i < len && (uint)(s[i] - '0') <= 9)
+            {
+                mantissa = mantissa * 10 + (s[i] - '0');
+                fractionDigits++;
+                totalDigits++;
+                i++;
+            }
+        }
+
+        // Must have consumed at least one digit and ALL characters.
+        // Any remaining chars (exponent, whitespace, etc.) → fall back.
+        if (totalDigits == 0 || i != len || totalDigits > 18)
+            return double.TryParse(s, XLHelper.NumberStyle, XLHelper.ParseCulture, out result);
+
+        // Assemble the double using exact division.
+        double d = fractionDigits == 0
+            ? mantissa
+            : mantissa / Pow10[fractionDigits];
+
+        result = negative ? -d : d;
+        return true;
+    }
+
+    /// <summary>
+    /// Fast-path parser for non-negative integer strings as found in OOXML shared string
+    /// indices. Only accepts pure ASCII digit sequences with no whitespace or signs.
+    /// </summary>
+    private static bool TryParseOoxmlNonNegativeInt(string s, out int result)
+    {
+        result = 0;
+        var len = s.Length;
+        if (len == 0)
+            return false;
+
+        for (var i = 0; i < len; i++)
+        {
+            var digit = (uint)(s[i] - '0');
+            if (digit > 9)
+            {
+                // Not a pure digit string — fall back to full parser.
+                return int.TryParse(s, XLHelper.NumberStyle, XLHelper.ParseCulture, out result);
+            }
+
+            result = result * 10 + (int)digit;
+        }
+
+        return true;
     }
 
     private static XLDataType ResolveMonthOrMinute(string format, int i, int length)

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -92,21 +92,56 @@ internal static class WorksheetSheetDataReader
     {
         Debug.Assert(reader.LocalName == "row");
 
+        // Parse all row attributes in a single pass instead of 8 separate linear scans.
+        // For data sheets where rows have only the 'r' attribute, this is ~8x less work.
         var attributes = reader.Attributes;
-        var rowIndexAttr = attributes.GetAttribute("r");
-        var rowIndex = string.IsNullOrEmpty(rowIndexAttr) ? ++state.LastRow : int.Parse(rowIndexAttr);
+        var rowIndex = 0;
+        double? height = null;
+        double? dyDescent = null;
+        bool hidden = false, collapsed = false, showPhonetic = false, customFormat = false;
+        int? outlineLevel = null;
+        int? styleIndex = null;
+        var count = attributes.Count;
+        for (var i = 0; i < count; i++)
+        {
+            var attr = attributes[i];
+            switch (attr.LocalName)
+            {
+                case "r" when string.IsNullOrEmpty(attr.NamespaceUri):
+                    TryParseOoxmlNonNegativeInt(attr.Value!, out rowIndex);
+                    break;
+                case "ht" when string.IsNullOrEmpty(attr.NamespaceUri):
+                    height = double.Parse(attr.Value!, NumberStyles.Float, XLHelper.ParseCulture);
+                    break;
+                case "dyDescent" when attr.NamespaceUri == OpenXmlConst.X14Ac2009SsNs:
+                    dyDescent = double.Parse(attr.Value!, NumberStyles.Float, XLHelper.ParseCulture);
+                    break;
+                case "hidden" when string.IsNullOrEmpty(attr.NamespaceUri):
+                    hidden = attr.Value == "1" || string.Equals(attr.Value, "true", StringComparison.OrdinalIgnoreCase);
+                    break;
+                case "collapsed" when string.IsNullOrEmpty(attr.NamespaceUri):
+                    collapsed = attr.Value == "1" || string.Equals(attr.Value, "true", StringComparison.OrdinalIgnoreCase);
+                    break;
+                case "outlineLevel" when string.IsNullOrEmpty(attr.NamespaceUri):
+                    outlineLevel = int.Parse(attr.Value!);
+                    break;
+                case "ph" when string.IsNullOrEmpty(attr.NamespaceUri):
+                    showPhonetic = attr.Value == "1" || string.Equals(attr.Value, "true", StringComparison.OrdinalIgnoreCase);
+                    break;
+                case "customFormat" when string.IsNullOrEmpty(attr.NamespaceUri):
+                    customFormat = attr.Value == "1" || string.Equals(attr.Value, "true", StringComparison.OrdinalIgnoreCase);
+                    break;
+                case "s" when string.IsNullOrEmpty(attr.NamespaceUri):
+                    styleIndex = int.Parse(attr.Value!);
+                    break;
+            }
+        }
+
+        if (rowIndex == 0)
+            rowIndex = ++state.LastRow;
         state.LastRow = rowIndex;
 
-        var rowProps = new RowProperties(
-            Height: attributes.GetDoubleAttribute("ht"),
-            DyDescent: attributes.GetDoubleAttribute("dyDescent", OpenXmlConst.X14Ac2009SsNs),
-            Hidden: attributes.GetBoolAttribute("hidden", false),
-            Collapsed: attributes.GetBoolAttribute("collapsed", false),
-            OutlineLevel: attributes.GetIntAttribute("outlineLevel"),
-            ShowPhonetic: attributes.GetBoolAttribute("ph", false),
-            CustomFormat: attributes.GetBoolAttribute("customFormat", false),
-            StyleIndex: attributes.GetIntAttribute("s"));
-
+        var rowProps = new RowProperties(height, dyDescent, hidden, collapsed, outlineLevel, showPhonetic, customFormat, styleIndex);
         if (rowProps.HasCustomProps)
         {
             ApplyRowCustomProps(in rowProps, context.Worksheet, rowIndex, context.Styles);
@@ -144,11 +179,53 @@ internal static class WorksheetSheetDataReader
     {
         Debug.Assert(reader is { LocalName: "c", IsStartElement: true });
 
+        // Parse all cell attributes in a single pass instead of 3 separate lookups
+        // (r, s, t) plus a 4th pass for misc attributes (ph, cm, vm).
+        // For 3.75M cells this reduces ~15M linear scans to ~3.75M single passes.
         var attributes = reader.Attributes;
-        var styleIndex = attributes.GetIntAttribute("s") ?? 0;
-        var cellAddress = attributes.GetCellRefAttribute("r") ?? new XLSheetPoint(rowIndex, state.LastColumnNumber + 1);
+        int styleIndex = 0;
+        XLSheetPoint? cellRef = null;
+        string? typeAttr = null;
+        bool showPhonetic = false;
+        uint? cellMetaIndex = null;
+        uint? valueMetaIndex = null;
+        bool hasMisc = false;
+        var count = attributes.Count;
+        for (var i = 0; i < count; i++)
+        {
+            var attr = attributes[i];
+            if (!string.IsNullOrEmpty(attr.NamespaceUri))
+                continue;
+
+            switch (attr.LocalName)
+            {
+                case "r":
+                    cellRef = XLSheetPoint.Parse(attr.Value!);
+                    break;
+                case "s":
+                    TryParseOoxmlNonNegativeInt(attr.Value!, out styleIndex);
+                    break;
+                case "t":
+                    typeAttr = attr.Value;
+                    break;
+                case "ph":
+                    showPhonetic = attr.Value == "1" || string.Equals(attr.Value, "true", StringComparison.OrdinalIgnoreCase);
+                    if (showPhonetic) hasMisc = true;
+                    break;
+                case "cm":
+                    cellMetaIndex = uint.Parse(attr.Value!);
+                    hasMisc = true;
+                    break;
+                case "vm":
+                    valueMetaIndex = uint.Parse(attr.Value!);
+                    hasMisc = true;
+                    break;
+            }
+        }
+
+        var cellAddress = cellRef ?? new XLSheetPoint(rowIndex, state.LastColumnNumber + 1);
         state.LastColumnNumber = cellAddress.Column;
-        var dataType = ParseCellDataType(attributes.GetAttribute("t"));
+        var dataType = ParseCellDataType(typeAttr);
 
         var cellStyleValue = ResolveCachedStyleValue(styleIndex, context.Styles, context.StyleList);
 
@@ -163,7 +240,16 @@ internal static class WorksheetSheetDataReader
         if (!styleMatchesInherited)
             cellsCollection.StyleSlice.SetNonDefault(cellAddress.Row, cellAddress.Column, cellStyleValue);
 
-        LoadCellMisc(attributes, cellsCollection, cellAddress);
+        if (hasMisc)
+        {
+            var misc = new XLMiscSliceContent
+            {
+                HasPhonetic = showPhonetic,
+                CellMetaIndex = cellMetaIndex,
+                ValueMetaIndex = valueMetaIndex
+            };
+            cellsCollection.MiscSlice.Set(cellAddress, in misc);
+        }
 
         // Move from the cell start element onwards.
         reader.MoveAhead();
@@ -619,54 +705,6 @@ internal static class WorksheetSheetDataReader
         }
     }
 
-    private static void LoadCellMisc(ReadOnlyCollection<OpenXmlAttribute> attributes,
-        XLCellsCollection cellsCollection, XLSheetPoint cellAddress)
-    {
-        // The misc attributes (ph, cm, vm) are extremely rare on <c> elements. Instead of
-        // 3 separate linear scans through the attribute list, do a single pass that checks
-        // for all three and exits early when none are found.
-        bool showPhonetic = false;
-        uint? cellMetaIndex = null;
-        uint? valueMetaIndex = null;
-        var found = false;
-        var count = attributes.Count;
-        for (var i = 0; i < count; i++)
-        {
-            var attr = attributes[i];
-            if (!string.IsNullOrEmpty(attr.NamespaceUri))
-                continue;
-
-            switch (attr.LocalName)
-            {
-                case "ph":
-                    showPhonetic = attr.Value == "1"
-                        || string.Equals(attr.Value, "true", StringComparison.OrdinalIgnoreCase);
-                    if (showPhonetic)
-                        found = true;
-                    break;
-                case "cm":
-                    cellMetaIndex = uint.Parse(attr.Value!);
-                    found = true;
-                    break;
-                case "vm":
-                    valueMetaIndex = uint.Parse(attr.Value!);
-                    found = true;
-                    break;
-            }
-        }
-
-        if (!found)
-            return;
-
-        var misc = new XLMiscSliceContent
-        {
-            HasPhonetic = showPhonetic,
-            CellMetaIndex = cellMetaIndex,
-            ValueMetaIndex = valueMetaIndex
-        };
-        cellsCollection.MiscSlice.Set(cellAddress, in misc);
-    }
-
     private static void LoadInlineString(CellValues dataType, XLCellsCollection cellsCollection,
         XLSheetPoint cellAddress, XLWorksheet ws, OpenXmlPartReader reader)
     {
@@ -1019,6 +1057,15 @@ internal static class WorksheetSheetDataReader
     /// Fast-path parser for non-negative integer strings as found in OOXML shared string
     /// indices. Only accepts pure ASCII digit sequences with no whitespace or signs.
     /// </summary>
+    /// <summary>
+    /// Parse a row index attribute value. Row indices in OOXML are always positive integers.
+    /// </summary>
+    private static int ParseRowIndex(string s)
+    {
+        TryParseOoxmlNonNegativeInt(s, out var result);
+        return result;
+    }
+
     private static bool TryParseOoxmlNonNegativeInt(string s, out int result)
     {
         result = 0;

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -299,7 +299,7 @@ internal static class WorksheetSheetDataReader
         if (formulaType == CellFormulaValues.Normal)
         {
             formula = XLCellFormula.NormalA1(formulaText);
-            formulaSlice.Set(cellAddress, formula);
+            formulaSlice.SetDuringLoad(cellAddress, formula);
         }
         else if (formulaType == CellFormulaValues.Array && attributes.GetRefAttribute("ref") is
         {
@@ -728,7 +728,7 @@ internal static class WorksheetSheetDataReader
         if (!sharedFormulasR1C1.TryGetValue(sharedIndex, out var sharedR1C1Formula))
         {
             formula = XLCellFormula.NormalA1(formulaText);
-            formulaSlice.Set(cellAddress, formula);
+            formulaSlice.SetDuringLoad(cellAddress, formula);
 
             var formulaR1C1 = FormulaTransformation.SafeToR1C1(formulaText, cellAddress.Row, cellAddress.Column);
             sharedFormulasR1C1.Add(sharedIndex, formulaR1C1);
@@ -738,7 +738,7 @@ internal static class WorksheetSheetDataReader
             var sharedFormulaA1 =
                 FormulaTransformation.SafeToA1(sharedR1C1Formula, cellAddress.Row, cellAddress.Column);
             formula = XLCellFormula.NormalA1(sharedFormulaA1);
-            formulaSlice.Set(cellAddress, formula);
+            formulaSlice.SetDuringLoad(cellAddress, formula);
         }
 
         return formula;
@@ -763,7 +763,7 @@ internal static class WorksheetSheetDataReader
             formula = XLCellFormula.DataTable1D(dataTableArea, input1, input1Deleted, isRowDataTable);
         }
 
-        formulaSlice.Set(cellAddress, formula);
+        formulaSlice.SetDuringLoad(cellAddress, formula);
 
         return formula;
     }

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -537,14 +537,10 @@ public partial class XLWorkbook : IXLWorkbook
 
     internal static void CopyStream(Stream input, Stream output)
     {
-        var buffer = new byte[8 * 1024];
-        int len;
-        // It is always a good idea to rewind the input stream, or not?
         if (input.CanSeek)
             input.Seek(0, SeekOrigin.Begin);
-        while ((len = input.Read(buffer, 0, buffer.Length)) > 0)
-            output.Write(buffer, 0, len);
-        // And flushing the output after writing
+
+        input.CopyTo(output);
         output.Flush();
     }
 

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -329,14 +329,10 @@ public partial class XLWorkbook
 
         using var reader = new OpenXmlPartReader(worksheetPart);
 
-        Type[] ignoredElements =
-        [
-            typeof(CustomSheetViews) // Custom sheet views contain their own auto filter data, and more, which should be ignored for now
-        ];
-
         while (reader.Read())
         {
-            while (ignoredElements.Contains(reader.ElementType))
+            // Custom sheet views contain their own auto filter data, and more, which should be ignored for now
+            while (reader.ElementType == typeof(CustomSheetViews))
                 reader.ReadNextSibling();
 
             if (reader.ElementType == typeof(Row))

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -387,7 +387,7 @@ public partial class XLWorkbook
         if (elementType == typeof(SheetFormatProperties))
             LoadSheetFormatProperties((SheetFormatProperties)reader.LoadCurrentElement()!, ws);
         else if (elementType == typeof(MergeCells))
-            LoadMergeCells((MergeCells)reader.LoadCurrentElement()!, ws);
+            LoadMergeCellsStreaming(reader, ws);
         else if (elementType == typeof(SheetViews))
             WorksheetElementReader.LoadSheetViews((SheetViews)reader.LoadCurrentElement()!, ws);
         else if (elementType == typeof(Columns))
@@ -456,10 +456,26 @@ public partial class XLWorkbook
             ws.ColumnWidth = CalculateColumnWidth(sfp.BaseColumnWidth.Value, ws.Style.Font, this);
     }
 
-    private static void LoadMergeCells(MergeCells mergedCells, XLWorksheet ws)
+    /// <summary>
+    /// Reads <c>&lt;mergeCells&gt;</c> using the streaming <see cref="OpenXmlPartReader"/>
+    /// instead of building the full DOM via <c>LoadCurrentElement()</c>. Each
+    /// <c>&lt;mergeCell ref="..."/&gt;</c> child has a single attribute, so streaming
+    /// avoids allocating the parent <see cref="MergeCells"/> collection and all
+    /// child <see cref="MergeCell"/> DOM objects.
+    /// </summary>
+    private static void LoadMergeCellsStreaming(OpenXmlPartReader reader, XLWorksheet ws)
     {
-        foreach (var mergeCell in mergedCells.Elements<MergeCell>())
-            ws.Range(mergeCell.Reference!)!.Merge(false);
+        // We're positioned at <mergeCells>. Move into children.
+        reader.MoveAhead();
+
+        while (reader.IsStartElement("mergeCell"))
+        {
+            var reference = reader.Attributes.GetAttribute("ref");
+            if (!string.IsNullOrEmpty(reference))
+                ws.Range(reference)!.Merge(false);
+
+            reader.Skip();
+        }
     }
 
     private static void LoadRichValueImages(LoadContext context, XLWorksheet ws)

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -99,7 +99,14 @@ public partial class XLWorkbook
         var workbookPart = dSpreadsheet.WorkbookPart!;
         var shareStringPart = workbookPart.GetPartsOfType<SharedStringTablePart>().FirstOrDefault();
         if (shareStringPart is not null)
+        {
             sharedStrings = SharedStringReader.Read(shareStringPart);
+
+            // Pre-size the workbook's internal SST to avoid repeated resizing
+            // as cell values reference these strings during sheet loading.
+            if (sharedStrings.Length > 0)
+                SharedStringTable.EnsureCapacity(sharedStrings.Length);
+        }
 
         LoadWorkbookTheme(workbookPart.ThemePart, this);
 

--- a/XLibur/Extensions/XmlWriterExtensions.cs
+++ b/XLibur/Extensions/XmlWriterExtensions.cs
@@ -36,8 +36,10 @@ internal static class XmlWriterExtensions
 
         public void WriteAttribute(string attrName, uint value)
         {
+            // Cast to long to avoid boxing via XmlWriter.WriteValue(object).
+            // XmlWriter has a WriteValue(long) overload but not WriteValue(uint).
             w.WriteStartAttribute(attrName);
-            w.WriteValue(value);
+            w.WriteValue((long)value);
             w.WriteEndAttribute();
         }
 

--- a/XLibur/Utils/XmlEncoder.cs
+++ b/XLibur/Utils/XmlEncoder.cs
@@ -95,6 +95,12 @@ internal static partial class XmlEncoder
     {
         if (string.IsNullOrEmpty(decodeStr)) return string.Empty;
 
+        // Fast-path: if the string contains no underscore it cannot have any
+        // _xHHHH_ or _XHHHH_ escape sequences, so return as-is.
+        // The vast majority of shared strings are plain text.
+        if (!decodeStr.Contains('_'))
+            return decodeStr;
+
         // Strings "escaped" with _X (capital X) should not be treated as escaped
         // Example: _Xceed_Something
         // https://github.com/XLibur/XLibur/issues/1154


### PR DESCRIPTION
## Summary
- **Load optimizations**: Pre-allocate SharedStringReader from SST count, stream MergeCells instead of building full DOM, optimize WorksheetSheetDataReader hot paths with single-pass attribute parsing and DecodeString fast-path, skip calc engine overhead for formula cells during load
- **Save optimizations**: Fix uint boxing in XmlWriter, combine value slice reads, replace manual CopyStream with Stream.CopyTo
- **Data structure improvements**: Add SetNonDefault fast paths to Slice, Lut, RowData, and ValueSlice; replace LINQ Contains with direct type comparison in sheet reader loop
- **Benchmark enhancements**: Add SUM formula to CreateAndSave benchmarks, configure JoinSummary for unified comparison tables, add custom LibraryNameColumn for short library display names

## Test plan
- [ ] Run `CreateAndSave` and `CreateFormattedAndSave` benchmarks across all three libraries to verify joined summary output
- [ ] Run existing test suite to confirm no regressions from load/save optimizations
- [ ] Verify SUM formula row appears correctly in benchmark-generated workbooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster worksheet loading via streaming and reduced per-cell allocations.
  * Improved cell value/formula handling and XML string decoding for large files.

* **New Features**
  * Benchmark summaries now include a concise library name column and per-benchmark totals row in joined reports.

* **Internal Optimizations**
  * Pre-sized shared-string storage and refined style inheritance lookups to reduce memory churn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->