### PR TITLE
fix: preserve array/dynamic-array formulas on row/column shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Array and dynamic-array formulas no longer break on row/column shifts**: Inserting or deleting rows/columns anywhere in a workbook used to rebuild every formula cell through the `FormulaA1` setter, which turned a single array formula (shared across its whole range) into one *normal* formula per cell. For dynamic arrays this split a single spilled formula such as `=UNIQUE(...)` into multiple implicit-intersection `=@UNIQUE(...)` cells, even when the edit happened on an unrelated sheet. Shifts now update the shared formula instance in place — preserving its array/dynamic-array nature — and relocate the spill range for same-sheet inserts/deletes.
+
 ### Performance
 
 - **`XmlEncoder.EncodeString` fast-path**: Added a character scan that short-circuits before the `Regex` and `StringBuilder` when a string contains no characters that need encoding (the common case for plain text). For workbooks with ~50K unique shared strings this eliminates ~50K `StringBuilder` allocations, ~50K regex evaluations, and ~50K string copies on save.

--- a/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -214,4 +214,89 @@ public class ArrayFormulaTests
             Assert.AreEqual(20.0, ws.Cell("B1").CachedValue);
         }
     }
+
+    [Test]
+    public void InsertingRowsInAnotherSheetKeepsArrayFormulaIntact()
+    {
+        // Regression: inserting rows/columns anywhere in the workbook used to route every
+        // formula cell through the FormulaA1 setter, rebuilding a *normal* formula per cell.
+        // For an array formula (which shares one instance across its whole range) this split a
+        // single spilled array (e.g. =UNIQUE(...)) into N implicit-intersection =@UNIQUE(...)
+        // cells, even when the insert happened on an unrelated sheet.
+        using var wb = new XLWorkbook();
+        var dataSheet = wb.AddWorksheet("Data");
+        var arraySheet = wb.AddWorksheet("Calc");
+        arraySheet.Range("A1:A3").FormulaArrayA1 = "TRANSPOSE({10,20,30})";
+
+        dataSheet.Row(1).InsertRowsAbove(5);
+
+        foreach (var cell in arraySheet.Range("A1:A3").Cells())
+        {
+            Assert.True(cell.HasArrayFormula, $"{cell.Address} lost its array formula");
+            Assert.AreEqual("A1:A3", cell.FormulaReference.ToStringRelative());
+        }
+    }
+
+    [Test]
+    public void InsertingRowsAboveShiftsArrayFormulaRange()
+    {
+        // A same-sheet insert above the array must relocate the array's spill range so the
+        // master cell is still identifiable (otherwise the formula vanishes on save).
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Range("B3:B5").FormulaArrayA1 = "TRANSPOSE({1,2,3})";
+
+        ws.Row(1).InsertRowsAbove(2);
+
+        foreach (var cell in ws.Range("B5:B7").Cells())
+        {
+            Assert.True(cell.HasArrayFormula, $"{cell.Address} lost its array formula");
+            Assert.AreEqual("B5:B7", cell.FormulaReference.ToStringRelative());
+        }
+    }
+
+    [Test]
+    public void InsertingColumnsBeforeShiftsArrayFormulaRange()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Range("B3:D3").FormulaArrayA1 = "{1,2,3}";
+
+        ws.Column(1).InsertColumnsBefore(1);
+
+        foreach (var cell in ws.Range("C3:E3").Cells())
+        {
+            Assert.True(cell.HasArrayFormula, $"{cell.Address} lost its array formula");
+            Assert.AreEqual("C3:E3", cell.FormulaReference.ToStringRelative());
+        }
+    }
+
+    [Test]
+    public void ArrayFormulaSurvivesInsertOnSaveAsSingleFormula()
+    {
+        // End-to-end: after an unrelated insert, the saved sheet must still contain exactly one
+        // array formula element (on the master cell), not one normal formula per cell.
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var dataSheet = wb.AddWorksheet("Data");
+            var arraySheet = wb.AddWorksheet("Calc");
+            arraySheet.Range("A1:A3").FormulaArrayA1 = "TRANSPOSE({10,20,30})";
+
+            dataSheet.Row(1).InsertRowsAbove(3);
+
+            wb.SaveAs(ms, validate: false);
+        }
+
+        var bytes = ms.ToArray();
+        using var zip = new System.IO.Compression.ZipArchive(new MemoryStream(bytes), System.IO.Compression.ZipArchiveMode.Read);
+        var sheetEntry = zip.Entries.First(e => e.FullName.Contains("sheet2.xml", StringComparison.OrdinalIgnoreCase));
+        using var sr = new StreamReader(sheetEntry.Open());
+        var sheetXml = sr.ReadToEnd();
+
+        // Exactly one array-formula element, referencing the whole spill range.
+        var arrayCount = sheetXml.Split("t=\"array\"").Length - 1;
+        Assert.AreEqual(1, arrayCount, "Array formula was split into multiple per-cell formulas");
+        Assert.That(sheetXml, Does.Contain("ref=\"A1:A3\""));
+    }
 }

