### PR TITLE
chore: bump package versions

### DIFF
--- a/XLibur.Benchmarks/XLibur.Benchmarks.csproj
+++ b/XLibur.Benchmarks/XLibur.Benchmarks.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.dotMemory" Version="0.15.8" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.15.8" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
-    <PackageReference Include="EPPlus" Version="8.5.0" />
-    <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.16" />
+    <PackageReference Include="EPPlus" Version="8.5.3" />
+    <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.17" />
   </ItemGroup>
 
 </Project>

--- a/XLibur.Fonts.SixLabors.Tests/XLibur.Fonts.SixLabors.Tests.csproj
+++ b/XLibur.Fonts.SixLabors.Tests/XLibur.Fonts.SixLabors.Tests.csproj
@@ -12,11 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>

--- a/XLibur.Tests/XLibur.Tests.csproj
+++ b/XLibur.Tests/XLibur.Tests.csproj
@@ -17,12 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>

--- a/XLibur/XLibur.csproj
+++ b/XLibur/XLibur.csproj
@@ -37,9 +37,9 @@
         <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1"/>
         <PackageReference Include="ExcelNumberFormat" Version="1.1.0"/>
         <PackageReference Include="JetBrains.Annotations" Version="2025.2.4"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
         <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All"/>
-        <PackageReference Include="Polyfill" Version="9.23.0">
+        <PackageReference Include="Polyfill" Version="10.3.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
- EPPlus 8.5.0 -> 8.5.3
- JetBrains.Profiler.SelfApi 2.5.16 -> 2.5.17
- coverlet.collector 8.0.1 -> 10.0.0
- Microsoft.NET.Test.Sdk 18.3.0 -> 18.5.1
- Microsoft.Data.SqlClient 7.0.0 -> 7.0.1
- Microsoft.SourceLink.GitHub 10.0.201 -> 10.0.203
- Polyfill 9.23.0 -> 10.3.0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external NuGet package dependencies to their latest available versions across the core library and multiple test suites. This includes updates to benchmark profiling utilities, test framework SDKs, code coverage analyzers, database connectivity libraries, and source linking packages. All affected project configuration files have been synchronized with current dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->