### PR TITLE
fix: shift conditional-format ranges once on insert (ClosedXML #2850)

### DIFF
--- a/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
+++ b/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
@@ -1,0 +1,64 @@
+using XLibur.Excel;
+using NUnit.Framework;
+using System.Linq;
+
+namespace XLibur.Tests.Excel.ConditionalFormats;
+
+// Regression coverage for ClosedXML issue #2850: inserting rows/columns must shift every
+// conditional-format (and data-validation) range by exactly the inserted amount. The original
+// defect doubled the offset for rules whose shifted target address collided with another
+// existing rule's range, because the range repository handed back the same aliased instance
+// which was then shifted a second time by the blanket auto-shift.
+[TestFixture]
+public class ConditionalFormatRangeShiftTests
+{
+    [Test]
+    public void InsertRowsAbove_ShiftsCfRangesByExactAmount()
+    {
+        // Layout from the issue: multiple rules per row, and rows whose shifted target collides
+        // with another rule's row (13+10 == 23, which already hosts rules).
+        var rows = new[] { 12, 12, 12, 13, 13, 13, 16, 16, 16, 17, 17, 17, 23, 23, 31, 31, 32, 34, 34, 35 };
+        const int inserted = 10;
+
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        foreach (var r in rows)
+            ws.Cell(r, 11 /* K */).AddConditionalFormat().WhenGreaterThan(1).Fill.SetBackgroundColor(XLColor.Red);
+
+        ws.Row(13).InsertRowsAbove(inserted);
+
+        var expected = rows.Select(r => r < 13
+            ? $"K12:K{12 + inserted}"      // row above the insertion expands to swallow inserted rows
+            : $"K{r + inserted}:K{r + inserted}"); // rows at/below the insertion move down
+
+        var actual = ws.ConditionalFormats.Select(cf => cf.Ranges.Single().RangeAddress.ToString());
+        Assert.That(actual, Is.EqualTo(expected.ToList()));
+    }
+
+    [Test]
+    public void InsertColumnsBefore_ShiftsCfRangesByExactAmount()
+    {
+        // Column analogue: C+10 == M, which already hosts rules.
+        var cols = new[] { 2, 2, 3, 3, 6, 13, 13, 15 }; // B, C, F, M, O
+        const int inserted = 10;
+
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        foreach (var c in cols)
+            ws.Cell(20, c).AddConditionalFormat().WhenGreaterThan(1).Fill.SetBackgroundColor(XLColor.Red);
+
+        ws.Column(3).InsertColumnsBefore(inserted);
+
+        var actual = ws.ConditionalFormats
+            .Select(cf => cf.Ranges.Single().RangeAddress)
+            .Select(a => (a.FirstAddress.ColumnNumber, a.LastAddress.ColumnNumber))
+            .ToList();
+
+        var expected = cols.Select(c => c < 3
+            ? (c, c + inserted)          // column before the insertion expands
+            : (c + inserted, c + inserted)) // columns at/after the insertion move right
+            .ToList();
+
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+}

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -1172,6 +1172,20 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
 
         WorksheetRangeShiftedRows(range, rowsShifted);
 
+        // When the insertion is below row 1, the worksheet-level shift above already
+        // repositioned conditional-format and data-validation ranges
+        // (ShiftConditionalFormattingRows / ShiftDataValidationRows). Those handlers obtain
+        // replacement ranges through the range repository, which deduplicates by address — so
+        // when a shifted target lands on an address that already owns a stored range, they
+        // receive that pre-existing instance, which is also present in rangesToShift. Re-applying
+        // the blanket shift below would move it a second time (the "doubled" offset in ClosedXML
+        // issue #2850). Exclude those ranges so each is shifted exactly once. For a first-row
+        // insert the explicit handlers short-circuit and delegate to the blanket shift, so no
+        // exclusion applies.
+        var alreadyShifted = range.RangeAddress.FirstAddress.RowNumber != 1
+            ? GetExplicitlyShiftedRanges()
+            : null;
+
         var collapsed = false;
         foreach (var storedRange in rangesToShift)
         {
@@ -1179,6 +1193,9 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
                 continue;
 
             if (ReferenceEquals(range, storedRange))
+                continue;
+
+            if (alreadyShifted?.Contains(storedRange) == true)
                 continue;
 
             storedRange.WorksheetRangeShiftedRows(range, rowsShifted);
@@ -1203,6 +1220,14 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
 
         WorksheetRangeShiftedColumns(range, columnsShifted);
 
+        // See NotifyRangeShiftedRows: for inserts past the first column, CF/DV ranges are
+        // repositioned explicitly and can alias a stored range at the shifted target address, so
+        // exclude them from the blanket shift to avoid the doubled offset (ClosedXML issue #2850).
+        // A first-column insert short-circuits the explicit handlers, so no exclusion applies.
+        var alreadyShifted = range.RangeAddress.FirstAddress.ColumnNumber != 1
+            ? GetExplicitlyShiftedRanges()
+            : null;
+
         var collapsed = false;
         foreach (var storedRange in rangesToShift)
         {
@@ -1210,6 +1235,9 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
                 continue;
 
             if (ReferenceEquals(range, storedRange))
+                continue;
+
+            if (alreadyShifted?.Contains(storedRange) == true)
                 continue;
 
             storedRange.WorksheetRangeShiftedColumns(range, columnsShifted);
@@ -1223,6 +1251,34 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
         {
             range.WorksheetRangeShiftedColumns(range, columnsShifted);
         }
+    }
+
+    /// <summary>
+    /// Collects the range instances currently owned by conditional formats and data validations.
+    /// These are repositioned explicitly during a row/column shift; because the range repository
+    /// deduplicates by address, an explicit replacement can be the very same instance the blanket
+    /// shift in <see cref="NotifyRangeShiftedRows"/> / <see cref="NotifyRangeShiftedColumns"/> is
+    /// about to move, which would double the offset (ClosedXML issue #2850). Callers use the
+    /// returned set to shift each range exactly once. Reference identity is required because
+    /// distinct range instances may share an address.
+    /// </summary>
+    private HashSet<object> GetExplicitlyShiftedRanges()
+    {
+        var handled = new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        foreach (var cf in ConditionalFormats)
+        {
+            foreach (var cfRange in cf.Ranges)
+                handled.Add(cfRange);
+        }
+
+        foreach (var dv in DataValidations)
+        {
+            foreach (var dvRange in dv.Ranges)
+                handled.Add(dvRange);
+        }
+
+        return handled;
     }
 
     public XLRow Row(int rowNumber, bool pingCells)


### PR DESCRIPTION
## Problem

Inserting rows (or columns) below the first line **doubles the shift** for any conditional-format rule whose shifted target address collides with another rule's existing range — the defect reported in **ClosedXML issue [#2850](https://github.com/ClosedXML/ClosedXML/issues/2850)**.

Example: 20 CF rules on column K at rows 12, 13, 16, 17, 23, 31, 32, 34, 35, then `ws.Row(13).InsertRowsAbove(10)`. A rule at K13 should move to **K23**, but lands at **K33** (offset applied twice). Rules at K16/K17 shift correctly because their targets (K26/K27) are empty. The issue's insert-15 case corroborates exactly: K16/K17 double (targets K31/K32 are occupied) while K13 (target K28, empty) is fine.

## Root cause — a double shift

`NotifyRangeShiftedRows` / `NotifyRangeShiftedColumns`:

1. Snapshot every live range in the repository.
2. Run the worksheet-level shift, which repositions CF/DV ranges explicitly via `worksheet.Range(...)`.
3. Blanket-shift each snapshot range in place.

The range repository **deduplicates by address**. When step 2's shifted target lands on an address that already owns a stored range, the explicit handler gets back that *pre-existing* instance — which is also in the step-1 snapshot — so step 3 shifts it a **second time**. Only colliding rules double, which is why the failure looked inconsistent.

Non-colliding rules are safe: step 2 creates a fresh instance at an empty address (not in the snapshot), and the stale originals it replaced are no longer referenced.

## Fix

Exclude the ranges already repositioned by the explicit handlers (`ShiftConditionalFormattingRows` / `ShiftDataValidationRows` and their column counterparts) from the blanket shift, so each range moves exactly once.

The exclusion applies **only for inserts past the first row/column**. A first-row/column insert short-circuits the explicit handlers (there is no line above to expand into) and delegates entirely to the blanket shift — excluding there would leave those ranges unmoved, so no exclusion is applied in that case. Identity is compared by reference (`ReferenceEqualityComparer`) because distinct range instances may share an address.

## Tests

Adds `ConditionalFormatRangeShiftTests`:
- `InsertRowsAbove_ShiftsCfRangesByExactAmount` — the issue's row layout, including the colliding target address.
- `InsertColumnsBefore_ShiftsCfRangesByExactAmount` — the column analogue.

Full suite: **6106 passed, 0 failed**.

## Note (out of scope)

Data-validation ranges share this code path and are covered by the same exclusion. While validating the fix I found a **separate, pre-existing** DV defect: on insert, a validation range whose target collides can be *dropped* entirely (stale rule-range index in `SplitExistingRanges`, see the comment in `XLDataValidations.cs`). That is unrelated to #2850 and unchanged here — flagging it for a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed conditional formatting ranges shifting more than once when rows or columns are inserted.
  - Conditional formatting ranges now move by exactly the number of inserted rows or columns, including overlapping ranges.
  - Improved range handling for data validation rules during row and column insertions, preventing unintended duplicate shifts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->