### PR TITLE
fix: tolerate invalid casing in alignment values on load

### DIFF
--- a/XLibur.Tests/Excel/Styles/AlignmentTests.cs
+++ b/XLibur.Tests/Excel/Styles/AlignmentTests.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel;
+using XLibur.Utils;
 using NUnit.Framework;
 
 namespace XLibur.Tests.Excel.Styles;
@@ -56,5 +59,51 @@ public class AlignmentTests
             var ws = wb.AddWorksheet();
             ws.FirstCell().Style.Alignment.TextRotation = textRotation;
         });
+    }
+
+    // Some third-party tools write spec-invalid upper-case alignment values
+    // (e.g. horizontal="Center"). XLibur tolerates the casing rather than failing the load.
+    [TestCase("center", XLAlignmentHorizontalValues.Center)]
+    [TestCase("Center", XLAlignmentHorizontalValues.Center)]
+    [TestCase("RIGHT", XLAlignmentHorizontalValues.Right)]
+    public void HorizontalAlignmentToleratesInvalidCasing(string raw, XLAlignmentHorizontalValues expected)
+    {
+        var source = new EnumValue<HorizontalAlignmentValues> { InnerText = raw };
+        Assert.AreEqual(expected, source.ToXLiburOrNull());
+    }
+
+    [TestCase("center", XLAlignmentVerticalValues.Center)]
+    [TestCase("Center", XLAlignmentVerticalValues.Center)]
+    [TestCase("TOP", XLAlignmentVerticalValues.Top)]
+    public void VerticalAlignmentToleratesInvalidCasing(string raw, XLAlignmentVerticalValues expected)
+    {
+        var source = new EnumValue<VerticalAlignmentValues> { InnerText = raw };
+        Assert.AreEqual(expected, source.ToXLiburOrNull());
+    }
+
+    [Test]
+    public void UnrecognizedAlignmentValueIsDiscarded()
+    {
+        var horizontal = new EnumValue<HorizontalAlignmentValues> { InnerText = "not-an-alignment" };
+        var vertical = new EnumValue<VerticalAlignmentValues> { InnerText = "not-an-alignment" };
+        Assert.IsNull(horizontal.ToXLiburOrNull());
+        Assert.IsNull(vertical.ToXLiburOrNull());
+    }
+
+    [Test]
+    public void AlignmentToXLiburKeepsDefaultWhenValueUnrecognized()
+    {
+        var defaultKey = XLAlignmentValue.Default.Key;
+        var alignment = new Alignment
+        {
+            Horizontal = new EnumValue<HorizontalAlignmentValues> { InnerText = "Center" },
+            Vertical = new EnumValue<VerticalAlignmentValues> { InnerText = "bogus" },
+        };
+
+        var result = OpenXmlHelper.AlignmentToXLibur(alignment, defaultKey);
+
+        // Bad casing is recovered; truly unknown values fall back to the default.
+        Assert.AreEqual(XLAlignmentHorizontalValues.Center, result.Horizontal);
+        Assert.AreEqual(defaultKey.Vertical, result.Vertical);
     }
 }

--- a/XLibur/Excel/EnumConverter.cs
+++ b/XLibur/Excel/EnumConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel.Drawings;
@@ -1057,6 +1058,55 @@ internal static class EnumConverter
     public static XLAlignmentVerticalValues ToXLibur(this VerticalAlignmentValues value)
     {
         return VerticalAlignmentMap[value];
+    }
+
+    /// <summary>
+    /// Leniently converts a horizontal alignment attribute to its XLibur equivalent.
+    /// The OOXML spec requires lower-case values (e.g. <c>center</c>), but some third-party
+    /// tools emit invalid casing (e.g. <c>Center</c>). Such values are tolerated by retrying
+    /// the lookup with a lower-cased value. Values that remain unrecognized return
+    /// <c>null</c> so the offending alignment can be discarded and the file still loaded.
+    /// </summary>
+    public static XLAlignmentHorizontalValues? ToXLiburOrNull(this EnumValue<HorizontalAlignmentValues>? source)
+    {
+        if (source is null)
+            return null;
+
+        // HasValue parses without throwing; a valid (spec-compliant) value is always mapped.
+        if (source.HasValue)
+            return HorizontalAlignmentMap[source.Value];
+
+        return LenientAlignmentLookup(source.InnerText, HorizontalAlignmentMap, raw => new HorizontalAlignmentValues(raw));
+    }
+
+    /// <summary>
+    /// Leniently converts a vertical alignment attribute to its XLibur equivalent.
+    /// See <see cref="ToXLiburOrNull(EnumValue{HorizontalAlignmentValues})"/> for the casing
+    /// tolerance and discard-on-failure behavior.
+    /// </summary>
+    public static XLAlignmentVerticalValues? ToXLiburOrNull(this EnumValue<VerticalAlignmentValues>? source)
+    {
+        if (source is null)
+            return null;
+
+        if (source.HasValue)
+            return VerticalAlignmentMap[source.Value];
+
+        return LenientAlignmentLookup(source.InnerText, VerticalAlignmentMap, raw => new VerticalAlignmentValues(raw));
+    }
+
+    private static TValue? LenientAlignmentLookup<TKey, TValue>(
+        string? rawText,
+        Dictionary<TKey, TValue> map,
+        Func<string, TKey> factory)
+        where TKey : notnull
+        where TValue : struct
+    {
+        if (string.IsNullOrEmpty(rawText))
+            return null;
+
+        var lowered = factory(rawText!.ToLowerInvariant());
+        return map.TryGetValue(lowered, out var result) ? result : null;
     }
 
     public static XLPageOrderValues ToXLibur(this PageOrderValues value)

