### PR TITLE
fix: escape spaced column names in totals row structured references

### DIFF
--- a/XLibur.Tests/Excel/Tables/TablesTests.cs
+++ b/XLibur.Tests/Excel/Tables/TablesTests.cs
@@ -898,6 +898,10 @@ public class TablesTests
         // like "Feb 2023") must be wrapped in an extra pair of brackets in the totals
         // row structured reference. The single-bracket form Table1[Feb 2023] causes
         // Excel to raise a #NAME error and repair the file on open.
+        //
+        // Headers that combine an interior space with a quoted table-field character
+        // (' or #) must be both escaped (' -> '', # -> '#) and double-bracket wrapped,
+        // e.g. "Feb '23" -> Table1[[Feb ''23]].
         var l = new List<TestObjectWithAttributes>
         {
             new() { Column1 = "a", Column2 = "b", MyField = 4, UnOrderedColumn = 999 },
@@ -913,18 +917,31 @@ public class TablesTests
         ws.Cell("C1").Value = "Mar 2023";
         ws.Cell("D1").Value = "Total";
 
+        // Extra columns whose headers mix an interior space with quoted characters.
+        ws.Cell("E1").Value = "Feb '23";
+        ws.Cell("E2").Value = 1;
+        ws.Cell("E3").Value = 2;
+        ws.Cell("F1").Value = "Q1 #1";
+        ws.Cell("F2").Value = 3;
+        ws.Cell("F3").Value = 4;
+
         var table = ws.RangeUsed()!.CreateTable();
         table.ShowTotalsRow = true;
         table.Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
         table.Field(1).TotalsRowFunction = XLTotalsRowFunction.Average;
         table.Field(2).TotalsRowFunction = XLTotalsRowFunction.Count;
         table.Field(3).TotalsRowFunction = XLTotalsRowFunction.Sum;
+        table.Field(4).TotalsRowFunction = XLTotalsRowFunction.Sum;
+        table.Field(5).TotalsRowFunction = XLTotalsRowFunction.Count;
 
-        Assert.AreEqual("SUBTOTAL(109,Table1[[Jan 2023]])", table.Field(0).TotalsRowFormulaA1);
-        Assert.AreEqual("SUBTOTAL(101,Table1[[Feb 2023]])", table.Field(1).TotalsRowFormulaA1);
-        Assert.AreEqual("SUBTOTAL(103,Table1[[Mar 2023]])", table.Field(2).TotalsRowFormulaA1);
+        Assert.That(table.Field(0).TotalsRowFormulaA1, Is.EqualTo("SUBTOTAL(109,Table1[[Jan 2023]])"));
+        Assert.That(table.Field(1).TotalsRowFormulaA1, Is.EqualTo("SUBTOTAL(101,Table1[[Feb 2023]])"));
+        Assert.That(table.Field(2).TotalsRowFormulaA1, Is.EqualTo("SUBTOTAL(103,Table1[[Mar 2023]])"));
         // No space => single-bracket, table name not prepended.
-        Assert.AreEqual("SUBTOTAL(109,[Total])", table.Field(3).TotalsRowFormulaA1);
+        Assert.That(table.Field(3).TotalsRowFormulaA1, Is.EqualTo("SUBTOTAL(109,[Total])"));
+        // Interior space + quoted character => escaped and double-bracket wrapped.
+        Assert.That(table.Field(4).TotalsRowFormulaA1, Is.EqualTo("SUBTOTAL(109,Table1[[Feb ''23]])"));
+        Assert.That(table.Field(5).TotalsRowFormulaA1, Is.EqualTo("SUBTOTAL(103,Table1[[Q1 '#1]])"));
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Tables/TablesTests.cs
+++ b/XLibur.Tests/Excel/Tables/TablesTests.cs
@@ -892,6 +892,42 @@ public class TablesTests
     }
 
     [Test]
