### PR TITLE
feat: add XLibur.Bundle convenience meta-package

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: NuGet login
         if: ${{ inputs.dry-run == false }}
-        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         id: nuget-login
         with:
           user: jafin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Pack XLibur.Fonts.SixLabors.V1
         run: dotnet pack XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj --configuration Release --no-build --output ./artifacts
 
+      - name: Pack XLibur.Bundle
+        run: dotnet pack XLibur.Bundle/XLibur.Bundle.csproj --configuration Release --no-build --output ./artifacts
+
       - name: Pack XLibur.Fonts.SixLabors
         run: dotnet pack XLibur.Fonts.SixLabors/XLibur.Fonts.SixLabors.csproj --configuration Release --no-build --output ./artifacts
 

--- a/XLibur.Bundle/NUGET_README.md
+++ b/XLibur.Bundle/NUGET_README.md
@@ -1,0 +1,26 @@
+# XLibur.Bundle
+
+A convenience meta-package that installs [XLibur](https://www.nuget.org/packages/XLibur) together with its default font engine, [XLibur.Fonts.SixLabors.V1](https://www.nuget.org/packages/XLibur.Fonts.SixLabors.V1) (SixLabors.Fonts 1.x, Apache 2.0).
+
+This package contains no code of its own — it exists purely to pull both dependencies in via a single `PackageReference`.
+
+## Install
+
+```
+dotnet add package XLibur.Bundle
+```
+
+That's all. The default font engine registers itself automatically when the assembly loads.
+
+## When to use this
+
+Install `XLibur.Bundle` if you want the recommended, license-safe defaults and don't want to think about font engines.
+
+## When to install the pieces separately
+
+- You want a different font engine (e.g. `XLibur.Fonts.SixLabors` for SixLabors.Fonts 2.x), in which case install `XLibur` plus the engine of your choice.
+- You're a library author and don't want to force a font-engine choice on downstream consumers — depend only on `XLibur`.
+
+## Documentation
+
+For full documentation, source, and contribution guidelines, visit the [GitHub repository](https://github.com/XLibur/XLibur).

--- a/XLibur.Bundle/NUGET_README.md
+++ b/XLibur.Bundle/NUGET_README.md
@@ -6,7 +6,7 @@ This package contains no code of its own — it exists purely to pull both depen
 
 ## Install
 
-```
+```bash
 dotnet add package XLibur.Bundle
 ```
 

--- a/XLibur.Bundle/XLibur.Bundle.csproj
+++ b/XLibur.Bundle/XLibur.Bundle.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <Description>Convenience meta-package for XLibur. Installs XLibur together with the default SixLabors.Fonts 1.x font engine (Apache 2.0). Equivalent to installing XLibur and XLibur.Fonts.SixLabors.V1 separately.</Description>
+        <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
+        <PackageTags>Excel OpenXml xlsx Bundle</PackageTags>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <IncludeSymbols>false</IncludeSymbols>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);NU5128</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)'=='Release'">
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\resources\logo\nuget-logo.png" Pack="true" PackagePath="\" />
+        <None Include="NUGET_README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\XLibur\XLibur.csproj" />
+        <ProjectReference Include="..\XLibur.Fonts.SixLabors.V1\XLibur.Fonts.SixLabors.V1.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
+    </ItemGroup>
+
+</Project>

--- a/XLibur.slnx
+++ b/XLibur.slnx
@@ -16,5 +16,6 @@
   <Project Path="XLibur.Benchmarks/XLibur.Benchmarks.csproj" />
   <Project Path="XLibur.Examples/XLibur.Examples.csproj" />
   <Project Path="XLibur/XLibur.csproj" />
+  <Project Path="XLibur.Bundle/XLibur.Bundle.csproj" />
   <Project Path="XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

Adds a fourth NuGet package, `XLibur.Bundle`, which is a dependency-only meta-package that pulls in `XLibur` together with the default font engine `XLibur.Fonts.SixLabors.V1` (Apache 2.0). New users can now install the recommended, license-safe defaults with a single `PackageReference` and avoid accidentally picking the SixLabors.Fonts 2.x package whose upstream license is incompatible.

The bundle has no code of its own. `<ProjectReference>` entries become `<PackageDependency>` entries at pack time, each pinned to the *referenced* project's MinVer-derived version — so `XLibur` and `XLibur.Fonts.SixLabors.V1` keep their independent release cadences and the bundle re-pins to whatever is current at pack time.

Versioning: bundle inherits the `v*` MinVer prefix from `Directory.Build.props`, so it ships every time core XLibur ships. No new release tag prefix introduced.

## Changes

- New project `XLibur.Bundle/XLibur.Bundle.csproj` — empty SDK project with `IncludeBuildOutput=false`, `IncludeSymbols=false`, and `NU5128` suppressed (no `lib/` folder is intentional).
- New `XLibur.Bundle/NUGET_README.md` describing when to install the bundle vs the underlying pieces separately.
- `XLibur.slnx` updated so the bundle builds and restores with the rest of the solution.
- `.github/workflows/release.yml` — one `Pack XLibur.Bundle` step added; the existing `dotnet nuget push ./artifacts/*.nupkg` glob already publishes it.
- `.github/workflows/release-prerelease.yml` — bumps `NuGet/login` from `v1` to `v1.2.0` (SHA pinned) so both release workflows are aligned.

## Related Issues

<!-- none -->

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually

Manual verification:

1. `dotnet build XLibur.slnx -c Release` — succeeds with 0 warnings, 0 errors (NU5128 correctly suppressed and not elevated by `TreatWarningsAsErrors`).
2. `dotnet pack XLibur.Bundle/XLibur.Bundle.csproj -c Release --no-build -o ./artifacts-test` — produces a single `.nupkg` (no `.snupkg`, by design).
3. Inspected the generated `XLibur.Bundle.nuspec`:
   - **No `lib/` folder** — only `_rels/`, `[Content_Types].xml`, `XLibur.Bundle.nuspec`, `nuget-logo.png`, `NUGET_README.md`.
   - `<dependencies>` element contains exactly two entries per TFM group (`net8.0`, `net9.0`, `net10.0`):
     - `XLibur` pinned to the core's MinVer version
     - `XLibur.Fonts.SixLabors.V1` pinned to *its own* MinVer version (computed from `fonts-sixlabors-1-v*` tags), distinct from the bundle's own version. Confirms ProjectReference auto-conversion is using each project's own version, not the bundle's.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch