### PR TITLE
fix: match font engine parameter names to interface (S927)

### DIFF
--- a/XLibur.Fonts.SixLabors.V1/DefaultFontEngine.cs
+++ b/XLibur.Fonts.SixLabors.V1/DefaultFontEngine.cs
@@ -140,11 +140,11 @@ public class DefaultFontEngine : IXLFontEngine
         return PointsToPixels(-metrics.VerticalMetrics.Descender * font.FontSize / metrics.UnitsPerEm, dpiY);
     }
 
-    public double GetMaxDigitWidth(IXLFontBase fontBase, double dpiX)
+    public double GetMaxDigitWidth(IXLFontBase font, double dpiX)
     {
-        var metricId = new MetricId(fontBase);
+        var metricId = new MetricId(font);
         var maxDigitWidth = _maxDigitWidths.GetOrAdd(metricId, _calculateMaxDigitWidth);
-        return PointsToPixels(maxDigitWidth * fontBase.FontSize, dpiX);
+        return PointsToPixels(maxDigitWidth * font.FontSize, dpiX);
     }
 
     public double GetTextHeight(IXLFontBase font, double dpiY)
@@ -155,15 +155,15 @@ public class DefaultFontEngine : IXLFontEngine
             metrics.UnitsPerEm, dpiY);
     }
 
-    public double GetTextWidth(string text, IXLFontBase fontBase, double dpiX)
+    public double GetTextWidth(string text, IXLFontBase font, double dpiX)
     {
-        var fontInstance = GetFont(fontBase);
+        var fontInstance = GetFont(font);
         var dimensionsPx = TextMeasurer.MeasureAdvance(text, new TextOptions(fontInstance)
         {
             Dpi = 72, // Normalize DPI, so 1px is 1pt
             KerningMode = KerningMode.None
         });
-        return PointsToPixels(dimensionsPx.Width / FontMetricSize * fontBase.FontSize, dpiX);
+        return PointsToPixels(dimensionsPx.Width / FontMetricSize * font.FontSize, dpiX);
     }
 
     /// <inheritdoc />

--- a/XLibur.Fonts.SixLabors/SixLaborsFontEngine.cs
+++ b/XLibur.Fonts.SixLabors/SixLaborsFontEngine.cs
@@ -126,11 +126,11 @@ public class SixLaborsFontEngine : IXLFontEngine
         return PointsToPixels(-metrics.VerticalMetrics.Descender * font.FontSize / metrics.UnitsPerEm, dpiY);
     }
 
-    public double GetMaxDigitWidth(IXLFontBase fontBase, double dpiX)
+    public double GetMaxDigitWidth(IXLFontBase font, double dpiX)
     {
-        var metricId = new MetricId(fontBase);
+        var metricId = new MetricId(font);
         var maxDigitWidth = _maxDigitWidths.GetOrAdd(metricId, _calculateMaxDigitWidth);
-        return PointsToPixels(maxDigitWidth * fontBase.FontSize, dpiX);
+        return PointsToPixels(maxDigitWidth * font.FontSize, dpiX);
     }
 
     public double GetTextHeight(IXLFontBase font, double dpiY)
@@ -141,15 +141,15 @@ public class SixLaborsFontEngine : IXLFontEngine
             metrics.UnitsPerEm, dpiY);
     }
 
-    public double GetTextWidth(string text, IXLFontBase fontBase, double dpiX)
+    public double GetTextWidth(string text, IXLFontBase font, double dpiX)
     {
-        var fontInstance = GetFont(fontBase);
+        var fontInstance = GetFont(font);
         var dimensionsPx = TextMeasurer.MeasureAdvance(text, new TextOptions(fontInstance)
         {
             Dpi = 72, // Normalize DPI, so 1px is 1pt
             KerningMode = KerningMode.None
         });
-        return PointsToPixels(dimensionsPx.Width / FontMetricSize * fontBase.FontSize, dpiX);
+        return PointsToPixels(dimensionsPx.Width / FontMetricSize * font.FontSize, dpiX);
     }
 
     /// <inheritdoc />

--- a/XLibur.Fonts.SkiaSharp/SkiaSharpFontEngine.cs
+++ b/XLibur.Fonts.SkiaSharp/SkiaSharpFontEngine.cs
@@ -128,11 +128,11 @@ public class SkiaSharpFontEngine : IXLFontEngine
         return PointsToPixels(entry.DescentFu * font.FontSize / entry.UnitsPerEm, dpiY);
     }
 
-    public double GetMaxDigitWidth(IXLFontBase fontBase, double dpiX)
+    public double GetMaxDigitWidth(IXLFontBase font, double dpiX)
     {
-        var metricId = new MetricId(fontBase);
+        var metricId = new MetricId(font);
         var maxDigitWidth = _maxDigitWidths.GetOrAdd(metricId, _calculateMaxDigitWidth);
-        return PointsToPixels(maxDigitWidth * fontBase.FontSize, dpiX);
+        return PointsToPixels(maxDigitWidth * font.FontSize, dpiX);
     }
 
     public double GetTextHeight(IXLFontBase font, double dpiY)
@@ -142,12 +142,12 @@ public class SkiaSharpFontEngine : IXLFontEngine
             (entry.AscentFu + 2 * entry.DescentFu) * font.FontSize / entry.UnitsPerEm, dpiY);
     }
 