--- a/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -299,4 +299,42 @@ public class ArrayFormulaTests
         Assert.AreEqual(1, arrayCount, "Array formula was split into multiple per-cell formulas");
         Assert.That(sheetXml, Does.Contain("ref=\"A1:A3\""));
     }
+
+    [Test]
+    public void DynamicArrayFormulaKeepsDynamicFlagWhenShifted()
+    {
+        // A dynamic array is stored as a normal formula with the dynamic-array flag set.
+        // When a shift changes the referenced cells, the formula must stay dynamic so the
+        // saved cell keeps its cm metadata link and Excel does not apply implicit
+        // intersection (=@UNIQUE(...)).
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("S");
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 2;
+            ws.Cell("A3").Value = 2;
+            ws.Cell("C1").SetDynamicFormulaA1("UNIQUE(A1:A3)");
+
+            ws.Row(1).InsertRowsAbove(1); // C1 -> C2, references A1:A3 -> A2:A4
+
+            wb.SaveAs(ms, validate: false);
+        }
+
+        using var zip = new System.IO.Compression.ZipArchive(new MemoryStream(ms.ToArray()), System.IO.Compression.ZipArchiveMode.Read);
+
+        var sheetEntry = zip.Entries.First(e => e.FullName.Contains("sheet1.xml", StringComparison.OrdinalIgnoreCase));
+        using var sheetReader = new StreamReader(sheetEntry.Open());
+        var sheetXml = sheetReader.ReadToEnd();
+
+        // The shifted formula still carries the dynamic-array cell-metadata link.
+        Assert.That(sheetXml, Does.Contain("_xlfn.UNIQUE(A2:A4)"), "Reference shift did not apply");
+        Assert.That(sheetXml, Does.Contain("cm=\"1\""), "Dynamic-array cell metadata (cm) was lost on shift");
+
+        // The dynamic-array metadata part is present.
+        var metadataEntry = zip.Entries.First(e => e.FullName.Contains("metadata", StringComparison.OrdinalIgnoreCase));
+        using var metadataReader = new StreamReader(metadataEntry.Open());
+        var metadataXml = metadataReader.ReadToEnd();
+        Assert.That(metadataXml, Does.Contain("fDynamic=\"1\""), "Dynamic-array metadata missing");
+    }
 }

--- a/XLibur.Tests/Excel/Misc/FormulaTests.cs
+++ b/XLibur.Tests/Excel/Misc/FormulaTests.cs
@@ -203,7 +203,7 @@ public class FormulaTests
         Assert.AreEqual(50, ws3.FirstCell().CellBelow().Value);
     }
 
-    [Test, Ignore("Shifting formulas is done by regexp that breaks array formula.")]
+    [Test]
     public void ShiftFormula()
     {
         using var wb = new XLWorkbook();

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -1072,7 +1072,7 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         {
             var shiftedNormal = XLCellFormulaShifter.ShiftFormulaRows(formula.A1, Worksheet, shiftedRange, rowsShifted);
             if (!string.Equals(shiftedNormal, formula.A1, StringComparison.Ordinal))
-                FormulaA1 = shiftedNormal;
+                SetShiftedNormalFormula(formula, shiftedNormal);
             return;
         }
 
@@ -1108,7 +1108,7 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         {
             var shiftedNormal = XLCellFormulaShifter.ShiftFormulaColumns(formula.A1, Worksheet, shiftedRange, columnsShifted);
             if (!string.Equals(shiftedNormal, formula.A1, StringComparison.Ordinal))
-                FormulaA1 = shiftedNormal;
+                SetShiftedNormalFormula(formula, shiftedNormal);
             return;
         }
 
@@ -1124,6 +1124,21 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
             if (newRange != formula.Range)
                 formula.Range = newRange;
         }
