### PR TITLE
test: guard LINQ filtering over ColumnsUsed/RowsUsed (#2867 not reproducible)

### DIFF
--- a/XLibur.Tests/Excel/Columns/ColumnsUsedLinqTests.cs
+++ b/XLibur.Tests/Excel/Columns/ColumnsUsedLinqTests.cs
@@ -62,12 +62,15 @@ public class ColumnsUsedLinqTests
 
         var visited = ws.ColumnsUsed()
             .Where(c => c.ColumnNumber() != 1)
-            .Select(c => c.ColumnNumber())
+            .Select(c => (Number: c.ColumnNumber(), WidthBefore: c.Width))
             .ToList();
         foreach (var column in ws.ColumnsUsed().Where(c => c.ColumnNumber() != 1))
             column.AdjustToContents();
 
-        Assert.That(visited, Is.EqualTo(new[] { 2, 3 }));
+        Assert.That(visited.Select(v => v.Number), Is.EqualTo(new[] { 2, 3 }));
+        foreach (var v in visited)
+            Assert.That(ws.Column(v.Number).Width, Is.Not.EqualTo(v.WidthBefore),
+                $"Visited column {v.Number} should have been adjusted.");
         Assert.That(ws.Column(1).Width, Is.EqualTo(20).Within(1e-9), "Filtered-out first column must keep its width.");
     }
 
@@ -80,14 +83,23 @@ public class ColumnsUsedLinqTests
         ws.Cell("A2").Value = "row2";
         ws.Cell("A3").Value = "row3";
 
-        // Fix the first row height; skipping it must leave this untouched.
+        // Give every used row the same non-default height. Skipping row 1 must leave it untouched,
+        // while the visited rows must be adjusted back to fit their content.
         ws.Row(1).Height = 40;
+        ws.Row(2).Height = 40;
+        ws.Row(3).Height = 40;
 
-        var visited = ws.RowsUsed().Skip(1).Select(r => r.RowNumber()).ToList();
+        var visited = ws.RowsUsed()
+            .Skip(1)
+            .Select(r => (Number: r.RowNumber(), HeightBefore: r.Height))
+            .ToList();
         foreach (var row in ws.RowsUsed().Skip(1))
             row.AdjustToContents();
 
-        Assert.That(visited, Is.EqualTo(new[] { 2, 3 }), "Only the trailing rows should be visited.");
+        Assert.That(visited.Select(v => v.Number), Is.EqualTo(new[] { 2, 3 }), "Only the trailing rows should be visited.");
+        foreach (var v in visited)
+            Assert.That(ws.Row(v.Number).Height, Is.Not.EqualTo(v.HeightBefore),
+                $"Visited row {v.Number} should have been adjusted.");
         Assert.That(ws.Row(1).Height, Is.EqualTo(40).Within(1e-9), "Skipped first row must keep its height.");
     }
 }

