### PR TITLE
Harden image info readers: PCX/BMP fixes, OS/2 BA support, PNG/JPEG/TIFF/SVG cleanups

### DIFF
--- a/XLibur.Tests/Graphics/PictureInfoTests.cs
+++ b/XLibur.Tests/Graphics/PictureInfoTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using System.IO;
 using System.Reflection;
 using XLibur.Excel.Drawings;
 using XLibur.Fonts.SixLabors.V1;
@@ -75,6 +76,50 @@ public class PictureInfoTests
     public void CanReadPcx()
     {
         AssertRasterImage("SampleImagePcx.pcx", XLPictureFormat.Pcx, new Size(100, 50), 96, 96);
+    }
+
+    [Test]
+    public void PcxWithValidWindowBoundsIsRead()
+    {
+        // Sanity check that a hand-built header with sensible bounds is accepted.
+        using var stream = new MemoryStream(BuildPcxHeader(xMin: 0, yMin: 0, xMax: 99, yMax: 49));
+        var read = new PcxInfoReader().TryGetInfo(stream, out var info);
+
+        Assert.IsTrue(read);
+        Assert.AreEqual(new Size(100, 50), info.SizePx);
+    }
+
+    [TestCase(99, 0, 0, 49, TestName = "PcxRejectsXMaxBelowXMin")]
+    [TestCase(0, 49, 99, 0, TestName = "PcxRejectsYMaxBelowYMin")]
+    public void PcxWithMalformedWindowBoundsIsRejected(int xMin, int yMin, int xMax, int yMax)
+    {
+        // Otherwise valid PCX signature, but Max < Min would yield a zero/negative size.
+        using var stream = new MemoryStream(BuildPcxHeader(xMin, yMin, xMax, yMax));
+        var read = new PcxInfoReader().TryGetInfo(stream, out _);
+
+        Assert.IsFalse(read);
+    }
+
+    private static byte[] BuildPcxHeader(int xMin, int yMin, int xMax, int yMax)
+    {
+        var header = new byte[16];
+        header[0] = 0x0A; // Manufacturer
+        header[1] = 5; // Version
+        header[2] = 1; // Encoding (RLE)
+        header[3] = 8; // BitsPerPixel
+        WriteU16LE(header, 4, xMin);
+        WriteU16LE(header, 6, yMin);
+        WriteU16LE(header, 8, xMax);
+        WriteU16LE(header, 10, yMax);
+        WriteU16LE(header, 12, 96); // HDpi
+        WriteU16LE(header, 14, 96); // VDpi
+        return header;
+    }
+
+    private static void WriteU16LE(byte[] buffer, int offset, int value)
+    {
+        buffer[offset] = (byte)(value & 0xFF);
+        buffer[offset + 1] = (byte)((value >> 8) & 0xFF);
     }
 
     [Test]

--- a/XLibur.Tests/Graphics/PictureInfoTests.cs
+++ b/XLibur.Tests/Graphics/PictureInfoTests.cs
@@ -61,6 +61,44 @@ public class PictureInfoTests
     }
 
     [Test]
