### PR TITLE
chore(deps): bump EPPlus, SkiaSharp, and Polyfill

### DIFF
--- a/XLibur.Benchmarks/XLibur.Benchmarks.csproj
+++ b/XLibur.Benchmarks/XLibur.Benchmarks.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="EPPlus" Version="8.6.2" />
     <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.18" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/XLibur.Benchmarks/XLibur.Benchmarks.csproj
+++ b/XLibur.Benchmarks/XLibur.Benchmarks.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="EPPlus" Version="8.6.2" />
     <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.18" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
 </Project>

--- a/XLibur.Benchmarks/XLibur.Benchmarks.csproj
+++ b/XLibur.Benchmarks/XLibur.Benchmarks.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.dotMemory" Version="0.15.8" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.15.8" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
-    <PackageReference Include="EPPlus" Version="8.6.1" />
+    <PackageReference Include="EPPlus" Version="8.6.2" />
     <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.18" />
   </ItemGroup>
 

--- a/XLibur.Benchmarks/XLibur.Benchmarks.csproj
+++ b/XLibur.Benchmarks/XLibur.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <AssemblyName>XLibur.Benchmarks</AssemblyName>

--- a/XLibur.Benchmarks/XLibur.Benchmarks.csproj
+++ b/XLibur.Benchmarks/XLibur.Benchmarks.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="EPPlus" Version="8.6.2" />
     <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.18" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
+++ b/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
@@ -34,8 +34,8 @@
 
     <ItemGroup>
         <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
-        <PackageReference Include="SkiaSharp" Version="4.150.0" />
-        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.150.0" />
+        <PackageReference Include="SkiaSharp" Version="4.150.1" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.150.1" />
     </ItemGroup>
 
 </Project>

--- a/XLibur.Tests/Excel/Columns/ColumnsUsedLinqTests.cs
+++ b/XLibur.Tests/Excel/Columns/ColumnsUsedLinqTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 using NUnit.Framework;
 

--- a/XLibur.Tests/Excel/NamedRanges/NamedRangeDeletionTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangeDeletionTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using XLibur.Excel;
 using NUnit.Framework;
 

--- a/XLibur/XLibur.csproj
+++ b/XLibur/XLibur.csproj
@@ -39,7 +39,7 @@
         <PackageReference Include="JetBrains.Annotations" Version="2026.2.0"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
         <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All"/>
-        <PackageReference Include="Polyfill" Version="10.11.2">
+        <PackageReference Include="Polyfill" Version="11.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
## Summary

Routine dependency version bumps plus a small encoding-consistency fix.

### Dependency bumps
- **EPPlus** `8.6.1` → `8.6.2` (benchmarks project)
- **SkiaSharp** `4.150.0` → `4.150.1` (fonts SkiaSharp project, both the core and Linux native-assets packages)
- **Polyfill** `10.11.2` → `11.0.1` (core library)

### Encoding consistency
- Added a UTF-8 BOM to two test files (`ColumnsUsedLinqTests.cs`, `NamedRangeDeletionTests.cs`) to align their encoding with the rest of the test suite.

## Testing
- `dotnet test XLibur.Tests` — **6099 passed, 0 failed, 40 skipped** on both net8.0 and net10.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated underlying spreadsheet, graphics, and compatibility components to newer versions for improved stability and platform support.

* **Chores**
  * Performed maintenance updates across benchmarking and core components.
  * Standardized source-file formatting without changing application behavior or test coverage.

* **User Impact**
  * No new user-facing features or workflow changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->