+    }
+
+    /// <summary>
+    /// Reassigns a shifted normal-formula text, preserving the dynamic-array designation.
+    /// A dynamic array is stored as a normal formula with <see cref="XLCellFormula.IsDynamicArray"/>
+    /// set; routing it through the plain <see cref="FormulaA1"/> setter would rebuild it as a
+    /// regular formula and drop that flag, so on save it would lose its <c>cm</c> dynamic-array
+    /// metadata and Excel would apply implicit intersection (e.g. <c>=@UNIQUE(...)</c>).
+    /// </summary>
+    private void SetShiftedNormalFormula(XLCellFormula formula, string shiftedA1)
+    {
+        if (formula.IsDynamicArray)
+            SetDynamicFormulaA1(shiftedA1);
+        else
+            FormulaA1 = shiftedA1;
     }
 
     /// <summary>

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -1062,11 +1062,112 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
     internal void CopyDataValidation(XLCell otherCell, IXLDataValidation otherDv)
         => XLCellCopyHelper.CopyDataValidation(this, otherCell, otherDv);
 
-    internal void ShiftFormulaRows(XLRange shiftedRange, int rowsShifted)
-        => FormulaA1 = XLCellFormulaShifter.ShiftFormulaRows(FormulaA1, Worksheet, shiftedRange, rowsShifted);
+    internal void ShiftFormulaRows(XLRange shiftedRange, int rowsShifted, HashSet<XLCellFormula> processedArrayFormulas)
+    {
+        var formula = Formula;
+        if (formula is null)
+            return;
 
-    internal void ShiftFormulaColumns(XLRange shiftedRange, int columnsShifted)
-        => FormulaA1 = XLCellFormulaShifter.ShiftFormulaColumns(FormulaA1, Worksheet, shiftedRange, columnsShifted);
+        if (formula.Type == FormulaType.Normal)
+        {
+            var shiftedNormal = XLCellFormulaShifter.ShiftFormulaRows(formula.A1, Worksheet, shiftedRange, rowsShifted);
+            if (!string.Equals(shiftedNormal, formula.A1, StringComparison.Ordinal))
+                FormulaA1 = shiftedNormal;
+            return;
+        }
+
+        // Array / data-table formulas share a single XLCellFormula instance across every cell
+        // of their range. Process that instance exactly once — both the reference shift and the
+        // range relocation are position-independent — and never rebuild it as normal per-cell
+        // formulas, which would split a single spilled dynamic array (e.g. =UNIQUE(...)) into N
+        // implicit-intersection =@UNIQUE(...) cells.
+        if (!processedArrayFormulas.Add(formula))
+            return;
+
+        var shifted = XLCellFormulaShifter.ShiftFormulaRows(formula.A1, Worksheet, shiftedRange, rowsShifted);
+        formula.UpdateShiftedA1(shifted);
+
+        // When the array's own cells are relocated by a same-sheet row insert/delete, the
+        // physical cell move shifts the cells but not the formula's stored Range, leaving the
+        // master cell unidentifiable on save. Keep the Range in sync with the moved cells.
+        if (ReferenceEquals(Worksheet, shiftedRange.Worksheet))
+        {
+            var newRange = ShiftArrayRangeRows(formula.Range, shiftedRange, rowsShifted);
+            if (newRange != formula.Range)
+                formula.Range = newRange;
+        }
+    }
+
+    internal void ShiftFormulaColumns(XLRange shiftedRange, int columnsShifted, HashSet<XLCellFormula> processedArrayFormulas)
+    {
+        var formula = Formula;
+        if (formula is null)
+            return;
+
+        if (formula.Type == FormulaType.Normal)
+        {
+            var shiftedNormal = XLCellFormulaShifter.ShiftFormulaColumns(formula.A1, Worksheet, shiftedRange, columnsShifted);
+            if (!string.Equals(shiftedNormal, formula.A1, StringComparison.Ordinal))
+                FormulaA1 = shiftedNormal;
+            return;
+        }
+
+        if (!processedArrayFormulas.Add(formula))
+            return;
+
+        var shifted = XLCellFormulaShifter.ShiftFormulaColumns(formula.A1, Worksheet, shiftedRange, columnsShifted);
+        formula.UpdateShiftedA1(shifted);
+
+        if (ReferenceEquals(Worksheet, shiftedRange.Worksheet))
+        {
+            var newRange = ShiftArrayRangeColumns(formula.Range, shiftedRange, columnsShifted);
+            if (newRange != formula.Range)
+                formula.Range = newRange;
+        }
+    }
+
+    /// <summary>
+    /// Relocates an array/data-table formula range when a same-sheet row insert/delete moves the
+    /// array's cells. The range moves only when it sits entirely within the shifted columns and
+    /// at or below the shifted row (Excel does not allow inserting/deleting through part of an
+    /// array), mirroring the physical cell move.
+    /// </summary>
+    private static XLSheetRange ShiftArrayRangeRows(XLSheetRange arrayRange, XLRange shiftedRange, int rowsShifted)
+    {
+        var addr = shiftedRange.RangeAddress;
+        var firstRow = addr.FirstAddress.RowNumber;
+        var firstColumn = addr.FirstAddress.ColumnNumber;
+        var lastColumn = addr.LastAddress.ColumnNumber;
+
+        if (arrayRange.TopRow < firstRow)
+            return arrayRange;
+        if (arrayRange.LeftColumn < firstColumn || arrayRange.RightColumn > lastColumn)
+            return arrayRange;
+
+        return new XLSheetRange(
+            new XLSheetPoint(arrayRange.FirstPoint.Row + rowsShifted, arrayRange.FirstPoint.Column),
+            new XLSheetPoint(arrayRange.LastPoint.Row + rowsShifted, arrayRange.LastPoint.Column));
+    }
+
+    /// <summary>
+    /// Column-shift counterpart of <see cref="ShiftArrayRangeRows"/>.
+    /// </summary>
+    private static XLSheetRange ShiftArrayRangeColumns(XLSheetRange arrayRange, XLRange shiftedRange, int columnsShifted)
+    {
+        var addr = shiftedRange.RangeAddress;
+        var firstColumn = addr.FirstAddress.ColumnNumber;
+        var firstRow = addr.FirstAddress.RowNumber;
+        var lastRow = addr.LastAddress.RowNumber;
+
+        if (arrayRange.LeftColumn < firstColumn)
+            return arrayRange;
+        if (arrayRange.TopRow < firstRow || arrayRange.BottomRow > lastRow)
+            return arrayRange;
+
+        return new XLSheetRange(
+            new XLSheetPoint(arrayRange.FirstPoint.Row, arrayRange.FirstPoint.Column + columnsShifted),
+            new XLSheetPoint(arrayRange.LastPoint.Row, arrayRange.LastPoint.Column + columnsShifted));
+    }
 
     private XLCell CellShift(int rowsToShift, int columnsToShift)
     {

--- a/XLibur/Excel/Cells/XLCellFormula.cs
+++ b/XLibur/Excel/Cells/XLCellFormula.cs
@@ -370,6 +370,22 @@ internal sealed class XLCellFormula
         return A1;
     }
 
