### PR TITLE
ci: pack XLibur.Bundle in pre-release workflow

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Pack XLibur.Fonts.SixLabors.V1
         run: dotnet pack XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj --configuration Release --no-build --output ./artifacts
 
+      - name: Pack XLibur.Bundle
+        run: dotnet pack XLibur.Bundle/XLibur.Bundle.csproj --configuration Release --no-build --output ./artifacts
+
       - name: Pack XLibur.Fonts.SixLabors
         run: dotnet pack XLibur.Fonts.SixLabors/XLibur.Fonts.SixLabors.csproj --configuration Release --no-build --output ./artifacts
 


### PR DESCRIPTION
## Summary
- Add `Pack XLibur.Bundle` step to `release-prerelease.yml`, mirroring the ordering already used in `release.yml`
- Ensures pre-release runs publish the `XLibur.Bundle` meta-package alongside the other artifacts

## Test plan
- [ ] Trigger the Pre-release workflow with `dry-run: true` and confirm `./artifacts/` contains `XLibur.Bundle.*.nupkg`