### PR TITLE
fix: shrink named range when deleting its top row/left column

### DIFF
--- a/XLibur.Tests/Excel/NamedRanges/NamedRangeDeletionTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangeDeletionTests.cs
@@ -1,0 +1,141 @@
+using System.Linq;
+using XLibur.Excel;
+using NUnit.Framework;
+
+namespace XLibur.Tests.Excel.NamedRanges;
+
+[TestFixture]
+public class NamedRangeDeletionTests
+{
+    private static string RefersTo(XLWorkbook wb, string name)
+    {
+        return wb.DefinedNames.First(dn => dn.Name == name).RefersTo;
+    }
+
+    /// <summary>
+    /// Regression for issue #2866. Deleting the top row of a named range must remove that row and shift the
+    /// survivors up (A3:A4 -> A3:A3), matching Excel. Previously ClosedXML shifted both endpoints upward,
+    /// expanding the range to A2:A3 and including a row that was never part of it.
+    /// </summary>
+    [Test]
+    public void DeletingTopRowOfNamedRange_ShrinksAndShifts()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A3").Value = "deleted";
+        ws.Cell("A4").Value = "survivor";
+        ws.Range("A3:A4").AddToNamed("TopDelete", XLScope.Workbook);
+
+        ws.Row(3).Delete();
+
+        Assert.That(RefersTo(wb, "TopDelete"), Is.EqualTo("Sheet1!$A$3:$A$3"));
+    }
+
+    /// <summary>
+    /// Deleting several rows that overlap the top boundary clamps the first row to the deletion start and
+    /// shifts the surviving bottom up: A3:A5 with rows 2:3 deleted becomes A2:A3.
+    /// </summary>
+    [Test]
+    public void DeletingRowsOverlappingTopBoundary_ClampsFirstRow()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A3").Value = "top";
+        ws.Cell("A4").Value = "mid";
+        ws.Cell("A5").Value = "bottom";
+        ws.Range("A3:A5").AddToNamed("OverlapTop", XLScope.Workbook);
+
+        ws.Rows(2, 3).Delete();
+
+        Assert.That(RefersTo(wb, "OverlapTop"), Is.EqualTo("Sheet1!$A$2:$A$3"));
+    }
+
+    /// <summary>
+    /// Deleting a row inside the range (not on the top boundary) shrinks it from within, leaving the top
+    /// fixed: A3:A5 with row 4 deleted becomes A3:A4. This case was already correct and must not regress.
+    /// </summary>
+    [Test]
+    public void DeletingMiddleRowOfNamedRange_ShrinksFromWithin()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A3").Value = "top";
+        ws.Cell("A4").Value = "mid";
+        ws.Cell("A5").Value = "bottom";
+        ws.Range("A3:A5").AddToNamed("MidDelete", XLScope.Workbook);
+
+        ws.Row(4).Delete();
+
+        Assert.That(RefersTo(wb, "MidDelete"), Is.EqualTo("Sheet1!$A$3:$A$4"));
+    }
+
+    /// <summary>
+    /// Deleting a row entirely above the range shifts the whole range up without shrinking:
+    /// A3:A4 with row 1 deleted becomes A2:A3. This case was already correct and must not regress.
+    /// </summary>
+    [Test]
+    public void DeletingRowAboveNamedRange_ShiftsWholeRangeUp()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A3").Value = "a";
+        ws.Cell("A4").Value = "b";
+        ws.Range("A3:A4").AddToNamed("AboveDelete", XLScope.Workbook);
+
+        ws.Row(1).Delete();
+
+        Assert.That(RefersTo(wb, "AboveDelete"), Is.EqualTo("Sheet1!$A$2:$A$3"));
+    }
+
+    /// <summary>
+    /// The top-boundary shrink also applies across multiple columns: B3:D4 with row 3 deleted becomes B3:D3.
+    /// </summary>
+    [Test]
+    public void DeletingTopRowOfMultiColumnNamedRange_ShrinksAndShifts()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Range("B3:D4").Value = "x";
+        ws.Range("B3:D4").AddToNamed("Block", XLScope.Workbook);
+
+        ws.Row(3).Delete();
+
+        Assert.That(RefersTo(wb, "Block"), Is.EqualTo("Sheet1!$B$3:$D$3"));
+    }
+
+    /// <summary>
+    /// Column counterpart of the top-row bug: deleting the left column of a named range removes it and
+    /// shifts survivors left (C1:D1 -> C1:C1) rather than expanding to B1:C1.
+    /// </summary>
+    [Test]
+    public void DeletingLeftColumnOfNamedRange_ShrinksAndShifts()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("C1").Value = "deleted";
+        ws.Cell("D1").Value = "survivor";
+        ws.Range("C1:D1").AddToNamed("LeftDelete", XLScope.Workbook);
+
+        ws.Column(3).Delete();
+
+        Assert.That(RefersTo(wb, "LeftDelete"), Is.EqualTo("Sheet1!$C$1:$C$1"));
+    }
+
+    /// <summary>
+    /// Deleting a column entirely to the left of the range shifts the whole range left without shrinking:
+    /// C1:D1 with column A deleted becomes B1:C1. Guards against over-clamping the column path.
+    /// </summary>
+    [Test]
+    public void DeletingColumnLeftOfNamedRange_ShiftsWholeRangeLeft()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("C1").Value = "a";
+        ws.Cell("D1").Value = "b";
+        ws.Range("C1:D1").AddToNamed("ColAbove", XLScope.Workbook);
+
+        ws.Column(1).Delete();
+
+        Assert.That(RefersTo(wb, "ColAbove"), Is.EqualTo("Sheet1!$B$1:$C$1"));
+    }
+}

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -90,9 +90,44 @@ internal static partial class XLCellFormulaShifter
         if (A1RowRegex.IsMatch(rangeAddress))
             AppendShiftedRowOnlyRange(sb, rangeAddress, rowsShifted);
         else if (shiftedRange.RangeAddress.FirstAddress.RowNumber <= matchRange.RangeAddress.FirstAddress.RowNumber)
