### PR TITLE
refactor: reduce cognitive complexity of 11 methods (S3776)

### DIFF
--- a/XLibur/Excel/CalcEngine/Reference.cs
+++ b/XLibur/Excel/CalcEngine/Reference.cs
@@ -193,18 +193,8 @@ namespace XLibur.Excel.CalcEngine
             // The two references must share a single worksheet (default = context). Walk both
             // sides with a direct loop instead of Concat/Distinct/ToList.
             XLWorksheet? sheet = null;
-            foreach (var area in lhs)
-            {
-                var ws = area.Worksheet ?? ctx.Worksheet;
-                if (sheet is null) sheet = ws;
-                else if (sheet != ws) return XLError.IncompatibleValue;
-            }
-            foreach (var area in rhs)
-            {
-                var ws = area.Worksheet ?? ctx.Worksheet;
-                if (sheet is null) sheet = ws;
-                else if (sheet != ws) return XLError.IncompatibleValue;
-            }
+            if (!TryResolveSharedSheet(lhs, ctx, ref sheet) || !TryResolveSharedSheet(rhs, ctx, ref sheet))
+                return XLError.IncompatibleValue;
 
             // Sheet is non-null here because both references have at least one area and
             // ctx.Worksheet throws MissingContextException rather than returning null —
@@ -226,6 +216,23 @@ namespace XLibur.Excel.CalcEngine
             }
 
             return intersections is { Count: > 0 } ? new Reference(intersections) : XLError.NullValue;
+        }
+
+        /// <summary>
+        /// Resolve the single worksheet shared by all areas of <paramref name="reference"/> (areas
+        /// without an explicit worksheet default to the context worksheet), folding the result into
+        /// <paramref name="sheet"/>. Returns <c>false</c> if an area belongs to a different worksheet.
+        /// </summary>
+        private static bool TryResolveSharedSheet(Reference reference, CalcContext ctx, ref XLWorksheet? sheet)
+        {
+            foreach (var area in reference)
+            {
+                var ws = area.Worksheet ?? ctx.Worksheet;
+                if (sheet is null) sheet = ws;
+                else if (sheet != ws) return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/XLibur/Excel/Drawings/XLPictures.cs
+++ b/XLibur/Excel/Drawings/XLPictures.cs
@@ -208,6 +208,26 @@ internal sealed class XLPictures : IXLPictures, IEnumerable<XLPicture>
     {
         ArgumentNullException.ThrowIfNull(pictures);
 
+        var members = CollectDistinctMembers(pictures);
+        if (members.Count < 2)
+            throw new ArgumentException("A group needs at least two distinct pictures.", nameof(pictures));
+
+        var (minX, minY, maxX, maxY) = ValidateMembersAndComputeBounds(members);
+
+        var groupKey = AllocateGroupKey();
+        AssignIdentityGroupInfo(members, groupKey);
+
+        // members.Count >= 2 is guaranteed above, so the min/max sentinels are always
+        // overwritten in the loop, and minX <= maxX / minY <= maxY by construction (each
+        // member feeds x to minX and x+width to maxX). The subtraction cannot underflow.
+#pragma warning disable S3949 // Calculations should not overflow
+        PendingGroups.Add(new XLPendingGroup([.. members], minX, minY, maxX - minX, maxY - minY));
+#pragma warning restore S3949
+        return new XLPictureGroupView(_worksheet, groupKey);
+    }
+
+    private static List<XLPicture> CollectDistinctMembers(IXLPicture[] pictures)
+    {
         var members = new List<XLPicture>(pictures.Length);
         foreach (var picture in pictures)
         {
@@ -219,18 +239,20 @@ internal sealed class XLPictures : IXLPictures, IEnumerable<XLPicture>
                 members.Add(member);
         }
 
-        if (members.Count < 2)
-            throw new ArgumentException("A group needs at least two distinct pictures.", nameof(pictures));
+        return members;
+    }
 
+    private (long MinX, long MinY, long MaxX, long MaxY) ValidateMembersAndComputeBounds(List<XLPicture> members)
+    {
         var wb = _worksheet.Workbook;
         long minX = long.MaxValue, minY = long.MaxValue, maxX = long.MinValue, maxY = long.MinValue;
 
         foreach (var member in members)
         {
             if (!ReferenceEquals(member.Worksheet, _worksheet))
-                throw new ArgumentException("All pictures must belong to this worksheet.", nameof(pictures));
+                throw new ArgumentException("All pictures must belong to this worksheet.", "pictures");
             if (member.IsInGroup)
-                throw new ArgumentException($"Picture '{member.Name}' is already in a group.", nameof(pictures));
+                throw new ArgumentException($"Picture '{member.Name}' is already in a group.", "pictures");
             if (member.Placement != XLPicturePlacement.FreeFloating)
                 throw new NotSupportedException(
                     $"Only free-floating pictures can be grouped; '{member.Name}' is '{member.Placement}'. Call MoveTo(left, top) first.");
@@ -245,7 +267,11 @@ internal sealed class XLPictures : IXLPictures, IEnumerable<XLPicture>
             maxY = Math.Max(maxY, y + ToEmu(member.Height, wb.DpiY));
         }
 
-        var groupKey = AllocateGroupKey();
+        return (minX, minY, maxX, maxY);
+    }
+
+    private static void AssignIdentityGroupInfo(List<XLPicture> members, long groupKey)
+    {
         foreach (var member in members)
         {
             // Identity child space (chOff/chExt == off/ext), so a child's coordinates equal its
@@ -263,14 +289,6 @@ internal sealed class XLPictures : IXLPictures, IEnumerable<XLPicture>
                 LoadedTopPx = member.Top,
             };
         }
-
-        // members.Count >= 2 is guaranteed above, so the min/max sentinels are always
-        // overwritten in the loop, and minX <= maxX / minY <= maxY by construction (each
-        // member feeds x to minX and x+width to maxX). The subtraction cannot underflow.
-#pragma warning disable S3949 // Calculations should not overflow
-        PendingGroups.Add(new XLPendingGroup([.. members], minX, minY, maxX - minX, maxY - minY));
-#pragma warning restore S3949
-        return new XLPictureGroupView(_worksheet, groupKey);
     }
 
     private static long ToEmu(int pixels, double dpi) => Convert.ToInt64(914400L * pixels / dpi);

--- a/XLibur/Excel/IO/ChartReader.cs
+++ b/XLibur/Excel/IO/ChartReader.cs
@@ -532,22 +532,18 @@ internal static class ChartReader
 
     private static void ReadPositions(Xdr.TwoCellAnchor anchor, XLChart xlChart)
     {
-        var from = anchor.FromMarker;
-        if (from != null)
-        {
-            if (int.TryParse(from.ColumnId?.Text, out var col)) xlChart.Position.Column = col;
-            if (int.TryParse(from.RowId?.Text, out var row)) xlChart.Position.Row = row;
-            if (long.TryParse(from.ColumnOffset?.Text, out var colOff)) xlChart.Position.ColumnOffset = colOff / 9525.0;
-            if (long.TryParse(from.RowOffset?.Text, out var rowOff)) xlChart.Position.RowOffset = rowOff / 9525.0;
-        }
+        ReadMarker(anchor.FromMarker, xlChart.Position);
+        ReadMarker(anchor.ToMarker, xlChart.SecondPosition);
+    }
 
-        var to = anchor.ToMarker;
-        if (to != null)
-        {
-            if (int.TryParse(to.ColumnId?.Text, out var col)) xlChart.SecondPosition.Column = col;
-            if (int.TryParse(to.RowId?.Text, out var row)) xlChart.SecondPosition.Row = row;
-            if (long.TryParse(to.ColumnOffset?.Text, out var colOff)) xlChart.SecondPosition.ColumnOffset = colOff / 9525.0;
-            if (long.TryParse(to.RowOffset?.Text, out var rowOff)) xlChart.SecondPosition.RowOffset = rowOff / 9525.0;
-        }
+    private static void ReadMarker(Xdr.MarkerType? marker, IXLDrawingPosition position)
+    {
+        if (marker == null)
+            return;
+
+        if (int.TryParse(marker.ColumnId?.Text, out var col)) position.Column = col;
+        if (int.TryParse(marker.RowId?.Text, out var row)) position.Row = row;
+        if (long.TryParse(marker.ColumnOffset?.Text, out var colOff)) position.ColumnOffset = colOff / 9525.0;
+        if (long.TryParse(marker.RowOffset?.Text, out var rowOff)) position.RowOffset = rowOff / 9525.0;
     }
 }

