### PR TITLE
chore: bump SkiaSharp to 3.119.4

### DIFF
--- a/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
+++ b/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
@@ -34,8 +34,8 @@
 
     <ItemGroup>
         <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
-        <PackageReference Include="SkiaSharp" Version="3.116.1" />
-        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
+        <PackageReference Include="SkiaSharp" Version="3.119.4" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.4" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@
Bumps the SkiaSharp font engine dependencies from **3.116.1** to **3.119.4** (latest stable):

- `SkiaSharp`
- `SkiaSharp.NativeAssets.Linux.NoDependencies`

## Verification

- Release build clean (warnings-as-errors active).
- `XLibur.Fonts.SkiaSharp.Tests` — **31/31 pass on net8.0 and net10.0**, no metric or behavior change from the bump.
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SkiaSharp library and Linux native assets to version 3.119.4, bringing the latest stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->