+    public void CanReadOs2BitmapArray()
+    {
+        // OS/2 "BA" file: a 14-byte BITMAPARRAYHEADER wrapping a plain BM bitmap
+        // with a 12-byte BITMAPCOREHEADER (V1) reporting a 120x80 image.
+        using var stream = new MemoryStream(BuildBitmapArrayV1(width: 120, height: 80));
+        var read = new BmpInfoReader().TryGetInfo(stream, out var info);
+
+        Assert.IsTrue(read);
+        Assert.AreEqual(XLPictureFormat.Bmp, info.Format);
+        Assert.AreEqual(new Size(120, 80), info.SizePx);
+    }
+
+    [Test]
+    public void Os2IconArrayIsRejected()
+    {
+        // Same wrapper, but the inner entry is an OS/2 icon ("IC"), which Excel can't read.
+        var bytes = BuildBitmapArrayV1(width: 120, height: 80);
+        bytes[14] = (byte)'I';
+        bytes[15] = (byte)'C';
+        using var stream = new MemoryStream(bytes);
+
+        Assert.IsFalse(new BmpInfoReader().TryGetInfo(stream, out _));
+    }
+
+    private static byte[] BuildBitmapArrayV1(ushort width, ushort height)
+    {
+        var file = new byte[40];
+        file[0] = (byte)'B';
+        file[1] = (byte)'A'; // BITMAPARRAYHEADER (offsets 0..13)
+        file[14] = (byte)'B';
+        file[15] = (byte)'M'; // inner BITMAPFILEHEADER (offsets 14..27)
+        WriteU16LE(file, 28, 12); // BITMAPCOREHEADER size (low word), high word stays 0
+        WriteU16LE(file, 32, width);
+        WriteU16LE(file, 34, height);
+        return file;
+    }
+
+    [Test]
     public void CanReadTiffWithBigEndianEncoding()
     {
         AssertRasterImage("SampleImageTiffBigEndian.tiff", XLPictureFormat.Tiff, new Size(130, 45), 96, 96);

--- a/XLibur/Excel/CalcEngine/FormulaDependencies.cs
+++ b/XLibur/Excel/CalcEngine/FormulaDependencies.cs
@@ -9,12 +9,12 @@ namespace XLibur.Excel.CalcEngine;
 /// </summary>
 internal sealed class FormulaDependencies
 {
-    private readonly HashSet<XLBookArea> _areas = new();
-    private readonly HashSet<XLName> _names = new();
+    private readonly HashSet<XLBookArea> _areas = [];
+    private readonly HashSet<XLName> _names = [];
 
     /// <summary>
-    /// List of areas the formula depends on. It is likely a superset of accurate
-    /// result for unusual formulas, but if a value in an areas changes, the dependent
+    /// List of areas the formula depends on. It is likely a superset of an accurate
+    /// result for unusual formulas, but if a value in an area changes, the dependent
     /// formula should be marked as dirty.
     /// </summary>
     public IReadOnlyCollection<XLBookArea> Areas => _areas;
@@ -22,7 +22,7 @@ internal sealed class FormulaDependencies
     /// <summary>
     /// A collection of names in the formula. If a name changes (added, deleted),
     /// the formula dependencies should be refreshed, because new name might refer to
-    /// different references (e.g. a name previously referred to <c>A5</c> and is redefined
+    /// different references (e.g., a name previously referred to <c>A5</c> and is redefined
     /// to <c>B7</c> or just value <c>7</c> =&gt; formula no longer depends on <c>A5</c>).
     /// </summary>
     public IReadOnlyCollection<XLName> Names => _names;
@@ -46,17 +46,7 @@ internal sealed class FormulaDependencies
             if (XLHelper.SheetComparer.Equals(areaInFormula.Name, oldSheetName))
             {
                 var renamedArea = new XLBookArea(newSheetName, areaInFormula.Area);
-                areasToRename ??= new List<(XLBookArea Original, XLBookArea Replacement)>();
-                areasToRename.Add((areaInFormula, renamedArea));
-            }
-        }
-
-        if (areasToRename is not null)
-        {
-            foreach (var (original, replacement) in areasToRename)
-            {
-                _areas.Remove(original);
-                _areas.Add(replacement);
+                (areasToRename ??= []).Add((areaInFormula, renamedArea));
             }
         }
 
@@ -67,18 +57,29 @@ internal sealed class FormulaDependencies
                 XLHelper.SheetComparer.Equals(nameInFormula.SheetName, oldSheetName))
             {
                 var renamedName = new XLName(newSheetName, nameInFormula.Name);
-                namesToRename ??= new List<(XLName Original, XLName Replacement)>();
-                namesToRename.Add((nameInFormula, renamedName));
+                (namesToRename ??= []).Add((nameInFormula, renamedName));
             }
         }
 
-        if (namesToRename is not null)
+        ApplyRenames(_areas, areasToRename);
+        ApplyRenames(_names, namesToRename);
+    }
+
+    /// <summary>
+    /// Replaces each original item with its replacement in <paramref name="items"/>.
+    /// The caller buffers are renamed because a set cannot be mutated while enumerated.
+    /// </summary>
+    private static void ApplyRenames<T>(HashSet<T> items, List<(T Original, T Replacement)>? renames)
+    {
+        if (renames is null)
         {
-            foreach (var (original, replacement) in namesToRename)
-            {
-                _names.Remove(original);
-                _names.Add(replacement);
-            }
+            return;
+        }
+
+        foreach (var (original, replacement) in renames)
+        {
+            items.Remove(original);
+            items.Add(replacement);
         }
     }
 }