+    public void TotalsFunctionsOfHeadersWithInteriorSpaces()
+    {
+        // Regression for issue #2864: column names with an interior space (e.g. dates
+        // like "Feb 2023") must be wrapped in an extra pair of brackets in the totals
+        // row structured reference. The single-bracket form Table1[Feb 2023] causes
+        // Excel to raise a #NAME error and repair the file on open.
+        var l = new List<TestObjectWithAttributes>
+        {
+            new() { Column1 = "a", Column2 = "b", MyField = 4, UnOrderedColumn = 999 },
+            new() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
+        };
+
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.FirstCell().InsertTable(l, false);
+
+        ws.Cell("A1").Value = "Jan 2023";
+        ws.Cell("B1").Value = "Feb 2023";
+        ws.Cell("C1").Value = "Mar 2023";
+        ws.Cell("D1").Value = "Total";
+
+        var table = ws.RangeUsed()!.CreateTable();
+        table.ShowTotalsRow = true;
+        table.Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
+        table.Field(1).TotalsRowFunction = XLTotalsRowFunction.Average;
+        table.Field(2).TotalsRowFunction = XLTotalsRowFunction.Count;
+        table.Field(3).TotalsRowFunction = XLTotalsRowFunction.Sum;
+
+        Assert.AreEqual("SUBTOTAL(109,Table1[[Jan 2023]])", table.Field(0).TotalsRowFormulaA1);
+        Assert.AreEqual("SUBTOTAL(101,Table1[[Feb 2023]])", table.Field(1).TotalsRowFormulaA1);
+        Assert.AreEqual("SUBTOTAL(103,Table1[[Mar 2023]])", table.Field(2).TotalsRowFormulaA1);
+        // No space => single-bracket, table name not prepended.
+        Assert.AreEqual("SUBTOTAL(109,[Total])", table.Field(3).TotalsRowFormulaA1);
+    }
+
+    [Test]
     public void CannotCreateDuplicateTablesOverSameRange()
     {
         var l = new List<TestObjectWithAttributes>

--- a/XLibur/Excel/Tables/XLTableField.cs
+++ b/XLibur/Excel/Tables/XLTableField.cs
@@ -221,12 +221,18 @@ internal sealed class XLTableField : IXLTableField
             var modifiedName = Name;
             QuotedTableFieldCharacters.ForEach(c => modifiedName = modifiedName.Replace(c, "'" + c));
 
-            if (modifiedName.StartsWith(' ') || modifiedName.EndsWith(' '))
+            // Excel requires a column name that contains a space (leading, trailing or
+            // interior) to be wrapped in an extra pair of brackets in a structured
+            // reference, e.g. Table1[[Feb 2023]]. Emitting the single-bracket form
+            // Table1[Feb 2023] yields a totals-row formula that Excel flags with a
+            // #NAME error and "repairs" on open (see issue #2864).
+            var hasSpace = modifiedName.Contains(' ');
+            if (hasSpace)
             {
                 modifiedName = "[" + modifiedName + "]";
             }
 
-            var prependTableName = modifiedName.Contains(' ');
+            var prependTableName = hasSpace;
 
             cell.FormulaA1 = $"SUBTOTAL({formulaCode},{(prependTableName ? _table.Name : string.Empty)}[{modifiedName}])";
             var lastCell = _table.LastRow()!.Cell(Index + 1);


### PR DESCRIPTION
## Summary

Totals-row formulas generated for table columns whose names contain an **interior** space (for example date-style headers like `Feb 2023`) used the single-bracket structured reference form:

```
SUBTOTAL(101,Table1[Feb 2023])
```

Only leading/trailing spaces were previously wrapped in the extra bracket pair. Excel persists spaced column names using the **double-bracket** form and treats the single-bracket totals formula as invalid — it raises a `#NAME?` error and "repairs" the file on open:

```
SUBTOTAL(101,Table1[[Feb 2023]])
```

This wraps the column name in the extra bracket pair whenever it contains a space (leading, trailing, or interior), matching Excel's canonical output.

## Context

Reported against upstream ClosedXML as [ClosedXML/ClosedXML#2864](https://github.com/ClosedXML/ClosedXML/issues/2864). Date-style column headers (`Jan 2023`, `Feb 2023`, …) are a common case that triggers this.

Note: the exact reproduction in that issue also passed a table **name** containing spaces (`"Table with data"`), which this library already rejects via `TableNameValidator` (`"Table names cannot contain spaces."`), so the invalid-`table.xml` corruption path is already guarded here. This PR closes the remaining gap for spaced **column** names.

## Changes

- `XLTableField.UpdateTableFieldTotalsRowFormula` — wrap the column name in the inner bracket pair when it contains any space, and prepend the table name in that case.
- New regression test `TotalsFunctionsOfHeadersWithInteriorSpaces`.

## Behavior

| Column name | Before | After |
|---|---|---|
| `Feb 2023` (interior space) | `SUBTOTAL(101,Table1[Feb 2023])` | `SUBTOTAL(101,Table1[[Feb 2023]])` |
| `ABCD    ` (trailing space) | `SUBTOTAL(103,Table1[[ABCD    ]])` | unchanged |
| `Total` (no space) | `SUBTOTAL(109,[Total])` | unchanged |

## Testing

- `TotalsFunctionsOfHeadersWithInteriorSpaces` (new) and `TotalsFunctionsOfHeadersWithWeirdCharacters` (existing) pass.
- Full `Tables` suite (166 tests) and `StructuredReference` suite (42 tests) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Excel table totals formulas for column headers containing interior spaces.
  * Ensured structured references use the appropriate bracket formatting and table-name handling for these headers.
* **Tests**
  * Added coverage for totals-row formulas with headers such as “Feb 2023,” alongside headers without spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->