### PR TITLE
fix: resolve picture calc analyzer warnings (S1244, S3949)

### DIFF
--- a/XLibur/Excel/Drawings/XLPictures.cs
+++ b/XLibur/Excel/Drawings/XLPictures.cs
@@ -264,7 +264,12 @@ internal sealed class XLPictures : IXLPictures, IEnumerable<XLPicture>
             };
         }
 
+        // members.Count >= 2 is guaranteed above, so the min/max sentinels are always
+        // overwritten in the loop, and minX <= maxX / minY <= maxY by construction (each
+        // member feeds x to minX and x+width to maxX). The subtraction cannot underflow.
+#pragma warning disable S3949 // Calculations should not overflow
         PendingGroups.Add(new XLPendingGroup([.. members], minX, minY, maxX - minX, maxY - minY));
+#pragma warning restore S3949
         return new XLPictureGroupView(_worksheet, groupKey);
     }
 

--- a/XLibur/Excel/IO/PictureWriter.cs
+++ b/XLibur/Excel/IO/PictureWriter.cs
@@ -149,6 +149,12 @@ internal static class PictureWriter
         return Convert.ToInt64(914400L * pixels / resolution);
     }
 
+    // A group scale at or extremely near zero is degenerate: dividing by it would
+    // overflow the EMU long, so callers fall back to the untransformed sheet value.
+    private const double DegenerateScaleEpsilon = 1e-9;
+
+    private static bool IsDegenerateScale(double scale) => Math.Abs(scale) < DegenerateScaleEpsilon;
+
     private static void AddPictureAnchor(WorksheetPart worksheetPart, IXLPicture picture, SaveContext context)
     {
         var pic = (XLPicture)picture;
@@ -520,10 +526,10 @@ internal static class PictureWriter
         var sheetEmuX = ConvertToEnglishMetricUnits(pic.Left, wb.DpiX);
         var sheetEmuY = ConvertToEnglishMetricUnits(pic.Top, wb.DpiY);
 
-        var childCx = group.ScaleX == 0 ? sheetEmuCx : (long)Math.Round(sheetEmuCx / group.ScaleX);
-        var childCy = group.ScaleY == 0 ? sheetEmuCy : (long)Math.Round(sheetEmuCy / group.ScaleY);
-        var childX = group.ScaleX == 0 ? sheetEmuX : (long)Math.Round((sheetEmuX - group.OffsetX) / group.ScaleX);
-        var childY = group.ScaleY == 0 ? sheetEmuY : (long)Math.Round((sheetEmuY - group.OffsetY) / group.ScaleY);
+        var childCx = IsDegenerateScale(group.ScaleX) ? sheetEmuCx : (long)Math.Round(sheetEmuCx / group.ScaleX);
+        var childCy = IsDegenerateScale(group.ScaleY) ? sheetEmuCy : (long)Math.Round(sheetEmuCy / group.ScaleY);
+        var childX = IsDegenerateScale(group.ScaleX) ? sheetEmuX : (long)Math.Round((sheetEmuX - group.OffsetX) / group.ScaleX);
+        var childY = IsDegenerateScale(group.ScaleY) ? sheetEmuY : (long)Math.Round((sheetEmuY - group.OffsetY) / group.ScaleY);
 
         var picElement = new Xdr.Picture(
             new Xdr.NonVisualPictureProperties(
@@ -615,8 +621,8 @@ internal static class PictureWriter
             var sheetEmuCy = ConvertToEnglishMetricUnits(pic.Height, wb.DpiY);
 
             // Convert the sheet-space size back to the group's child coordinate space.
-            var childCx = group.ScaleX == 0 ? sheetEmuCx : (long)Math.Round(sheetEmuCx / group.ScaleX);
-            var childCy = group.ScaleY == 0 ? sheetEmuCy : (long)Math.Round(sheetEmuCy / group.ScaleY);
+            var childCx = IsDegenerateScale(group.ScaleX) ? sheetEmuCx : (long)Math.Round(sheetEmuCx / group.ScaleX);
+            var childCy = IsDegenerateScale(group.ScaleY) ? sheetEmuCy : (long)Math.Round(sheetEmuCy / group.ScaleY);
 
             transform.Extents ??= new Extents();
             transform.Extents.Cx = childCx;
@@ -629,8 +635,8 @@ internal static class PictureWriter
             var sheetEmuY = ConvertToEnglishMetricUnits(pic.Top, wb.DpiY);
 
             // Invert the composed affine (sheet = offset + child·scale) to get the child a:off.
-            var childOffX = group.ScaleX == 0 ? sheetEmuX : (long)Math.Round((sheetEmuX - group.OffsetX) / group.ScaleX);
-            var childOffY = group.ScaleY == 0 ? sheetEmuY : (long)Math.Round((sheetEmuY - group.OffsetY) / group.ScaleY);
+            var childOffX = IsDegenerateScale(group.ScaleX) ? sheetEmuX : (long)Math.Round((sheetEmuX - group.OffsetX) / group.ScaleX);
+            var childOffY = IsDegenerateScale(group.ScaleY) ? sheetEmuY : (long)Math.Round((sheetEmuY - group.OffsetY) / group.ScaleY);
 
             transform.Offset ??= new Offset();
             transform.Offset.X = childOffX;


### PR DESCRIPTION
@
Addresses two static-analysis quality findings in the grouped-picture code.

## `PictureWriter.cs` — exact float equality (S1244, ×8)

The `group.ScaleX == 0` / `group.ScaleY == 0` divide-by-zero guards used exact float equality. Replaced with a small-epsilon helper:

```csharp
private const double DegenerateScaleEpsilon = 1e-9;
private static bool IsDegenerateScale(double scale) => Math.Abs(scale) < DegenerateScaleEpsilon;
```

This clears the analyzer **and** is more correct: a *near*-zero scale would previously still divide and overflow the `long` cast. Behavior is identical for all real scales (incl. the `1.0` identity case) and for an exact `0.0`.

## `XLPictures.cs` — guaranteed-underflow (S3949, false positive)

The `maxX - minX` / `maxY - minY` group bounding-box subtraction is flagged as a guaranteed `long` underflow. It cannot underflow: the `members.Count < 2` guard guarantees the `long.MinValue/MaxValue` sentinels are overwritten, and `minX <= maxX` by construction (each member feeds `x` to `minX` and `x+width` to `maxX`). Suppressed with `#pragma warning disable S3949` + justification, matching the existing `S1244` suppression style in `GlyphBox.cs`.

## Verification

- Core builds clean in Release (0 warnings, warnings-as-errors active).
- 99/99 picture/group tests pass.
@