### PR TITLE
docs: fix unresolvable cref doc warning in ColumnsUsedLinqTests

### DIFF
--- a/XLibur.Tests/Excel/Columns/ColumnsUsedLinqTests.cs
+++ b/XLibur.Tests/Excel/Columns/ColumnsUsedLinqTests.cs
@@ -6,7 +6,7 @@ namespace XLibur.Tests.Excel.Columns;
 
 /// <summary>
 /// Guards that standard LINQ operators (<c>Skip</c>, <c>Where</c>) over the enumerable returned by
-/// <see cref="IXLWorksheet.ColumnsUsed()"/> / <see cref="IXLWorksheet.RowsUsed()"/> behave as expected:
+/// <c>IXLWorksheet.ColumnsUsed()</c> / <c>IXLWorksheet.RowsUsed()</c> behave as expected:
 /// a filtered-out column/row must not be visited and therefore must not be adjusted. See
 /// ClosedXML/ClosedXML#2867, which reports the opposite behavior on the parent library.
 /// </summary>


### PR DESCRIPTION
The XML doc summary on `ColumnsUsedLinqTests` (merged in #143) referenced `IXLWorksheet.ColumnsUsed()` / `RowsUsed()` via `<see cref>`. Those members only exist with optional parameters, so the parameterless cref cannot be resolved, producing CS1574 warnings on build.

Replaced the crefs with `<c>` code text. Build now completes with 0 warnings; no test behavior change.