--- a/XLibur/Utils/OpenXmlHelper.cs
+++ b/XLibur/Utils/OpenXmlHelper.cs
@@ -92,10 +92,12 @@ internal static class OpenXmlHelper
     {
         if (alignmentSource is null) return;
 
-        if (alignmentSource.Horizontal?.Value is not null)
-            alignment.Horizontal = alignmentSource.Horizontal.Value.ToXLibur();
-        if (alignmentSource.Vertical?.Value is not null)
-            alignment.Vertical = alignmentSource.Vertical.Value.ToXLibur();
+        var horizontal = alignmentSource.Horizontal.ToXLiburOrNull();
+        if (horizontal is not null)
+            alignment.Horizontal = horizontal.Value;
+        var vertical = alignmentSource.Vertical.ToXLiburOrNull();
+        if (vertical is not null)
+            alignment.Vertical = vertical.Value;
         if (alignmentSource.Indent?.Value is not null)
             alignment.Indent = checked((int)alignmentSource.Indent.Value);
         if (alignmentSource.ReadingOrder?.Value is not null)
@@ -279,8 +281,8 @@ internal static class OpenXmlHelper
         return new XLAlignmentKey
         {
             Indent = checked((int?)alignment.Indent?.Value) ?? defaultAlignment.Indent,
-            Horizontal = alignment.Horizontal?.Value.ToXLibur() ?? defaultAlignment.Horizontal,
-            Vertical = alignment.Vertical?.Value.ToXLibur() ?? defaultAlignment.Vertical,
+            Horizontal = alignment.Horizontal.ToXLiburOrNull() ?? defaultAlignment.Horizontal,
+            Vertical = alignment.Vertical.ToXLiburOrNull() ?? defaultAlignment.Vertical,
             ReadingOrder = alignment.ReadingOrder?.Value.ToXLibur() ?? defaultAlignment.ReadingOrder,
             WrapText = alignment.WrapText?.Value ?? defaultAlignment.WrapText,
             TextRotation = alignment.TextRotation is not null


### PR DESCRIPTION
@
## Problem

Spreadsheets produced by some third-party tools contain spec-invalid **upper-case** alignment values, e.g.:

```xml
<alignment horizontal="Center" vertical="Center"/>
```

The OOXML spec mandates lower-case values (`center`). When XLibur loads such a file, the OpenXML SDK throws a `FormatException` the moment `EnumValue<T>.Value` is accessed for the invalid value, which **aborts the entire load** — the file becomes unopenable.

## Fix

Be lenient when parsing alignment, as requested: try to recover the value by lower-casing it, and if it still cannot be recognized, discard just that alignment attribute so the rest of the file still loads.

- Added `ToXLiburOrNull` converters for horizontal/vertical alignment in `EnumConverter`:
  - use `HasValue` (which parses **without** throwing) for spec-compliant values,
  - retry the lookup with a lower-cased value to recover bad casing (`Center` → `center`),
  - return `null` for genuinely unrecognized values so the offending alignment is discarded rather than failing the load.
- `LoadAlignment` and `AlignmentToXLibur` now use these converters instead of the throwing `.Value.ToXLibur()`.

## Tests

Added regression tests in `AlignmentTests`:
- valid casing still works,
- bad casing recovered (`Center`, `RIGHT`, `TOP`),
- unknown values discarded (return `null` / fall back to default),
- end-to-end `AlignmentToXLibur` behavior.

All alignment tests pass; core library builds with 0 warnings/errors.

## Note

This change is scoped to alignment, matching the reported bug. The same upper-case intolerance theoretically affects other enum attributes (border styles, fill patterns, etc.) since they share the SDK parsing path — happy to generalize in a follow-up if desired.
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment value parsing to tolerate case-insensitive variations in alignment attributes.
  * Unrecognized alignment values now gracefully fall back to defaults instead of causing errors.

* **Tests**
  * Added comprehensive test coverage for alignment value conversion, including case-sensitivity and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->