### PR TITLE
feat: add XLibur.Bundle convenience meta-package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Pack XLibur.Fonts.SixLabors.V1
         run: dotnet pack XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj --configuration Release --no-build --output ./artifacts
 
+      - name: Pack XLibur.Bundle
+        run: dotnet pack XLibur.Bundle/XLibur.Bundle.csproj --configuration Release --no-build --output ./artifacts
+
       - name: Pack XLibur.Fonts.SixLabors
         run: dotnet pack XLibur.Fonts.SixLabors/XLibur.Fonts.SixLabors.csproj --configuration Release --no-build --output ./artifacts
 

--- a/XLibur.Bundle/NUGET_README.md
+++ b/XLibur.Bundle/NUGET_README.md
@@ -1,0 +1,26 @@
+# XLibur.Bundle
+
+A convenience meta-package that installs [XLibur](https://www.nuget.org/packages/XLibur) together with its default font engine, [XLibur.Fonts.SixLabors.V1](https://www.nuget.org/packages/XLibur.Fonts.SixLabors.V1) (SixLabors.Fonts 1.x, Apache 2.0).
+
+This package contains no code of its own — it exists purely to pull both dependencies in via a single `PackageReference`.
+
+## Install
+
+```
+dotnet add package XLibur.Bundle
+```
+
+That's all. The default font engine registers itself automatically when the assembly loads.
+
+## When to use this
+
+Install `XLibur.Bundle` if you want the recommended, license-safe defaults and don't want to think about font engines.
+
+## When to install the pieces separately
+
+- You want a different font engine (e.g. `XLibur.Fonts.SixLabors` for SixLabors.Fonts 2.x), in which case install `XLibur` plus the engine of your choice.
+- You're a library author and don't want to force a font-engine choice on downstream consumers — depend only on `XLibur`.
+
+## Documentation
+
+For full documentation, source, and contribution guidelines, visit the [GitHub repository](https://github.com/XLibur/XLibur).

--- a/XLibur.Bundle/NUGET_README.md
+++ b/XLibur.Bundle/NUGET_README.md
@@ -6,7 +6,7 @@ This package contains no code of its own — it exists purely to pull both depen
 
 ## Install
 
-```
+```bash
 dotnet add package XLibur.Bundle
 ```
 

--- a/XLibur.Bundle/XLibur.Bundle.csproj
+++ b/XLibur.Bundle/XLibur.Bundle.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <Description>Convenience meta-package for XLibur. Installs XLibur together with the default SixLabors.Fonts 1.x font engine (Apache 2.0). Equivalent to installing XLibur and XLibur.Fonts.SixLabors.V1 separately.</Description>
+        <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
+        <PackageTags>Excel OpenXml xlsx Bundle</PackageTags>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <IncludeSymbols>false</IncludeSymbols>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);NU5128</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)'=='Release'">
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\resources\logo\nuget-logo.png" Pack="true" PackagePath="\" />
+        <None Include="NUGET_README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\XLibur\XLibur.csproj" />
+        <ProjectReference Include="..\XLibur.Fonts.SixLabors.V1\XLibur.Fonts.SixLabors.V1.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
+    </ItemGroup>
+
+</Project>

--- a/XLibur.slnx
+++ b/XLibur.slnx
@@ -16,5 +16,6 @@
   <Project Path="XLibur.Benchmarks/XLibur.Benchmarks.csproj" />
   <Project Path="XLibur.Examples/XLibur.Examples.csproj" />
   <Project Path="XLibur/XLibur.csproj" />
+  <Project Path="XLibur.Bundle/XLibur.Bundle.csproj" />
   <Project Path="XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj" />
 </Solution>


### PR DESCRIPTION
Add a dependency-only NuGet meta-package that pulls in both XLibur and XLibur.Fonts.SixLabors.V1, so users get the recommended default install (core library plus the license-safe Apache 2.0 font engine) with a single PackageReference. New users no longer have to know to install both packages, and avoid accidentally picking the V2 fonts package whose upstream license is incompatible.

The bundle has no code of its own. ProjectReferences become PackageDependencies at pack time, each pinned to the referenced project's own MinVer-derived version - so XLibur and XLibur.Fonts.SixLabors.V1 keep their independent release cadences and the bundle re-pins to whatever is current at pack time.

- New project XLibur.Bundle/XLibur.Bundle.csproj with IncludeBuildOutput false and NU5128 suppressed (no lib/ folder is intentional)
- New NUGET_README.md describing when to use the bundle vs separate pieces
- XLibur.slnx updated so the bundle builds and restores with the solution
- release.yml gets one Pack XLibur.Bundle step; the existing dotnet nuget push glob already publishes it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * XLibur.Bundle NuGet package now available—a meta-package that bundles XLibur with the default font engine for simplified installation.

* **Documentation**
  * Added README explaining the bundle's purpose, installation instructions, and guidance on choosing between the bundle and individual packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->