### PR TITLE
Fix doc grammar and remove redundant null check

### DIFF
--- a/XLibur/Excel/AutoFilters/IXLFilteredColumn.cs
+++ b/XLibur/Excel/AutoFilters/IXLFilteredColumn.cs
@@ -23,6 +23,6 @@ public interface IXLFilteredColumn
     /// Add another grouping to a set of allowed groupings. See <see cref="IXLFilterColumn.AddDateGroupFilter"/>
     /// for more details.
     /// </summary>
-    /// <returns>Fluent API allowing adding an additional date group filter.</returns>
+    /// <returns>Fluent API allowing you to add an additional date group filter.</returns>
     IXLFilteredColumn AddDateGroupFilter(DateTime date, XLDateTimeGrouping dateTimeGrouping, bool reapply = true);
 }

--- a/XLibur/Excel/Caching/XLRepositoryBase.cs
+++ b/XLibur/Excel/Caching/XLRepositoryBase.cs
@@ -91,7 +91,7 @@ internal class XLRepositoryBase<Tkey, Tvalue> : XLRepositoryBase, IXLRepository<
 
     public Tvalue? Replace(ref Tkey oldKey, ref Tkey newKey)
     {
-        if (_storage.TryRemove(oldKey, out WeakReference? cachedReference) && cachedReference != null)
+        if (_storage.TryRemove(oldKey, out var cachedReference))
         {
             _storage.TryAdd(newKey, cachedReference);
             return GetOrCreate(ref newKey);


### PR DESCRIPTION
## Summary
- Fix grammar in `IXLFilteredColumn.AddDateGroupFilter` return XML doc comment ("allowing to add" → "allowing you to add an")
- Remove redundant `&& cachedReference != null` check in `XLRepositoryBase.Replace` since `_storage` is `ConcurrentDictionary<Tkey, WeakReference>` (non-nullable value type) and values are only ever inserted as `new WeakReference(value)`

## Test plan
- [ ] Verify build succeeds with no warnings (TreatWarningsAsErrors is enabled)
- [ ] Confirm existing tests pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal caching logic refinement and documentation updates for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->