### PR TITLE
lint: reorder EnumConverter and tidy comments

### DIFF
--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -104,7 +104,7 @@ internal static class Lookup
         if (!value.IsReference && areaNumber > 1)
             return XLError.CellReference;
 
-        // There must be two paths, one for array and one for reference. Reference path
+        // There must be two paths, one for an array and one for reference. Reference path
         // must return reference, so it behaves correctly with implicit intersection.
         if (!ResolveIndexData(value, areaNumber).TryPickT0(out var data, out var dataError))
             return dataError;
@@ -127,7 +127,7 @@ internal static class Lookup
 
         static Reference IndexArea(XLRangeAddress area, int rowNumber, int colNumber)
         {
-            // Return whole area
+            // Return the whole area
             if (rowNumber == 0 && colNumber == 0)
                 return new Reference(area);
 
@@ -147,7 +147,7 @@ internal static class Lookup
                 return new Reference(new XLRangeAddress(leftCell, rightCell));
             }
 
-            // Return single cell reference.
+            // Return a single cell reference.
             var areaCorner = area.FirstAddress;
             var cellAddress = new XLAddress(area.Worksheet, areaCorner.RowNumber + rowNumber - 1, areaCorner.ColumnNumber + colNumber - 1, true, true);
             return new Reference(new XLRangeAddress(cellAddress, cellAddress));
@@ -167,7 +167,7 @@ internal static class Lookup
             if (colNumber == 0)
                 return new SlicedArray(array, rowNumber - 1, 1, 0, array.Width);
 
-            // Return single value
+            // Return a single value
             return array[rowNumber - 1, colNumber - 1].ToAnyValue();
         }
     }
@@ -209,7 +209,7 @@ internal static class Lookup
             if (index == -1)
                 return index;
 
-            // When there are multiple same elements, return position of the last one
+            // When there are multiple same elements, return the position of the last one
             while (index < data.Height - 1 && comparer.Compare(data[index + 1, 0], data[index, 0]) == 0)
                 index++;
 
@@ -269,8 +269,8 @@ internal static class Lookup
     /// <param name="target">Value to look for.</param>
     /// <param name="data">Data in ascending order.</param>
     /// <param name="comparer">A comparator for comparing two values.</param>
-    /// <returns>Index of found element. If the <paramref name="data"/> contains
-    ///   a sequence of <paramref name="target"/> values, it can be index of any of them.
+    /// <returns>Index of the found element. If the <paramref name="data"/> contains
+    ///   a sequence of <paramref name="target"/> values, it can be an index of them.
     /// </returns>
     private static int Bisection(ScalarValue target, Array data, IComparer<ScalarValue> comparer)
     {
@@ -293,7 +293,7 @@ internal static class Lookup
                 low = Math.Min(high, middle + 1);
         }
 
-        // Final index might point to an element greater than the lookup
+        // The final index might point to an element greater than the lookup
         // (e.g. { 1, 2 } with lookup 1.5). The data should be ascending,
         // so just go in the expected order.
         for (var i = low; i >= 0; --i)
@@ -493,13 +493,17 @@ internal static class Lookup
         for (var i = 0; i < text.Length; i++)
         {
             var c = text[i];
-            if (c == '*' || c == '?')
-                return true;
-            if (c == '~' && i + 1 < text.Length)
+            switch (c)
             {
-                var next = text[i + 1];
-                if (next == '*' || next == '?' || next == '~')
+                case '*' or '?':
                     return true;
+                case '~' when i + 1 < text.Length:
+                {
+                    var next = text[i + 1];
+                    if (next is '*' or '?' or '~')
+                        return true;
+                    break;
+                }
             }
         }
 
@@ -555,7 +559,7 @@ internal static class Lookup
 
     private static int Bisection(Array range, ScalarValue lookupValue)
     {
-        // Bisection is predicated on a fact that values of the same type are sorted.
+        // Bisection is predicated on the fact that values of the same type are sorted.
         // If they are not, results are unpredictable.
         // Invariants:
         // * Low row has a value that is less or equal than lookup value
@@ -572,13 +576,13 @@ internal static class Lookup
         var lowValue = range[lowRow, 0];
         var lowCompare = ScalarValueComparer.SortIgnoreCase.Compare(lowValue, lookupValue);
 
-        // Ensure invariants before main loop. If even lowest value in the range is greater than lookup value,
+        // Ensure invariants before the main loop. If even if the lowest value in the range is greater than lookup value,
         // then there can't be any row that matches lookup value/lower.
         if (lowCompare > 0)
             return -1;
 
-        // Since we already know that there is at least one element of same type as lookup value,
-        // high row will find something, though it might be same row as lowRow.
+        // Since we already know that there is at least one element of the same type as lookup value,
+        // high row will find something, though it might be the same row as lowRow.
         highRow = FindSameTypeRow(range, lowRow, -1, highRow, in lookupValue);
 
         // Sanity check for unsorted ranges. For bisection to work, highRow always
@@ -586,15 +590,15 @@ internal static class Lookup
         var highValue = range[highRow, 0];
         var highCompare = ScalarValueComparer.SortIgnoreCase.Compare(highValue, lookupValue);
 
-        // Ensure invariants before main loop. If the lookup value is greater/equal than
+        // Ensure invariants before the main loop. If the lookup value is greater/equal than
         // the greatest value of the range, it is the result.
         if (highCompare <= 0)
             return highRow;
 
-        // Now we have two borders with actual values and we know the lookup value is less than high and greater/equal to lower
+        // Now we have two borders with actual values, and we know the lookup value is less than high and greater/equal to lower
         while (true)
         {
-            // The FindMiddle method returns only values [lowRow, highRow)
+            // The FindMiddle method returns only values [lowRow, highRow),
             // so in each loop it decreases the interval. The lowRow value is
             // the last one checked during search of a middle.
             var middleRow = FindMiddle(range, lowRow, highRow, in lookupValue);
@@ -617,7 +621,7 @@ internal static class Lookup
     }
 
     /// <summary>
-    /// Find a row with a value of same type as <paramref name="lookupValue"/>
+    /// Find a row with a value of the same type as <paramref name="lookupValue"/>
     /// between values <paramref name="low"/> and <c><paramref name="high"/> - 1</c>.
     /// We know that both <paramref name="low"/> and <paramref name="high"/>
     /// contain value of the same type, so we always get a valid row.
@@ -627,7 +631,7 @@ internal static class Lookup
         Debug.Assert(low < high);
         var middleRow = (low + high) / 2;
 
-        // Since low is < high, it's always possible skip high row for determining middle row
+        // Since low is < high, it's always possible to skip high row for determining middle row
         var higherIndex = FindSameTypeRow(range, high - 1, 1, middleRow, in lookupValue);
         if (higherIndex != -1)
             return higherIndex;
@@ -639,7 +643,7 @@ internal static class Lookup
     }
 
     /// <summary>
-    /// Find row index of an element with same type as the lookup value. Go from
+    /// Find the row index of an element with the same type as the lookup value. Go from
     /// <paramref name="startRow"/> to the <paramref name="limitRow"/> by a step
     /// of <paramref name="delta"/>. If there isn't any such row, return <c>-1</c>.
     /// </summary>
@@ -701,7 +705,7 @@ internal static class Lookup
             return XLError.CellReference;
 
         // Handle sheet prefix: "Sheet1!A1" or "'Sheet Name'!A1"
-        XLWorksheet? worksheet = ctx.Worksheet;
+        var worksheet = ctx.Worksheet;
         var addressText = refText;
 
         var bangIndex = refText.LastIndexOf('!');
@@ -732,12 +736,10 @@ internal static class Lookup
                 return XLError.CellReference;
             }
         }