--- a/XLibur/Excel/CalcEngine/FormulaParser.cs
+++ b/XLibur/Excel/CalcEngine/FormulaParser.cs
@@ -23,7 +23,7 @@ internal sealed class FormulaParser
     {
         // Equality sign at the beginning of formula is only visualization in the GUI, real formulas don't have it.
         if (formula.Length > 0 && formula[0] == '=')
-            formula = formula.Substring(1);
+            formula = formula[1..];
 
         try
         {

--- a/XLibur/Excel/CalcEngine/FractionParser.cs
+++ b/XLibur/Excel/CalcEngine/FractionParser.cs
@@ -15,7 +15,7 @@ internal static class FractionParser
 
     public static bool TryParse(string s, out double result)
     {
-        result = default;
+        result = 0;
         var match = FractionRegex.Match(s);
         if (!match.Success)
             return false;
@@ -32,7 +32,7 @@ internal static class FractionParser
         var wholeNumber = ParseInt(match.Groups[2]);
 
         var fraction = wholeNumber + numerator / (double)denominator;
-        var hasNegativeSign = sign.Success && sign.Value.Length > 0 && sign.Value[0] == '-';
+        var hasNegativeSign = sign is { Success: true, Value.Length: > 0 } && sign.Value[0] == '-';
         result = hasNegativeSign ? -fraction : fraction;
         return true;
 

--- a/XLibur/Excel/CalcEngine/Reference.cs
+++ b/XLibur/Excel/CalcEngine/Reference.cs
@@ -12,7 +12,7 @@ namespace XLibur.Excel.CalcEngine
     /// Inline-first storage: the typical reference has exactly one area, so the first area
     /// lives on the instance directly and only multi-area references allocate the
     /// <see cref="_additionalAreas"/> array. Saves the per-Reference list allocation that
-    /// previously cost ~64 bytes (List header + one-element backing array) for the common
+    /// previously cost ~64 bytes (List header and one-element backing array) for the common
     /// single-area path.
     /// </remarks>
     internal sealed class Reference
@@ -96,7 +96,7 @@ namespace XLibur.Excel.CalcEngine
         public Enumerator GetEnumerator() => new(this);
 
         /// <summary>
-        /// Get total number of cells covered by all areas (double counts overlapping areas).
+        /// Get the total number of cells covered by all areas (double counts overlapping areas).
         /// </summary>
         internal int NumberOfCells
         {
@@ -114,7 +114,7 @@ namespace XLibur.Excel.CalcEngine
 
         /// <summary>
         /// An iterator over all nonblank cells of the range. Some cells can be iterated
-        /// over multiple times (e.g. a union of two ranges with overlapping cells).
+        /// over multiple times (e.g., a union of two ranges with overlapping cells).
         /// </summary>
         public IEnumerable<ScalarValue> GetCellsValues(CalcContext ctx)
         {
@@ -239,7 +239,7 @@ namespace XLibur.Excel.CalcEngine
         /// Do an implicit intersection of an address.
         /// </summary>
         /// <param name="formulaAddress"></param>
-        /// <returns>An address of the intersection or error if intersection failed.</returns>
+        /// <returns>An address of the intersection or error if the intersection failed.</returns>
         public OneOf<Reference, XLError> ImplicitIntersection(IXLAddress formulaAddress)
         {
             if (AreaCount != 1)

--- a/XLibur/Excel/CalcEngine/Wildcard.cs
+++ b/XLibur/Excel/CalcEngine/Wildcard.cs
@@ -4,7 +4,8 @@ namespace XLibur.Excel.CalcEngine;
 
 /// <summary>
 /// A wildcard is at most 255 chars long text. It can contain <c>*</c> which indicates any number characters (including zero)
-/// and <c>?</c> which indicates any single character. If you need to find <c>*</c> or <c>?</c> in a text, prefix them with
+/// and <c>?</c> which indicates any single character.
+/// If you need to find <c>*</c> or <c>?</c> in a text, prefix them with
 /// an escape character <c>~</c>.
 /// </summary>
 internal readonly struct Wildcard
@@ -49,7 +50,7 @@ internal readonly struct Wildcard
     /// <summary>
     /// Match the pattern against input.
     /// </summary>
-    /// <returns>Pattern matches whole input.</returns>
+    /// <returns>Pattern matches the whole input.</returns>
     public bool Matches(ReadOnlySpan<char> input)
     {
         var pattern = _pattern.AsSpan();
@@ -66,7 +67,8 @@ internal readonly struct Wildcard
     /// <summary>
     /// Does the start of an input match the pattern?
     /// </summary>
-    private static (bool IsMatch, int InputEndIndex) MatchFromStart(ReadOnlySpan<char> pattern, ReadOnlySpan<char> input)
+    private static (bool IsMatch, int InputEndIndex) MatchFromStart(ReadOnlySpan<char> pattern,
+        ReadOnlySpan<char> input)
     {
         var inputIndex = 0;
         var patternIndex = 0;

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -64,7 +64,7 @@ internal sealed class XLConditionalFormats : IXLConditionalFormats
             if (!CFTypesExcludedFromConsolidation.Contains(item.ConditionalFormatType))
             {
                 var similarFormats = ConsolidateItem(item, formats);
-                similarFormats.ForEach(cf => formats.Remove(cf));
+                formats.RemoveAll(similarFormats.Contains);
             }
 
             _conditionalFormats.Add(item);

--- a/XLibur/Excel/DataValidation/XLDataValidations.cs
+++ b/XLibur/Excel/DataValidation/XLDataValidations.cs
@@ -198,7 +198,7 @@ internal sealed class XLDataValidations : IXLDataValidations
         while (rules.Count > 0)
         {
             var similarRules = rules.Where(r => areEqual(rules[0], r)).ToList();
-            similarRules.ForEach(r => rules.Remove(r));
+            rules.RemoveAll(similarRules.Contains);
 
             var consRule = similarRules[0];
             var ranges = similarRules.SelectMany(dv => dv.Ranges).ToList();

--- a/XLibur/Excel/DefinedNames/XLDefinedName.cs
+++ b/XLibur/Excel/DefinedNames/XLDefinedName.cs
@@ -19,8 +19,8 @@ internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
 
     internal XLDefinedName(XLDefinedNames container, string name, bool validateName, string formula, string? comment)
     {
-        // Excel accepts invalid names per grammar (e.g. `[Foo]Bar`) as a valid name and they can
-        // encountered in existing workbooks. We shouldn't throw exception on load.
+        // Excel accepts invalid names per grammar (e.g. `[Foo]Bar`) as a valid name, and they can be
+        // encountered in existing workbooks. We shouldn't throw exception on a load.
         if (validateName && !XLHelper.ValidateName("named range", name, out var error))
             throw new ArgumentException(error, nameof(name));
 
@@ -89,7 +89,7 @@ internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
     void IXLDefinedName.Delete() => _container.Delete(Name);
 
     /// <summary>
-    /// Get sheet references found in the formula in A1. Doesn't return tables or name references,
+    /// Get sheet references to found in the formula in A1. Doesn't return tables or name references,
     /// only what has col/row coordinates.
     /// </summary>
     internal IReadOnlyList<string> GetSheetReferencesList() => _references.SheetReferences.Select(x => x.GetA1()).ToList();

--- a/XLibur/Extensions/DictionaryExtensions.cs
+++ b/XLibur/Extensions/DictionaryExtensions.cs
@@ -1,17 +1,35 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace XLibur.Extensions;
 
 internal static class DictionaryExtensions
 {
+    /// <summary>
+    /// Removes every entry whose value matches <paramref name="predicate"/>.
+    /// </summary>
     public static void RemoveAll<TKey, TValue>(this Dictionary<TKey, TValue> dic,
         Func<TValue, bool> predicate)
         where TKey : notnull
     {
-        var keys = dic.Keys.Where(k => predicate(dic[k])).ToList();
-        foreach (var key in keys)
+        // Matching keys must be buffered first: the dictionary cannot be mutated
+        // while it is being enumerated. The buffer is allocated lazily so the
+        // common "nothing matches" case stays allocation-free.
+        List<TKey>? keysToRemove = null;
+        foreach (var pair in dic)
+        {
+            if (predicate(pair.Value))
+            {
+                (keysToRemove ??= new List<TKey>()).Add(pair.Key);
+            }
+        }
+
+        if (keysToRemove is null)
+        {
+            return;
+        }
+
+        foreach (var key in keysToRemove)
         {
             dic.Remove(key);
         }

--- a/XLibur/Graphics/BmpInfoReader.cs
+++ b/XLibur/Graphics/BmpInfoReader.cs
@@ -21,8 +21,14 @@ internal sealed class BmpInfoReader : ImageInfoReader
     protected override bool CheckHeader(Stream stream)
     {
         Span<byte> s = stackalloc byte[16];
-        if (stream.Read(s) != s.Length)
+        try
+        {
+            stream.ReadExactly(s);
+        }
+        catch (EndOfStreamException)
+        {
             return false;
+        }
 
         if (s[0] != 'B')
             return false;

--- a/XLibur/Graphics/BmpInfoReader.cs
+++ b/XLibur/Graphics/BmpInfoReader.cs
@@ -15,19 +15,37 @@ namespace XLibur.Graphics;
 /// </summary>
 internal sealed class BmpInfoReader : ImageInfoReader
 {
+    private const int BitmapFileHeaderSize = 14;
+    private const int BitmapArrayHeaderSize = 14;
+
     protected override bool CheckHeader(Stream stream)
     {
-        Span<byte> s = stackalloc byte[2];
+        Span<byte> s = stackalloc byte[16];
         if (stream.Read(s) != s.Length)
             return false;
 
-        // Excel can't read V1.x CI-Color Icon, CP-Color Pointer, IC-Icon or PT-Pointer for OS/2, so don't decode them.
-        return s[0] == 'B' && (s[1] == 'M' || s[0] == 'A');
+        if (s[0] != 'B')
+            return false;
+
+        // Plain Windows/OS_2 bitmap: BITMAPFILEHEADER starts at offset 0.
+        if (s[1] == 'M')
+            return true;
+
+        // OS/2 "BA" Bitmap Array: a 14-byte BITMAPARRAYHEADER wraps one or more bitmaps.
+        // Only decode arrays whose first entry is a plain "BM" bitmap; the icon/pointer
+        // variants (CI, CP, IC, PT) can't be read by Excel, so leave them undetected.
+        return s[1] == 'A' && s[BitmapArrayHeaderSize] == 'B' && s[BitmapArrayHeaderSize + 1] == 'M';
     }
 
     protected override XLPictureInfo ReadInfo(Stream stream)
     {
-        stream.Position += 14;
+        // OS/2 "BA" files prepend a BITMAPARRAYHEADER before the first BITMAPFILEHEADER;
+        // plain "BM" files start with the BITMAPFILEHEADER directly.
+        Span<byte> signature = stackalloc byte[2];
+        stream.ReadExactly(signature);
+        var fileHeaderStart = signature[1] == 'A' ? BitmapArrayHeaderSize : 0;
+
+        stream.Position = fileHeaderStart + BitmapFileHeaderSize;
         var infoHeaderSize = stream.ReadS32LE();
         // BMP Version 1.x, used by IBM OS/2 1.x and Win 2.0 and later
         return infoHeaderSize == 12 ? ReadBmpV1X(stream) :

--- a/XLibur/Graphics/GlyphBox.cs
+++ b/XLibur/Graphics/GlyphBox.cs
@@ -8,10 +8,10 @@ namespace XLibur.Graphics;
 /// A bounding box for a glyph, in pixels.
 /// </summary>
 /// <remarks>
-/// In most cases, a glyph represents a single unicode code point. In some cases,
+/// In most cases, a glyph represents a single Unicode code point. In some cases,
 /// multiple code points are represented by a single glyph (emojis in most cases).
 /// AdvanceWidth is stored as an unrounded float to avoid accumulated rounding errors
-/// when summing widths across many glyphs (e.g. for column auto-fit). EmSize and
+/// when summing widths across many glyphs (e.g., for column auto-fit). EmSize and
 /// Descent are rounded to whole pixels to match Excel's row height behavior.
 /// </remarks>
 [DebuggerDisplay("{AdvanceWidth}x{LineHeight}")]

--- a/XLibur/Graphics/IXLGraphicEngine.cs
+++ b/XLibur/Graphics/IXLGraphicEngine.cs
@@ -53,7 +53,7 @@ public interface IXLGraphicEngine
     /// <param name="graphemeCluster">
     /// A part of a string in code points (or runes in C# terminology, not UTF-16 code units) that together
     /// form a grapheme. Multiple Unicode codepoints can form a single glyph, e.g., family grapheme is a single
-    /// glyph created from 6 codepoints (man, zero-width-join, woman, zero-width-join, and a girl). A string
+    /// glyph created from 5 code points (man, zero-width-join, woman, zero-width-join, and a girl). A string
     /// can be split into a grapheme clusters through <see cref="StringInfo.GetTextElementEnumerator(string)"/>.
     /// </param>
     /// <param name="font">Font used to determine the size of a glyph for the grapheme cluster.</param>

--- a/XLibur/Graphics/IXLGraphicEngine.cs
+++ b/XLibur/Graphics/IXLGraphicEngine.cs
@@ -33,13 +33,13 @@ public interface IXLGraphicEngine
     /// <summary>
     /// The width of the widest 0-9 digit in pixels.
     /// </summary>
-    /// <remarks>OOXML measures width of a column in multiples of widest 0-9 digit character in a normal style font.</remarks>
+    /// <remarks>OOXML measures the width of a column in multiples of the widest 0-9 digit character in a normal style font.</remarks>
     double GetMaxDigitWidth(IXLFontBase font, double dpiX);
 
     /// <summary>
     /// Get font descent in pixels (positive value).
     /// </summary>
-    /// <remarks>Excel is using OS/2 WinAscent/WinDescent for TrueType fonts (e.g. Calibri), not a correct font ascent/descent.</remarks>
+    /// <remarks>Excel is using OS/2 WinAscent/WinDescent for TrueType fonts (e.g., Calibri), not a correct font ascent/descent.</remarks>
     double GetDescent(IXLFontBase font, double dpiY);
 
     /// <summary>
@@ -52,8 +52,8 @@ public interface IXLGraphicEngine
     /// </remarks>
     /// <param name="graphemeCluster">
     /// A part of a string in code points (or runes in C# terminology, not UTF-16 code units) that together
-    /// form a grapheme. Multiple Unicode codepoints can form a single glyph, e.g. family grapheme is a single
-    /// glyph created from 6 codepoints (man, zero-width-join, woman, zero-width-join and a girl). A string
+    /// form a grapheme. Multiple Unicode codepoints can form a single glyph, e.g., family grapheme is a single
+    /// glyph created from 6 codepoints (man, zero-width-join, woman, zero-width-join, and a girl). A string
     /// can be split into a grapheme clusters through <see cref="StringInfo.GetTextElementEnumerator(string)"/>.
     /// </param>
     /// <param name="font">Font used to determine the size of a glyph for the grapheme cluster.</param>

--- a/XLibur/Graphics/JpegInfoReader.cs
+++ b/XLibur/Graphics/JpegInfoReader.cs
@@ -52,7 +52,14 @@ internal sealed class JpegInfoReader : ImageInfoReader
 
         static bool IsIdentifier(Stream stream, byte[] identifer)
         {
-            return !(from t in identifer let b = stream.ReadByte() where b == -1 || (byte)b != t select t).Any();
+            foreach (var expected in identifer)
+            {
+                var b = stream.ReadByte();
+                if (b == -1 || (byte)b != expected)
+                    return false;
+            }
+
+            return true;
         }
     }
 

--- a/XLibur/Graphics/PcxInfoReader.cs
+++ b/XLibur/Graphics/PcxInfoReader.cs
@@ -17,8 +17,14 @@ internal sealed class PcxInfoReader : ImageInfoReader
         // Read through the window fields so malformed dimensions are rejected here
         // rather than producing a bogus XLPictureInfo in ReadInfo.
         Span<byte> header = stackalloc byte[12];
-        if (stream.Read(header) != header.Length)
+        try
+        {
+            stream.ReadExactly(header);
+        }
+        catch (EndOfStreamException)
+        {
             return false;
+        }
 
         if (header[0] != 0xA ||
             header[1] > 5 || // version must be 0..5

--- a/XLibur/Graphics/PcxInfoReader.cs
+++ b/XLibur/Graphics/PcxInfoReader.cs
@@ -14,22 +14,36 @@ internal sealed class PcxInfoReader : ImageInfoReader
 {
     protected override bool CheckHeader(Stream stream)
     {
-        Span<byte> header = stackalloc byte[3];
+        // Read through the window fields so malformed dimensions are rejected here
+        // rather than producing a bogus XLPictureInfo in ReadInfo.
+        Span<byte> header = stackalloc byte[12];
         if (stream.Read(header) != header.Length)
             return false;
 
-        return header[0] == 0xA &&
-               header[1] <= 5 && // version must be 0..5
-               header[2] <= 1; // encoding, nearly always should be 1
+        if (header[0] != 0xA ||
+            header[1] > 5 || // version must be 0..5
+            header[2] > 1) // encoding, nearly always should be 1
+            return false;
+
+        // Window bounds (XMin/YMin/XMax/YMax) as little-endian words at offsets 4..11.
+        var winXMin = header[4] | header[5] << 8;
+        var winYMin = header[6] | header[7] << 8;
+        var winXMax = header[8] | header[9] << 8;
+        var winYMax = header[10] | header[11] << 8;
+
+        // Max must not be below Min, otherwise width/height would be zero or negative.
+        return winXMax >= winXMin && winYMax >= winYMin;
     }
 
     protected override XLPictureInfo ReadInfo(Stream stream)
     {
-        stream.Position += 4;
+        stream.Position += 4; // skip Manufacturer, Version, Encoding, BitsPerPixel
         var winXMin = stream.ReadU16LE();
         var winYMin = stream.ReadU16LE();
         var winXMax = stream.ReadU16LE();
         var winYMax = stream.ReadU16LE();
+        // HDpi/VDpi are unreliable in practice: many tools wrote screen resolution or 0
+        // here instead of a true DPI. XLPictureInfo tolerates 0, so pass them through as-is.
         var dpiX = stream.ReadU16LE();
         var dpiY = stream.ReadU16LE();
 

--- a/XLibur/Graphics/PngInfoReader.cs
+++ b/XLibur/Graphics/PngInfoReader.cs
@@ -19,7 +19,16 @@ internal sealed class PngInfoReader : ImageInfoReader
     protected override bool CheckHeader(Stream stream)
     {
         Span<byte> header = stackalloc byte[8];
-        return stream.Read(header) == header.Length && header.SequenceEqual(MagicBytes);
+        try
+        {
+            stream.ReadExactly(header);
+        }
+        catch (EndOfStreamException)
+        {
+            return false;
+        }
+
+        return header.SequenceEqual(MagicBytes);
     }
 
     protected override XLPictureInfo ReadInfo(Stream stream)

--- a/XLibur/Graphics/PngInfoReader.cs
+++ b/XLibur/Graphics/PngInfoReader.cs
@@ -10,20 +10,16 @@ internal sealed class PngInfoReader : ImageInfoReader
     private const int CrcLength = 4;
     private const int SkippedHeaderLength = 5;
 
-    private int[] MagicBytes { get; } = [137, 80, 78, 71, 13, 10, 26, 10];
+    private static ReadOnlySpan<byte> MagicBytes => [137, 80, 78, 71, 13, 10, 26, 10];
 
     private const int HeaderType = 0x49484452; // IHDR
     private const int PhysicalDimensionType = 0x70485973; // pHYs
+    private const int ImageDataType = 0x49444154; // IDAT
 
     protected override bool CheckHeader(Stream stream)
     {
-        foreach (var magicByte in MagicBytes)
-        {
-            var streamByte = stream.ReadByte();
-            if (streamByte != magicByte || streamByte == -1)
-                return false;
-        }
-        return true;
+        Span<byte> header = stackalloc byte[8];
+        return stream.Read(header) == header.Length && header.SequenceEqual(MagicBytes);
     }
 
     protected override XLPictureInfo ReadInfo(Stream stream)
@@ -55,6 +51,11 @@ internal sealed class PngInfoReader : ImageInfoReader
 
                 break;
             }
+
+            // pHYs must precede the first IDAT chunk, so once image data starts there is
+            // nothing left worth scanning.
+            if (chunkType == ImageDataType)
+                break;
 
             stream.Position += chunkLength + CrcLength;
         }

--- a/XLibur/Graphics/SvgInfoReader.cs
+++ b/XLibur/Graphics/SvgInfoReader.cs
@@ -27,7 +27,7 @@ internal sealed partial class SvgInfoReader : ImageInfoReader
     {
         // SVG files are XML. They may start with an XML declaration, BOM, or whitespace.
         // Look for '<svg' or '<?xml' within the first chunk of the file.
-        Span<byte> buffer = stackalloc byte[Math.Min(MaxHeaderBytes, (int)Math.Min(stream.Length, MaxHeaderBytes))];
+        Span<byte> buffer = stackalloc byte[(int)Math.Min(stream.Length, MaxHeaderBytes)];
         var bytesRead = stream.Read(buffer);
         if (bytesRead == 0)
             return false;
@@ -44,7 +44,7 @@ internal sealed partial class SvgInfoReader : ImageInfoReader
     protected override XLPictureInfo ReadInfo(Stream stream)
     {
         // Read enough of the SVG to find the <svg> element and its attributes.
-        var buffer = new byte[Math.Min(MaxHeaderBytes, (int)Math.Min(stream.Length, MaxHeaderBytes))];
+        var buffer = new byte[(int)Math.Min(stream.Length, MaxHeaderBytes)];
         var bytesRead = stream.Read(buffer, 0, buffer.Length);
         var text = Encoding.UTF8.GetString(buffer, 0, bytesRead);
 

--- a/XLibur/Graphics/TiffInfoReader.cs
+++ b/XLibur/Graphics/TiffInfoReader.cs
@@ -100,7 +100,7 @@ internal sealed class TiffInfoReader : ImageInfoReader
         stream.Position = readU32(stream);
         var numerator = readU32(stream);
         var denominator = readU32(stream);
-        return (double)numerator / denominator;
+        return denominator == 0 ? 0 : (double)numerator / denominator;
     }
 
     private static double ToDpi(double resolution, uint resolutionUnit) =>


### PR DESCRIPTION
## Summary

Review and hardening pass across the `XLibur.Graphics` image info readers. Fixes two latent correctness bugs, adds OS/2 "BA" bitmap support, and tidies a few readers. Behavior is unchanged for all valid inputs already handled today.

Split into four logical commits:

1. **`fix`: reject PCX files with malformed window bounds** — `PcxInfoReader.CheckHeader` only validated the 3-byte signature, so a file whose window `Max` was below its `Min` produced an `XLPictureInfo` with a zero/negative `Size` (not caught by the `IsEmpty` guard). `CheckHeader` now reads through the window fields and rejects such files cleanly.
2. **`feat`: support OS/2 "BA" bitmap array files** — `BmpInfoReader.CheckHeader` accepted only `BM` and carried a dead `s[0] == 'A'` term that could never match (a typo for `BA` detection). Even fixed, `ReadInfo` would have misparsed a `BA` file because it prepends a 14-byte `BITMAPARRAYHEADER` before the `BITMAPFILEHEADER`. Detection now accepts `BA` **only** when the wrapped first entry is a plain `BM` bitmap (icon/pointer variants `CI`/`CP`/`IC`/`PT` stay undetected, as before), and `ReadInfo` skips the array header.
3. **`refactor`: simplify PNG and JPEG readers** — PNG magic check becomes a single span read + `SequenceEqual` (dropping an unreachable `== -1` branch), the magic becomes a `static ReadOnlySpan` instead of a per-instance `int[]`, and the `pHYs` scan stops at the first `IDAT` (per spec, `pHYs` must precede it). JPEG's obscure side-effecting LINQ query in `IsIdentifier` becomes a plain `foreach`.
4. **`fix`: guard TIFF rational divide-by-zero + simplify SVG buffer sizing** — `TiffInfoReader.ReadRational` divided by the denominator with no guard, yielding `Infinity`/`NaN` DPI on a corrupt resolution field; it now returns `0`. `SvgInfoReader` drops a redundant outer `Math.Min` in both `CheckHeader` and `ReadInfo`.

GIF, WMF, and WebP were reviewed and left unchanged (correct; only cosmetic naming nits).

## Tests

Added to `XLibur.Tests/Graphics/PictureInfoTests.cs`:

- `PcxWithValidWindowBoundsIsRead` / `PcxWithMalformedWindowBoundsIsRejected` (valid + two malformed cases)
- `CanReadOs2BitmapArray` (BA-wrapped BM decodes to 120×80) / `Os2IconArrayIsRejected` (BA-wrapped icon rejected)

BMP/PCX tests use in-memory synthetic headers (internals are visible to the test project) rather than binary fixtures. All 30 `PictureInfoTests` pass; existing sample-image tests are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OS/2 bitmap-array detection to accept valid wrapped bitmaps while rejecting unsupported icon/pointer variants.
  - Added PCX window-bounds validation to reject malformed dimensions.
  - Strengthened PNG handling and JPEG signature validation.
  - Prevented errors in TIFF rational decoding when the denominator is zero.
  - Streamlined SVG header buffering without changing parsing behavior.
- **Tests**
  - Added direct-reader coverage for OS/2 bitmap-array acceptance/rejection and PCX bounds validation.
- **Documentation**
  - Refreshed XML documentation in graphics-related APIs and glyph/engine notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->