### PR TITLE
fix: avoid out-of-bounds array range when a shift cuts through an array

### DIFF
--- a/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -337,4 +337,52 @@ public class ArrayFormulaTests
         var metadataXml = metadataReader.ReadToEnd();
         Assert.That(metadataXml, Does.Contain("fDynamic=\"1\""), "Dynamic-array metadata missing");
     }
+
+    [Test]
+    public void DeletingRowsThroughArrayDoesNotCorruptRange()
+    {
+        // Deleting rows that overlap an array used to push the stored range past row 1, producing
+        // an out-of-bounds coordinate (e.g. A0:A2) via the unchecked XLSheetPoint constructor.
+        // Excel forbids editing part of an array; XLibur must at least keep a valid range and a
+        // saveable workbook rather than silently corrupting it.
+        using var ms = new MemoryStream();
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("S");
+        ws.Range("A2:A4").FormulaArrayA1 = "TRANSPOSE({1,2,3})";
+
+        Assert.That(() => ws.Rows(1, 2).Delete(), Throws.Nothing);
+
+        foreach (var cell in ws.CellsUsed(c => c.HasArrayFormula))
+        {
+            var reference = cell.FormulaReference!;
+            Assert.That(reference.FirstAddress.RowNumber, Is.GreaterThanOrEqualTo(1),
+                $"{cell.Address} array range has an out-of-bounds row: {reference.ToStringRelative()}");
+            Assert.That(reference.FirstAddress.ColumnNumber, Is.GreaterThanOrEqualTo(1),
+                $"{cell.Address} array range has an out-of-bounds column: {reference.ToStringRelative()}");
+        }
+
+        Assert.That(() => wb.SaveAs(ms, validate: false), Throws.Nothing);
+    }
+
+    [Test]
+    public void DeletingColumnsThroughArrayDoesNotCorruptRange()
+    {
+        using var ms = new MemoryStream();
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("S");
+        ws.Range("B1:D1").FormulaArrayA1 = "{1,2,3}";
+
+        Assert.That(() => ws.Columns(1, 2).Delete(), Throws.Nothing); // delete A:B, overlaps the array's left edge
+
+        foreach (var cell in ws.CellsUsed(c => c.HasArrayFormula))
+        {
+            var reference = cell.FormulaReference!;
+            Assert.That(reference.FirstAddress.ColumnNumber, Is.GreaterThanOrEqualTo(1),
+                $"{cell.Address} array range has an out-of-bounds column: {reference.ToStringRelative()}");
+            Assert.That(reference.FirstAddress.RowNumber, Is.GreaterThanOrEqualTo(1),
+                $"{cell.Address} array range has an out-of-bounds row: {reference.ToStringRelative()}");
+        }
+
+        Assert.That(() => wb.SaveAs(ms, validate: false), Throws.Nothing);
+    }
 }

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -1143,20 +1143,30 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
 
     /// <summary>
     /// Relocates an array/data-table formula range when a same-sheet row insert/delete moves the
-    /// array's cells. The range moves only when it sits entirely within the shifted columns and
-    /// at or below the shifted row (Excel does not allow inserting/deleting through part of an
-    /// array), mirroring the physical cell move.
+    /// array's cells as a whole, mirroring the physical cell move. The range is relocated only
+    /// when the array sits entirely within the shifted columns AND entirely inside the region the
+    /// shift actually moves; if the operation cuts through the array (Excel does not allow editing
+    /// part of an array) the range is left unchanged rather than producing a torn or out-of-bounds
+    /// range — e.g. deleting rows that overlap the array must not push its top below row 1.
     /// </summary>
     private static XLSheetRange ShiftArrayRangeRows(XLSheetRange arrayRange, XLRange shiftedRange, int rowsShifted)
     {
         var addr = shiftedRange.RangeAddress;
-        var firstRow = addr.FirstAddress.RowNumber;
         var firstColumn = addr.FirstAddress.ColumnNumber;
         var lastColumn = addr.LastAddress.ColumnNumber;
 
-        if (arrayRange.TopRow < firstRow)
-            return arrayRange;
         if (arrayRange.LeftColumn < firstColumn || arrayRange.RightColumn > lastColumn)
+            return arrayRange;
+
+        // Rows at or below this threshold are physically relocated by the shift: the insertion row
+        // for an insert (rowsShifted > 0), or the first row after the deleted band for a delete
+        // (rowsShifted < 0). Requiring the whole array to start at/below it also guarantees the
+        // shifted coordinates stay >= 1 (for a delete, TopRow > lastRow implies TopRow - count >= firstRow).
+        var movedRegionTop = rowsShifted >= 0
+            ? addr.FirstAddress.RowNumber
+            : addr.LastAddress.RowNumber + 1;
+
+        if (arrayRange.TopRow < movedRegionTop)
             return arrayRange;
 
         return new XLSheetRange(
@@ -1170,13 +1180,17 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
     private static XLSheetRange ShiftArrayRangeColumns(XLSheetRange arrayRange, XLRange shiftedRange, int columnsShifted)
     {
         var addr = shiftedRange.RangeAddress;
-        var firstColumn = addr.FirstAddress.ColumnNumber;
         var firstRow = addr.FirstAddress.RowNumber;
         var lastRow = addr.LastAddress.RowNumber;
 
-        if (arrayRange.LeftColumn < firstColumn)
-            return arrayRange;
         if (arrayRange.TopRow < firstRow || arrayRange.BottomRow > lastRow)
+            return arrayRange;
+
+        var movedRegionLeft = columnsShifted >= 0
+            ? addr.FirstAddress.ColumnNumber
+            : addr.LastAddress.ColumnNumber + 1;
+
+        if (arrayRange.LeftColumn < movedRegionLeft)
             return arrayRange;
 
         return new XLSheetRange(


### PR DESCRIPTION
## Problem

Follow-up to #109. The array/dynamic-array shift handling added in #109 relocates an array formula's stored spill range when a row/column insert or delete moves the array's cells. When a **delete overlaps the array** (deleting part of it — which Excel forbids interactively but the XLibur API allows), the relocation subtracts the deleted count from the array's top edge and can drive the coordinate below 1.

`XLSheetPoint`'s constructor does not validate bounds (`(uint)(row - 1)`), so a non-positive coordinate silently overflows, corrupting the stored range.

Reproduction:

```csharp
ws.Range("A2:A4").FormulaArrayA1 = "TRANSPOSE({1,2,3})";
ws.Rows(1, 2).Delete();   // deletes through the array
// before fix: array range becomes A0:A2 — invalid row 0; on save the master
//             cell (A0) doesn't exist, so the <f t="array"> element is dropped.
```

## Fix

`ShiftArrayRangeRows`/`ShiftArrayRangeColumns` now relocate the range only when the array lies **entirely within the region the shift actually moves**:
- inserts (positive shift): the array must start at/after the insertion edge;
- deletes (negative shift): the array must start strictly **after** the deleted band (`lastRow + 1` / `lastColumn + 1`).

This guarantees the shifted coordinates stay `>= 1` and avoids relocating an array the operation cuts through. Cut-through cases leave the range unchanged (valid coordinates, saveable workbook) rather than corrupting it.

## Tests

- `DeletingRowsThroughArrayDoesNotCorruptRange`
- `DeletingColumnsThroughArrayDoesNotCorruptRange`

Both assert the surviving array range stays in-bounds and the workbook still saves. Full suite: **6052 passed, 0 failed**.