--- a/XLibur.Tests/Excel/Columns/ColumnsUsedLinqTests.cs
+++ b/XLibur.Tests/Excel/Columns/ColumnsUsedLinqTests.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using XLibur.Excel;
+using NUnit.Framework;
+
+namespace XLibur.Tests.Excel.Columns;
+
+/// <summary>
+/// Guards that standard LINQ operators (<c>Skip</c>, <c>Where</c>) over the enumerable returned by
+/// <see cref="IXLWorksheet.ColumnsUsed()"/> / <see cref="IXLWorksheet.RowsUsed()"/> behave as expected:
+/// a filtered-out column/row must not be visited and therefore must not be adjusted. See
+/// ClosedXML/ClosedXML#2867, which reports the opposite behavior on the parent library.
+/// </summary>
+[TestFixture]
+public class ColumnsUsedLinqTests
+{
+    [Test]
+    public void ColumnsUsed_EnumeratesInAscendingColumnOrder()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("C1").Value = "c";
+        ws.Cell("A1").Value = "a";
+        ws.Cell("B1").Value = "b";
+
+        var order = ws.ColumnsUsed().Select(c => c.ColumnNumber()).ToList();
+
+        Assert.That(order, Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void ColumnsUsed_Skip_DoesNotAdjustSkippedColumn()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = "Cheesecake sablfdsa daskjfhdsakjdsa and what more thing we have...!";
+        ws.Cell("A2").Value = "Medovik";
+        ws.Cell("B1").Value = 14;
+        ws.Cell("B2").Value = 6;
+
+        // Fix the first column width; skipping it must leave this untouched.
+        ws.Column(1).Width = 20;
+        var defaultBWidth = ws.Column(2).Width;
+
+        var visited = ws.ColumnsUsed().Skip(1).Select(c => c.ColumnNumber()).ToList();
+        foreach (var column in ws.ColumnsUsed().Skip(1))
+            column.AdjustToContents();
+
+        Assert.That(visited, Is.EqualTo(new[] { 2 }), "Only the second column should be visited.");
+        Assert.That(ws.Column(1).Width, Is.EqualTo(20).Within(1e-9), "Skipped first column must keep its width.");
+        Assert.That(ws.Column(2).Width, Is.Not.EqualTo(defaultBWidth), "Second column should have been adjusted.");
+    }
+
+    [Test]
+    public void ColumnsUsed_Where_DoesNotAdjustFilteredColumn()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = "Long long long long long long text";
+        ws.Cell("B1").Value = "short";
+        ws.Cell("C1").Value = "short";
+        ws.Column(1).Width = 20;
+
+        var visited = ws.ColumnsUsed()
+            .Where(c => c.ColumnNumber() != 1)
+            .Select(c => c.ColumnNumber())
+            .ToList();
+        foreach (var column in ws.ColumnsUsed().Where(c => c.ColumnNumber() != 1))
+            column.AdjustToContents();
+
+        Assert.That(visited, Is.EqualTo(new[] { 2, 3 }));
+        Assert.That(ws.Column(1).Width, Is.EqualTo(20).Within(1e-9), "Filtered-out first column must keep its width.");
+    }
+
+    [Test]
+    public void RowsUsed_Skip_DoesNotAdjustSkippedRow()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = "row1";
+        ws.Cell("A2").Value = "row2";
+        ws.Cell("A3").Value = "row3";
+
+        // Fix the first row height; skipping it must leave this untouched.
+        ws.Row(1).Height = 40;
+
+        var visited = ws.RowsUsed().Skip(1).Select(r => r.RowNumber()).ToList();
+        foreach (var row in ws.RowsUsed().Skip(1))
+            row.AdjustToContents();
+
+        Assert.That(visited, Is.EqualTo(new[] { 2, 3 }), "Only the trailing rows should be visited.");
+        Assert.That(ws.Row(1).Height, Is.EqualTo(40).Within(1e-9), "Skipped first row must keep its height.");
+    }
+}


### PR DESCRIPTION
## Summary

[ClosedXML/ClosedXML#2867](https://github.com/ClosedXML/ClosedXML/issues/2867) reports that LINQ filtering (`Skip`, `Where`) over `IXLWorksheet.ColumnsUsed()` (and rows) does not work as expected — e.g. `ColumnsUsed().Skip(1)` supposedly still adjusts the first column.

**This fork is not affected.** Verified against every variant the reporter described:

| Operation | Behavior in this fork |
|---|---|
| `ws.ColumnsUsed().Skip(1)` + `AdjustToContents()` | visits only column 2; column 1 keeps its width |
| `ws.ColumnsUsed().Where(c => c.ColumnNumber() != 1)` | visits columns 2,3; column 1 untouched |
| `ws.RowsUsed().Skip(1)` | visits rows 2,3; row 1 keeps its height |
| exact `InsertData` repro (wrap + width 20 + `Skip(1)`) | column A stays width 20 |

`XLColumns.GetEnumerator()` orders by column number and `ColumnsUsed()` returns a materialized collection, so `Skip`/`Where` are stable and correctly ordered.

## Changes

Test-only. Adds `ColumnsUsedLinqTests` (4 tests) to lock in the correct filtering behavior and guard against regression, since the enumerator is shared with upstream:

- `ColumnsUsed_EnumeratesInAscendingColumnOrder`
- `ColumnsUsed_Skip_DoesNotAdjustSkippedColumn`
- `ColumnsUsed_Where_DoesNotAdjustFilteredColumn`
- `RowsUsed_Skip_DoesNotAdjustSkippedRow`

No production code change.

Refs [ClosedXML/ClosedXML#2867](https://github.com/ClosedXML/ClosedXML/issues/2867)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for worksheet column and row enumeration with standard LINQ operations.
  - Verified columns are returned in ascending order.
  - Confirmed skipped or filtered rows and columns remain unchanged when adjusting contents.
  - Confirmed unfiltered items are adjusted as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->