-        else
-        {
-            // R1C1 style: support absolute references (R1C1, R1C1:R5C3)
-            // Relative R1C1 (R[-1]C[2]) is not supported — return #REF!
-            return TryParseR1C1Reference(worksheet, addressText);
-        }
+
+        // R1C1 style: support absolute references (R1C1, R1C1:R5C3)
+        // Relative R1C1 (R[-1]C[2]) is not supported — return #REF!
+        return TryParseR1C1Reference(worksheet, addressText);
     }
 
     private static readonly Regex AbsoluteR1C1Regex = new(
@@ -762,10 +764,8 @@ internal static class Lookup
         if (parts.Length == 2)
         {
             var lastMatch = AbsoluteR1C1Regex.Match(parts[1]);
-            if (!lastMatch.Success)
-                return XLError.CellReference;
-
-            if (!int.TryParse(lastMatch.Groups[1].Value, out lastRow)
+            if (!lastMatch.Success
+                || !int.TryParse(lastMatch.Groups[1].Value, out lastRow)
                 || !int.TryParse(lastMatch.Groups[2].Value, out lastCol))
                 return XLError.CellReference;
         }

--- a/XLibur/Excel/EnumConverter.cs
+++ b/XLibur/Excel/EnumConverter.cs
@@ -11,17 +11,22 @@ namespace XLibur.Excel;
 
 internal static class EnumConverter
 {
-    #region To OpenXml
-
-    public static UnderlineValues ToOpenXml(this XLFontUnderlineValues value) => value switch
-    {
-        XLFontUnderlineValues.Double => UnderlineValues.Double,
-        XLFontUnderlineValues.DoubleAccounting => UnderlineValues.DoubleAccounting,
-        XLFontUnderlineValues.None => UnderlineValues.None,
-        XLFontUnderlineValues.Single => UnderlineValues.Single,
-        XLFontUnderlineValues.SingleAccounting => UnderlineValues.SingleAccounting,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
-    };
+    private static readonly Dictionary<XLPictureFormat, PartTypeInfo> PictureFormatMap =
+        new()
+        {
+            { XLPictureFormat.Unknown, new PartTypeInfo("image/unknown", ".bin") },
+            { XLPictureFormat.Bmp, ImagePartType.Bmp },
+            { XLPictureFormat.Gif, ImagePartType.Gif },
+            { XLPictureFormat.Png, ImagePartType.Png },
+            { XLPictureFormat.Tiff, ImagePartType.Tiff },
+            { XLPictureFormat.Icon, ImagePartType.Icon },
+            { XLPictureFormat.Pcx, ImagePartType.Pcx },
+            { XLPictureFormat.Jpeg, ImagePartType.Jpeg },
+            { XLPictureFormat.Emf, ImagePartType.Emf },
+            { XLPictureFormat.Wmf, ImagePartType.Wmf },
+            { XLPictureFormat.Webp, new PartTypeInfo("image/webp", ".webp") },
+            { XLPictureFormat.Svg, new PartTypeInfo("image/svg+xml", ".svg") }
+        };
 
     private static readonly string[] XLFontUnderlineValuesStrings =
     [
@@ -32,25 +37,6 @@ internal static class EnumConverter
         "singleAccounting"
     ];
 
-    public static string ToOpenXmlString(this XLFontUnderlineValues value)
-        => XLFontUnderlineValuesStrings[(int)value];
-
-    public static OrientationValues ToOpenXml(this XLPageOrientation value) => value switch
-    {
-        XLPageOrientation.Default => OrientationValues.Default,
-        XLPageOrientation.Landscape => OrientationValues.Landscape,
-        XLPageOrientation.Portrait => OrientationValues.Portrait,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
-    };
-
-    public static VerticalAlignmentRunValues ToOpenXml(this XLFontVerticalTextAlignmentValues value) => value switch
-    {
-        XLFontVerticalTextAlignmentValues.Baseline => VerticalAlignmentRunValues.Baseline,
-        XLFontVerticalTextAlignmentValues.Subscript => VerticalAlignmentRunValues.Subscript,
-        XLFontVerticalTextAlignmentValues.Superscript => VerticalAlignmentRunValues.Superscript,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
-    };
-
     private static readonly string[] XLFontVerticalTextAlignmentValuesStrings =
     [
         "baseline",
@@ -58,8 +44,21 @@ internal static class EnumConverter
         "superscript"
     ];
 
-    public static string ToOpenXmlString(this XLFontVerticalTextAlignmentValues value)
-        => XLFontVerticalTextAlignmentValuesStrings[(int)value];
+    private static readonly string[] XLPhoneticAlignmentStrings =
+    [
+        "center",
+        "distributed",
+        "left",
+        "noControl"
+    ];
+
+    private static readonly string[] XLPhoneticTypeStrings =
+    [
+        "fullwidthKatakana",
+        "halfwidthKatakana",
+        "Hiragana",
+        "noConversion"
+    ];
 
     private static readonly string[] XLFontSchemeStrings =
     [
@@ -67,6 +66,505 @@ internal static class EnumConverter
         "major",
         "minor"
     ];
+
+    private static readonly Dictionary<UnderlineValues, XLFontUnderlineValues> UnderlineValuesMap =
+        new()
+        {
+            { UnderlineValues.Double, XLFontUnderlineValues.Double },
+            { UnderlineValues.DoubleAccounting, XLFontUnderlineValues.DoubleAccounting },
+            { UnderlineValues.None, XLFontUnderlineValues.None },
+            { UnderlineValues.Single, XLFontUnderlineValues.Single },
+            { UnderlineValues.SingleAccounting, XLFontUnderlineValues.SingleAccounting },
+        };
+
+    private static readonly Dictionary<FontSchemeValues, XLFontScheme> FontSchemeMap =
+        new()
+        {
+            { FontSchemeValues.None, XLFontScheme.None },
+            { FontSchemeValues.Major, XLFontScheme.Major },
+            { FontSchemeValues.Minor, XLFontScheme.Minor },
+        };
+
+    private static readonly Dictionary<OrientationValues, XLPageOrientation> OrientationMap =
+        new()
+        {
+            { OrientationValues.Default, XLPageOrientation.Default },
+            { OrientationValues.Landscape, XLPageOrientation.Landscape },
+            { OrientationValues.Portrait, XLPageOrientation.Portrait },
+        };
+
+    private static readonly Dictionary<VerticalAlignmentRunValues, XLFontVerticalTextAlignmentValues>
+        VerticalAlignmentRunMap =
+            new()
+            {
+                { VerticalAlignmentRunValues.Baseline, XLFontVerticalTextAlignmentValues.Baseline },
+                { VerticalAlignmentRunValues.Subscript, XLFontVerticalTextAlignmentValues.Subscript },
+                { VerticalAlignmentRunValues.Superscript, XLFontVerticalTextAlignmentValues.Superscript },
+            };
+
+    private static readonly Dictionary<PatternValues, XLFillPatternValues> PatternMap =
+        new()
+        {
+            { PatternValues.DarkDown, XLFillPatternValues.DarkDown },
+            { PatternValues.DarkGray, XLFillPatternValues.DarkGray },
+            { PatternValues.DarkGrid, XLFillPatternValues.DarkGrid },
+            { PatternValues.DarkHorizontal, XLFillPatternValues.DarkHorizontal },
+            { PatternValues.DarkTrellis, XLFillPatternValues.DarkTrellis },
+            { PatternValues.DarkUp, XLFillPatternValues.DarkUp },
+            { PatternValues.DarkVertical, XLFillPatternValues.DarkVertical },
+            { PatternValues.Gray0625, XLFillPatternValues.Gray0625 },
+            { PatternValues.Gray125, XLFillPatternValues.Gray125 },
+            { PatternValues.LightDown, XLFillPatternValues.LightDown },
+            { PatternValues.LightGray, XLFillPatternValues.LightGray },
+            { PatternValues.LightGrid, XLFillPatternValues.LightGrid },
+            { PatternValues.LightHorizontal, XLFillPatternValues.LightHorizontal },
+            { PatternValues.LightTrellis, XLFillPatternValues.LightTrellis },
+            { PatternValues.LightUp, XLFillPatternValues.LightUp },
+            { PatternValues.LightVertical, XLFillPatternValues.LightVertical },
+            { PatternValues.MediumGray, XLFillPatternValues.MediumGray },
+            { PatternValues.None, XLFillPatternValues.None },
+            { PatternValues.Solid, XLFillPatternValues.Solid },
+        };
+
+    private static readonly Dictionary<BorderStyleValues, XLBorderStyleValues> BorderStyleMap =
+        new()
+        {
+            { BorderStyleValues.DashDot, XLBorderStyleValues.DashDot },
+            { BorderStyleValues.DashDotDot, XLBorderStyleValues.DashDotDot },
+            { BorderStyleValues.Dashed, XLBorderStyleValues.Dashed },
+            { BorderStyleValues.Dotted, XLBorderStyleValues.Dotted },
+            { BorderStyleValues.Double, XLBorderStyleValues.Double },
+            { BorderStyleValues.Hair, XLBorderStyleValues.Hair },
+            { BorderStyleValues.Medium, XLBorderStyleValues.Medium },
+            { BorderStyleValues.MediumDashDot, XLBorderStyleValues.MediumDashDot },
+            { BorderStyleValues.MediumDashDotDot, XLBorderStyleValues.MediumDashDotDot },
+            { BorderStyleValues.MediumDashed, XLBorderStyleValues.MediumDashed },
+            { BorderStyleValues.None, XLBorderStyleValues.None },
+            { BorderStyleValues.SlantDashDot, XLBorderStyleValues.SlantDashDot },
+            { BorderStyleValues.Thick, XLBorderStyleValues.Thick },
+            { BorderStyleValues.Thin, XLBorderStyleValues.Thin },
+        };
+
+    private static readonly Dictionary<HorizontalAlignmentValues, XLAlignmentHorizontalValues>
+        HorizontalAlignmentMap =
+            new()
+            {
+                { HorizontalAlignmentValues.Center, XLAlignmentHorizontalValues.Center },
+                { HorizontalAlignmentValues.CenterContinuous, XLAlignmentHorizontalValues.CenterContinuous },
+                { HorizontalAlignmentValues.Distributed, XLAlignmentHorizontalValues.Distributed },
+                { HorizontalAlignmentValues.Fill, XLAlignmentHorizontalValues.Fill },
+                { HorizontalAlignmentValues.General, XLAlignmentHorizontalValues.General },
+                { HorizontalAlignmentValues.Justify, XLAlignmentHorizontalValues.Justify },
+                { HorizontalAlignmentValues.Left, XLAlignmentHorizontalValues.Left },
+                { HorizontalAlignmentValues.Right, XLAlignmentHorizontalValues.Right },
+            };
+
+    private static readonly Dictionary<VerticalAlignmentValues, XLAlignmentVerticalValues>
+        VerticalAlignmentMap =
+            new()
+            {
+                { VerticalAlignmentValues.Bottom, XLAlignmentVerticalValues.Bottom },
+                { VerticalAlignmentValues.Center, XLAlignmentVerticalValues.Center },
+                { VerticalAlignmentValues.Distributed, XLAlignmentVerticalValues.Distributed },
+                { VerticalAlignmentValues.Justify, XLAlignmentVerticalValues.Justify },
+                { VerticalAlignmentValues.Top, XLAlignmentVerticalValues.Top },
+            };
+
+    private static readonly Dictionary<PageOrderValues, XLPageOrderValues> PageOrdersMap =
+        new()
+        {
+            { PageOrderValues.DownThenOver, XLPageOrderValues.DownThenOver },
+            { PageOrderValues.OverThenDown, XLPageOrderValues.OverThenDown },
+        };
+
+    private static readonly Dictionary<CellCommentsValues, XLShowCommentsValues> CellCommentsMap =
+        new()
+        {
+            { CellCommentsValues.AsDisplayed, XLShowCommentsValues.AsDisplayed },
+            { CellCommentsValues.AtEnd, XLShowCommentsValues.AtEnd },
+            { CellCommentsValues.None, XLShowCommentsValues.None },
+        };
+
+    private static readonly Dictionary<PrintErrorValues, XLPrintErrorValues> PrintErrorMap =
+        new()
+        {
+            { PrintErrorValues.Blank, XLPrintErrorValues.Blank },
+            { PrintErrorValues.Dash, XLPrintErrorValues.Dash },
+            { PrintErrorValues.Displayed, XLPrintErrorValues.Displayed },
+            { PrintErrorValues.NA, XLPrintErrorValues.NA },
+        };
+
+    private static readonly Dictionary<CalculateModeValues, XLCalculateMode> CalculateModeMap =
+        new()
+        {
+            { CalculateModeValues.Auto, XLCalculateMode.Auto },
+            { CalculateModeValues.AutoNoTable, XLCalculateMode.AutoNoTable },
+            { CalculateModeValues.Manual, XLCalculateMode.Manual },
+        };
+
+    private static readonly Dictionary<ReferenceModeValues, XLReferenceStyle> ReferenceModeMap =
+        new()
+        {
+            { ReferenceModeValues.R1C1, XLReferenceStyle.R1C1 },
+            { ReferenceModeValues.A1, XLReferenceStyle.A1 },
+        };
+
+    private static readonly Dictionary<TotalsRowFunctionValues, XLTotalsRowFunction> TotalsRowFunctionMap =
+        new()
+        {
+            { TotalsRowFunctionValues.None, XLTotalsRowFunction.None },
+            { TotalsRowFunctionValues.Sum, XLTotalsRowFunction.Sum },
+            { TotalsRowFunctionValues.Minimum, XLTotalsRowFunction.Minimum },
+            { TotalsRowFunctionValues.Maximum, XLTotalsRowFunction.Maximum },
+            { TotalsRowFunctionValues.Average, XLTotalsRowFunction.Average },
+            { TotalsRowFunctionValues.Count, XLTotalsRowFunction.Count },
+            { TotalsRowFunctionValues.CountNumbers, XLTotalsRowFunction.CountNumbers },
+            { TotalsRowFunctionValues.StandardDeviation, XLTotalsRowFunction.StandardDeviation },
+            { TotalsRowFunctionValues.Variance, XLTotalsRowFunction.Variance },
+            { TotalsRowFunctionValues.Custom, XLTotalsRowFunction.Custom },
+        };
+
+    private static readonly Dictionary<DataValidationValues, XLAllowedValues> DataValidationMap =
+        new()
+        {
+            { DataValidationValues.None, XLAllowedValues.AnyValue },
+            { DataValidationValues.Custom, XLAllowedValues.Custom },
+            { DataValidationValues.Date, XLAllowedValues.Date },
+            { DataValidationValues.Decimal, XLAllowedValues.Decimal },
+            { DataValidationValues.List, XLAllowedValues.List },
+            { DataValidationValues.TextLength, XLAllowedValues.TextLength },
+            { DataValidationValues.Time, XLAllowedValues.Time },
+            { DataValidationValues.Whole, XLAllowedValues.WholeNumber },
+        };
+
+    private static readonly Dictionary<DataValidationErrorStyleValues, XLErrorStyle>
+        DataValidationErrorStyleMap =
+            new()
+            {
+                { DataValidationErrorStyleValues.Information, XLErrorStyle.Information },
+                { DataValidationErrorStyleValues.Warning, XLErrorStyle.Warning },
+                { DataValidationErrorStyleValues.Stop, XLErrorStyle.Stop },
+            };
+
+    private static readonly Dictionary<DataValidationOperatorValues, XLOperator> DataValidationOperatorMap =
+        new()
+        {
+            { DataValidationOperatorValues.Between, XLOperator.Between },
+            { DataValidationOperatorValues.GreaterThanOrEqual, XLOperator.EqualOrGreaterThan },
+            { DataValidationOperatorValues.LessThanOrEqual, XLOperator.EqualOrLessThan },
+            { DataValidationOperatorValues.Equal, XLOperator.EqualTo },
+            { DataValidationOperatorValues.GreaterThan, XLOperator.GreaterThan },
+            { DataValidationOperatorValues.LessThan, XLOperator.LessThan },
+            { DataValidationOperatorValues.NotBetween, XLOperator.NotBetween },
+            { DataValidationOperatorValues.NotEqual, XLOperator.NotEqualTo },
+        };
+
+    private static readonly Dictionary<SheetStateValues, XLWorksheetVisibility> SheetStateMap =
+        new()
+        {
+            { SheetStateValues.Visible, XLWorksheetVisibility.Visible },
+            { SheetStateValues.Hidden, XLWorksheetVisibility.Hidden },
+            { SheetStateValues.VeryHidden, XLWorksheetVisibility.VeryHidden },
+        };
+
+    private static readonly Dictionary<PhoneticAlignmentValues, XLPhoneticAlignment> PhoneticAlignmentMap =
+        new()
+        {
+            { PhoneticAlignmentValues.Center, XLPhoneticAlignment.Center },
+            { PhoneticAlignmentValues.Distributed, XLPhoneticAlignment.Distributed },
+            { PhoneticAlignmentValues.Left, XLPhoneticAlignment.Left },
+            { PhoneticAlignmentValues.NoControl, XLPhoneticAlignment.NoControl },
+        };
+
+    private static readonly Dictionary<PhoneticValues, XLPhoneticType> PhoneticMap =
+        new()
+        {
+            { PhoneticValues.FullWidthKatakana, XLPhoneticType.FullWidthKatakana },
+            { PhoneticValues.HalfWidthKatakana, XLPhoneticType.HalfWidthKatakana },
+            { PhoneticValues.Hiragana, XLPhoneticType.Hiragana },
+            { PhoneticValues.NoConversion, XLPhoneticType.NoConversion },
+        };
+
+    private static readonly Dictionary<DataConsolidateFunctionValues, XLPivotSummary>
+        DataConsolidateFunctionMap =
+            new()
+            {
+                { DataConsolidateFunctionValues.Sum, XLPivotSummary.Sum },
+                { DataConsolidateFunctionValues.Count, XLPivotSummary.Count },
+                { DataConsolidateFunctionValues.Average, XLPivotSummary.Average },
+                { DataConsolidateFunctionValues.Minimum, XLPivotSummary.Minimum },
+                { DataConsolidateFunctionValues.Maximum, XLPivotSummary.Maximum },
+                { DataConsolidateFunctionValues.Product, XLPivotSummary.Product },
+                { DataConsolidateFunctionValues.CountNumbers, XLPivotSummary.CountNumbers },
+                { DataConsolidateFunctionValues.StandardDeviation, XLPivotSummary.StandardDeviation },
+                { DataConsolidateFunctionValues.StandardDeviationP, XLPivotSummary.PopulationStandardDeviation },
+                { DataConsolidateFunctionValues.Variance, XLPivotSummary.Variance },
+                { DataConsolidateFunctionValues.VarianceP, XLPivotSummary.PopulationVariance },
+            };
+
+    private static readonly Dictionary<ShowDataAsValues, XLPivotCalculation> ShowDataAsMap =
+        new()
+        {
+            { ShowDataAsValues.Normal, XLPivotCalculation.Normal },
+            { ShowDataAsValues.Difference, XLPivotCalculation.DifferenceFrom },
+            { ShowDataAsValues.Percent, XLPivotCalculation.PercentageOf },
+            { ShowDataAsValues.PercentageDifference, XLPivotCalculation.PercentageDifferenceFrom },
+            { ShowDataAsValues.RunTotal, XLPivotCalculation.RunningTotal },
+            {
+                ShowDataAsValues.PercentOfRaw, XLPivotCalculation.PercentageOfRow
+            }, // There's a typo in the OpenXML SDK =)
+            { ShowDataAsValues.PercentOfColumn, XLPivotCalculation.PercentageOfColumn },
+            { ShowDataAsValues.PercentOfTotal, XLPivotCalculation.PercentageOfTotal },
+            { ShowDataAsValues.Index, XLPivotCalculation.Index },
+        };
+
+    private static readonly Dictionary<FilterOperatorValues, XLFilterOperator> FilterOperatorMap =
+        new()
+        {
+            { FilterOperatorValues.Equal, XLFilterOperator.Equal },
+            { FilterOperatorValues.NotEqual, XLFilterOperator.NotEqual },
+            { FilterOperatorValues.GreaterThan, XLFilterOperator.GreaterThan },
+            { FilterOperatorValues.LessThan, XLFilterOperator.LessThan },
+            { FilterOperatorValues.GreaterThanOrEqual, XLFilterOperator.EqualOrGreaterThan },
+            { FilterOperatorValues.LessThanOrEqual, XLFilterOperator.EqualOrLessThan },
+        };
+
+    private static readonly Dictionary<DynamicFilterValues, XLFilterDynamicType> DynamicFilterMap =
+        new()
+        {
+            { DynamicFilterValues.AboveAverage, XLFilterDynamicType.AboveAverage },
+            { DynamicFilterValues.BelowAverage, XLFilterDynamicType.BelowAverage },
+        };
+
+    private static readonly Dictionary<DateTimeGroupingValues, XLDateTimeGrouping> DateTimeGroupingMap =
+        new()
+        {
+            { DateTimeGroupingValues.Year, XLDateTimeGrouping.Year },
+            { DateTimeGroupingValues.Month, XLDateTimeGrouping.Month },
+            { DateTimeGroupingValues.Day, XLDateTimeGrouping.Day },
+            { DateTimeGroupingValues.Hour, XLDateTimeGrouping.Hour },
+            { DateTimeGroupingValues.Minute, XLDateTimeGrouping.Minute },
+            { DateTimeGroupingValues.Second, XLDateTimeGrouping.Second },
+        };
+
+    private static readonly Dictionary<SheetViewValues, XLSheetViewOptions> SheetViewMap =
+        new()
+        {
+            { SheetViewValues.Normal, XLSheetViewOptions.Normal },
+            { SheetViewValues.PageBreakPreview, XLSheetViewOptions.PageBreakPreview },
+            { SheetViewValues.PageLayout, XLSheetViewOptions.PageLayout },
+        };
+
+    private static readonly Dictionary<Vml.StrokeLineStyleValues, XLLineStyle> StrokeLineStyleMap =
+        new()
+        {
+            { Vml.StrokeLineStyleValues.Single, XLLineStyle.Single },
+            { Vml.StrokeLineStyleValues.ThickBetweenThin, XLLineStyle.ThickBetweenThin },
+            { Vml.StrokeLineStyleValues.ThickThin, XLLineStyle.ThickThin },
+            { Vml.StrokeLineStyleValues.ThinThick, XLLineStyle.ThinThick },
+            { Vml.StrokeLineStyleValues.ThinThin, XLLineStyle.ThinThin },
+        };
+
+    private static readonly Dictionary<ConditionalFormatValues, XLConditionalFormatType> ConditionalFormatMap =
+        new()
+        {
+            { ConditionalFormatValues.Expression, XLConditionalFormatType.Expression },
+            { ConditionalFormatValues.CellIs, XLConditionalFormatType.CellIs },
+            { ConditionalFormatValues.ColorScale, XLConditionalFormatType.ColorScale },
+            { ConditionalFormatValues.DataBar, XLConditionalFormatType.DataBar },
+            { ConditionalFormatValues.IconSet, XLConditionalFormatType.IconSet },
+            { ConditionalFormatValues.Top10, XLConditionalFormatType.Top10 },
+            { ConditionalFormatValues.UniqueValues, XLConditionalFormatType.IsUnique },
+            { ConditionalFormatValues.DuplicateValues, XLConditionalFormatType.IsDuplicate },
+            { ConditionalFormatValues.ContainsText, XLConditionalFormatType.ContainsText },
+            { ConditionalFormatValues.NotContainsText, XLConditionalFormatType.NotContainsText },
+            { ConditionalFormatValues.BeginsWith, XLConditionalFormatType.StartsWith },
+            { ConditionalFormatValues.EndsWith, XLConditionalFormatType.EndsWith },
+            { ConditionalFormatValues.ContainsBlanks, XLConditionalFormatType.IsBlank },
+            { ConditionalFormatValues.NotContainsBlanks, XLConditionalFormatType.NotBlank },
+            { ConditionalFormatValues.ContainsErrors, XLConditionalFormatType.IsError },
+            { ConditionalFormatValues.NotContainsErrors, XLConditionalFormatType.NotError },
+            { ConditionalFormatValues.TimePeriod, XLConditionalFormatType.TimePeriod },
+            { ConditionalFormatValues.AboveAverage, XLConditionalFormatType.AboveAverage },
+        };
+
+    private static readonly Dictionary<ConditionalFormatValueObjectValues, XLCFContentType>
+        ConditionalFormatValueObjectMap =
+            new()
+            {
+                { ConditionalFormatValueObjectValues.Number, XLCFContentType.Number },
+                { ConditionalFormatValueObjectValues.Percent, XLCFContentType.Percent },
+                { ConditionalFormatValueObjectValues.Max, XLCFContentType.Maximum },
+                { ConditionalFormatValueObjectValues.Min, XLCFContentType.Minimum },
+                { ConditionalFormatValueObjectValues.Formula, XLCFContentType.Formula },
+                { ConditionalFormatValueObjectValues.Percentile, XLCFContentType.Percentile },
+            };
+
+    private static readonly Dictionary<ConditionalFormattingOperatorValues, XLCFOperator>
+        ConditionalFormattingOperatorMap =
+            new()
+            {
+                { ConditionalFormattingOperatorValues.LessThan, XLCFOperator.LessThan },
+                { ConditionalFormattingOperatorValues.LessThanOrEqual, XLCFOperator.EqualOrLessThan },
+                { ConditionalFormattingOperatorValues.Equal, XLCFOperator.Equal },
+                { ConditionalFormattingOperatorValues.NotEqual, XLCFOperator.NotEqual },
+                { ConditionalFormattingOperatorValues.GreaterThanOrEqual, XLCFOperator.EqualOrGreaterThan },
+                { ConditionalFormattingOperatorValues.GreaterThan, XLCFOperator.GreaterThan },
+                { ConditionalFormattingOperatorValues.Between, XLCFOperator.Between },
+                { ConditionalFormattingOperatorValues.NotBetween, XLCFOperator.NotBetween },
+                { ConditionalFormattingOperatorValues.ContainsText, XLCFOperator.Contains },
+                { ConditionalFormattingOperatorValues.NotContains, XLCFOperator.NotContains },
+                { ConditionalFormattingOperatorValues.BeginsWith, XLCFOperator.StartsWith },
+                { ConditionalFormattingOperatorValues.EndsWith, XLCFOperator.EndsWith },
+            };
+
+    private static readonly Dictionary<IconSetValues, XLIconSetStyle> IconSetMap =
+        new()
+        {
+            { IconSetValues.ThreeArrows, XLIconSetStyle.ThreeArrows },
+            { IconSetValues.ThreeArrowsGray, XLIconSetStyle.ThreeArrowsGray },
+            { IconSetValues.ThreeFlags, XLIconSetStyle.ThreeFlags },
+            { IconSetValues.ThreeTrafficLights1, XLIconSetStyle.ThreeTrafficLights1 },
+            { IconSetValues.ThreeTrafficLights2, XLIconSetStyle.ThreeTrafficLights2 },
+            { IconSetValues.ThreeSigns, XLIconSetStyle.ThreeSigns },
+            { IconSetValues.ThreeSymbols, XLIconSetStyle.ThreeSymbols },
+            { IconSetValues.ThreeSymbols2, XLIconSetStyle.ThreeSymbols2 },
+            { IconSetValues.FourArrows, XLIconSetStyle.FourArrows },
+            { IconSetValues.FourArrowsGray, XLIconSetStyle.FourArrowsGray },
+            { IconSetValues.FourRedToBlack, XLIconSetStyle.FourRedToBlack },
+            { IconSetValues.FourRating, XLIconSetStyle.FourRating },
+            { IconSetValues.FourTrafficLights, XLIconSetStyle.FourTrafficLights },
+            { IconSetValues.FiveArrows, XLIconSetStyle.FiveArrows },
+            { IconSetValues.FiveArrowsGray, XLIconSetStyle.FiveArrowsGray },
+            { IconSetValues.FiveRating, XLIconSetStyle.FiveRating },
+            { IconSetValues.FiveQuarters, XLIconSetStyle.FiveQuarters },
+        };
+
+    private static readonly Dictionary<TimePeriodValues, XLTimePeriod> TimePeriodMap =
+        new()
+        {
+            { TimePeriodValues.Yesterday, XLTimePeriod.Yesterday },
+            { TimePeriodValues.Today, XLTimePeriod.Today },
+            { TimePeriodValues.Tomorrow, XLTimePeriod.Tomorrow },
+            { TimePeriodValues.Last7Days, XLTimePeriod.InTheLast7Days },
+            { TimePeriodValues.LastWeek, XLTimePeriod.LastWeek },
+            { TimePeriodValues.ThisWeek, XLTimePeriod.ThisWeek },
+            { TimePeriodValues.NextWeek, XLTimePeriod.NextWeek },
+            { TimePeriodValues.LastMonth, XLTimePeriod.LastMonth },
+            { TimePeriodValues.ThisMonth, XLTimePeriod.ThisMonth },
+            { TimePeriodValues.NextMonth, XLTimePeriod.NextMonth },
+        };
+
+    private static readonly Dictionary<PivotAreaValues, XLPivotAreaType> PivotAreaMap =
+        new()
+        {
+            { PivotAreaValues.None, XLPivotAreaType.None },
+            { PivotAreaValues.Normal, XLPivotAreaType.Normal },
+            { PivotAreaValues.Data, XLPivotAreaType.Data },
+            { PivotAreaValues.All, XLPivotAreaType.All },
+            { PivotAreaValues.Origin, XLPivotAreaType.Origin },
+            { PivotAreaValues.Button, XLPivotAreaType.Button },
+            { PivotAreaValues.TopRight, XLPivotAreaType.TopRight },
+            { PivotAreaValues.TopEnd, XLPivotAreaType.TopEnd },
+        };
+
+    private static readonly Dictionary<X14.SparklineTypeValues, XLSparklineType> SparklineTypeMap =
+        new()
+        {
+            { X14.SparklineTypeValues.Line, XLSparklineType.Line },
+            { X14.SparklineTypeValues.Column, XLSparklineType.Column },
+            { X14.SparklineTypeValues.Stacked, XLSparklineType.Stacked },
+        };
+
+    private static readonly Dictionary<X14.SparklineAxisMinMaxValues, XLSparklineAxisMinMax>
+        SparklineAxisMinMaxMap =
+            new()
+            {
+                { X14.SparklineAxisMinMaxValues.Individual, XLSparklineAxisMinMax.Automatic },
+                { X14.SparklineAxisMinMaxValues.Group, XLSparklineAxisMinMax.SameForAll },
+                { X14.SparklineAxisMinMaxValues.Custom, XLSparklineAxisMinMax.Custom },
+            };
+
+    private static readonly Dictionary<X14.DisplayBlanksAsValues, XLDisplayBlanksAsValues> DisplayBlanksAsMap =
+        new()
+        {
+            { X14.DisplayBlanksAsValues.Span, XLDisplayBlanksAsValues.Interpolate },
+            { X14.DisplayBlanksAsValues.Gap, XLDisplayBlanksAsValues.NotPlotted },
+            { X14.DisplayBlanksAsValues.Zero, XLDisplayBlanksAsValues.Zero },
+        };
+
+    private static readonly Dictionary<FieldSortValues, XLPivotSortType> FieldSortMap =
+        new()
+        {
+            { FieldSortValues.Manual, XLPivotSortType.Default },
+            { FieldSortValues.Ascending, XLPivotSortType.Ascending },
+            { FieldSortValues.Descending, XLPivotSortType.Descending },
+        };
+
+    private static readonly Dictionary<PivotTableAxisValues, XLPivotAxis> PivotTableAxisMap =
+        new()
+        {
+            { PivotTableAxisValues.AxisRow, XLPivotAxis.AxisRow },
+            { PivotTableAxisValues.AxisColumn, XLPivotAxis.AxisCol },
+            { PivotTableAxisValues.AxisPage, XLPivotAxis.AxisPage },
+            { PivotTableAxisValues.AxisValues, XLPivotAxis.AxisValues },
+        };
+
+    private static readonly Dictionary<ItemValues, XLPivotItemType> ItemMap =
+        new()
+        {
+            { ItemValues.Data, XLPivotItemType.Data },
+            { ItemValues.Default, XLPivotItemType.Default },
+            { ItemValues.Sum, XLPivotItemType.Sum },
+            { ItemValues.CountA, XLPivotItemType.CountA },
+            { ItemValues.Average, XLPivotItemType.Avg },
+            { ItemValues.Maximum, XLPivotItemType.Max },
+            { ItemValues.Minimum, XLPivotItemType.Min },
+            { ItemValues.Product, XLPivotItemType.Product },
+            { ItemValues.Count, XLPivotItemType.Count },
+            { ItemValues.StandardDeviation, XLPivotItemType.StdDev },
+            { ItemValues.StandardDeviationP, XLPivotItemType.StdDevP },
+            { ItemValues.Variance, XLPivotItemType.Var },
+            { ItemValues.VarianceP, XLPivotItemType.VarP },
+            { ItemValues.Grand, XLPivotItemType.Grand },
+            { ItemValues.Blank, XLPivotItemType.Blank },
+        };
+
+    private static readonly Dictionary<FormatActionValues, XLPivotFormatAction> FormatActionMap =
+        new()
+        {
+            { FormatActionValues.Blank, XLPivotFormatAction.Blank },
+            { FormatActionValues.Formatting, XLPivotFormatAction.Formatting },
+        };
+
+    private static readonly Dictionary<ScopeValues, XLPivotCfScope> ScopeMap =
+        new()
+        {
+            { ScopeValues.Selection, XLPivotCfScope.SelectedCells },
+            { ScopeValues.Data, XLPivotCfScope.DataFields },
+            { ScopeValues.Field, XLPivotCfScope.FieldIntersections },
+        };
+
+    private static readonly Dictionary<RuleValues, XLPivotCfRuleType> RuleMap =
+        new()
+        {
+            { RuleValues.None, XLPivotCfRuleType.None },
+            { RuleValues.All, XLPivotCfRuleType.All },
+            { RuleValues.Row, XLPivotCfRuleType.Row },
+            { RuleValues.Column, XLPivotCfRuleType.Column },
+        };
+
+    public static string ToOpenXmlString(this XLFontUnderlineValues value)
+        => XLFontUnderlineValuesStrings[(int)value];
+
+    public static string ToOpenXmlString(this XLFontVerticalTextAlignmentValues value)
+        => XLFontVerticalTextAlignmentValuesStrings[(int)value];
+
+    public static string ToOpenXmlString(this XLPhoneticAlignment value)
+        => XLPhoneticAlignmentStrings[(int)value];
+
+    public static string ToOpenXmlString(this XLPhoneticType value)
+        => XLPhoneticTypeStrings[(int)value];
 
     extension(XLFontScheme value)
     {
@@ -84,6 +582,32 @@ internal static class EnumConverter
             };
         }
     }
+
+    public static UnderlineValues ToOpenXml(this XLFontUnderlineValues value) => value switch
+    {
+        XLFontUnderlineValues.Double => UnderlineValues.Double,
+        XLFontUnderlineValues.DoubleAccounting => UnderlineValues.DoubleAccounting,
+        XLFontUnderlineValues.None => UnderlineValues.None,
+        XLFontUnderlineValues.Single => UnderlineValues.Single,
+        XLFontUnderlineValues.SingleAccounting => UnderlineValues.SingleAccounting,
+        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+    };
+
+    public static OrientationValues ToOpenXml(this XLPageOrientation value) => value switch
+    {
+        XLPageOrientation.Default => OrientationValues.Default,
+        XLPageOrientation.Landscape => OrientationValues.Landscape,
+        XLPageOrientation.Portrait => OrientationValues.Portrait,
+        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+    };
+
+    public static VerticalAlignmentRunValues ToOpenXml(this XLFontVerticalTextAlignmentValues value) => value switch
+    {
+        XLFontVerticalTextAlignmentValues.Baseline => VerticalAlignmentRunValues.Baseline,
+        XLFontVerticalTextAlignmentValues.Subscript => VerticalAlignmentRunValues.Subscript,
+        XLFontVerticalTextAlignmentValues.Superscript => VerticalAlignmentRunValues.Superscript,
+        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+    };
 
     public static PatternValues ToOpenXml(this XLFillPatternValues value) => value switch
     {
@@ -255,17 +779,6 @@ internal static class EnumConverter
         _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
     };
 
-    private static readonly string[] XLPhoneticAlignmentStrings =
-    [
-        "center",
-        "distributed",
-        "left",
-        "noControl"
-    ];
-
-    public static string ToOpenXmlString(this XLPhoneticAlignment value)
-        => XLPhoneticAlignmentStrings[(int)value];
-
     public static PhoneticValues ToOpenXml(this XLPhoneticType value) => value switch
     {
         XLPhoneticType.FullWidthKatakana => PhoneticValues.FullWidthKatakana,
@@ -274,17 +787,6 @@ internal static class EnumConverter
         XLPhoneticType.NoConversion => PhoneticValues.NoConversion,
         _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
     };
-
-    private static readonly string[] XLPhoneticTypeStrings =
-    [
-        "fullwidthKatakana",
-        "halfwidthKatakana",
-        "Hiragana",
-        "noConversion"
-    ];
-
-    public static string ToOpenXmlString(this XLPhoneticType value)
-        => XLPhoneticTypeStrings[(int)value];
 
     public static DataConsolidateFunctionValues ToOpenXml(this XLPivotSummary value) => value switch
     {
@@ -451,23 +953,6 @@ internal static class EnumConverter
         _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
     };
 
-    private static readonly Dictionary<XLPictureFormat, PartTypeInfo> PictureFormatMap =
-        new Dictionary<XLPictureFormat, PartTypeInfo>
-        {
-            { XLPictureFormat.Unknown, new PartTypeInfo("image/unknown", ".bin") },
-            { XLPictureFormat.Bmp, ImagePartType.Bmp },
-            { XLPictureFormat.Gif, ImagePartType.Gif },
-            { XLPictureFormat.Png, ImagePartType.Png },
-            { XLPictureFormat.Tiff, ImagePartType.Tiff },
-            { XLPictureFormat.Icon, ImagePartType.Icon },
-            { XLPictureFormat.Pcx, ImagePartType.Pcx },
-            { XLPictureFormat.Jpeg, ImagePartType.Jpeg },
-            { XLPictureFormat.Emf, ImagePartType.Emf },
-            { XLPictureFormat.Wmf, ImagePartType.Wmf },
-            { XLPictureFormat.Webp, new PartTypeInfo("image/webp", ".webp") },
-            { XLPictureFormat.Svg, new PartTypeInfo("image/svg+xml", ".svg") }
-        };
-
     public static PartTypeInfo ToOpenXml(this XLPictureFormat value)
     {
         return PictureFormatMap[value];
@@ -534,212 +1019,65 @@ internal static class EnumConverter
         throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!");
     }
 
-    #endregion To OpenXml
-
-    #region To XLibur
-
-    private static readonly Dictionary<UnderlineValues, XLFontUnderlineValues> UnderlineValuesMap =
-        new Dictionary<UnderlineValues, XLFontUnderlineValues>
-        {
-            { UnderlineValues.Double, XLFontUnderlineValues.Double },
-            { UnderlineValues.DoubleAccounting, XLFontUnderlineValues.DoubleAccounting },
-            { UnderlineValues.None, XLFontUnderlineValues.None },
-            { UnderlineValues.Single, XLFontUnderlineValues.Single },
-            { UnderlineValues.SingleAccounting, XLFontUnderlineValues.SingleAccounting },
-        };
-
     public static XLFontUnderlineValues ToXLibur(this UnderlineValues value)
     {
         return UnderlineValuesMap[value];
     }
-
-    private static readonly Dictionary<FontSchemeValues, XLFontScheme> FontSchemeMap =
-        new Dictionary<FontSchemeValues, XLFontScheme>
-        {
-            { FontSchemeValues.None, XLFontScheme.None },
-            { FontSchemeValues.Major, XLFontScheme.Major },
-            { FontSchemeValues.Minor, XLFontScheme.Minor },
-        };
 
     public static XLFontScheme ToXLibur(this FontSchemeValues value)
     {
         return FontSchemeMap[value];
     }
 
-    private static readonly Dictionary<OrientationValues, XLPageOrientation> OrientationMap =
-        new Dictionary<OrientationValues, XLPageOrientation>
-        {
-            { OrientationValues.Default, XLPageOrientation.Default },
-            { OrientationValues.Landscape, XLPageOrientation.Landscape },
-            { OrientationValues.Portrait, XLPageOrientation.Portrait },
-        };
-
     public static XLPageOrientation ToXLibur(this OrientationValues value)
     {
         return OrientationMap[value];
     }
-
-    private static readonly Dictionary<VerticalAlignmentRunValues, XLFontVerticalTextAlignmentValues>
-        VerticalAlignmentRunMap =
-            new Dictionary<VerticalAlignmentRunValues, XLFontVerticalTextAlignmentValues>
-            {
-                { VerticalAlignmentRunValues.Baseline, XLFontVerticalTextAlignmentValues.Baseline },
-                { VerticalAlignmentRunValues.Subscript, XLFontVerticalTextAlignmentValues.Subscript },
-                { VerticalAlignmentRunValues.Superscript, XLFontVerticalTextAlignmentValues.Superscript },
-            };
-
 
     public static XLFontVerticalTextAlignmentValues ToXLibur(this VerticalAlignmentRunValues value)
     {
         return VerticalAlignmentRunMap[value];
     }
 
-    private static readonly Dictionary<PatternValues, XLFillPatternValues> PatternMap =
-        new Dictionary<PatternValues, XLFillPatternValues>
-        {
-            { PatternValues.DarkDown, XLFillPatternValues.DarkDown },
-            { PatternValues.DarkGray, XLFillPatternValues.DarkGray },
-            { PatternValues.DarkGrid, XLFillPatternValues.DarkGrid },
-            { PatternValues.DarkHorizontal, XLFillPatternValues.DarkHorizontal },
-            { PatternValues.DarkTrellis, XLFillPatternValues.DarkTrellis },
-            { PatternValues.DarkUp, XLFillPatternValues.DarkUp },
-            { PatternValues.DarkVertical, XLFillPatternValues.DarkVertical },
-            { PatternValues.Gray0625, XLFillPatternValues.Gray0625 },
-            { PatternValues.Gray125, XLFillPatternValues.Gray125 },
-            { PatternValues.LightDown, XLFillPatternValues.LightDown },
-            { PatternValues.LightGray, XLFillPatternValues.LightGray },
-            { PatternValues.LightGrid, XLFillPatternValues.LightGrid },
-            { PatternValues.LightHorizontal, XLFillPatternValues.LightHorizontal },
-            { PatternValues.LightTrellis, XLFillPatternValues.LightTrellis },
-            { PatternValues.LightUp, XLFillPatternValues.LightUp },
-            { PatternValues.LightVertical, XLFillPatternValues.LightVertical },
-            { PatternValues.MediumGray, XLFillPatternValues.MediumGray },
-            { PatternValues.None, XLFillPatternValues.None },
-            { PatternValues.Solid, XLFillPatternValues.Solid },
-        };
-
     public static XLFillPatternValues ToXLibur(this PatternValues value)
     {
         return PatternMap[value];
     }
-
-    private static readonly Dictionary<BorderStyleValues, XLBorderStyleValues> BorderStyleMap =
-        new Dictionary<BorderStyleValues, XLBorderStyleValues>
-        {
-            { BorderStyleValues.DashDot, XLBorderStyleValues.DashDot },
-            { BorderStyleValues.DashDotDot, XLBorderStyleValues.DashDotDot },
-            { BorderStyleValues.Dashed, XLBorderStyleValues.Dashed },
-            { BorderStyleValues.Dotted, XLBorderStyleValues.Dotted },
-            { BorderStyleValues.Double, XLBorderStyleValues.Double },
-            { BorderStyleValues.Hair, XLBorderStyleValues.Hair },
-            { BorderStyleValues.Medium, XLBorderStyleValues.Medium },
-            { BorderStyleValues.MediumDashDot, XLBorderStyleValues.MediumDashDot },
-            { BorderStyleValues.MediumDashDotDot, XLBorderStyleValues.MediumDashDotDot },
-            { BorderStyleValues.MediumDashed, XLBorderStyleValues.MediumDashed },
-            { BorderStyleValues.None, XLBorderStyleValues.None },
-            { BorderStyleValues.SlantDashDot, XLBorderStyleValues.SlantDashDot },
-            { BorderStyleValues.Thick, XLBorderStyleValues.Thick },
-            { BorderStyleValues.Thin, XLBorderStyleValues.Thin },
-        };
 
     public static XLBorderStyleValues ToXLibur(this BorderStyleValues value)
     {
         return BorderStyleMap[value];
     }
 
-    private static readonly Dictionary<HorizontalAlignmentValues, XLAlignmentHorizontalValues>
-        HorizontalAlignmentMap =
-            new Dictionary<HorizontalAlignmentValues, XLAlignmentHorizontalValues>
-            {
-                { HorizontalAlignmentValues.Center, XLAlignmentHorizontalValues.Center },
-                { HorizontalAlignmentValues.CenterContinuous, XLAlignmentHorizontalValues.CenterContinuous },
-                { HorizontalAlignmentValues.Distributed, XLAlignmentHorizontalValues.Distributed },
-                { HorizontalAlignmentValues.Fill, XLAlignmentHorizontalValues.Fill },
-                { HorizontalAlignmentValues.General, XLAlignmentHorizontalValues.General },
-                { HorizontalAlignmentValues.Justify, XLAlignmentHorizontalValues.Justify },
-                { HorizontalAlignmentValues.Left, XLAlignmentHorizontalValues.Left },
-                { HorizontalAlignmentValues.Right, XLAlignmentHorizontalValues.Right },
-            };
-
     public static XLAlignmentHorizontalValues ToXLibur(this HorizontalAlignmentValues value)
     {
         return HorizontalAlignmentMap[value];
     }
-
-    private static readonly Dictionary<VerticalAlignmentValues, XLAlignmentVerticalValues>
-        VerticalAlignmentMap =
-            new Dictionary<VerticalAlignmentValues, XLAlignmentVerticalValues>
-            {
-                { VerticalAlignmentValues.Bottom, XLAlignmentVerticalValues.Bottom },
-                { VerticalAlignmentValues.Center, XLAlignmentVerticalValues.Center },
-                { VerticalAlignmentValues.Distributed, XLAlignmentVerticalValues.Distributed },
-                { VerticalAlignmentValues.Justify, XLAlignmentVerticalValues.Justify },
-                { VerticalAlignmentValues.Top, XLAlignmentVerticalValues.Top },
-            };
 
     public static XLAlignmentVerticalValues ToXLibur(this VerticalAlignmentValues value)
     {
         return VerticalAlignmentMap[value];
     }
 
-    private static readonly Dictionary<PageOrderValues, XLPageOrderValues> PageOrdersMap =
-        new Dictionary<PageOrderValues, XLPageOrderValues>
-        {
-            { PageOrderValues.DownThenOver, XLPageOrderValues.DownThenOver },
-            { PageOrderValues.OverThenDown, XLPageOrderValues.OverThenDown },
-        };
-
     public static XLPageOrderValues ToXLibur(this PageOrderValues value)
     {
         return PageOrdersMap[value];
     }
-
-    private static readonly Dictionary<CellCommentsValues, XLShowCommentsValues> CellCommentsMap =
-        new Dictionary<CellCommentsValues, XLShowCommentsValues>
-        {
-            { CellCommentsValues.AsDisplayed, XLShowCommentsValues.AsDisplayed },
-            { CellCommentsValues.AtEnd, XLShowCommentsValues.AtEnd },
-            { CellCommentsValues.None, XLShowCommentsValues.None },
-        };
 
     public static XLShowCommentsValues ToXLibur(this CellCommentsValues value)
     {
         return CellCommentsMap[value];
     }
 
-    private static readonly Dictionary<PrintErrorValues, XLPrintErrorValues> PrintErrorMap =
-        new Dictionary<PrintErrorValues, XLPrintErrorValues>
-        {
-            { PrintErrorValues.Blank, XLPrintErrorValues.Blank },
-            { PrintErrorValues.Dash, XLPrintErrorValues.Dash },
-            { PrintErrorValues.Displayed, XLPrintErrorValues.Displayed },
-            { PrintErrorValues.NA, XLPrintErrorValues.NA },
-        };
-
     public static XLPrintErrorValues ToXLibur(this PrintErrorValues value)
     {
         return PrintErrorMap[value];
     }
 
-    private static readonly Dictionary<CalculateModeValues, XLCalculateMode> CalculateModeMap =
-        new Dictionary<CalculateModeValues, XLCalculateMode>
-        {
-            { CalculateModeValues.Auto, XLCalculateMode.Auto },
-            { CalculateModeValues.AutoNoTable, XLCalculateMode.AutoNoTable },
-            { CalculateModeValues.Manual, XLCalculateMode.Manual },
-        };
-
     public static XLCalculateMode ToXLibur(this CalculateModeValues value)
     {
         return CalculateModeMap[value];
     }
-
-    private static readonly Dictionary<ReferenceModeValues, XLReferenceStyle> ReferenceModeMap =
-        new Dictionary<ReferenceModeValues, XLReferenceStyle>
-        {
-            { ReferenceModeValues.R1C1, XLReferenceStyle.R1C1 },
-            { ReferenceModeValues.A1, XLReferenceStyle.A1 },
-        };
 
     public static XLReferenceStyle ToXLibur(this ReferenceModeValues value)
     {
@@ -754,492 +1092,145 @@ internal static class EnumConverter
         _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
     };
 
-    private static readonly Dictionary<TotalsRowFunctionValues, XLTotalsRowFunction> TotalsRowFunctionMap =
-        new Dictionary<TotalsRowFunctionValues, XLTotalsRowFunction>
-        {
-            { TotalsRowFunctionValues.None, XLTotalsRowFunction.None },
-            { TotalsRowFunctionValues.Sum, XLTotalsRowFunction.Sum },
-            { TotalsRowFunctionValues.Minimum, XLTotalsRowFunction.Minimum },
-            { TotalsRowFunctionValues.Maximum, XLTotalsRowFunction.Maximum },
-            { TotalsRowFunctionValues.Average, XLTotalsRowFunction.Average },
-            { TotalsRowFunctionValues.Count, XLTotalsRowFunction.Count },
-            { TotalsRowFunctionValues.CountNumbers, XLTotalsRowFunction.CountNumbers },
-            { TotalsRowFunctionValues.StandardDeviation, XLTotalsRowFunction.StandardDeviation },
-            { TotalsRowFunctionValues.Variance, XLTotalsRowFunction.Variance },
-            { TotalsRowFunctionValues.Custom, XLTotalsRowFunction.Custom },
-        };
-
-
     public static XLTotalsRowFunction ToXLibur(this TotalsRowFunctionValues value)
     {
         return TotalsRowFunctionMap[value];
     }
-
-    private static readonly Dictionary<DataValidationValues, XLAllowedValues> DataValidationMap =
-        new Dictionary<DataValidationValues, XLAllowedValues>
-        {
-            { DataValidationValues.None, XLAllowedValues.AnyValue },
-            { DataValidationValues.Custom, XLAllowedValues.Custom },
-            { DataValidationValues.Date, XLAllowedValues.Date },
-            { DataValidationValues.Decimal, XLAllowedValues.Decimal },
-            { DataValidationValues.List, XLAllowedValues.List },
-            { DataValidationValues.TextLength, XLAllowedValues.TextLength },
-            { DataValidationValues.Time, XLAllowedValues.Time },
-            { DataValidationValues.Whole, XLAllowedValues.WholeNumber },
-        };
 
     public static XLAllowedValues ToXLibur(this DataValidationValues value)
     {
         return DataValidationMap[value];
     }
 
-    private static readonly Dictionary<DataValidationErrorStyleValues, XLErrorStyle>
-        DataValidationErrorStyleMap =
-            new Dictionary<DataValidationErrorStyleValues, XLErrorStyle>
-            {
-                { DataValidationErrorStyleValues.Information, XLErrorStyle.Information },
-                { DataValidationErrorStyleValues.Warning, XLErrorStyle.Warning },
-                { DataValidationErrorStyleValues.Stop, XLErrorStyle.Stop },
-            };
-
     public static XLErrorStyle ToXLibur(this DataValidationErrorStyleValues value)
     {
         return DataValidationErrorStyleMap[value];
     }
-
-    private static readonly Dictionary<DataValidationOperatorValues, XLOperator> DataValidationOperatorMap =
-        new Dictionary<DataValidationOperatorValues, XLOperator>
-        {
-            { DataValidationOperatorValues.Between, XLOperator.Between },
-            { DataValidationOperatorValues.GreaterThanOrEqual, XLOperator.EqualOrGreaterThan },
-            { DataValidationOperatorValues.LessThanOrEqual, XLOperator.EqualOrLessThan },
-            { DataValidationOperatorValues.Equal, XLOperator.EqualTo },
-            { DataValidationOperatorValues.GreaterThan, XLOperator.GreaterThan },
-            { DataValidationOperatorValues.LessThan, XLOperator.LessThan },
-            { DataValidationOperatorValues.NotBetween, XLOperator.NotBetween },
-            { DataValidationOperatorValues.NotEqual, XLOperator.NotEqualTo },
-        };
 
     public static XLOperator ToXLibur(this DataValidationOperatorValues value)
     {
         return DataValidationOperatorMap[value];
     }
 
-    private static readonly Dictionary<SheetStateValues, XLWorksheetVisibility> SheetStateMap =
-        new Dictionary<SheetStateValues, XLWorksheetVisibility>
-        {
-            { SheetStateValues.Visible, XLWorksheetVisibility.Visible },
-            { SheetStateValues.Hidden, XLWorksheetVisibility.Hidden },
-            { SheetStateValues.VeryHidden, XLWorksheetVisibility.VeryHidden },
-        };
-
     public static XLWorksheetVisibility ToXLibur(this SheetStateValues value)
     {
         return SheetStateMap[value];
     }
-
-    private static readonly Dictionary<PhoneticAlignmentValues, XLPhoneticAlignment> PhoneticAlignmentMap =
-        new Dictionary<PhoneticAlignmentValues, XLPhoneticAlignment>
-        {
-            { PhoneticAlignmentValues.Center, XLPhoneticAlignment.Center },
-            { PhoneticAlignmentValues.Distributed, XLPhoneticAlignment.Distributed },
-            { PhoneticAlignmentValues.Left, XLPhoneticAlignment.Left },
-            { PhoneticAlignmentValues.NoControl, XLPhoneticAlignment.NoControl },
-        };
-
 
     public static XLPhoneticAlignment ToXLibur(this PhoneticAlignmentValues value)
     {
         return PhoneticAlignmentMap[value];
     }
 
-    private static readonly Dictionary<PhoneticValues, XLPhoneticType> PhoneticMap =
-        new Dictionary<PhoneticValues, XLPhoneticType>
-        {
-            { PhoneticValues.FullWidthKatakana, XLPhoneticType.FullWidthKatakana },
-            { PhoneticValues.HalfWidthKatakana, XLPhoneticType.HalfWidthKatakana },
-            { PhoneticValues.Hiragana, XLPhoneticType.Hiragana },
-            { PhoneticValues.NoConversion, XLPhoneticType.NoConversion },
-        };
-
     public static XLPhoneticType ToXLibur(this PhoneticValues value)
     {
         return PhoneticMap[value];
     }
-
-    private static readonly Dictionary<DataConsolidateFunctionValues, XLPivotSummary>
-        DataConsolidateFunctionMap =
-            new Dictionary<DataConsolidateFunctionValues, XLPivotSummary>
-            {
-                { DataConsolidateFunctionValues.Sum, XLPivotSummary.Sum },
-                { DataConsolidateFunctionValues.Count, XLPivotSummary.Count },
-                { DataConsolidateFunctionValues.Average, XLPivotSummary.Average },
-                { DataConsolidateFunctionValues.Minimum, XLPivotSummary.Minimum },
-                { DataConsolidateFunctionValues.Maximum, XLPivotSummary.Maximum },
-                { DataConsolidateFunctionValues.Product, XLPivotSummary.Product },
-                { DataConsolidateFunctionValues.CountNumbers, XLPivotSummary.CountNumbers },
-                { DataConsolidateFunctionValues.StandardDeviation, XLPivotSummary.StandardDeviation },
-                { DataConsolidateFunctionValues.StandardDeviationP, XLPivotSummary.PopulationStandardDeviation },
-                { DataConsolidateFunctionValues.Variance, XLPivotSummary.Variance },
-                { DataConsolidateFunctionValues.VarianceP, XLPivotSummary.PopulationVariance },
-            };
 
     public static XLPivotSummary ToXLibur(this DataConsolidateFunctionValues value)
     {
         return DataConsolidateFunctionMap[value];
     }
 
-    private static readonly Dictionary<ShowDataAsValues, XLPivotCalculation> ShowDataAsMap =
-        new Dictionary<ShowDataAsValues, XLPivotCalculation>
-        {
-            { ShowDataAsValues.Normal, XLPivotCalculation.Normal },
-            { ShowDataAsValues.Difference, XLPivotCalculation.DifferenceFrom },
-            { ShowDataAsValues.Percent, XLPivotCalculation.PercentageOf },
-            { ShowDataAsValues.PercentageDifference, XLPivotCalculation.PercentageDifferenceFrom },
-            { ShowDataAsValues.RunTotal, XLPivotCalculation.RunningTotal },
-            {
-                ShowDataAsValues.PercentOfRaw, XLPivotCalculation.PercentageOfRow
-            }, // There's a typo in the OpenXML SDK =)
-            { ShowDataAsValues.PercentOfColumn, XLPivotCalculation.PercentageOfColumn },
-            { ShowDataAsValues.PercentOfTotal, XLPivotCalculation.PercentageOfTotal },
-            { ShowDataAsValues.Index, XLPivotCalculation.Index },
-        };
-
     public static XLPivotCalculation ToXLibur(this ShowDataAsValues value)
     {
         return ShowDataAsMap[value];
     }
-
-    private static readonly Dictionary<FilterOperatorValues, XLFilterOperator> FilterOperatorMap =
-        new Dictionary<FilterOperatorValues, XLFilterOperator>
-        {
-            { FilterOperatorValues.Equal, XLFilterOperator.Equal },
-            { FilterOperatorValues.NotEqual, XLFilterOperator.NotEqual },
-            { FilterOperatorValues.GreaterThan, XLFilterOperator.GreaterThan },
-            { FilterOperatorValues.LessThan, XLFilterOperator.LessThan },
-            { FilterOperatorValues.GreaterThanOrEqual, XLFilterOperator.EqualOrGreaterThan },
-            { FilterOperatorValues.LessThanOrEqual, XLFilterOperator.EqualOrLessThan },
-        };
 
     public static XLFilterOperator ToXLibur(this FilterOperatorValues value)
     {
         return FilterOperatorMap[value];
     }
 
-    private static readonly Dictionary<DynamicFilterValues, XLFilterDynamicType> DynamicFilterMap =
-        new Dictionary<DynamicFilterValues, XLFilterDynamicType>
-        {
-            { DynamicFilterValues.AboveAverage, XLFilterDynamicType.AboveAverage },
-            { DynamicFilterValues.BelowAverage, XLFilterDynamicType.BelowAverage },
-        };
-
     public static XLFilterDynamicType ToXLibur(this DynamicFilterValues value)
     {
         return DynamicFilterMap[value];
     }
-
-    private static readonly Dictionary<DateTimeGroupingValues, XLDateTimeGrouping> DateTimeGroupingMap =
-        new Dictionary<DateTimeGroupingValues, XLDateTimeGrouping>
-        {
-            { DateTimeGroupingValues.Year, XLDateTimeGrouping.Year },
-            { DateTimeGroupingValues.Month, XLDateTimeGrouping.Month },
-            { DateTimeGroupingValues.Day, XLDateTimeGrouping.Day },
-            { DateTimeGroupingValues.Hour, XLDateTimeGrouping.Hour },
-            { DateTimeGroupingValues.Minute, XLDateTimeGrouping.Minute },
-            { DateTimeGroupingValues.Second, XLDateTimeGrouping.Second },
-        };
 
     public static XLDateTimeGrouping ToXLibur(this DateTimeGroupingValues value)
     {
         return DateTimeGroupingMap[value];
     }
 
-    private static readonly Dictionary<SheetViewValues, XLSheetViewOptions> SheetViewMap =
-        new Dictionary<SheetViewValues, XLSheetViewOptions>
-        {
-            { SheetViewValues.Normal, XLSheetViewOptions.Normal },
-            { SheetViewValues.PageBreakPreview, XLSheetViewOptions.PageBreakPreview },
-            { SheetViewValues.PageLayout, XLSheetViewOptions.PageLayout },
-        };
-
     public static XLSheetViewOptions ToXLibur(this SheetViewValues value)
     {
         return SheetViewMap[value];
     }
-
-    private static readonly Dictionary<Vml.StrokeLineStyleValues, XLLineStyle> StrokeLineStyleMap =
-        new Dictionary<Vml.StrokeLineStyleValues, XLLineStyle>
-        {
-            { Vml.StrokeLineStyleValues.Single, XLLineStyle.Single },
-            { Vml.StrokeLineStyleValues.ThickBetweenThin, XLLineStyle.ThickBetweenThin },
-            { Vml.StrokeLineStyleValues.ThickThin, XLLineStyle.ThickThin },
-            { Vml.StrokeLineStyleValues.ThinThick, XLLineStyle.ThinThick },
-            { Vml.StrokeLineStyleValues.ThinThin, XLLineStyle.ThinThin },
-        };
 
     public static XLLineStyle ToXLibur(this Vml.StrokeLineStyleValues value)
     {
         return StrokeLineStyleMap[value];
     }
 
-    private static readonly Dictionary<ConditionalFormatValues, XLConditionalFormatType> ConditionalFormatMap =
-        new Dictionary<ConditionalFormatValues, XLConditionalFormatType>
-        {
-            { ConditionalFormatValues.Expression, XLConditionalFormatType.Expression },
-            { ConditionalFormatValues.CellIs, XLConditionalFormatType.CellIs },
-            { ConditionalFormatValues.ColorScale, XLConditionalFormatType.ColorScale },
-            { ConditionalFormatValues.DataBar, XLConditionalFormatType.DataBar },
-            { ConditionalFormatValues.IconSet, XLConditionalFormatType.IconSet },
-            { ConditionalFormatValues.Top10, XLConditionalFormatType.Top10 },
-            { ConditionalFormatValues.UniqueValues, XLConditionalFormatType.IsUnique },
-            { ConditionalFormatValues.DuplicateValues, XLConditionalFormatType.IsDuplicate },
-            { ConditionalFormatValues.ContainsText, XLConditionalFormatType.ContainsText },
-            { ConditionalFormatValues.NotContainsText, XLConditionalFormatType.NotContainsText },
-            { ConditionalFormatValues.BeginsWith, XLConditionalFormatType.StartsWith },
-            { ConditionalFormatValues.EndsWith, XLConditionalFormatType.EndsWith },
-            { ConditionalFormatValues.ContainsBlanks, XLConditionalFormatType.IsBlank },
-            { ConditionalFormatValues.NotContainsBlanks, XLConditionalFormatType.NotBlank },
-            { ConditionalFormatValues.ContainsErrors, XLConditionalFormatType.IsError },
-            { ConditionalFormatValues.NotContainsErrors, XLConditionalFormatType.NotError },
-            { ConditionalFormatValues.TimePeriod, XLConditionalFormatType.TimePeriod },
-            { ConditionalFormatValues.AboveAverage, XLConditionalFormatType.AboveAverage },
-        };
-
     public static XLConditionalFormatType ToXLibur(this ConditionalFormatValues value)
     {
         return ConditionalFormatMap[value];
     }
-
-    private static readonly Dictionary<ConditionalFormatValueObjectValues, XLCFContentType>
-        ConditionalFormatValueObjectMap =
-            new Dictionary<ConditionalFormatValueObjectValues, XLCFContentType>
-            {
-                { ConditionalFormatValueObjectValues.Number, XLCFContentType.Number },
-                { ConditionalFormatValueObjectValues.Percent, XLCFContentType.Percent },
-                { ConditionalFormatValueObjectValues.Max, XLCFContentType.Maximum },
-                { ConditionalFormatValueObjectValues.Min, XLCFContentType.Minimum },
-                { ConditionalFormatValueObjectValues.Formula, XLCFContentType.Formula },
-                { ConditionalFormatValueObjectValues.Percentile, XLCFContentType.Percentile },
-            };
 
     public static XLCFContentType ToXLibur(this ConditionalFormatValueObjectValues value)
     {
         return ConditionalFormatValueObjectMap[value];
     }
 
-    private static readonly Dictionary<ConditionalFormattingOperatorValues, XLCFOperator>
-        ConditionalFormattingOperatorMap =
-            new Dictionary<ConditionalFormattingOperatorValues, XLCFOperator>
-            {
-                { ConditionalFormattingOperatorValues.LessThan, XLCFOperator.LessThan },
-                { ConditionalFormattingOperatorValues.LessThanOrEqual, XLCFOperator.EqualOrLessThan },
-                { ConditionalFormattingOperatorValues.Equal, XLCFOperator.Equal },
-                { ConditionalFormattingOperatorValues.NotEqual, XLCFOperator.NotEqual },
-                { ConditionalFormattingOperatorValues.GreaterThanOrEqual, XLCFOperator.EqualOrGreaterThan },
-                { ConditionalFormattingOperatorValues.GreaterThan, XLCFOperator.GreaterThan },
-                { ConditionalFormattingOperatorValues.Between, XLCFOperator.Between },
-                { ConditionalFormattingOperatorValues.NotBetween, XLCFOperator.NotBetween },
-                { ConditionalFormattingOperatorValues.ContainsText, XLCFOperator.Contains },
-                { ConditionalFormattingOperatorValues.NotContains, XLCFOperator.NotContains },
-                { ConditionalFormattingOperatorValues.BeginsWith, XLCFOperator.StartsWith },
-                { ConditionalFormattingOperatorValues.EndsWith, XLCFOperator.EndsWith },
-            };
-
     public static XLCFOperator ToXLibur(this ConditionalFormattingOperatorValues value)
     {
         return ConditionalFormattingOperatorMap[value];
     }
-
-    private static readonly Dictionary<IconSetValues, XLIconSetStyle> IconSetMap =
-        new Dictionary<IconSetValues, XLIconSetStyle>
-        {
-            { IconSetValues.ThreeArrows, XLIconSetStyle.ThreeArrows },
-            { IconSetValues.ThreeArrowsGray, XLIconSetStyle.ThreeArrowsGray },
-            { IconSetValues.ThreeFlags, XLIconSetStyle.ThreeFlags },
-            { IconSetValues.ThreeTrafficLights1, XLIconSetStyle.ThreeTrafficLights1 },
-            { IconSetValues.ThreeTrafficLights2, XLIconSetStyle.ThreeTrafficLights2 },
-            { IconSetValues.ThreeSigns, XLIconSetStyle.ThreeSigns },
-            { IconSetValues.ThreeSymbols, XLIconSetStyle.ThreeSymbols },
-            { IconSetValues.ThreeSymbols2, XLIconSetStyle.ThreeSymbols2 },
-            { IconSetValues.FourArrows, XLIconSetStyle.FourArrows },
-            { IconSetValues.FourArrowsGray, XLIconSetStyle.FourArrowsGray },
-            { IconSetValues.FourRedToBlack, XLIconSetStyle.FourRedToBlack },
-            { IconSetValues.FourRating, XLIconSetStyle.FourRating },
-            { IconSetValues.FourTrafficLights, XLIconSetStyle.FourTrafficLights },
-            { IconSetValues.FiveArrows, XLIconSetStyle.FiveArrows },
-            { IconSetValues.FiveArrowsGray, XLIconSetStyle.FiveArrowsGray },
-            { IconSetValues.FiveRating, XLIconSetStyle.FiveRating },
-            { IconSetValues.FiveQuarters, XLIconSetStyle.FiveQuarters },
-        };
 
     public static XLIconSetStyle ToXLibur(this IconSetValues value)
     {
         return IconSetMap[value];
     }
 
-    private static readonly Dictionary<TimePeriodValues, XLTimePeriod> TimePeriodMap =
-        new Dictionary<TimePeriodValues, XLTimePeriod>
-        {
-            { TimePeriodValues.Yesterday, XLTimePeriod.Yesterday },
-            { TimePeriodValues.Today, XLTimePeriod.Today },
-            { TimePeriodValues.Tomorrow, XLTimePeriod.Tomorrow },
-            { TimePeriodValues.Last7Days, XLTimePeriod.InTheLast7Days },
-            { TimePeriodValues.LastWeek, XLTimePeriod.LastWeek },
-            { TimePeriodValues.ThisWeek, XLTimePeriod.ThisWeek },
-            { TimePeriodValues.NextWeek, XLTimePeriod.NextWeek },
-            { TimePeriodValues.LastMonth, XLTimePeriod.LastMonth },
-            { TimePeriodValues.ThisMonth, XLTimePeriod.ThisMonth },
-            { TimePeriodValues.NextMonth, XLTimePeriod.NextMonth },
-        };
-
     public static XLTimePeriod ToXLibur(this TimePeriodValues value)
     {
         return TimePeriodMap[value];
     }
-
-    private static readonly Dictionary<PivotAreaValues, XLPivotAreaType> PivotAreaMap =
-        new Dictionary<PivotAreaValues, XLPivotAreaType>
-        {
-            { PivotAreaValues.None, XLPivotAreaType.None },
-            { PivotAreaValues.Normal, XLPivotAreaType.Normal },
-            { PivotAreaValues.Data, XLPivotAreaType.Data },
-            { PivotAreaValues.All, XLPivotAreaType.All },
-            { PivotAreaValues.Origin, XLPivotAreaType.Origin },
-            { PivotAreaValues.Button, XLPivotAreaType.Button },
-            { PivotAreaValues.TopRight, XLPivotAreaType.TopRight },
-            { PivotAreaValues.TopEnd, XLPivotAreaType.TopEnd },
-        };
 
     public static XLPivotAreaType ToXLibur(this PivotAreaValues value)
     {
         return PivotAreaMap[value];
     }
 
-    private static readonly Dictionary<X14.SparklineTypeValues, XLSparklineType> SparklineTypeMap =
-        new Dictionary<X14.SparklineTypeValues, XLSparklineType>
-        {
-            { X14.SparklineTypeValues.Line, XLSparklineType.Line },
-            { X14.SparklineTypeValues.Column, XLSparklineType.Column },
-            { X14.SparklineTypeValues.Stacked, XLSparklineType.Stacked },
-        };
-
     public static XLSparklineType ToXLibur(this X14.SparklineTypeValues value)
     {
         return SparklineTypeMap[value];
     }
-
-    private static readonly Dictionary<X14.SparklineAxisMinMaxValues, XLSparklineAxisMinMax>
-        SparklineAxisMinMaxMap =
-            new Dictionary<X14.SparklineAxisMinMaxValues, XLSparklineAxisMinMax>
-            {
-                { X14.SparklineAxisMinMaxValues.Individual, XLSparklineAxisMinMax.Automatic },
-                { X14.SparklineAxisMinMaxValues.Group, XLSparklineAxisMinMax.SameForAll },
-                { X14.SparklineAxisMinMaxValues.Custom, XLSparklineAxisMinMax.Custom },
-            };
 
     public static XLSparklineAxisMinMax ToXLibur(this X14.SparklineAxisMinMaxValues value)
     {
         return SparklineAxisMinMaxMap[value];
     }
 
-    private static readonly Dictionary<X14.DisplayBlanksAsValues, XLDisplayBlanksAsValues> DisplayBlanksAsMap =
-        new Dictionary<X14.DisplayBlanksAsValues, XLDisplayBlanksAsValues>
-        {
-            { X14.DisplayBlanksAsValues.Span, XLDisplayBlanksAsValues.Interpolate },
-            { X14.DisplayBlanksAsValues.Gap, XLDisplayBlanksAsValues.NotPlotted },
-            { X14.DisplayBlanksAsValues.Zero, XLDisplayBlanksAsValues.Zero },
-        };
-
     public static XLDisplayBlanksAsValues ToXLibur(this X14.DisplayBlanksAsValues value)
     {
         return DisplayBlanksAsMap[value];
     }
-
-    private static readonly Dictionary<FieldSortValues, XLPivotSortType> FieldSortMap =
-        new Dictionary<FieldSortValues, XLPivotSortType>
-        {
-            { FieldSortValues.Manual, XLPivotSortType.Default },
-            { FieldSortValues.Ascending, XLPivotSortType.Ascending },
-            { FieldSortValues.Descending, XLPivotSortType.Descending },
-        };
 
     public static XLPivotSortType ToXLibur(this FieldSortValues value)
     {
         return FieldSortMap[value];
     }
 
-    private static readonly Dictionary<PivotTableAxisValues, XLPivotAxis> PivotTableAxisMap =
-        new Dictionary<PivotTableAxisValues, XLPivotAxis>
-        {
-            { PivotTableAxisValues.AxisRow, XLPivotAxis.AxisRow },
-            { PivotTableAxisValues.AxisColumn, XLPivotAxis.AxisCol },
-            { PivotTableAxisValues.AxisPage, XLPivotAxis.AxisPage },
-            { PivotTableAxisValues.AxisValues, XLPivotAxis.AxisValues },
-        };
-
     internal static XLPivotAxis ToXLibur(this PivotTableAxisValues value)
     {
         return PivotTableAxisMap[value];
     }
-
-    private static readonly Dictionary<ItemValues, XLPivotItemType> ItemMap =
-        new Dictionary<ItemValues, XLPivotItemType>
-        {
-            { ItemValues.Data, XLPivotItemType.Data },
-            { ItemValues.Default, XLPivotItemType.Default },
-            { ItemValues.Sum, XLPivotItemType.Sum },
-            { ItemValues.CountA, XLPivotItemType.CountA },
-            { ItemValues.Average, XLPivotItemType.Avg },
-            { ItemValues.Maximum, XLPivotItemType.Max },
-            { ItemValues.Minimum, XLPivotItemType.Min },
-            { ItemValues.Product, XLPivotItemType.Product },
-            { ItemValues.Count, XLPivotItemType.Count },
-            { ItemValues.StandardDeviation, XLPivotItemType.StdDev },
-            { ItemValues.StandardDeviationP, XLPivotItemType.StdDevP },
-            { ItemValues.Variance, XLPivotItemType.Var },
-            { ItemValues.VarianceP, XLPivotItemType.VarP },
-            { ItemValues.Grand, XLPivotItemType.Grand },
-            { ItemValues.Blank, XLPivotItemType.Blank },
-        };
 
     internal static XLPivotItemType ToXLibur(this ItemValues value)
     {
         return ItemMap[value];
     }
 
-    private static readonly Dictionary<FormatActionValues, XLPivotFormatAction> FormatActionMap =
-        new Dictionary<FormatActionValues, XLPivotFormatAction>
-        {
-            { FormatActionValues.Blank, XLPivotFormatAction.Blank },
-            { FormatActionValues.Formatting, XLPivotFormatAction.Formatting },
-        };
-
     internal static XLPivotFormatAction ToXLibur(this FormatActionValues value)
     {
         return FormatActionMap[value];
     }
 
-    private static readonly Dictionary<ScopeValues, XLPivotCfScope> ScopeMap =
-        new Dictionary<ScopeValues, XLPivotCfScope>
-        {
-            { ScopeValues.Selection, XLPivotCfScope.SelectedCells },
-            { ScopeValues.Data, XLPivotCfScope.DataFields },
-            { ScopeValues.Field, XLPivotCfScope.FieldIntersections },
-        };
-
     internal static XLPivotCfScope ToXLibur(this ScopeValues value)
     {
         return ScopeMap[value];
     }
-
-    private static readonly Dictionary<RuleValues, XLPivotCfRuleType> RuleMap =
-        new Dictionary<RuleValues, XLPivotCfRuleType>
-        {
-            { RuleValues.None, XLPivotCfRuleType.None },
-            { RuleValues.All, XLPivotCfRuleType.All },
-            { RuleValues.Row, XLPivotCfRuleType.Row },
-            { RuleValues.Column, XLPivotCfRuleType.Column },
-        };
 
     internal static XLPivotCfRuleType ToXLibur(this RuleValues value)
     {
@@ -1254,5 +1245,4 @@ internal static class EnumConverter
         throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!");
     }
 
-    #endregion To XLibur
 }


### PR DESCRIPTION
## Summary

- Reorder `EnumConverter.cs` sections for consistency
- Tidy comments in `Lookup.cs`

Cleanup-only changes — no functional impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal reference parsing and validation logic for improved code maintainability
  * Refactored enum conversion system to use lookup-based approach for consistent performance
  * Extended support for phonetic alignment and type enum conversions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->