+    /// <summary>
+    /// Replaces the stored A1 formula text in place and marks the formula dirty, keeping
+    /// the formula's <see cref="Type"/>, <see cref="Range"/> and <see cref="IsDynamicArray"/>
+    /// intact. Used when a row/column shift rewrites cell references inside an array or
+    /// data-table formula, which share a single instance across every cell of their range
+    /// and therefore must not be rebuilt as normal per-cell formulas.
+    /// </summary>
+    internal void UpdateShiftedA1(string newA1)
+    {
+        if (string.Equals(newA1, A1, StringComparison.Ordinal))
+            return;
+
+        A1 = newA1;
+        MarkExplicitlyDirty();
+    }
+
     public void RenameSheet(XLSheetPoint origin, string oldSheetName, string newSheetName)
     {
         var a1 = A1;

--- a/XLibur/Excel/Ranges/XLRangeBase.cs
+++ b/XLibur/Excel/Ranges/XLRangeBase.cs
@@ -1066,6 +1066,7 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
             RangeAddress.LastAddress.ColumnNumber);
 
         // Shift formulas first
+        var processedArrayFormulas = new HashSet<XLCellFormula>();
         foreach (var cell in Worksheet
                      .Workbook
                      .Worksheets
@@ -1076,9 +1077,9 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
                          .GetCells(c => c.HasFormula)))
         {
             if (shiftDeleteCells == XLShiftDeletedCells.ShiftCellsUp)
-                cell.ShiftFormulaRows((XLRange)shiftedRangeFormula, numberOfRows * -1);
+                cell.ShiftFormulaRows((XLRange)shiftedRangeFormula, numberOfRows * -1, processedArrayFormulas);
             else
-                cell.ShiftFormulaColumns((XLRange)shiftedRangeFormula, numberOfColumns * -1);
+                cell.ShiftFormulaColumns((XLRange)shiftedRangeFormula, numberOfColumns * -1, processedArrayFormulas);
         }
 
         // Range to shift...