-    public double GetTextWidth(string text, IXLFontBase fontBase, double dpiX)
+    public double GetTextWidth(string text, IXLFontBase font, double dpiX)
     {
-        var entry = GetFont(fontBase);
-        using var font = new SKFont(entry.Typeface, FontMetricSize);
-        var advance = font.MeasureText(text);
-        return PointsToPixels(advance / FontMetricSize * fontBase.FontSize, dpiX);
+        var entry = GetFont(font);
+        using var skFont = new SKFont(entry.Typeface, FontMetricSize);
+        var advance = skFont.MeasureText(text);
+        return PointsToPixels(advance / FontMetricSize * font.FontSize, dpiX);
     }
 
     /// <inheritdoc />

--- a/XLibur/Graphics/DefaultGraphicEngine.cs
+++ b/XLibur/Graphics/DefaultGraphicEngine.cs
@@ -63,14 +63,14 @@ public class DefaultGraphicEngine : IXLGraphicEngine, IXLFontEngine
     double IXLGraphicEngine.GetMaxDigitWidth(IXLFontBase font, double dpiX)
         => GetMaxDigitWidth(font, dpiX);
 
-    public double GetMaxDigitWidth(IXLFontBase fontBase, double dpiX) => _fontEngine.GetMaxDigitWidth(fontBase, dpiX);
+    public double GetMaxDigitWidth(IXLFontBase font, double dpiX) => _fontEngine.GetMaxDigitWidth(font, dpiX);
 
     public double GetTextHeight(IXLFontBase font, double dpiY) => _fontEngine.GetTextHeight(font, dpiY);
 
     double IXLGraphicEngine.GetTextWidth(string text, IXLFontBase font, double dpiX)
         => GetTextWidth(text, font, dpiX);
 
-    public double GetTextWidth(string text, IXLFontBase fontBase, double dpiX) => _fontEngine.GetTextWidth(text, fontBase, dpiX);
+    public double GetTextWidth(string text, IXLFontBase font, double dpiX) => _fontEngine.GetTextWidth(text, font, dpiX);
 
     /// <inheritdoc />
     public GlyphBox GetGlyphBox(ReadOnlySpan<int> graphemeCluster, IXLFontBase font, Dpi dpi)

--- a/XLibur/PublicAPI.Shipped.txt
+++ b/XLibur/PublicAPI.Shipped.txt
@@ -3548,10 +3548,10 @@ XLibur.Graphics.DefaultGraphicEngine
 XLibur.Graphics.DefaultGraphicEngine.DefaultGraphicEngine(string! fallbackFont) -> void
 XLibur.Graphics.DefaultGraphicEngine.GetDescent(XLibur.Excel.IXLFontBase! font, double dpiY) -> double
 XLibur.Graphics.DefaultGraphicEngine.GetGlyphBox(System.ReadOnlySpan<int> graphemeCluster, XLibur.Excel.IXLFontBase! font, XLibur.Graphics.Dpi dpi) -> XLibur.Graphics.GlyphBox
-XLibur.Graphics.DefaultGraphicEngine.GetMaxDigitWidth(XLibur.Excel.IXLFontBase! fontBase, double dpiX) -> double
+XLibur.Graphics.DefaultGraphicEngine.GetMaxDigitWidth(XLibur.Excel.IXLFontBase! font, double dpiX) -> double
 XLibur.Graphics.DefaultGraphicEngine.GetPictureInfo(System.IO.Stream! stream, XLibur.Excel.Drawings.XLPictureFormat expectedFormat) -> XLibur.Graphics.XLPictureInfo
 XLibur.Graphics.DefaultGraphicEngine.GetTextHeight(XLibur.Excel.IXLFontBase! font, double dpiY) -> double
-XLibur.Graphics.DefaultGraphicEngine.GetTextWidth(string! text, XLibur.Excel.IXLFontBase! fontBase, double dpiX) -> double
+XLibur.Graphics.DefaultGraphicEngine.GetTextWidth(string! text, XLibur.Excel.IXLFontBase! font, double dpiX) -> double
 XLibur.Graphics.Dpi
 XLibur.Graphics.Dpi.Dpi() -> void
 XLibur.Graphics.Dpi.Dpi(double dpiX, double dpiY) -> void


### PR DESCRIPTION
@
Resolves 8 SonarCloud **S927** issues (MAINTAINABILITY=HIGH): implementation/override parameters named `fontBase` did not match the `IXLFontEngine` declaration, which uses `font`.

Pure parameter rename (name + in-body usages) — no type/order/behavior change.

| File | Methods |
|---|---|
| `XLibur.Fonts.SixLabors.V1/DefaultFontEngine.cs` | `GetMaxDigitWidth`, `GetTextWidth` |
| `XLibur.Fonts.SixLabors/SixLaborsFontEngine.cs` | `GetMaxDigitWidth`, `GetTextWidth` |
| `XLibur.Fonts.SkiaSharp/SkiaSharpFontEngine.cs` | `GetMaxDigitWidth`, `GetTextWidth` |
| `XLibur/Graphics/DefaultGraphicEngine.cs` | `GetMaxDigitWidth`, `GetTextWidth` |

## Notes

- **SkiaSharp `GetTextWidth`** had a local `SKFont` named `font`; renamed it to `skFont` to avoid shadowing the renamed parameter.
- **`PublicAPI.Shipped.txt`** updated for the two public `DefaultGraphicEngine` signatures — the public API analyzer (RS0017) tracks parameter names.
- Private helpers (`GetFont`, `GetMetrics`, the `MetricId` ctor, `GetFontStyle`) keep `fontBase` — they are not interface methods, so S927 does not apply.

## Verification

- Full solution builds clean in Release (0 warnings, warnings-as-errors active).
- Tests pass: SkiaSharp 31/31, SixLabors 31/31, core font tests 19/19.
@