### PR TITLE
fix: reconcile data-validation index before Consolidate (prevents empty sqref on column/row insert)

### DIFF
--- a/XLibur.Tests/Excel/Columns/InsertColumnBeforeDataValidationTests.cs
+++ b/XLibur.Tests/Excel/Columns/InsertColumnBeforeDataValidationTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;

--- a/XLibur.Tests/Excel/Columns/InsertColumnBeforeDataValidationTests.cs
+++ b/XLibur.Tests/Excel/Columns/InsertColumnBeforeDataValidationTests.cs
@@ -1,0 +1,131 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using NUnit.Framework;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Columns;
+
+[TestFixture]
+public class InsertColumnBeforeDataValidationTests
+{
+    [Test]
+    public void InsertColumnBeforeCol1_PreservesMultiColumnDvSqrefsThroughSave()
+    {
+        using var saved = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+
+            // Multi-column dv straddling the col-1 insert point.
+            var rule1 = ws.Range("A2:B2").CreateDataValidation();
+            rule1.InputTitle = "Rule1";
+            rule1.InputMessage = "Rule1";
+
+            // Multi-column dv well right of the insert point.
+            var rule2 = ws.Range("D2:E2").CreateDataValidation();
+            rule2.InputTitle = "Rule2";
+            rule2.InputMessage = "Rule2";
+
+            ws.Column(1).InsertColumnsBefore(1);
+            wb.SaveAs(saved);
+        }
+
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        var sheetPart = doc.WorkbookPart!.WorksheetParts.First();
+        var written = sheetPart.Worksheet.Descendants<DataValidation>()
+            .Select(dv => (title: dv.PromptTitle?.Value ?? string.Empty,
+                           sqref: dv.SequenceOfReferences!.InnerText))
+            .ToList();
+
+        var rule1Out = written.SingleOrDefault(x => x.title == "Rule1");
+        var rule2Out = written.SingleOrDefault(x => x.title == "Rule2");
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("B2:C2", rule1Out.sqref,
+                "Multi-column dv straddling the insert point lost its sqref during save.");
+            Assert.AreEqual("E2:F2", rule2Out.sqref,
+                "Multi-column dv right of the insert point lost its sqref during save.");
+        });
+    }
+
+    [Test]
+    public void InsertColumnBeforeCol1_ManyAdjacentDvsAllSurviveWithCorrectSqrefs()
+    {
+        // Reproduces the production scenario where a workbook has many distinct dvs
+        // packed sequentially across columns. Each row-2 dv is a single cell at
+        // consecutive columns; without the index-reconciliation fix in
+        // XLDataValidations.Consolidate, dvs whose post-shift address happens to match
+        // a neighbour's pre-shift address get double-shifted (or wiped) at save time,
+        // producing empty sqrefs that Excel rejects on open.
+        using var saved = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+
+            // Multi-column dv straddling the insert point + multi-row+col dv.
+            Add(ws.Range("A2:B2"), "Straddle");
+            Add(ws.Range("J3:K100"), "DataRange");
+
+            // Single-cell row-2 dvs at adjacent columns: shifting any one
+            // produces an address that collides with another's pre-shift address.
+            for (var col = 3; col <= 9; col++)
+                Add(ws.Cell(2, col).AsRange(), $"Cell{col}");
+
+            // A dv with formula1 to verify formula round-trips (allowed-value rules
+            // exercise a different writer path than property-only rules).
+            var withFormula = ws.Range("M3:M50").CreateDataValidation();
+            withFormula.InputTitle = "WithFormula";
+            withFormula.TextLength.GreaterThan(3);
+
+            ws.Column(1).InsertColumnsBefore(1);
+            wb.SaveAs(saved);
+
+            static void Add(IXLRange range, string title)
+            {
+                var rule = range.CreateDataValidation();
+                rule.InputTitle = title;
+                rule.InputMessage = title;
+            }
+        }
+
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        var sheetPart = doc.WorkbookPart!.WorksheetParts.First();
+        var dvs = sheetPart.Worksheet.Descendants<DataValidation>()
+            .Select(dv => (title: dv.PromptTitle?.Value ?? string.Empty,
+                           sqref: dv.SequenceOfReferences!.InnerText,
+                           f1: dv.Formula1?.InnerText ?? string.Empty))
+            .ToList();
+
+        var empties = dvs.Where(x => string.IsNullOrEmpty(x.sqref)).ToList();
+        Assert.IsEmpty(empties,
+            $"Saved file has {empties.Count} dv(s) with empty sqref — Excel will reject "
+            + "the file with a 'Removed Records: Data validation' recovery dialog.");
+
+        // Verify every original dv survived AND landed at the expected shifted address.
+        // Cell{col} originally at column `col` should shift to `col + 1`.
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("B2:C2", FindSqref(dvs, "Straddle"));
+            Assert.AreEqual("K3:L100", FindSqref(dvs, "DataRange"));
+            for (var col = 3; col <= 9; col++)
+            {
+                var expectedCol = XLHelper.GetColumnLetterFromNumber(col + 1);
+                Assert.AreEqual($"{expectedCol}2:{expectedCol}2", FindSqref(dvs, $"Cell{col}"),
+                    $"Cell{col} dv should have shifted from column {col} to {col + 1}.");
+            }
+
+            var withFormulaOut = dvs.Single(x => x.title == "WithFormula");
+            Assert.AreEqual("N3:N50", withFormulaOut.sqref,
+                "Formula-bearing dv lost or mis-shifted its sqref.");
+            Assert.AreEqual("3", withFormulaOut.f1);
+        });
+    }
+
+    private static string FindSqref(
+        System.Collections.Generic.IEnumerable<(string title, string sqref, string f1)> dvs,
+        string title) => dvs.Single(x => x.title == title).sqref;
+}