-            AppendShiftedRowCellRange(sb, worksheetInAction, matchRange, rangeAddress, rowsShifted);
+        {
+            if (IsTopBoundaryDeletion(shiftedRange, matchRange, rowsShifted))
+                AppendClampedTopRowShift(sb, worksheetInAction, shiftedRange, matchRange, rowsShifted);
+            else
+                AppendShiftedRowCellRange(sb, worksheetInAction, matchRange, rangeAddress, rowsShifted);
+        }
         else
             AppendPartialRowShift(sb, worksheetInAction, matchRange, rowsShifted);
+    }
+
+    /// <summary>
+    /// True when a row deletion removes the top boundary of <paramref name="matchRange"/> while some
+    /// rows below the deletion survive. Excel keeps the range's top row fixed at the deletion start and
+    /// shifts only the bottom up (shrink + shift), e.g. deleting row 3 turns A3:A4 into A3:A3. Shifting
+    /// both endpoints (as for a range that is entirely below the deletion) would instead expand the range
+    /// upward to A2:A3. See issue #2866.
+    /// </summary>
+    private static bool IsTopBoundaryDeletion(XLRange shiftedRange, IXLRange matchRange, int rowsShifted)
+    {
+        return rowsShifted < 0
+            && matchRange.RangeAddress.FirstAddress.RowNumber <= shiftedRange.RangeAddress.LastAddress.RowNumber
+            && matchRange.RangeAddress.LastAddress.RowNumber > shiftedRange.RangeAddress.LastAddress.RowNumber;
+    }
+
+    private static void AppendClampedTopRowShift(StringBuilder sb, XLWorksheet ws, XLRange shiftedRange,
+        IXLRange matchRange, int rowsShifted)
+    {
+        sb.Append(new XLAddress(ws,
+            XLHelper.TrimRowNumber(shiftedRange.RangeAddress.FirstAddress.RowNumber),
+            matchRange.RangeAddress.FirstAddress.ColumnLetter,
+            matchRange.RangeAddress.FirstAddress.FixedRow,
+            matchRange.RangeAddress.FirstAddress.FixedColumn));
+        sb.Append(':');
+        sb.Append(new XLAddress(ws,
+            XLHelper.TrimRowNumber(matchRange.RangeAddress.LastAddress.RowNumber + rowsShifted),
+            matchRange.RangeAddress.LastAddress.ColumnLetter,
+            matchRange.RangeAddress.LastAddress.FixedRow,
+            matchRange.RangeAddress.LastAddress.FixedColumn));
     }
 
     private static bool IsRowRangeWithinShiftedRange(XLRange shiftedRange, IXLRange matchRange)
@@ -210,9 +245,43 @@ internal static partial class XLCellFormulaShifter
         if (A1ColumnRegex.IsMatch(rangeAddress))
             AppendShiftedColumnOnlyRange(sb, rangeAddress, columnsShifted);
         else if (shiftedRange.RangeAddress.FirstAddress.ColumnNumber <= matchRange.RangeAddress.FirstAddress.ColumnNumber)