--- a/XLibur/Excel/IO/PictureWriter.cs
+++ b/XLibur/Excel/IO/PictureWriter.cs
@@ -25,44 +25,79 @@ internal static class PictureWriter
         SaveContext context)
     {
         if (worksheetPart.DrawingsPart != null)
+            ProcessDeletedPicturesAndGroups(worksheetPart.DrawingsPart, (XLPictures)xlWorksheet.Pictures);
+
+        var groupedPictureCount = WritePictureAnchors(worksheetPart, xlWorksheet, context);
+
+        // Rebasing renumbers every NonVisualDrawingProperties id. That would break connector
+        // start/end connection references (a:stCxn/@id, a:endCxn/@id) inside a group, so only do
+        // it for the historical picture-only case where the drawing contains no group shapes.
+        if (xlWorksheet.Pictures.Count > 0 && groupedPictureCount == 0 &&
+            !(worksheetPart.DrawingsPart?.WorksheetDrawing?.Descendants<Xdr.GroupShape>().Any() ?? false))
+            RebaseNonVisualDrawingPropertiesIds(worksheetPart);
+
+        var tableParts = worksheet.Elements<TableParts>().First();
+        if (xlWorksheet.Pictures.Count > 0 && !worksheet.OfType<Drawing>().Any())
         {
-            var xlPictures = (XLPictures)xlWorksheet.Pictures;
-            foreach (var removedPicture in xlPictures.Deleted)
-            {
-                var anchor = GetAnchorFromImageId(worksheetPart.DrawingsPart, removedPicture);
-
-                // Deleting a picture that lives in a group would otherwise dismantle the whole
-                // group (and its sibling shapes). Removing a single picture from a group is not
-                // supported yet, so leave the group — and its image part — intact.
-                if (anchor is not null && anchor.Descendants<Xdr.GroupShape>().Any())
-                    continue;
-
-                if (anchor is not null)
-                    worksheetPart.DrawingsPart.WorksheetDrawing!.RemoveChild(anchor);
-
-                worksheetPart.DrawingsPart.DeletePart(removedPicture);
-            }
-
-            xlPictures.Deleted.Clear();
-
-            // Pictures deleted from inside a group are removed in place so the group and its other
-            // shapes survive. Guard on Count so we don't materialize (and thus re-serialize) the
-            // drawing DOM for sheets that have nothing to remove.
-            if (xlPictures.DeletedFromGroups.Count > 0)
-            {
-                RemoveGroupedPictures(worksheetPart.DrawingsPart, xlPictures.DeletedFromGroups);
-                xlPictures.DeletedFromGroups.Clear();
-            }
-
-            // Newly requested groups must be built before the picture loop, which then sees their
-            // members as ordinary grouped pictures.
-            if (xlPictures.PendingGroups.Count > 0)
-            {
-                CreateGroups(worksheetPart.DrawingsPart, xlPictures.PendingGroups);
-                xlPictures.PendingGroups.Clear();
-            }
+            var worksheetDrawing = new Drawing { Id = worksheetPart.GetIdOfPart(worksheetPart.DrawingsPart!) };
+            worksheetDrawing.AddNamespaceDeclaration("r",
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+            worksheet.InsertBefore(worksheetDrawing, tableParts);
+            cm.SetElement(XLWorksheetContents.Drawing, worksheet.Elements<Drawing>().First());
         }
 
+        RemoveEmptyDrawingPart(worksheet, cm, xlWorksheet, worksheetPart);
+    }
+
+    /// <summary>
+    /// Apply pending deletions and group requests to the drawing before the picture-writing pass:
+    /// remove deleted (non-grouped) pictures, remove pictures deleted from inside groups in place,
+    /// and build any newly requested groups so their members appear as ordinary grouped pictures.
+    /// </summary>
+    private static void ProcessDeletedPicturesAndGroups(DrawingsPart drawingsPart, XLPictures xlPictures)
+    {
+        foreach (var removedPicture in xlPictures.Deleted)
+        {
+            var anchor = GetAnchorFromImageId(drawingsPart, removedPicture);
+
+            // Deleting a picture that lives in a group would otherwise dismantle the whole
+            // group (and its sibling shapes). Removing a single picture from a group is not
+            // supported yet, so leave the group — and its image part — intact.
+            if (anchor is not null && anchor.Descendants<Xdr.GroupShape>().Any())
+                continue;
+
+            if (anchor is not null)
+                drawingsPart.WorksheetDrawing!.RemoveChild(anchor);
+
+            drawingsPart.DeletePart(removedPicture);
+        }
+
+        xlPictures.Deleted.Clear();
+
+        // Pictures deleted from inside a group are removed in place so the group and its other
+        // shapes survive. Guard on Count so we don't materialize (and thus re-serialize) the
+        // drawing DOM for sheets that have nothing to remove.
+        if (xlPictures.DeletedFromGroups.Count > 0)
+        {
+            RemoveGroupedPictures(drawingsPart, xlPictures.DeletedFromGroups);
+            xlPictures.DeletedFromGroups.Clear();
+        }
+
+        // Newly requested groups must be built before the picture loop, which then sees their
+        // members as ordinary grouped pictures.
+        if (xlPictures.PendingGroups.Count > 0)
+        {
+            CreateGroups(drawingsPart, xlPictures.PendingGroups);
+            xlPictures.PendingGroups.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Write every picture's anchor: free-floating pictures get a fresh anchor, grouped pictures are
+    /// inserted into or updated within their group. Returns the number of grouped pictures handled.
+    /// </summary>
+    private static int WritePictureAnchors(WorksheetPart worksheetPart, XLWorksheet xlWorksheet, SaveContext context)
+    {
         var groupedPictures = new List<XLPicture>();
         foreach (var pic in xlWorksheet.Pictures)
         {
@@ -81,24 +116,17 @@ internal static class PictureWriter
                 UpdateGroupedPicture(worksheetPart, groupedPicture);
         }
 
-        // Rebasing renumbers every NonVisualDrawingProperties id. That would break connector
-        // start/end connection references (a:stCxn/@id, a:endCxn/@id) inside a group, so only do
-        // it for the historical picture-only case where the drawing contains no group shapes.
-        if (xlWorksheet.Pictures.Count > 0 && groupedPictures.Count == 0 &&
-            !(worksheetPart.DrawingsPart?.WorksheetDrawing?.Descendants<Xdr.GroupShape>().Any() ?? false))
-            RebaseNonVisualDrawingPropertiesIds(worksheetPart);
+        return groupedPictures.Count;
+    }
 
-        var tableParts = worksheet.Elements<TableParts>().First();
-        if (xlWorksheet.Pictures.Count > 0 && !worksheet.OfType<Drawing>().Any())
-        {
-            var worksheetDrawing = new Drawing { Id = worksheetPart.GetIdOfPart(worksheetPart.DrawingsPart!) };
-            worksheetDrawing.AddNamespaceDeclaration("r",
-                "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
-            worksheet.InsertBefore(worksheetDrawing, tableParts);
-            cm.SetElement(XLWorksheetContents.Drawing, worksheet.Elements<Drawing>().First());
-        }
-
-        // Instead of saving a file with an empty Drawings.xml file, rather remove the .xml file
+    /// <summary>
+    /// Remove the sheet's DrawingsPart (and its workbook reference) when it would otherwise be saved
+    /// empty — no pictures, charts, legacy shapes, or other drawing children. Avoids writing an empty
+    /// Drawings.xml part.
+    /// </summary>
+    private static void RemoveEmptyDrawingPart(Worksheet worksheet, XLWorksheetContentManager cm,
+        XLWorksheet xlWorksheet, WorksheetPart worksheetPart)
+    {
         var hasCharts = worksheetPart.DrawingsPart is not null && worksheetPart.DrawingsPart.Parts.Any();
         var hasNewCharts = xlWorksheet.Charts.Any(c => ((XLChart)c).IsNew);
         if (worksheetPart.DrawingsPart is not null && // There is a drawing part for the sheet that could be deleted
@@ -155,6 +183,18 @@ internal static class PictureWriter
 
     private static bool IsDegenerateScale(double scale) => Math.Abs(scale) < DegenerateScaleEpsilon;
 
+    private static void EnsureDrawingNamespaces(Xdr.WorksheetDrawing worksheetDrawing)
+    {
+        if (!worksheetDrawing.NamespaceDeclarations.Any(nd =>
+                nd.Value.Equals("http://schemas.openxmlformats.org/drawingml/2006/main")))
+            worksheetDrawing.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");
+
+        if (!worksheetDrawing.NamespaceDeclarations.Any(nd =>
+                nd.Value.Equals("http://schemas.openxmlformats.org/officeDocument/2006/relationships")))
+            worksheetDrawing.AddNamespaceDeclaration("r",
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+    }
+
     private static void AddPictureAnchor(WorksheetPart worksheetPart, IXLPicture picture, SaveContext context)
     {
         var pic = (XLPicture)picture;
@@ -165,15 +205,7 @@ internal static class PictureWriter
 
         var worksheetDrawing = drawingsPart.WorksheetDrawing;
 
-        // Add namespaces
-        if (!worksheetDrawing.NamespaceDeclarations.Any(nd =>
-                nd.Value.Equals("http://schemas.openxmlformats.org/drawingml/2006/main")))
-            worksheetDrawing.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");
-
-        if (!worksheetDrawing.NamespaceDeclarations.Any(nd =>
-                nd.Value.Equals("http://schemas.openxmlformats.org/officeDocument/2006/relationships")))
-            worksheetDrawing.AddNamespaceDeclaration("r",
-                "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+        EnsureDrawingNamespaces(worksheetDrawing);
 
         // Overwrite actual image binary data
         ImagePart imagePart;
@@ -397,10 +429,7 @@ internal static class PictureWriter
 
         foreach (var pending in pendingGroups)
         {
-            uint maxId = 0;
-            foreach (var nvdpr in worksheetDrawing.Descendants<Xdr.NonVisualDrawingProperties>())
-                maxId = Math.Max(maxId, nvdpr.Id?.Value ?? 0);
-            var groupId = maxId + 1;
+            var groupId = ComputeMaxDrawingId(worksheetDrawing) + 1;
 
             var groupShape = new Xdr.GroupShape(
                 new Xdr.NonVisualGroupShapeProperties(
@@ -417,59 +446,12 @@ internal static class PictureWriter
                 )
             );
 
-            foreach (var member in pending.Members)
-            {
-                var anchor = string.IsNullOrEmpty(member.RelId)
-                    ? null
-                    : GetAnchorFromImageId(drawingsPart, member.RelId!);
-                var picElement = anchor?.Descendants<Xdr.Picture>().FirstOrDefault();
-                if (anchor is null || picElement is null)
-                    continue;
-
-                var wb = member.Worksheet.Workbook;
-                var transform = picElement.ShapeProperties?.Transform2D;
-                if (transform is not null)
-                {
-                    // Identity child space: child coordinates are the member's absolute sheet EMU.
-                    transform.Offset ??= new Offset();
-                    transform.Offset.X = ConvertToEnglishMetricUnits(member.Left, wb.DpiX);
-                    transform.Offset.Y = ConvertToEnglishMetricUnits(member.Top, wb.DpiY);
-                    transform.Extents ??= new Extents();
-                    transform.Extents.Cx = ConvertToEnglishMetricUnits(member.Width, wb.DpiX);
-                    transform.Extents.Cy = ConvertToEnglishMetricUnits(member.Height, wb.DpiY);
-                }
-
-                picElement.Remove();
-                groupShape.Append(picElement);
-                anchor.Remove();
-
-                member.GroupInfo = new XLPictureGroup
-                {
-                    ScaleX = 1.0,
-                    ScaleY = 1.0,
-                    OffsetX = 0.0,
-                    OffsetY = 0.0,
-                    GroupId = groupId,
-                    GroupKey = member.GroupInfo?.GroupKey ?? 0,
-                    LoadedWidthPx = member.Width,
-                    LoadedHeightPx = member.Height,
-                    LoadedLeftPx = member.Left,
-                    LoadedTopPx = member.Top,
-                };
-            }
+            MoveMembersIntoGroup(drawingsPart, pending, groupShape, groupId);
 
             // Propagate the new group id to every member sharing this group's key — including
             // pictures added to the group before its first save, which carry a null group id and
             // would otherwise be skipped during insertion.
-            var groupKey = pending.Members.Count > 0 ? pending.Members[0].GroupInfo?.GroupKey : null;
-            if (groupKey is not null)
-            {
-                foreach (var pic in (IEnumerable<XLPicture>)(XLPictures)pending.Members[0].Worksheet.Pictures)
-                {
-                    if (pic.GroupInfo is { } info && info.GroupKey == groupKey && info.GroupId != groupId)
-                        pic.GroupInfo = info with { GroupId = groupId };
-                }
-            }
+            PropagateGroupIdToMembers(pending, groupId);
 
             var absoluteAnchor = new Xdr.AbsoluteAnchor(
                 new Xdr.Position { X = pending.OffsetX, Y = pending.OffsetY },
@@ -478,6 +460,82 @@ internal static class PictureWriter
                 new Xdr.ClientData()
             );
             worksheetDrawing.Append(absoluteAnchor);
+        }
+    }
+
+    /// <summary>The highest <c>NonVisualDrawingProperties</c> id currently present in the drawing (0 if none).</summary>
+    private static uint ComputeMaxDrawingId(Xdr.WorksheetDrawing worksheetDrawing)
+    {
+        uint maxId = 0;
+        foreach (var nvdpr in worksheetDrawing.Descendants<Xdr.NonVisualDrawingProperties>())
+            maxId = Math.Max(maxId, nvdpr.Id?.Value ?? 0);
+        return maxId;
+    }
+
+    /// <summary>
+    /// Move each member's existing top-level <c>xdr:pic</c> into <paramref name="groupShape"/>, setting its
+    /// child <c>off</c>/<c>ext</c> to the member's absolute sheet geometry (identity child space) and removing
+    /// the now-empty top-level anchor.
+    /// </summary>
+    private static void MoveMembersIntoGroup(DrawingsPart drawingsPart, XLPendingGroup pending,
+        Xdr.GroupShape groupShape, uint groupId)
+    {
+        foreach (var member in pending.Members)
+        {
+            var anchor = string.IsNullOrEmpty(member.RelId)
+                ? null
+                : GetAnchorFromImageId(drawingsPart, member.RelId!);
+            var picElement = anchor?.Descendants<Xdr.Picture>().FirstOrDefault();
+            if (anchor is null || picElement is null)
+                continue;
+
+            var wb = member.Worksheet.Workbook;
+            var transform = picElement.ShapeProperties?.Transform2D;
+            if (transform is not null)
+            {
+                // Identity child space: child coordinates are the member's absolute sheet EMU.
+                transform.Offset ??= new Offset();
+                transform.Offset.X = ConvertToEnglishMetricUnits(member.Left, wb.DpiX);
+                transform.Offset.Y = ConvertToEnglishMetricUnits(member.Top, wb.DpiY);
+                transform.Extents ??= new Extents();
+                transform.Extents.Cx = ConvertToEnglishMetricUnits(member.Width, wb.DpiX);
+                transform.Extents.Cy = ConvertToEnglishMetricUnits(member.Height, wb.DpiY);
+            }
+
+            picElement.Remove();
+            groupShape.Append(picElement);
+            anchor.Remove();
+
+            member.GroupInfo = new XLPictureGroup
+            {
+                ScaleX = 1.0,
+                ScaleY = 1.0,
+                OffsetX = 0.0,
+                OffsetY = 0.0,
+                GroupId = groupId,
+                GroupKey = member.GroupInfo?.GroupKey ?? 0,
+                LoadedWidthPx = member.Width,
+                LoadedHeightPx = member.Height,
+                LoadedLeftPx = member.Left,
+                LoadedTopPx = member.Top,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Propagate <paramref name="groupId"/> to every picture on the worksheet sharing the group's key,
+    /// including members added before the group's first save (which carry a null group id).
+    /// </summary>
+    private static void PropagateGroupIdToMembers(XLPendingGroup pending, uint groupId)
+    {
+        var groupKey = pending.Members.Count > 0 ? pending.Members[0].GroupInfo?.GroupKey : null;
+        if (groupKey is null)
+            return;
+
+        foreach (var pic in (IEnumerable<XLPicture>)(XLPictures)pending.Members[0].Worksheet.Pictures)
+        {
+            if (pic.GroupInfo is { } info && info.GroupKey == groupKey && info.GroupId != groupId)
+                pic.GroupInfo = info with { GroupId = groupId };
         }
     }
 
@@ -578,17 +636,7 @@ internal static class PictureWriter
 
         var worksheetDrawing = drawingsPart.WorksheetDrawing;
 
-        Xdr.Picture? picElement = null;
-        foreach (var candidate in worksheetDrawing.Descendants<Xdr.Picture>())
-        {
-            var id = candidate.NonVisualPictureProperties?.NonVisualDrawingProperties?.Id?.Value;
-            if (id == (uint)pic.Id && candidate.Ancestors<Xdr.GroupShape>().Any())
-            {
-                picElement = candidate;
-                break;
-            }
-        }
-
+        var picElement = FindGroupedPictureById(worksheetDrawing, pic.Id);
         if (picElement is null)
             return;
 
@@ -616,32 +664,54 @@ internal static class PictureWriter
         var wb = pic.Worksheet.Workbook;
 
         if (sizeChanged)
-        {
-            var sheetEmuCx = ConvertToEnglishMetricUnits(pic.Width, wb.DpiX);
-            var sheetEmuCy = ConvertToEnglishMetricUnits(pic.Height, wb.DpiY);
-
-            // Convert the sheet-space size back to the group's child coordinate space.
-            var childCx = IsDegenerateScale(group.ScaleX) ? sheetEmuCx : (long)Math.Round(sheetEmuCx / group.ScaleX);
-            var childCy = IsDegenerateScale(group.ScaleY) ? sheetEmuCy : (long)Math.Round(sheetEmuCy / group.ScaleY);
-
-            transform.Extents ??= new Extents();
-            transform.Extents.Cx = childCx;
-            transform.Extents.Cy = childCy;
-        }
+            ApplyGroupedChildExtents(transform, pic, group, wb);
 
         if (positionChanged)
+            ApplyGroupedChildOffset(transform, pic, group, wb);
+    }
+
+    /// <summary>
+    /// Locate the <c>xdr:pic</c> inside a group shape that carries the given drawing id. The save DOM
+    /// is an independent re-parse, so the picture is matched by id rather than object reference.
+    /// </summary>
+    private static Xdr.Picture? FindGroupedPictureById(Xdr.WorksheetDrawing worksheetDrawing, int id)
+    {
+        foreach (var candidate in worksheetDrawing.Descendants<Xdr.Picture>())
         {
-            var sheetEmuX = ConvertToEnglishMetricUnits(pic.Left, wb.DpiX);
-            var sheetEmuY = ConvertToEnglishMetricUnits(pic.Top, wb.DpiY);
-
-            // Invert the composed affine (sheet = offset + child·scale) to get the child a:off.
-            var childOffX = IsDegenerateScale(group.ScaleX) ? sheetEmuX : (long)Math.Round((sheetEmuX - group.OffsetX) / group.ScaleX);
-            var childOffY = IsDegenerateScale(group.ScaleY) ? sheetEmuY : (long)Math.Round((sheetEmuY - group.OffsetY) / group.ScaleY);
-
-            transform.Offset ??= new Offset();
-            transform.Offset.X = childOffX;
-            transform.Offset.Y = childOffY;
+            var candidateId = candidate.NonVisualPictureProperties?.NonVisualDrawingProperties?.Id?.Value;
+            if (candidateId == (uint)id && candidate.Ancestors<Xdr.GroupShape>().Any())
+                return candidate;
         }
+
+        return null;
+    }
+
+    private static void ApplyGroupedChildExtents(Transform2D transform, XLPicture pic, XLPictureGroup group, XLWorkbook wb)
+    {
+        var sheetEmuCx = ConvertToEnglishMetricUnits(pic.Width, wb.DpiX);
+        var sheetEmuCy = ConvertToEnglishMetricUnits(pic.Height, wb.DpiY);
+
+        // Convert the sheet-space size back to the group's child coordinate space.
+        var childCx = IsDegenerateScale(group.ScaleX) ? sheetEmuCx : (long)Math.Round(sheetEmuCx / group.ScaleX);
+        var childCy = IsDegenerateScale(group.ScaleY) ? sheetEmuCy : (long)Math.Round(sheetEmuCy / group.ScaleY);
+
+        transform.Extents ??= new Extents();
+        transform.Extents.Cx = childCx;
+        transform.Extents.Cy = childCy;
+    }
+
+    private static void ApplyGroupedChildOffset(Transform2D transform, XLPicture pic, XLPictureGroup group, XLWorkbook wb)
+    {
+        var sheetEmuX = ConvertToEnglishMetricUnits(pic.Left, wb.DpiX);
+        var sheetEmuY = ConvertToEnglishMetricUnits(pic.Top, wb.DpiY);
+
+        // Invert the composed affine (sheet = offset + child·scale) to get the child a:off.
+        var childOffX = IsDegenerateScale(group.ScaleX) ? sheetEmuX : (long)Math.Round((sheetEmuX - group.OffsetX) / group.ScaleX);
+        var childOffY = IsDegenerateScale(group.ScaleY) ? sheetEmuY : (long)Math.Round((sheetEmuY - group.OffsetY) / group.ScaleY);
+
+        transform.Offset ??= new Offset();
+        transform.Offset.X = childOffX;
+        transform.Offset.Y = childOffY;
     }
 
     /// <summary>

--- a/XLibur/Excel/IO/SheetDataWriter.cs
+++ b/XLibur/Excel/IO/SheetDataWriter.cs
@@ -254,20 +254,7 @@ internal static class SheetDataWriter
         var saveContext = ctx.SaveContext;
 
         if (ctx.SaveOptions.EvaluateFormulasBeforeSaving && formula.IsDirty(xlWorksheet.Workbook))
-        {
-            try
-            {
-                var workbook = xlWorksheet.Workbook;
-                if (!workbook.CalcEngine.TryEvaluateSingleCell(formula, point, xlWorksheet))
-                    workbook.CalcEngine.Recalculate(workbook, null);
-            }
-            catch
-            {
-                // Match XLCell.Evaluate(false) tolerance: unimplemented features should not
-                // abort the save. The cell is left with whatever cached value (if any) it
-                // already has.
-            }
-        }
+            EvaluateFormulaForSave(xlWorksheet, formula, point);
 
         // Determine cell type from cached value (preserves type round-trip for formulas
         // whose evaluation is unsupported).
@@ -319,6 +306,22 @@ internal static class SheetDataWriter
         }
 
         xml.WriteEndElement(); // cell
+    }
+
+    private static void EvaluateFormulaForSave(XLWorksheet xlWorksheet, XLCellFormula formula, XLSheetPoint point)
+    {
+        try
+        {
+            var workbook = xlWorksheet.Workbook;
+            if (!workbook.CalcEngine.TryEvaluateSingleCell(formula, point, xlWorksheet))
+                workbook.CalcEngine.Recalculate(workbook, null);
+        }
+        catch
+        {
+            // Match XLCell.Evaluate(false) tolerance: unimplemented features should not
+            // abort the save. The cell is left with whatever cached value (if any) it
+            // already has.
+        }
     }
 
     /// <summary>

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -1023,28 +1023,18 @@ internal static class WorksheetSheetDataReader
 
         // Integer part — accumulate in long for exact precision.
         long mantissa = 0;
-        int totalDigits = 0;
-        while (i < len && (uint)(s[i] - '0') <= 9)
-        {
-            mantissa = mantissa * 10 + (s[i] - '0');
-            totalDigits++;
-            i++;
-        }
+        var integerDigits = ScanDigits(s, ref i, ref mantissa);
 
-        int fractionDigits = 0;
+        var fractionDigits = 0;
 
         // Fractional part.
         if (i < len && s[i] == '.')
         {
             i++;
-            while (i < len && (uint)(s[i] - '0') <= 9)
-            {
-                mantissa = mantissa * 10 + (s[i] - '0');
-                fractionDigits++;
-                totalDigits++;
-                i++;
-            }
+            fractionDigits = ScanDigits(s, ref i, ref mantissa);
         }
+
+        var totalDigits = integerDigits + fractionDigits;
 
         // Must have consumed at least one digit and ALL characters.
         // Any remaining chars (exponent, whitespace, etc.) → fall back.
@@ -1058,6 +1048,24 @@ internal static class WorksheetSheetDataReader
 
         result = negative ? -d : d;
         return true;
+    }
+
+    /// <summary>
+    /// Consume the run of ASCII digits starting at <paramref name="i"/>, folding them into
+    /// <paramref name="mantissa"/>. Advances <paramref name="i"/> past the digits and returns the
+    /// number of digits consumed.
+    /// </summary>
+    private static int ScanDigits(string s, ref int i, ref long mantissa)
+    {
+        var start = i;
+        var len = s.Length;
+        while (i < len && (uint)(s[i] - '0') <= 9)
+        {
+            mantissa = mantissa * 10 + (s[i] - '0');
+            i++;
+        }
+
+        return i - start;
     }
 
     /// <summary>

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -187,6 +187,25 @@ public partial class XLWorkbook
 
     private static void DeleteRemovedWorksheets(WorkbookPart workbookPart, XLWorksheets worksheets)
     {
+        var partsToRemove = CollectDeletedWorksheetParts(workbookPart, worksheets);
+        var pivotCacheDefinitionsToRemove = CollectPivotCacheDefinitions(partsToRemove);
+
+        // Collect relationship IDs before deleting parts, because GetIdOfPart
+        // throws after the part has been removed.
+        var pivotCacheRelIds = CollectPivotCacheRelIds(workbookPart, pivotCacheDefinitionsToRemove);
+
+        foreach (var c in pivotCacheDefinitionsToRemove)
+            workbookPart.DeletePart(c);
+
+        if (pivotCacheRelIds is not null)
+            RemovePivotCacheElements(workbookPart, pivotCacheRelIds);
+
+        foreach (var ws in worksheets.Deleted)
+            DeleteSheetAndDependencies(workbookPart, ws);
+    }
+
+    private static List<IdPartPair> CollectDeletedWorksheetParts(WorkbookPart workbookPart, XLWorksheets worksheets)
+    {
         var partsToRemove = new List<IdPartPair>();
         foreach (var s in workbookPart.Parts)
         {
@@ -194,6 +213,11 @@ public partial class XLWorkbook
                 partsToRemove.Add(s);
         }
 
+        return partsToRemove;
+    }
+
+    private static List<PivotTableCacheDefinitionPart> CollectPivotCacheDefinitions(List<IdPartPair> partsToRemove)
+    {
         var pivotCacheDefinitionsToRemove = new List<PivotTableCacheDefinitionPart>();
         var seenDefs = new HashSet<PivotTableCacheDefinitionPart>();
         foreach (var s in partsToRemove)
@@ -206,37 +230,36 @@ public partial class XLWorkbook
             }
         }
 
-        // Collect relationship IDs before deleting parts, because GetIdOfPart
-        // throws after the part has been removed.
-        HashSet<string>? pivotCacheRelIds = null;
-        if (workbookPart.Workbook is { PivotCaches: not null })
+        return pivotCacheDefinitionsToRemove;
+    }
+
+    private static HashSet<string>? CollectPivotCacheRelIds(WorkbookPart workbookPart,
+        List<PivotTableCacheDefinitionPart> pivotCacheDefinitionsToRemove)
+    {
+        if (workbookPart.Workbook is not { PivotCaches: not null })
+            return null;
+
+        var pivotCacheRelIds = new HashSet<string>(pivotCacheDefinitionsToRemove.Count);
+        foreach (var def in pivotCacheDefinitionsToRemove)
+            pivotCacheRelIds.Add(workbookPart.GetIdOfPart(def));
+
+        return pivotCacheRelIds;
+    }
+
+    private static void RemovePivotCacheElements(WorkbookPart workbookPart, HashSet<string> pivotCacheRelIds)
+    {
+        List<OpenXmlElement>? pivotCachesToRemove = null;
+        foreach (var pc in workbookPart.Workbook!.PivotCaches!)
         {
-            pivotCacheRelIds = new HashSet<string>(pivotCacheDefinitionsToRemove.Count);
-            foreach (var def in pivotCacheDefinitionsToRemove)
-                pivotCacheRelIds.Add(workbookPart.GetIdOfPart(def));
+            if (((PivotCache)pc).Id?.Value is { } idVal && pivotCacheRelIds.Contains(idVal))
+                (pivotCachesToRemove ??= []).Add(pc);
         }
 
-        foreach (var c in pivotCacheDefinitionsToRemove)
-            workbookPart.DeletePart(c);
+        if (pivotCachesToRemove is null)
+            return;
 
-        if (pivotCacheRelIds is not null)
-        {
-            List<OpenXmlElement>? pivotCachesToRemove = null;
-            foreach (var pc in workbookPart.Workbook!.PivotCaches!)
-            {
-                if (((PivotCache)pc).Id?.Value is { } idVal && pivotCacheRelIds.Contains(idVal))
-                    (pivotCachesToRemove ??= []).Add(pc);
-            }
-
-            if (pivotCachesToRemove is not null)
-            {
-                foreach (var c in pivotCachesToRemove)
-                    workbookPart.Workbook.PivotCaches!.RemoveChild(c);
-            }
-        }
-
-        foreach (var ws in worksheets.Deleted)
-            DeleteSheetAndDependencies(workbookPart, ws);
+        foreach (var c in pivotCachesToRemove)
+            workbookPart.Workbook.PivotCaches!.RemoveChild(c);
     }
 
     private void GenerateWorkbookLevelParts(SpreadsheetDocument document, WorkbookPart workbookPart,
@@ -812,6 +835,13 @@ public partial class XLWorkbook
         foreach (var pt in allPivotTables)
             workbookCacheRelIds.Add(pt.PivotCache.CastTo<XLPivotCache>().WorkbookCacheRelId);
 
+        RemoveOrphanedCacheDefinitionParts(workbookPart, workbookCacheRelIds);
+        RemoveOrphanedPivotCacheReferences(workbookPart);
+    }
+
+    private static void RemoveOrphanedCacheDefinitionParts(WorkbookPart workbookPart,
+        HashSet<string?> workbookCacheRelIds)
+    {
         // Materialize before deleting because DeletePart invalidates the GetPartsOfType enumerator.
         List<PivotTableCacheDefinitionPart>? orphanedParts = null;
         foreach (var pcdp in workbookPart.GetPartsOfType<PivotTableCacheDefinitionPart>())
@@ -820,34 +850,37 @@ public partial class XLWorkbook
                 (orphanedParts ??= []).Add(pcdp);
         }
 
-        if (orphanedParts is not null)
+        if (orphanedParts is null)
+            return;
+
+        foreach (var orphanPart in orphanedParts)
         {
-            foreach (var orphanPart in orphanedParts)
-            {
-                // PivotTableCacheRecordsPart is optional per ECMA-376 (caches with
-                // external data sources may have no records part).
-                if (orphanPart.PivotTableCacheRecordsPart is { } recordsPart)
-                    orphanPart.DeletePart(recordsPart);
-                workbookPart.DeletePart(orphanPart);
-            }
+            // PivotTableCacheRecordsPart is optional per ECMA-376 (caches with
+            // external data sources may have no records part).
+            if (orphanPart.PivotTableCacheRecordsPart is { } recordsPart)
+                orphanPart.DeletePart(recordsPart);
+            workbookPart.DeletePart(orphanPart);
+        }
+    }
+
+    private static void RemoveOrphanedPivotCacheReferences(WorkbookPart workbookPart)
+    {
+        if (workbookPart.Workbook!.PivotCaches is null)
+            return;
+
+        // Materialize before removing because Remove() mutates the iterated collection.
+        List<PivotCache>? orphanedCaches = null;
+        foreach (var pc in workbookPart.Workbook.PivotCaches.Elements<PivotCache>())
+        {
+            if (pc.Id is null || !workbookPart.HasPartWithId(pc.Id!.Value!))
+                (orphanedCaches ??= []).Add(pc);
         }
 
-        if (workbookPart.Workbook!.PivotCaches is not null)
-        {
-            // Materialize before removing because Remove() mutates the iterated collection.
-            List<PivotCache>? orphanedCaches = null;
-            foreach (var pc in workbookPart.Workbook.PivotCaches.Elements<PivotCache>())
-            {
-                if (pc.Id is null || !workbookPart.HasPartWithId(pc.Id!.Value!))
-                    (orphanedCaches ??= []).Add(pc);
-            }
+        if (orphanedCaches is null)
+            return;
 
-            if (orphanedCaches is not null)
-            {
-                foreach (var pc in orphanedCaches)
-                    pc.Remove();
-            }
-        }
+        foreach (var pc in orphanedCaches)
+            pc.Remove();
     }
 
     /// <summary>


### PR DESCRIPTION
@
## Summary

Resolves all 19 open SonarCloud **S3776 — Cognitive Complexity** issues (11 methods) flagged with MAINTAINABILITY = HIGH. Each method is brought below the threshold of 15 by extracting well-named private helpers and flattening nested conditionals with guard clauses. **Behavior is preserved exactly** — no public signatures changed.

## Changes per method

| File | Method | From → ≤15 | Approach |
|------|--------|-----|----------|
| `Reference.cs` | `Intersect` | 17 | `TryResolveSharedSheet` folds both shared-sheet validation loops |
| `XLPictures.cs` | `Group` | 18 | `CollectDistinctMembers`, `ValidateMembersAndComputeBounds`, `AssignIdentityGroupInfo` |
| `ChartReader.cs` | `ReadPositions` | 18 | `ReadMarker` collapses the identical from/to blocks |
| `PictureWriter.cs` | `WriteDrawings` | 29 | `ProcessDeletedPicturesAndGroups`, `WritePictureAnchors`, `RemoveEmptyDrawingPart` |
| `PictureWriter.cs` | `AddPictureAnchor` | 17 | `EnsureDrawingNamespaces` |
| `PictureWriter.cs` | `CreateGroups` | 28 | `ComputeMaxDrawingId`, `MoveMembersIntoGroup`, `PropagateGroupIdToMembers` |
| `PictureWriter.cs` | `UpdateGroupedPicture` | 24 | `FindGroupedPictureById`, `ApplyGroupedChildExtents`, `ApplyGroupedChildOffset` |
| `SheetDataWriter.cs` | `WriteFormulaCellDirect` | 16 | `EvaluateFormulaForSave` (the try/catch eval block) |
| `WorksheetSheetDataReader.cs` | `TryParseOoxmlDouble` | 17 | `ScanDigits` replaces both digit-scan loops |
| `XLWorkbook_Save.cs` | `RemoveUnusedPivotCacheDefinitionParts` | 22 | `RemoveOrphanedCacheDefinitionParts`, `RemoveOrphanedPivotCacheReferences` |
| `XLWorkbook_Save.cs` | `DeleteRemovedWorksheets` | 27 | `CollectDeletedWorksheetParts`, `CollectPivotCacheDefinitions`, `CollectPivotCacheRelIds`, `RemovePivotCacheElements` |

Note: in `XLPictures.ValidateMembersAndComputeBounds` the thrown `ArgumentException`s keep the literal `"pictures"` param name so the public exception `ParamName` is unchanged.

## Verification

- Build: **0 warnings, 0 errors** (with `TreatWarningsAsErrors`)
- Tests: **985 passing**, 0 failures across the affected areas (pictures/groups, charts, pivots, formulas, save/load)
@