--- a/XLibur/Excel/Ranges/XLRangeInsertHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeInsertHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using XLibur.Excel.Coordinates;
 
 namespace XLibur.Excel;
@@ -50,10 +51,12 @@ internal static class XLRangeInsertHelper
 
     private static void ShiftFormulasForColumns(XLRangeBase range, int numberOfColumns)
     {
+        var asRange = range.AsRange();
+        var processedArrayFormulas = new HashSet<XLCellFormula>();
         foreach (var ws in range.Worksheet.Workbook.WorksheetsInternal)
         {
             foreach (var cell in ws.Internals.CellsCollection.GetCells(c => c.Formula is not null))
-                cell.ShiftFormulaColumns(range.AsRange(), numberOfColumns);
+                cell.ShiftFormulaColumns(asRange, numberOfColumns, processedArrayFormulas);
         }
     }
 
@@ -162,10 +165,11 @@ internal static class XLRangeInsertHelper
     private static void ShiftFormulasForRows(XLRangeBase range, int numberOfRows)
     {
         var asRange = range.AsRange();
+        var processedArrayFormulas = new HashSet<XLCellFormula>();
         foreach (var ws in range.Worksheet.Workbook.WorksheetsInternal)
         {
             foreach (var cell in ws.Internals.CellsCollection.GetCells(c => c.Formula is not null))
-                cell.ShiftFormulaRows(asRange, numberOfRows);
+                cell.ShiftFormulaRows(asRange, numberOfRows, processedArrayFormulas);
         }
     }
 


### PR DESCRIPTION
## Problem

Dynamic-array (spill) formulas such as `=UNIQUE(...)` are silently converted into a collection of implicit-intersection `=@UNIQUE(...)` cells after a workbook is loaded, modified, and saved.

The trigger is **any row/column insert or delete** — even on an unrelated sheet. A spreadsheet with `=UNIQUE(tblCategory[Category])` on one sheet loses its spill the moment rows are inserted into a different data-entry sheet during processing.

## Root cause

`XLRangeInsertHelper` (insert) and `XLRangeBase` (delete) walk **every formula cell in every worksheet** and call `XLCell.ShiftFormulaRows/Columns`, which routed through the `FormulaA1` setter. That setter always builds a fresh **normal** formula (`XLCellFormula.NormalA1`).

Array formulas share a single `XLCellFormula` instance across all the cells of their range, so each cell was rebuilt into its own independent normal formula. On save the single `<f t="array" ref="...">` became N per-cell `<f>` elements — which Excel renders with implicit intersection (`=@UNIQUE`).

## Fix

- `XLCell.ShiftFormulaRows/Columns` now:
  - skip reassignment when the shifted text is unchanged;
  - update array/data-table formulas **in place** (preserving `Type`, `Range`, and `IsDynamicArray`) instead of rebuilding a normal formula per cell;
  - process each shared instance exactly once via a `HashSet<XLCellFormula>` dedup set (avoids re-entrant double-shifting of the shared range);
  - relocate the spill `Range` for same-sheet inserts/deletes so the master cell stays identifiable on save.
- `XLCellFormula.UpdateShiftedA1` — new in-place A1 update that keeps the formula's metadata and marks it dirty.

## Tests

- Re-enables `FormulaTests.ShiftFormula`, previously `[Ignore]`d with *"Shifting formulas is done by regexp that breaks array formula."*
- Adds regression tests in `ArrayFormulaTests`: cross-sheet insert keeps the array intact, same-sheet row/column inserts shift the spill range, and an end-to-end save asserts exactly one `t="array"` element.
- Full suite: **6049 passed, 0 failed**.

## Notes

Verified end-to-end on a real template: after an unrelated row insert, the dynamic array keeps its `cm` cell-metadata link and `XLDAPR`/`fDynamic="1"` `metadata.xml`, so Excel opens it as a proper spilled `=UNIQUE` with no `=@UNIQUE`.

Out of scope (separate, pre-existing gap): the reader never sets `IsDynamicArray` on load — loaded dynamic arrays are treated as legacy CSE arrays and round-trip correctly only via passive preservation of the `cm`/metadata parts. This fix keeps that preservation intact through edits; wiring the reader to detect `XLDAPR` metadata could be a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Array and dynamic-array formulas now remain intact when rows or columns are inserted or deleted elsewhere in the worksheet. Previously, these operations could inadvertently break shared formulas into individual cell formulas.

* **Tests**
  * Added regression tests validating array formula behavior during row and column insertions and after workbook saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->