### PR TITLE
chore(deps): bump SkiaSharp to 4.150.0 and PublicApiAnalyzers to 5.6.0

### DIFF
--- a/XLibur.Fonts.SkiaSharp.Tests/SkiaSharpFontEngineTests.cs
+++ b/XLibur.Fonts.SkiaSharp.Tests/SkiaSharpFontEngineTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using NUnit.Framework;
 using XLibur.Excel;

--- a/XLibur.Fonts.SkiaSharp.Tests/TestHelper.cs
+++ b/XLibur.Fonts.SkiaSharp.Tests/TestHelper.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 
 namespace XLibur.Fonts.SkiaSharp.Tests;

--- a/XLibur.Fonts.SkiaSharp/SkiaSharpFontEngine.cs
+++ b/XLibur.Fonts.SkiaSharp/SkiaSharpFontEngine.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;

--- a/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
+++ b/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
@@ -34,8 +34,8 @@
 
     <ItemGroup>
         <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
-        <PackageReference Include="SkiaSharp" Version="3.119.4" />
-        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.4" />
+        <PackageReference Include="SkiaSharp" Version="4.150.0" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.150.0" />
     </ItemGroup>
 
 </Project>

--- a/XLibur.Tests/Excel/Drawings/GroupedPictureTests.cs
+++ b/XLibur.Tests/Excel/Drawings/GroupedPictureTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;

--- a/XLibur.Tests/Excel/Worksheets/XLFocusCellTests.cs
+++ b/XLibur.Tests/Excel/Worksheets/XLFocusCellTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.IO;
 using System.Linq;

--- a/XLibur/Excel/Drawings/IXLPictureGroup.cs
+++ b/XLibur/Excel/Drawings/IXLPictureGroup.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 
 namespace XLibur.Excel.Drawings;

--- a/XLibur/Excel/Drawings/XLPictureGroup.cs
+++ b/XLibur/Excel/Drawings/XLPictureGroup.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel.Drawings;
+﻿namespace XLibur.Excel.Drawings;
 
 /// <summary>
 /// Metadata describing a picture that lives inside a drawing group shape

--- a/XLibur/Excel/Drawings/XLPictureGroupView.cs
+++ b/XLibur/Excel/Drawings/XLPictureGroupView.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -96,3 +96,10 @@ XLibur.Excel.IXLWorksheet.SetActiveCell(XLibur.Excel.IXLCell! cell) -> XLibur.Ex
 XLibur.Excel.IXLWorksheet.FocusCell(string! address) -> XLibur.Excel.IXLWorksheet!
 XLibur.Excel.IXLWorksheet.FocusCell(XLibur.Excel.IXLCell! cell) -> XLibur.Excel.IXLWorksheet!
 XLibur.Excel.IXLCell.Focus() -> XLibur.Excel.IXLCell!
+~override XLibur.Excel.XLAlignmentKey.Equals(object obj) -> bool
+override XLibur.Excel.XLAlignmentKey.GetHashCode() -> int
+XLibur.Excel.XLAlignmentKey.Equals(XLibur.Excel.XLAlignmentKey other) -> bool
+static XLibur.Excel.XLAlignmentKey.operator ==(XLibur.Excel.XLAlignmentKey left, XLibur.Excel.XLAlignmentKey right) -> bool
+static XLibur.Excel.XLAlignmentKey.operator !=(XLibur.Excel.XLAlignmentKey left, XLibur.Excel.XLAlignmentKey right) -> bool
+static XLibur.AttributeExtensions.GetMethod<T>(this T instance, System.Linq.Expressions.Expression<System.Func<T, object!>!>! methodSelector) -> System.Reflection.MethodInfo!
+static XLibur.AttributeExtensions.GetMethod<T>(this T instance, System.Linq.Expressions.Expression<System.Action<T>!>! methodSelector) -> System.Reflection.MethodInfo!

--- a/XLibur/XLibur.csproj
+++ b/XLibur/XLibur.csproj
@@ -45,7 +45,7 @@
         </PackageReference>
         <PackageReference Include="RBush.Signed" Version="4.0.0"/>
         <PackageReference Include="ClosedXML.Parser" Version="2.0.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
## Summary

Bumps two dev/runtime dependencies to their latest stable versions.

| Package | From | To |
| --- | --- | --- |
| `SkiaSharp` | 3.119.4 | 4.150.0 |
| `SkiaSharp.NativeAssets.Linux.NoDependencies` | 3.119.4 | 4.150.0 |
| `Microsoft.CodeAnalysis.PublicApiAnalyzers` | 3.3.4 | 5.6.0 |

## Notes

- The **SkiaSharp** major-version bump (3.x → 4.x) builds and tests cleanly with no source changes required.
- The new **PublicApiAnalyzers v5** is stricter than 3.3.4 and correctly flagged public API symbols the old analyzer missed (`RS0016`):
  - `XLAlignmentKey` record-struct synthesized members (`Equals`/`GetHashCode`/`operator ==`/`operator !=`)
  - `AttributeExtensions.GetMethod<T>` extension overloads
  
  These were added to `PublicAPI.Unshipped.txt`.
- Ran `dotnet format`, which added the missing UTF-8 BOM (per `.editorconfig` `charset`) to 8 files.

## Testing

- `XLibur.Fonts.SkiaSharp.Tests`: **31 passed** (net8.0 + net10.0)
- `XLibur.Tests`: **6087 passed**, 40 skipped, 0 failed (net8.0 + net10.0)
- `XLibur` core builds clean on net8.0/net9.0/net10.0 (0 warnings, 0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated the SkiaSharp graphics components to a newer version for improved compatibility and platform support.
  - Updated code-analysis tooling to support current development standards.
  - Standardized source-file formatting and encoding across affected components.
  - Modernized namespace syntax without changing application behavior or public APIs.

- **Tests**
  - Confirmed that existing font, drawing, worksheet, and picture-group test coverage remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->