--- a/XLibur/Excel/DataValidation/XLDataValidations.cs
+++ b/XLibur/Excel/DataValidation/XLDataValidations.cs
@@ -166,6 +166,13 @@ internal sealed class XLDataValidations : IXLDataValidations
 
     public void Consolidate()
     {
+        // Make sure the rule-range index reflects the current rule ranges before we
+        // start tearing down and rebuilding rules. After column/row shifts the
+        // address-keyed index can hold stale entries, and the split-on-add logic
+        // would otherwise interpret a rule's own out-of-date entry as a competing
+        // rule and wipe its ranges.
+        ReconcileIndex();
+
         Func<IXLDataValidation, IXLDataValidation, bool> areEqual = (dv1, dv2) =>
         {
             return
@@ -232,6 +239,26 @@ internal sealed class XLDataValidations : IXLDataValidations
         var entries = _dataValidationIndex.GetIntersectedRanges((XLRangeAddress)range.RangeAddress)
             .Where(e => Equals(e.RangeAddress, range.RangeAddress));
         entries.ToArray().ForEach(entry => _dataValidationIndex.Remove(entry.RangeAddress));
+    }
+
+    /// <summary>
+    /// Rebuild the internal rule-range spatial index from the current ranges of every
+    /// rule. Address-keyed index entries can fall out of sync with their backing
+    /// <see cref="XLRange"/> instances after column/row inserts that mutate addresses
+    /// in place (the shifter updates each <c>XLRange.RangeAddress</c> but does not
+    /// re-key the index entry). A stale index causes <see cref="SplitExistingRanges"/>
+    /// to split rules against their own outdated entries, wiping their range collection.
+    /// </summary>
+    internal void ReconcileIndex()
+    {
+        _dataValidationIndex.RemoveAll();
+        foreach (var dv in _dataValidations.OfType<XLDataValidation>())
+        {
+            foreach (var range in dv.Ranges)
+            {
+                _dataValidationIndex.Add(new XLDataValidationIndexEntry(range.RangeAddress, dv));
+            }
+        }
     }
 
     private void SplitExistingRanges(IXLRangeAddress rangeAddress)


### PR DESCRIPTION
## Summary

- Inserting a column or row mutates each data-validation range's `XLRange.RangeAddress` in place, but `XLDataValidations._dataValidationIndex` keys its entries by address at insert time and is never re-keyed. The shifter masks this on the `firstCol/firstRow > 1` path by tearing down and re-adding each rule's ranges (firing `RangeRemoved`/`RangeAdded`), but bails out early on inserts at col 1 / row 1 — leaving the index stale.
- The damage manifests at save time inside `Consolidate`: re-adding each rule calls `ProcessRangeAdded` → `SplitExistingRanges`, which finds the rule's own out-of-date entry as a "competing" rule and `SplitBy(includeIntersection: false)` strips its ranges. The writer then emits `<dataValidation sqref="" .../>`, which Excel rejects on open with *"Removed Records: Data validation from /xl/worksheets/sheetN.xml part"*.
- Fix: add `ReconcileIndex()` which rebuilds `_dataValidationIndex` from the current ranges of every rule, and call it at the top of `Consolidate` so the split logic operates on a consistent index. No changes to the shifter — the fix is self-contained in the only consumer of the index for cross-rule queries.

## Repro

```csharp
using var wb = new XLWorkbook("workbook-with-data-validations.xlsx");
var ws = wb.Worksheet("sheet-with-dvs");
ws.Column(1).InsertColumnsBefore(1);
wb.SaveAs("out.xlsx");
// Opening out.xlsx in Excel triggers the recovery dialog and drops dvs whose
// post-shift addresses collided with neighbours' pre-shift addresses.
```

## Test plan

- [x] New `InsertColumnBeforeDataValidationTests.InsertColumnBeforeCol1_PreservesMultiColumnDvSqrefsThroughSave` — minimal multi-column dv straddling the insert point + one to the right.
- [x] New `InsertColumnBeforeDataValidationTests.InsertColumnBeforeCol1_ManyAdjacentDvsAllSurviveWithCorrectSqrefs` — richer case with seven adjacent single-cell dvs whose post-shift addresses collide with neighbours' pre-shift addresses (the case that surfaces in production workbooks); plus a multi-row multi-col dv and a formula-bearing dv.
- [x] Sanity-checked by temporarily reverting `ReconcileIndex()` — both new tests fail without the fix and pass with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where data validation rules could be unexpectedly removed or corrupted when inserting columns and saving the workbook.

* **Tests**
  * Added comprehensive test coverage for column insertion scenarios to ensure data validation rules are properly preserved and their applicable ranges correctly adjusted following the insertion operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XLibur/XLibur/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->