-            AppendShiftedColumnCellRange(sb, worksheetInAction, matchRange, rangeAddress, columnsShifted);
+        {
+            if (IsLeftBoundaryDeletion(shiftedRange, matchRange, columnsShifted))
+                AppendClampedLeftColumnShift(sb, worksheetInAction, shiftedRange, matchRange, columnsShifted);
+            else
+                AppendShiftedColumnCellRange(sb, worksheetInAction, matchRange, rangeAddress, columnsShifted);
+        }
         else
             AppendPartialColumnShift(sb, worksheetInAction, matchRange, columnsShifted);
+    }
+
+    /// <summary>
+    /// Column-wise counterpart of <see cref="IsTopBoundaryDeletion"/>: true when a column deletion removes
+    /// the left boundary of <paramref name="matchRange"/> while some columns to the right survive. Excel
+    /// keeps the range's left column fixed at the deletion start and shifts only the right edge left, e.g.
+    /// deleting column C turns C1:D1 into C1:C1 rather than expanding it to B1:C1. See issue #2866.
+    /// </summary>
+    private static bool IsLeftBoundaryDeletion(XLRange shiftedRange, IXLRange matchRange, int columnsShifted)
+    {
+        return columnsShifted < 0
+            && matchRange.RangeAddress.FirstAddress.ColumnNumber <= shiftedRange.RangeAddress.LastAddress.ColumnNumber
+            && matchRange.RangeAddress.LastAddress.ColumnNumber > shiftedRange.RangeAddress.LastAddress.ColumnNumber;
+    }
+
+    private static void AppendClampedLeftColumnShift(StringBuilder sb, XLWorksheet ws, XLRange shiftedRange,
+        IXLRange matchRange, int columnsShifted)
+    {
+        sb.Append(new XLAddress(ws,
+            matchRange.RangeAddress.FirstAddress.RowNumber,
+            XLHelper.TrimColumnNumber(shiftedRange.RangeAddress.FirstAddress.ColumnNumber),
+            matchRange.RangeAddress.FirstAddress.FixedRow,
+            matchRange.RangeAddress.FirstAddress.FixedColumn));
+        sb.Append(':');
+        sb.Append(new XLAddress(ws,
+            matchRange.RangeAddress.LastAddress.RowNumber,
+            XLHelper.TrimColumnNumber(matchRange.RangeAddress.LastAddress.ColumnNumber + columnsShifted),
+            matchRange.RangeAddress.LastAddress.FixedRow,
+            matchRange.RangeAddress.LastAddress.FixedColumn));
     }
 
     private static bool IsColumnRangeWithinShiftedRange(XLRange shiftedRange, IXLRange matchRange)


### PR DESCRIPTION
## Summary

Deleting the **first row of a named range** shifted both endpoints upward instead of removing the deleted row and shifting the survivors up. A named range `A3:A4` with row 3 deleted became `A2:A3` — expanding the range to include a row (`A2`) that was never part of it — where Excel produces `A3:A3`.

```
Before: $A$3:$A$4
After (was):      $A$2:$A$3
After (Excel/fix): $A$3:$A$3
```

## Root cause

In `XLCellFormulaShifter`, when the deleted region starts at or before the range's first row, the code took the "range is entirely below the deleted region" branch and shifted **both** endpoints by the shift amount. That is only correct when the deletion is fully *above* the range. When the deletion overlaps the range's **top boundary** while rows below it survive, Excel clamps the top edge to the deletion start and shifts only the bottom edge up.

## Changes

- `XLCellFormulaShifter.AppendShiftedRowMatch` — new `IsTopBoundaryDeletion` guard routes the overlapping-top case to `AppendClampedTopRowShift` (leading edge → deletion start, trailing edge → shifted).
- Symmetric fix for the **column** path (`AppendShiftedColumnMatch` / `IsLeftBoundaryDeletion` / `AppendClampedLeftColumnShift`): deleting the left column of `C1:D1` now yields `C1:C1` instead of `B1:C1`.
- Both guards require a negative shift, so **row/column insertion behavior is unchanged**.

## Behavior

| Operation | Named range | Before | After |
|---|---|---|---|
| Delete top row | `A3:A4` | `A2:A3` | `A3:A3` |
| Delete rows 2:3 | `A3:A5` | `A1:A3` | `A2:A3` |
| Delete middle row 4 | `A3:A5` | `A3:A4` | unchanged |
| Delete row above (row 1) | `A3:A4` | `A2:A3` | unchanged |
| Delete left column | `C1:D1` | `B1:C1` | `C1:C1` |

## Testing

- New `NamedRangeDeletionTests` (7 cases): top-row shrink, multi-row top overlap, middle-row regression guard, row-above regression guard, multi-column block, left-column shrink, column-left regression guard.
- Full suite: **6095 passed, 0 failed**.

Refs [ClosedXML/ClosedXML#2866](https://github.com/ClosedXML/ClosedXML/issues/2866)
