### PR TITLE
feat: value-typed XLAreaList sqref model; migrate conditional formats onto it (ClosedXML #2850)

### DIFF
--- a/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
+++ b/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
@@ -1,5 +1,8 @@
 using XLibur.Excel;
+using XLibur.Excel.ConditionalFormats;
+using XLibur.Excel.Coordinates;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace XLibur.Tests.Excel.ConditionalFormats;
@@ -72,7 +75,12 @@ public class ConditionalFormatRangeShiftTests
         var ws = wb.AddWorksheet("Sheet1");
         var cf = ws.Range("A5:A7").AddConditionalFormat();
         cf.WhenGreaterThan(1).Fill.SetBackgroundColor(XLColor.Red);
-        cf.Ranges.Add(ws.Range("C10:C12"));
+        // Coverage is stored as an XLAreaList; extend it with a second disjoint area.
+        ((XLConditionalFormat)cf).SetAreas(new XLAreaList(new List<XLSheetRange>
+        {
+            XLSheetRange.Parse("A5:A7"),
+            XLSheetRange.Parse("C10:C12"),
+        }));
 
         ws.Row(6).InsertRowsAbove(3);
 

--- a/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
+++ b/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
@@ -61,4 +61,27 @@ public class ConditionalFormatRangeShiftTests
 
         Assert.That(actual, Is.EqualTo(expected));
     }
+
+    [Test]
+    public void InsertRowsAbove_ShiftsMultiAreaCf_ExtendsAndShiftsTogether()
+    {
+        // A single CF covering two disjoint areas. Inserting rows inside the first must extend it,
+        // while the second (below the insertion) shifts down — the value-typed area transform
+        // handles both in one pass.
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var cf = ws.Range("A5:A7").AddConditionalFormat();
+        cf.WhenGreaterThan(1).Fill.SetBackgroundColor(XLColor.Red);
+        cf.Ranges.Add(ws.Range("C10:C12"));
+
+        ws.Row(6).InsertRowsAbove(3);
+
+        var areas = ws.ConditionalFormats.Single().Ranges
+            .Select(r => r.RangeAddress.ToString())
+            .OrderBy(s => s)
+            .ToList();
+
+        // A5:A7 spans the insertion at row 6 -> extends to A5:A10; C10:C12 is below -> C13:C15.
+        Assert.That(areas, Is.EqualTo(new[] { "A5:A10", "C13:C15" }));
+    }
 }

--- a/XLibur.Tests/Excel/Coordinates/XLAreaConsolidatorTests.cs
+++ b/XLibur.Tests/Excel/Coordinates/XLAreaConsolidatorTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using XLibur.Excel.Coordinates;
+using NUnit.Framework;
+
+namespace XLibur.Tests.Excel.Coordinates;
+
+[TestFixture]
+internal class XLAreaConsolidatorTests
+{
+    [TestCase("", ExpectedResult = "")] // Empty stays empty
+    [TestCase("B2:C3", ExpectedResult = "B2:C3")] // Single area passes through
+    [TestCase("A1:B2 A3:B4", ExpectedResult = "A1:B4")] // Vertically adjacent, same columns - merge
+    [TestCase("A1:B2 C1:D2", ExpectedResult = "A1:D2")] // Horizontally adjacent, same rows - merge
+    [TestCase("A1:C2 B1:D2", ExpectedResult = "A1:D2")] // Overlapping - merge
+    [TestCase("A1:C1 E1:G1 A3:C3 E3:G3", ExpectedResult = "A1:C1 E1:G1 A3:C3 E3:G3")] // Sparse - no merge
+    public string Consolidate_merges_overlapping_and_adjacent_areas(string areaListText)
+    {
+        return Parse(areaListText).GetConsolidated().ToSpaceList();
+    }
+
+    [Test]
+    public void Consolidate_matches_ClosedXML_baseline()
+    {
+        // Ported from ClosedXML RangesConsolidationTests.ConsolidateRangesSameWorksheet, whose
+        // IXLRanges engine runs the same bitmask algorithm as XLAreaConsolidator.
+        var input = Parse("A1:E3 A4:B10 E2:F12 C6:I8 G9 C9:D9 H9 I9:I13 C4:D5");
+
+        var result = input.GetConsolidated().ToSpaceList();
+
+        Assert.AreEqual("A1:E9 F2:F12 G6:I9 A10:B10 E10:E12 I10:I13", result);
+    }
+
+    private static XLAreaList Parse(string spaceList)
+    {
+        if (spaceList.Length == 0)
+            return XLAreaList.Empty;
+
+        var list = new List<XLSheetRange>();
+        foreach (var reference in spaceList.Split(' '))
+            list.Add(XLSheetRange.Parse(reference));
+
+        return new XLAreaList(list);
+    }
+}

--- a/XLibur.Tests/Excel/Coordinates/XLAreaListTests.cs
+++ b/XLibur.Tests/Excel/Coordinates/XLAreaListTests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Linq;
+using XLibur.Excel.Coordinates;
+using NUnit.Framework;
+
+namespace XLibur.Tests.Excel.Coordinates;
+
+// Ported from ClosedXML's XLAreaListTests, adapted to XLibur's XLSheetRange/XLSheetPoint.
+// Covers the value-typed sqref transforms that back conditional-format / data-validation
+// coverage (see XLAreaList). Resource-file baseline comparisons are intentionally omitted.
+[TestFixture]
+internal class XLAreaListTests
+{
+    [TestCase("A1:C3", "A1", "B1:C3 A2:A4")]
+    [TestCase("A1:C3", "B1", "A1:A3 C1:C3 B2:B4")]
+    [TestCase("A1:C3", "C1", "A1:B3 C2:C4")]
+    [TestCase("A1:C3", "A2", "A1:C1 B2:C3 A2:A4")]
+    [TestCase("A1:C3", "B2", "A1:C1 A2:A3 C2:C3 B2:B4")]
+    [TestCase("A1:C3", "C2", "A1:C1 A2:B3 C2:C4")]
+    [TestCase("A1:C3", "A3", "A1:C2 B3:C3 A3:A4")]
+    [TestCase("A1:C3", "B3", "A1:C2 A3 C3 B3:B4")]
+    [TestCase("A1:C3", "C3", "A1:C2 A3:B3 C3:C4")]
+    [TestCase("B1:D3", "A1:A3", "B1:D3")] // Insert to left side - don't move
+    [TestCase("A2:C4", "A1:C1", "A3:C5")] // Insert to top side - shift
+    [TestCase("A2:C4", "A2:C2", "A3:C5")] // Insert to top edge - shift
+    [TestCase("A2:C4", "A1", "B2:C4 A3:A5")] // Insert to top side - shift
+    [TestCase("A1:C3", "D1:D3", "A1:C3")] // Insert to right side - don't move
+    [TestCase("A1:C3", "A4:C5", "A1:C5")] // Insert to bottom edge - extend
+    [TestCase("A1:C3", "A4", "A1:C3 A4")] // Insert to bottom side - extend
+    [TestCase("A1:C3", "B4:E5", "A1:C3 B4:C5")] // Insert to bottom edge (inserted area out of bounds) - extend
+    [TestCase("A1048576", "A1048576", "")] // Push out of sheet
+    [TestCase("A1048575:A1048576", "A1048575", "A1048576")] // Partially push out of sheet
+    [TestCase("A1:A1048576", "A1", "A1:A1048576")] // Columns are not changed
+    public void InsertAndShiftDown(string areaList, string insertedArea, string expected)
+    {
+        var list = new XLAreaList(XLSheetRange.Parse(areaList));
+        var result = list.InsertAndShiftDown(XLSheetRange.Parse(insertedArea));
+
+        Assert.AreEqual(expected, result.ToSpaceList());
+    }
+
+    [TestCase("A1:C3", "A1", "A2:C3 B1:D1")]
+    [TestCase("A1:C3", "B1", "A2:C3 A1:D1")]
+    [TestCase("A1:C3", "C1", "A2:C3 A1:D1")]
+    [TestCase("A1:C3", "A2", "A1:C1 A3:C3 B2:D2")]
+    [TestCase("A1:C3", "B2", "A1:C1 A3:C3 A2:D2")]
+    [TestCase("A1:C3", "C2", "A1:C1 A3:C3 A2:D2")]
+    [TestCase("A1:C3", "A3", "A1:C2 B3:D3")]
+    [TestCase("A1:C3", "B3", "A1:C2 A3:D3")]
+    [TestCase("A1:C3", "C3", "A1:C2 A3:D3")]
+    [TestCase("A1:C3", "A1:A3", "B1:D3")] // Insert to left edge - shift, don't extend
+    [TestCase("A2:C4", "A1", "A2:C4")] // Insert to top side - don't move
+    [TestCase("A1:C3", "D1:D3", "A1:D3")] // Insert to right edge - extend
+    [TestCase("A1:C3", "D2:E10", "A1:C3 D2:E3")] // Insert to right edge (inserted area out of bounds) - extend
+    [TestCase("A1:C3", "E1:E3", "A1:C3")] // Insert to right side - don't move
+    [TestCase("A1:C3", "A4", "A1:C3")] // Insert to bottom side - don't move
+    [TestCase("XFD1", "XFD1", "")] // Push out of sheet
+    [TestCase("XFC1:XFD1", "XFC1", "XFD1")] // Partially push out of sheet
+    [TestCase("A1:XFD1", "A1", "A1:XFD1")] // Rows are not changed
+    public void InsertAndShiftRight(string areaList, string insertedArea, string expected)
+    {
+        var list = new XLAreaList(XLSheetRange.Parse(areaList));
+        var result = list.InsertAndShiftRight(XLSheetRange.Parse(insertedArea));
+
+        Assert.AreEqual(expected, result.ToSpaceList());
+    }
+
+    [TestCase("A1:C3", "A1", "B1:C3 A1:A2")]
+    [TestCase("A1:C3", "B1", "A1:A3 C1:C3 B1:B2")]
+    [TestCase("A1:C3", "C1", "A1:B3 C1:C2")]
+    [TestCase("A1:C3", "A2", "A1:C1 B2:C3 A2")]
+    [TestCase("A1:C3", "B2", "A1:C1 A2:A3 C2:C3 B2")]
+    [TestCase("A1:C3", "C2", "A1:C1 A2:B3 C2")]
+    [TestCase("A1:C3", "A3", "A1:C2 B3:C3")]
+    [TestCase("A1:C3", "B3", "A1:C2 A3 C3")]
+    [TestCase("A1:C3", "C3", "A1:C2 A3:B3")]
+    [TestCase("B1:D3", "A1:A3", "B1:D3")] // Delete on the left side - don't move
+    [TestCase("A2:C4", "A1:C1", "A1:C3")] // Delete on top side - shift
+    [TestCase("A1:C3", "D1:D3", "A1:C3")] // Delete on right side - don't move
+    [TestCase("A1:C3", "A4", "A1:C3")] // Delete on bottom side - don't move
+    [TestCase("A1:A3", "A1:D5", "")] // Delete completely
+    [TestCase("A1:A1048576", "A1", "A1:A1048576")] // Columns are not changed
+    public void DeleteAndShiftUp(string areaList, string deletedArea, string expected)
+    {
+        var list = new XLAreaList(XLSheetRange.Parse(areaList));
+        var result = list.DeleteAndShiftUp(XLSheetRange.Parse(deletedArea));
+
+        Assert.AreEqual(expected, result.ToSpaceList());
+    }
+
+    [TestCase("A1:C3", "A1", "A2:C3 A1:B1")]
+    [TestCase("A1:C3", "B1", "A2:C3 A1 B1")]
+    [TestCase("A1:C3", "C1", "A2:C3 A1:B1")]
+    [TestCase("A1:C3", "A2", "A1:C1 A3:C3 A2:B2")]
+    [TestCase("A1:C3", "B2", "A1:C1 A3:C3 A2 B2")]
+    [TestCase("A1:C3", "C2", "A1:C1 A3:C3 A2:B2")]
+    [TestCase("A1:C3", "A3", "A1:C2 A3:B3")]
+    [TestCase("A1:C3", "B3", "A1:C2 A3 B3")]
+    [TestCase("A1:C3", "C3", "A1:C2 A3:B3")]
+    [TestCase("B1:D3", "A1:A3", "A1:C3")] // Delete on the left side - shift
+    [TestCase("A2:C4", "A1", "A2:C4")] // Delete on top side - don't move
+    [TestCase("A1:C3", "D1:D3", "A1:C3")] // Delete on right side - don't move
+    [TestCase("A1:C3", "A4", "A1:C3")] // Delete on bottom side - don't move
+    [TestCase("A1:A3", "A1:D5", "")] // Delete completely
+    [TestCase("A1:XFD1", "A1", "A1:XFD1")] // Rows are not changed
+    public void DeleteAndShiftLeft(string areaList, string deletedArea, string expected)
+    {
+        var list = new XLAreaList(XLSheetRange.Parse(areaList));
+        var result = list.DeleteAndShiftLeft(XLSheetRange.Parse(deletedArea));
+
+        Assert.AreEqual(expected, result.ToSpaceList());
+    }
+
+    [TestCase("A1", "A1", ExpectedResult = true)]
+    [TestCase("A1:C3", "B2", ExpectedResult = true)]
+    [TestCase("B2:C3", "A2", ExpectedResult = false)]
+    [TestCase("A1:C2 B3:C3", "A3", ExpectedResult = false)]
+    public bool IntersectsWith_determines_intersection_with_any_area(string areaListText, string areaText)
+    {
+        var areaList = Parse(areaListText);
+        var area = XLSheetRange.Parse(areaText);
+        return areaList.IntersectsWith(area);
+    }
+
+    [TestCase("A1", "A1", ExpectedResult = "A1")]
+    [TestCase("A1:C3", "B2", ExpectedResult = "A1:C3")]
+    [TestCase("A1:C3", "B2:D4", ExpectedResult = "A1:C3")]
+    [TestCase("A1 C1", "A1:C1", ExpectedResult = "A1 C1")]
+    [TestCase("A1 C1", "B1", ExpectedResult = "")]
+    [TestCase("A1 C1", "B1:D2", ExpectedResult = "C1")]
+    public string IntersectingWith_returns_areas_intersecting_with_the_other_area(string areaListText, string areaText)
+    {
+        var areaList = Parse(areaListText);
+        var area = XLSheetRange.Parse(areaText);
+        return new XLAreaList(areaList.IntersectingWith(area).ToList()).ToSpaceList();
+    }
+
+    [TestCase("A1", "B1", ExpectedResult = "A1")]
+    [TestCase("A1:E5", "C3:C4", ExpectedResult = "A1:E2 A5:E5 A3:B4 D3:E4")]
+    [TestCase("B2:C5 B9 C4:D7", "C4:C5", ExpectedResult = "B2:C3 B4:B5 B9 C6:D7 D4:D5")]
+    public string Excluding_returns_area_list_without_excluded(string areaListText, string excludedAreaText)
+    {
+        var areaList = Parse(areaListText);
+        var excludedArea = XLSheetRange.Parse(excludedAreaText);
+        return areaList.Excluding(excludedArea).ToSpaceList();
+    }
+
+    [TestCase("A1", "A1", "A1", ExpectedResult = "A1")] // Copy from same point to the same point
+    [TestCase("A1", "B5", "A1", ExpectedResult = "B5")] // Copy to different point
+    [TestCase("B2", "D2", "A1:C3", ExpectedResult = "E3")] // Intersected area not in corner and shifted doesn't start at target
+    [TestCase("D3:G6", "A1", "E4:F5", ExpectedResult = "A1:B2")]
+    [TestCase("B2", "XFD1048576", "A1:C3", ExpectedResult = null)] // Copied area out of sheet
+    public string TryCopyAreaTo_return_list_of_intersecting_areas_shifted_to_target(string areaListText, string targetPointText, string areaToCopyText)
+    {
+        var areaList = Parse(areaListText);
+        var targetPoint = XLSheetPoint.Parse(targetPointText);
+        var areaToCopy = XLSheetRange.Parse(areaToCopyText);
+        return areaList.TryCopyAreaTo(targetPoint, areaToCopy, out var result) ? result.ToSpaceList() : null;
+    }
+
+    private static XLAreaList Parse(string spaceList)
+    {
+        var list = new List<XLSheetRange>();
+        foreach (var reference in spaceList.Split(' '))
+            list.Add(XLSheetRange.Parse(reference));
+
+        return new XLAreaList(list);
+    }
+}

--- a/XLibur.Tests/Excel/DataValidations/DataValidationDropOnInsertTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationDropOnInsertTests.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using NUnit.Framework;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.DataValidations;
+
+// Regression coverage: inserting rows/columns must shift every data-validation rule by exactly
+// the inserted amount without dropping any. The original defect wiped a rule whose extended
+// neighbour transiently overlapped it during the shift (SplitExistingRanges against a
+// not-yet-shifted rule). Related to the conditional-format #2850 double-shift class.
+[TestFixture]
+public class DataValidationDropOnInsertTests
+{
+    [Test]
+    public void InsertRowsAbove_KeepsAllValidationsAndShiftsThem()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        // Distinct rules so nothing consolidates; 13+10 == 23 collides with an existing rule.
+        ws.Range("K12:K12").CreateDataValidation().WholeNumber.GreaterThan(0);
+        ws.Range("K13:K13").CreateDataValidation().WholeNumber.GreaterThan(1);
+        ws.Range("K23:K23").CreateDataValidation().WholeNumber.GreaterThan(2);
+
+        ws.Row(13).InsertRowsAbove(10);
+
+        var actual = ws.DataValidations
+            .SelectMany(dv => dv.Ranges.Select(r => r.RangeAddress.ToString()))
+            .OrderBy(s => s)
+            .ToList();
+
+        // K12 spans the insertion -> K12:K22; K13 -> K23 (not dropped); K23 -> K33.
+        Assert.That(actual, Is.EqualTo(new[] { "K12:K22", "K23:K23", "K33:K33" }));
+    }
+
+    [Test]
+    public void InsertColumnsBefore_KeepsAllValidationsAndShiftsThem()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Range("B20:B20").CreateDataValidation().WholeNumber.GreaterThan(0);
+        ws.Range("C20:C20").CreateDataValidation().WholeNumber.GreaterThan(1);
+        ws.Range("M20:M20").CreateDataValidation().WholeNumber.GreaterThan(2);
+
+        ws.Column(3).InsertColumnsBefore(10); // C+10 == M collides
+
+        var actual = ws.DataValidations
+            .SelectMany(dv => dv.Ranges.Select(r => r.RangeAddress.ToString()))
+            .OrderBy(s => s, System.StringComparer.Ordinal)
+            .ToList();
+
+        // B spans the insertion boundary column -> B20:L20; C20 -> M20; M20 -> W20.
+        Assert.That(actual, Is.EquivalentTo(new[] { "B20:L20", "M20:M20", "W20:W20" }));
+    }
+}

--- a/XLibur/Excel/Cells/XLCellCopyHelper.cs
+++ b/XLibur/Excel/Cells/XLCellCopyHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using XLibur.Excel.ConditionalFormats;
+using XLibur.Excel.Coordinates;
 using XLibur.Excel.Rows;
 
 namespace XLibur.Excel;
@@ -148,7 +149,8 @@ internal static class XLCellCopyHelper
             {
                 if (!cf.Ranges.GetIntersectedRanges(target).Any())
                 {
-                    cf.Ranges.Add(target);
+                    var xlCf = (XLConditionalFormat)cf;
+                    xlCf.SetAreas(xlCf.Areas.With(new XLSheetRange(target.SheetPoint)));
                 }
             }
             else

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using XLibur.Excel.Coordinates;
 using XLibur.Extensions;
 
 namespace XLibur.Excel.ConditionalFormats;
@@ -204,6 +205,26 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
     }
 
     public IXLRanges Ranges { get; private set; }
+
+    /// <summary>
+    /// The conditional format's coverage projected onto a value-typed <see cref="XLAreaList"/>.
+    /// Used to run structural (row/column insert &amp; delete) shifts with the sqref transforms
+    /// instead of mutating aliased repository ranges — see <see cref="SetAreas"/> and
+    /// ClosedXML issue #2850. <see cref="Ranges"/> remains the stored source of truth.
+    /// </summary>
+    internal XLAreaList Areas => XLAreaList.FromRanges(Ranges);
+
+    /// <summary>
+    /// Replace the coverage with <paramref name="areas"/>, materialized as ranges on
+    /// <paramref name="worksheet"/>. Used by the range shifter to write back the result of a
+    /// value-typed area transform.
+    /// </summary>
+    internal void SetAreas(XLAreaList areas, XLWorksheet worksheet)
+    {
+        Ranges.RemoveAll();
+        foreach (var area in areas)
+            Ranges.Add(worksheet.Range(area.TopRow, area.LeftColumn, area.BottomRow, area.RightColumn));
+    }
 
     public XLConditionalFormatType ConditionalFormatType { get; set; }
 

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -130,11 +130,14 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
 
     #region Constructors
 
-    private XLConditionalFormat()
+    private readonly XLWorksheet _worksheet;
+
+    private XLConditionalFormat(XLWorksheet worksheet)
         : base(XLStyle.Default.Value)
     {
+        _worksheet = worksheet;
         Id = Guid.NewGuid();
-        Ranges = new XLRanges();
+        Areas = XLAreaList.Empty;
         Values = new XLDictionary<XLFormula>();
         Colors = new XLDictionary<XLColor>();
         ContentTypes = new XLDictionary<XLCFContentType>();
@@ -142,16 +145,16 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
     }
 
     public XLConditionalFormat(XLRange range, bool copyDefaultModify = false)
-        : this()
+        : this((XLWorksheet)range.Worksheet)
     {
-        Ranges.Add(range);
+        Areas = new XLAreaList(XLSheetRange.FromRangeAddress(range.RangeAddress));
         CopyDefaultModify = copyDefaultModify;
     }
 
     public XLConditionalFormat(IEnumerable<XLRange> ranges, bool copyDefaultModify = false)
-        : this()
+        : this(WorksheetOf(ranges))
     {
-        ranges.ForEach(range => Ranges.Add(range));
+        Areas = XLAreaList.FromRanges(ranges);
         CopyDefaultModify = copyDefaultModify;
     }
 
@@ -161,10 +164,17 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
     }
 
     public XLConditionalFormat(XLConditionalFormat conditionalFormat, IEnumerable<IXLRange> targetRanges)
-        : this()
+        : this(WorksheetOf(targetRanges))
     {
-        targetRanges.ForEach(range => Ranges.Add(range));
+        Areas = XLAreaList.FromRanges(targetRanges);
         CopyFrom(conditionalFormat);
+    }
+
+    private static XLWorksheet WorksheetOf(IEnumerable<IXLRange> ranges)
+    {
+        var first = ranges.FirstOrDefault()
+                    ?? throw new InvalidOperationException("XLConditionalFormat requires at least one range.");
+        return (XLWorksheet)first.Worksheet;
     }
 
     #endregion Constructors
@@ -196,35 +206,44 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
 
     public IXLRange Range
     {
-        get => Ranges.FirstOrDefault() ?? throw new InvalidOperationException("XLConditionalFormat requires at least one Range.");
-        set
+        get => Areas.Count > 0
+            ? MaterializeRange(Areas[0])
+            : throw new InvalidOperationException("XLConditionalFormat requires at least one Range.");
+        set => Areas = new XLAreaList(XLSheetRange.FromRangeAddress(value.RangeAddress));
+    }
+
+    /// <summary>
+    /// The conditional format's coverage, as a value-typed <see cref="XLAreaList"/>. This is the
+    /// source of truth: coverage lives here rather than as live repository ranges, so structural
+    /// (row/column insert &amp; delete) shifts run as pure area transforms and can never alias or
+    /// double-shift (ClosedXML issue #2850). <see cref="Ranges"/> and <see cref="Range"/> are
+    /// projections of it.
+    /// </summary>
+    internal XLAreaList Areas { get; private set; }
+
+    /// <summary>
+    /// Coverage materialized as ranges on the owning worksheet. A fresh snapshot each call —
+    /// mutating the returned collection has no effect; change coverage via <see cref="Range"/> or
+    /// <see cref="SetAreas"/>.
+    /// </summary>
+    public IXLRanges Ranges
+    {
+        get
         {
-            Ranges.RemoveAll();
-            Ranges.Add(value);
+            var ranges = new XLRanges();
+            foreach (var area in Areas)
+                ranges.Add(MaterializeRange(area));
+            return ranges;
         }
     }
 
-    public IXLRanges Ranges { get; private set; }
-
     /// <summary>
-    /// The conditional format's coverage projected onto a value-typed <see cref="XLAreaList"/>.
-    /// Used to run structural (row/column insert &amp; delete) shifts with the sqref transforms
-    /// instead of mutating aliased repository ranges — see <see cref="SetAreas"/> and
-    /// ClosedXML issue #2850. <see cref="Ranges"/> remains the stored source of truth.
+    /// Replace the coverage. Used by the range shifter to write back a value-typed area transform.
     /// </summary>
-    internal XLAreaList Areas => XLAreaList.FromRanges(Ranges);
+    internal void SetAreas(XLAreaList areas) => Areas = areas;
 
-    /// <summary>
-    /// Replace the coverage with <paramref name="areas"/>, materialized as ranges on
-    /// <paramref name="worksheet"/>. Used by the range shifter to write back the result of a
-    /// value-typed area transform.
-    /// </summary>
-    internal void SetAreas(XLAreaList areas, XLWorksheet worksheet)
-    {
-        Ranges.RemoveAll();
-        foreach (var area in areas)
-            Ranges.Add(worksheet.Range(area.TopRow, area.LeftColumn, area.BottomRow, area.RightColumn));
-    }
+    private XLRange MaterializeRange(XLSheetRange area)
+        => _worksheet.Range(area.TopRow, area.LeftColumn, area.BottomRow, area.RightColumn);
 
     public XLConditionalFormatType ConditionalFormatType { get; set; }
 

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -88,9 +88,8 @@ internal sealed class XLConditionalFormats : IXLConditionalFormats
 
         var similarFormats = FindSimilarFormats(formats, rangesToJoin, skippedRanges, IsSameFormat);
 
-        var consRanges = rangesToJoin.Consolidate();
-        item.Ranges.RemoveAll();
-        consRanges.ForEach(r => item.Ranges.Add(r));
+        var consAreas = XLAreaList.FromRanges(rangesToJoin).GetConsolidated();
+        ((XLConditionalFormat)item).SetAreas(consAreas);
 
         var targetCell = (XLCell)item.Ranges.First().FirstCell();
         ((XLConditionalFormat)item).AdjustFormulas(baseCell, targetCell);

--- a/XLibur/Excel/Coordinates/XLAreaConsolidator.cs
+++ b/XLibur/Excel/Coordinates/XLAreaConsolidator.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace XLibur.Excel.Coordinates;
+
+/// <summary>
+/// Consolidates an <see cref="XLAreaList"/> into an equivalent list of non-overlapping areas,
+/// merging overlapping and adjacent rectangles into maximal blocks (rows first, then columns).
+/// Operates purely on <see cref="XLSheetRange"/> value structs via a sparse bit matrix keyed by
+/// the boundary rows of the input areas. Separate from the <see cref="XLibur.Excel.Ranges"/>
+/// <c>XLRangeConsolidationEngine</c>, which works on live <see cref="IXLRanges"/>.
+/// </summary>
+internal static class XLAreaConsolidator
+{
+    internal static XLAreaList Consolidate(XLAreaList areas)
+    {
+        if (areas.Count == 0)
+            return areas;
+
+        var matrix = new XLAreaConsolidationMatrix(areas);
+        var consolidated = matrix.GetConsolidatedRanges().ToList();
+        return new XLAreaList(consolidated);
+    }
+
+    /// <summary>
+    /// Represents the covered cells as a set of bit rows (one per boundary row of the input),
+    /// then reads maximal rectangles back out.
+    /// </summary>
+    private sealed class XLAreaConsolidationMatrix
+    {
+        private readonly Dictionary<int, BitArray> _bitMatrix;
+        private readonly int _minColumn;
+
+        internal XLAreaConsolidationMatrix(XLAreaList areas)
+        {
+            (_bitMatrix, _minColumn) = PrepareBitMatrix(areas);
+            FillBitMatrix(areas);
+        }
+
+        public IEnumerable<XLSheetRange> GetConsolidatedRanges()
+        {
+            var rowNumbers = _bitMatrix.Keys.OrderBy(k => k).ToArray();
+            for (var i = 0; i < rowNumbers.Length; i++)
+            {
+                var startRow = rowNumbers[i];
+                var startings = GetRangesBoundariesStartingByRow(_bitMatrix[startRow]);
+
+                foreach (var starting in startings)
+                {
+                    var j = i + 1;
+                    while (j < rowNumbers.Length && RowIncludesRange(_bitMatrix[rowNumbers[j]], starting)) j++;
+
+                    var endRow = rowNumbers[j - 1];
+                    var startColumn = starting.Item1 + _minColumn - 1;
+                    var endColumn = starting.Item2 + _minColumn - 1;
+
+                    yield return new XLSheetRange(startRow, startColumn, endRow, endColumn);
+
+                    while (j > i)
+                    {
+                        ClearRangeInRow(_bitMatrix[rowNumbers[j - 1]], starting);
+                        j--;
+                    }
+                }
+            }
+        }
+
+        private void AddToBitMatrix(XLSheetRange area)
+        {
+            var rows = _bitMatrix.Keys
+                .Where(k => k >= area.TopRow && k <= area.BottomRow);
+
+            var minIndex = area.LeftColumn - _minColumn + 1;
+            var maxIndex = area.RightColumn - _minColumn + 1;
+
+            foreach (var rowNum in rows)
+            {
+                for (var i = minIndex; i <= maxIndex; i++)
+                {
+                    _bitMatrix[rowNum][i] = true;
+                }
+            }
+        }
+
+        private static void ClearRangeInRow(BitArray rowArray, Tuple<int, int> rangeBoundaries)
+        {
+            for (var i = rangeBoundaries.Item1; i <= rangeBoundaries.Item2; i++)
+            {
+                rowArray[i] = false;
+            }
+        }
+
+        private void FillBitMatrix(IEnumerable<XLSheetRange> areas)
+        {
+            foreach (var area in areas)
+            {
+                AddToBitMatrix(area);
+            }
+        }
+
+        private static IEnumerable<Tuple<int, int>> GetRangesBoundariesStartingByRow(BitArray rowArray)
+        {
+            var startIdx = 0;
+            for (var i = 1; i < rowArray.Length - 1; i++)
+            {
+                if (!rowArray[i - 1] && rowArray[i])
+                    startIdx = i;
+                if (rowArray[i] && !rowArray[i + 1])
+                    yield return new Tuple<int, int>(startIdx, i);
+            }
+        }
+
+        private static (Dictionary<int, BitArray> BitMatrix, int MinColumn) PrepareBitMatrix(XLAreaList areas)
+        {
+            var minColumn = XLHelper.MaxColumnNumber + 1;
+            var maxColumn = 0;
+            foreach (var area in areas)
+            {
+                minColumn = minColumn <= area.LeftColumn ? minColumn : area.LeftColumn;
+                maxColumn = maxColumn >= area.RightColumn ? maxColumn : area.RightColumn;
+            }
+
+            // Two guard columns (indices 0 and Length-1) stay clear so boundary detection is uniform.
+            var bitMaskSize = maxColumn - minColumn + 3;
+            var bitMatrix = new Dictionary<int, BitArray>();
+            foreach (var area in areas)
+            {
+                AddRowBitmask(bitMatrix, area.TopRow, bitMaskSize);
+                AddRowBitmask(bitMatrix, area.BottomRow, bitMaskSize);
+                AddRowBitmask(bitMatrix, area.BottomRow + 1, bitMaskSize);
+            }
+
+            return (bitMatrix, minColumn);
+
+            static void AddRowBitmask(Dictionary<int, BitArray> bitMatrix, int rowNum, int bitMaskSize)
+            {
+                if (!bitMatrix.ContainsKey(rowNum))
+                    bitMatrix.Add(rowNum, new BitArray(bitMaskSize, false));
+            }
+        }
+
+        private static bool RowIncludesRange(BitArray rowArray, Tuple<int, int> rangeBoundaries)
+        {
+            for (var i = rangeBoundaries.Item1; i <= rangeBoundaries.Item2; i++)
+            {
+                if (!rowArray[i])
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/XLibur/Excel/Coordinates/XLAreaList.cs
+++ b/XLibur/Excel/Coordinates/XLAreaList.cs
@@ -309,6 +309,14 @@ internal sealed class XLAreaList : IEnumerable<XLSheetRange>
         return new XLAreaList(result);
     }
 
+    /// <summary>
+    /// Return an equivalent list with overlapping and adjacent areas merged into maximal blocks.
+    /// </summary>
+    internal XLAreaList GetConsolidated()
+    {
+        return XLAreaConsolidator.Consolidate(this);
+    }
+
     internal bool IntersectsWith(XLSheetRange otherArea)
     {
         foreach (var area in _areas)

--- a/XLibur/Excel/Coordinates/XLAreaList.cs
+++ b/XLibur/Excel/Coordinates/XLAreaList.cs
@@ -1,0 +1,399 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace XLibur.Excel.Coordinates;
+
+/// <summary>
+/// An immutable, value-typed list of rectangular sheet areas (the model behind an OOXML
+/// <c>sqref</c>). Structural operations — <see cref="InsertAndShiftDown"/>,
+/// <see cref="InsertAndShiftRight"/>, <see cref="DeleteAndShiftUp"/>,
+/// <see cref="DeleteAndShiftLeft"/> — return a new list, transformed by pure functions on
+/// <see cref="XLSheetRange"/>. Because areas are plain structs (not shared, repository-backed
+/// range objects), a shift can never alias or double-apply — the failure mode behind
+/// ClosedXML issue #2850. Intended to back conditional-format and data-validation coverage.
+/// </summary>
+internal sealed class XLAreaList : IEnumerable<XLSheetRange>
+{
+    internal static readonly XLAreaList Empty = new(new List<XLSheetRange>());
+
+    private readonly List<XLSheetRange> _areas;
+
+    internal XLAreaList(XLSheetRange area)
+    {
+        _areas = new List<XLSheetRange>(1) { area };
+    }
+
+    internal XLAreaList(List<XLSheetRange> areas)
+    {
+        _areas = areas;
+    }
+
+    internal int Count => _areas.Count;
+
+    internal XLSheetRange this[int idx] => _areas[idx];
+
+    internal static XLAreaList FromRanges(IEnumerable<IXLRange> ranges)
+    {
+        var areas = new List<XLSheetRange>();
+        foreach (var range in ranges)
+            areas.Add(XLSheetRange.FromRangeAddress(range.RangeAddress));
+
+        return new XLAreaList(areas);
+    }
+
+    /// <summary>
+    /// Return a new list with an additional area appended.
+    /// </summary>
+    internal XLAreaList With(XLSheetRange area)
+    {
+        return new XLAreaList(new List<XLSheetRange>(_areas) { area });
+    }
+
+    /// <summary>
+    /// Return a new list with the first occurrence of <paramref name="area"/> removed.
+    /// </summary>
+    internal XLAreaList Without(XLSheetRange area)
+    {
+        var newList = new List<XLSheetRange>(_areas);
+        newList.Remove(area);
+        return new XLAreaList(newList);
+    }
+
+    internal XLAreaList InsertAndShiftDown(XLSheetRange insertedArea)
+    {
+        // Method is not symmetrical with InsertAndShiftRight, because Excel doesn't produce
+        // symmetrical results (e.g. original C3:E5 and insert down at C3 produces asymmetrical
+        // results from insert right at E3).
+        var result = new List<XLSheetRange>(_areas.Count);
+        foreach (var originalArea in _areas)
+        {
+            if (originalArea.HasFullColumnHeight)
+            {
+                result.Add(originalArea);
+                continue;
+            }
+
+            // Skip all cases that don't shift or extend the area in some way.
+            if (insertedArea.RightColumn < originalArea.LeftColumn ||
+                insertedArea.LeftColumn > originalArea.RightColumn ||
+                insertedArea.TopRow > originalArea.BottomRow + 1)
+            {
+                result.Add(originalArea);
+                continue;
+            }
+
+            if (originalArea.SplitAbove(insertedArea.TopRow, out var above, out var remaining) &&
+                above.Value.LeftColumn >= insertedArea.LeftColumn &&
+                above.Value.RightColumn <= insertedArea.RightColumn)
+            {
+                // Special case: if inserted area covers the full width of the original area and
+                // there is something above, the whole area is just extended downwards. The null
+                // check handles the inserted area attaching to the bottom of the original.
+                var mergedAndExtended = above.Value.ExtendBelow(insertedArea.Height + (remaining?.Height ?? 0));
+                result.Add(mergedAndExtended);
+                continue;
+            }
+
+            XLSheetRange? left = null, right = null;
+            if (remaining is not null)
+                remaining.Value.SplitBefore(insertedArea.LeftColumn, out left, out remaining);
+
+            if (remaining is not null)
+                remaining.Value.SplitAfter(insertedArea.RightColumn, out right, out remaining);
+
+            if (above is not null)
+                result.Add(above.Value);
+
+            if (left is not null)
+                result.Add(left.Value);
+
+            if (right is not null)
+                result.Add(right.Value);
+
+            if (above is not null)
+            {
+                // There was something above the inserted area, so extend.
+                if (remaining is not null)
+                {
+                    var extended = remaining.Value.ExtendBelow(insertedArea.Height);
+                    result.Add(extended);
+                }
+                else if (insertedArea.TopRow == originalArea.BottomRow + 1)
+                {
+                    // Partial cover attaching at the bottom of the original area, e.g. insert to
+                    // B2 with original A1:C1.
+                    var cutToWidth = new XLSheetRange(
+                        insertedArea.TopRow,
+                        Math.Max(insertedArea.LeftColumn, originalArea.LeftColumn),
+                        insertedArea.BottomRow,
+                        Math.Min(insertedArea.RightColumn, originalArea.RightColumn));
+                    result.Add(cutToWidth);
+                }
+            }
+            else
+            {
+                // There was nothing above the inserted area, so shift.
+                if (remaining is null)
+                    throw new UnreachableException();
+
+                if (remaining.Value.ShiftRowsAndClip(insertedArea.Height) is { } shifted)
+                    result.Add(shifted);
+            }
+        }
+
+        return new XLAreaList(result);
+    }
+
+    internal XLAreaList InsertAndShiftRight(XLSheetRange insertedArea)
+    {
+        var result = new List<XLSheetRange>(_areas.Count);
+        foreach (var originalArea in _areas)
+        {
+            if (originalArea.HasFullRowWidth)
+            {
+                result.Add(originalArea);
+                continue;
+            }
+
+            // Skip all cases that don't shift or extend the area in some way.
+            if (insertedArea.BottomRow < originalArea.TopRow ||
+                insertedArea.TopRow > originalArea.BottomRow ||
+                insertedArea.LeftColumn > originalArea.RightColumn + 1)
+            {
+                result.Add(originalArea);
+                continue;
+            }
+
+            // Deal with the special case of attachment at the right side.
+            if (insertedArea.LeftColumn == originalArea.RightColumn + 1)
+            {
+                if (originalArea.TopRow >= insertedArea.TopRow &&
+                    originalArea.BottomRow <= insertedArea.BottomRow)
+                {
+                    result.Add(originalArea.ExtendRight(insertedArea.Width));
+                }
+                else
+                {
+                    // Attaches at the right of the original area, e.g. insert to B2 with original A1:C1.
+                    var cutToHeight = new XLSheetRange(
+                        Math.Max(insertedArea.TopRow, originalArea.TopRow),
+                        insertedArea.LeftColumn,
+                        Math.Min(insertedArea.BottomRow, originalArea.BottomRow),
+                        insertedArea.RightColumn);
+                    result.Add(originalArea);
+                    result.Add(cutToHeight);
+                }
+
+                continue;
+            }
+
+            XLSheetRange? below = null, left = null;
+            originalArea.SplitAbove(insertedArea.TopRow, out var above, out var remaining);
+
+            if (remaining is not null)
+                remaining.Value.SplitBelow(insertedArea.BottomRow, out below, out remaining);
+
+            if (remaining is not null)
+                remaining.Value.SplitBefore(insertedArea.LeftColumn, out left, out remaining);
+
+            // Something must remain: the inserted area intersects the original area (the right-side
+            // attachment special case is handled above) and we only cut three times, one per side.
+            if (remaining is null)
+                throw new UnreachableException();
+
+            if (above is not null)
+                result.Add(above.Value);
+
+            if (below is not null)
+                result.Add(below.Value);
+
+            if (left is not null)
+            {
+                // There was something on the left of the inserted area, so extend.
+                var mergedAndExtended = left.Value.ExtendRight(insertedArea.Width + remaining.Value.Width);
+                result.Add(mergedAndExtended);
+            }
+            else
+            {
+                // There is nothing on the left side, so shift.
+                if (remaining.Value.ShiftColumnsAndClip(insertedArea.Width) is { } shifted)
+                    result.Add(shifted);
+            }
+        }
+
+        return new XLAreaList(result);
+    }
+
+    internal XLAreaList DeleteAndShiftUp(XLSheetRange deletedArea)
+    {
+        var groove = deletedArea.ExtendBelow(XLHelper.MaxRowNumber);
+        var result = new List<XLSheetRange>(_areas.Count);
+        foreach (var originalArea in _areas)
+        {
+            if (originalArea.HasFullColumnHeight)
+            {
+                result.Add(originalArea);
+                continue;
+            }
+
+            var deleteWontSplitOriginalArea =
+                deletedArea.LeftColumn <= originalArea.LeftColumn && deletedArea.RightColumn >= originalArea.RightColumn;
+            if (deleteWontSplitOriginalArea)
+            {
+                var shiftedArea = originalArea.ShiftOrShrinkUp(deletedArea.TopRow, deletedArea.Height);
+                if (shiftedArea is not null)
+                    result.Add(shiftedArea.Value);
+            }
+            else
+            {
+                var inGrooveArea = originalArea.Exclude(groove, result);
+                if (inGrooveArea is not null)
+                {
+                    // There is something to shift, so shift it upwards.
+                    var shiftedArea = inGrooveArea.Value.ShiftOrShrinkUp(deletedArea.TopRow, deletedArea.Height);
+                    if (shiftedArea is not null)
+                        result.Add(shiftedArea.Value);
+                }
+            }
+        }
+
+        return new XLAreaList(result);
+    }
+
+    internal XLAreaList DeleteAndShiftLeft(XLSheetRange deletedArea)
+    {
+        var groove = deletedArea.ExtendRight(XLHelper.MaxColumnNumber);
+        var result = new List<XLSheetRange>(_areas.Count);
+        foreach (var originalArea in _areas)
+        {
+            if (originalArea.HasFullRowWidth)
+            {
+                result.Add(originalArea);
+                continue;
+            }
+
+            var deleteWontSplitOriginalArea =
+                deletedArea.TopRow <= originalArea.TopRow && deletedArea.BottomRow >= originalArea.BottomRow;
+            if (deleteWontSplitOriginalArea)
+            {
+                var shiftedArea = originalArea.ShiftOrShrinkLeft(deletedArea.LeftColumn, deletedArea.Width);
+                if (shiftedArea is not null)
+                    result.Add(shiftedArea.Value);
+            }
+            else
+            {
+                var inGrooveArea = originalArea.Exclude(groove, result);
+                if (inGrooveArea is not null)
+                {
+                    // There is something to shift, so shift it leftward.
+                    var shiftedArea = inGrooveArea.Value.ShiftOrShrinkLeft(deletedArea.LeftColumn, deletedArea.Width);
+                    if (shiftedArea is not null)
+                        result.Add(shiftedArea.Value);
+                }
+            }
+        }
+
+        return new XLAreaList(result);
+    }
+
+    internal XLAreaList DeleteWithoutShift(XLSheetRange deletedArea)
+    {
+        var result = new List<XLSheetRange>(_areas.Count);
+        foreach (var originalArea in _areas)
+            originalArea.Exclude(deletedArea, result);
+
+        return new XLAreaList(result);
+    }
+
+    internal bool IntersectsWith(XLSheetRange otherArea)
+    {
+        foreach (var area in _areas)
+        {
+            if (area.Intersects(otherArea))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Return the areas in the list (at their original size) intersecting <paramref name="otherArea"/>.
+    /// </summary>
+    internal IEnumerable<XLSheetRange> IntersectingWith(XLSheetRange otherArea)
+    {
+        foreach (var area in _areas)
+        {
+            if (area.Intersects(otherArea))
+                yield return area;
+        }
+    }
+
+    /// <summary>
+    /// Take the areas, intersect them with <paramref name="areaToCopy"/> and shift the pieces to
+    /// <paramref name="target"/>. Used mostly in copy&amp;paste.
+    /// </summary>
+    internal bool TryCopyAreaTo(XLSheetPoint target, XLSheetRange areaToCopy, [NotNullWhen(true)] out XLAreaList? result)
+    {
+        var rowShift = target.Row - areaToCopy.FirstPoint.Row;
+        var columnShift = target.Column - areaToCopy.FirstPoint.Column;
+        List<XLSheetRange>? copyList = null;
+        foreach (var area in _areas)
+        {
+            if (area.Intersect(areaToCopy) is not { } intersection)
+                continue;
+
+            // The end can be cut off, but the area always has at least 1x1 so it stays valid.
+            if (intersection.ShiftAndClip(rowShift, columnShift) is not { } shiftedArea)
+                continue;
+
+            copyList ??= new List<XLSheetRange>();
+            copyList.Add(shiftedArea);
+        }
+
+        if (copyList is not null)
+        {
+            result = new XLAreaList(copyList);
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Return a new list with <paramref name="excludedArea"/> cut out of every area.
+    /// </summary>
+    internal XLAreaList Excluding(XLSheetRange excludedArea)
+    {
+        if (!IntersectsWith(excludedArea))
+            return this;
+
+        var list = new List<XLSheetRange>();
+        foreach (var area in _areas)
+            area.Exclude(excludedArea, list);
+
+        return new XLAreaList(list);
+    }
+
+    public IEnumerator<XLSheetRange> GetEnumerator()
+    {
+        return _areas.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    /// <summary>
+    /// Render the areas as a space-separated <c>sqref</c> string (e.g. <c>"A1:B2 D4"</c>).
+    /// </summary>
+    internal string ToSpaceList()
+    {
+        return string.Join(" ", _areas.Select(a => a.ToString()));
+    }
+}

--- a/XLibur/Excel/Coordinates/XLSheetRange.cs
+++ b/XLibur/Excel/Coordinates/XLSheetRange.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace XLibur.Excel.Coordinates;
 
@@ -68,6 +69,16 @@ internal readonly struct XLSheetRange : IEquatable<XLSheetRange>, IEnumerable<XL
     /// Greater or equal to <see cref="TopRow"/>.
     /// </summary>
     public int BottomRow => LastPoint.Row;
+
+    /// <summary>
+    /// Does the range span the full width of a sheet (first column to last column)?
+    /// </summary>
+    internal bool HasFullRowWidth => LeftColumn == XLHelper.MinColumnNumber && RightColumn == XLHelper.MaxColumnNumber;
+
+    /// <summary>
+    /// Does the range span the full height of a sheet (first row to last row)?
+    /// </summary>
+    internal bool HasFullColumnHeight => TopRow == XLHelper.MinRowNumber && BottomRow == XLHelper.MaxRowNumber;
 
     public override bool Equals(object? obj)
     {
@@ -640,5 +651,304 @@ internal readonly struct XLSheetRange : IEquatable<XLSheetRange>, IEnumerable<XL
 
         result = repositioned;
         return true;
+    }
+
+    /// <summary>
+    /// Shift the range by rows and then columns, clipping any part pushed outside the sheet.
+    /// </summary>
+    /// <returns>The shifted, clipped range, or <c>null</c> if it was pushed entirely off the sheet.</returns>
+    internal XLSheetRange? ShiftAndClip(int rowShift, int columnShift)
+    {
+        if (ShiftRowsAndClip(rowShift) is not { } rowShifted)
+            return null;
+
+        if (rowShifted.ShiftColumnsAndClip(columnShift) is not { } rowAndColumnShifted)
+            return null;
+
+        return rowAndColumnShifted;
+    }
+
+    /// <summary>
+    /// Shift the range vertically by <paramref name="rowShift"/>. If the shifted range is out of
+    /// sheet bounds, clip the part that is out.
+    /// </summary>
+    /// <returns>Shifted clipped range or <c>null</c> if shifted completely off the sheet.</returns>
+    internal XLSheetRange? ShiftRowsAndClip(int rowShift)
+    {
+        var shiftedTop = TopRow + rowShift;
+        if (shiftedTop > XLHelper.MaxRowNumber)
+            return null;
+
+        var shiftedBottom = BottomRow + rowShift;
+        if (shiftedBottom < XLHelper.MinRowNumber)
+            return null;
+
+        var clippedTop = Math.Max(shiftedTop, XLHelper.MinRowNumber);
+        var clippedBottom = Math.Min(shiftedBottom, XLHelper.MaxRowNumber);
+
+        return new XLSheetRange(clippedTop, LeftColumn, clippedBottom, RightColumn);
+    }
+
+    /// <summary>
+    /// Shift the range horizontally by <paramref name="columnShift"/>. If the shifted range is out
+    /// of sheet bounds, clip the part that is out.
+    /// </summary>
+    /// <returns>Shifted clipped range or <c>null</c> if shifted completely off the sheet.</returns>
+    internal XLSheetRange? ShiftColumnsAndClip(int columnShift)
+    {
+        var shiftedLeft = LeftColumn + columnShift;
+        if (shiftedLeft > XLHelper.MaxColumnNumber)
+            return null;
+
+        var shiftedRight = RightColumn + columnShift;
+        if (shiftedRight < XLHelper.MinColumnNumber)
+            return null;
+
+        var clippedLeft = Math.Max(shiftedLeft, XLHelper.MinColumnNumber);
+        var clippedRight = Math.Min(shiftedRight, XLHelper.MaxColumnNumber);
+
+        return new XLSheetRange(TopRow, clippedLeft, BottomRow, clippedRight);
+    }
+
+    /// <summary>
+    /// Remove <paramref name="range"/> from this range, appending the remaining (up to four)
+    /// rectangular pieces to <paramref name="nonExcludedAreas"/>.
+    /// </summary>
+    /// <returns>The intersection that was excluded, or <c>null</c> if the ranges don't intersect.</returns>
+    internal XLSheetRange? Exclude(XLSheetRange range, List<XLSheetRange> nonExcludedAreas)
+    {
+        if (Intersect(range) is not { } intersection)
+        {
+            nonExcludedAreas.Add(this);
+            return null;
+        }
+
+        // top
+        if (TopRow < intersection.TopRow)
+            nonExcludedAreas.Add(new XLSheetRange(TopRow, LeftColumn, intersection.TopRow - 1, RightColumn));
+
+        // bottom
+        if (BottomRow > intersection.BottomRow)
+            nonExcludedAreas.Add(new XLSheetRange(intersection.BottomRow + 1, LeftColumn, BottomRow, RightColumn));
+
+        // left
+        if (LeftColumn < intersection.LeftColumn)
+            nonExcludedAreas.Add(new XLSheetRange(intersection.TopRow, LeftColumn, intersection.BottomRow, intersection.LeftColumn - 1));
+
+        // right
+        if (RightColumn > intersection.RightColumn)
+            nonExcludedAreas.Add(new XLSheetRange(intersection.TopRow, intersection.RightColumn + 1, intersection.BottomRow, RightColumn));
+
+        return intersection;
+    }
+
+    /// <summary>
+    /// Reposition the range as if columns were inserted at <paramref name="insertedLeftColumn"/>,
+    /// mimicking Excel behavior (shift when the insert is to the left, extend when inside).
+    /// </summary>
+    internal XLSheetRange? ShiftOrExtendRight(int insertedLeftColumn, int insertedWidth)
+    {
+        Debug.Assert(insertedWidth >= 0);
+
+        // Range inserted at the right edge extends - hence the - 1
+        if (RightColumn < insertedLeftColumn - 1)
+            return this; // inserted is to the right of range -> no shift
+
+        if (LeftColumn >= insertedLeftColumn)
+            return ShiftColumnsAndClip(insertedWidth); // inserted is to the left -> shift
+
+        // inserted is in the middle of the range: LeftColumn < insertedLeftColumn <= RightColumn
+        return ExtendRight(insertedWidth);
+    }
+
+    /// <summary>
+    /// Reposition the range as if rows were inserted at <paramref name="insertedTopRow"/>,
+    /// mimicking Excel behavior (shift when the insert is above, extend when inside).
+    /// </summary>
+    internal XLSheetRange? ShiftOrExtendDown(int insertedTopRow, int insertedHeight)
+    {
+        Debug.Assert(insertedHeight >= 0);
+
+        // Range inserted at the bottom edge extends - hence the - 1
+        if (BottomRow < insertedTopRow - 1)
+            return this; // inserted is below the range -> no shift
+
+        if (TopRow >= insertedTopRow)
+            return ShiftRowsAndClip(insertedHeight); // inserted is above -> shift
+
+        // inserted is in the middle of the range: TopRow < insertedTopRow <= BottomRow
+        return ExtendBelow(insertedHeight);
+    }
+
+    /// <summary>
+    /// Reposition the range as if rows were deleted from <paramref name="deletedTopRow"/>,
+    /// mimicking Excel behavior (shift when the delete is above, shrink when overlapping).
+    /// </summary>
+    internal XLSheetRange? ShiftOrShrinkUp(int deletedTopRow, int deletedHeight)
+    {
+        Debug.Assert(deletedHeight >= 0);
+        if (BottomRow < deletedTopRow || deletedHeight == 0)
+            return this; // deleted is below the range -> no shift or shrink
+
+        var deletedBottomRow = deletedTopRow + deletedHeight - 1;
+        if (deletedBottomRow < TopRow)
+            return ShiftRows(-deletedHeight); // deleted completely above -> only shift
+
+        // Shrink by how much the deleted range and this range overlap
+        var shrink = Math.Min(BottomRow, deletedBottomRow) - Math.Max(TopRow, deletedTopRow) + 1;
+        if (shrink == Height)
+            return null;
+
+        var shift = Math.Max(TopRow - deletedTopRow, 0);
+        var shifted = ShiftRows(-shift);
+        return new XLSheetRange(shifted.TopRow, shifted.LeftColumn, shifted.BottomRow - shrink, shifted.RightColumn);
+    }
+
+    /// <summary>
+    /// Reposition the range as if columns were deleted from <paramref name="deletedLeftColumn"/>,
+    /// mimicking Excel behavior (shift when the delete is to the left, shrink when overlapping).
+    /// </summary>
+    internal XLSheetRange? ShiftOrShrinkLeft(int deletedLeftColumn, int deletedWidth)
+    {
+        Debug.Assert(deletedWidth >= 0);
+        if (RightColumn < deletedLeftColumn || deletedWidth == 0)
+            return this; // deleted is to the right of the range -> no shift or shrink
+
+        var deletedRightColumn = deletedLeftColumn + deletedWidth - 1;
+        if (deletedRightColumn < LeftColumn)
+            return ShiftColumns(-deletedWidth); // deleted completely to the left -> only shift
+
+        // Shrink by how much the deleted range and this range overlap
+        var shrink = Math.Min(RightColumn, deletedRightColumn) - Math.Max(LeftColumn, deletedLeftColumn) + 1;
+        if (shrink == Width)
+            return null;
+
+        var shift = Math.Max(LeftColumn - deletedLeftColumn, 0);
+        var shifted = ShiftColumns(-shift);
+        return new XLSheetRange(shifted.TopRow, shifted.LeftColumn, shifted.BottomRow, shifted.RightColumn - shrink);
+    }
+
+    /// <summary>
+    /// Split the range above <paramref name="row"/>, into <paramref name="above"/> (rows before
+    /// <paramref name="row"/>) and <paramref name="below"/> (from <paramref name="row"/> down).
+    /// </summary>
+    /// <returns><c>true</c> if <paramref name="above"/> is not null.</returns>
+    internal bool SplitAbove(int row, [NotNullWhen(true)] out XLSheetRange? above, out XLSheetRange? below)
+    {
+        if (row is < XLHelper.MinRowNumber or > XLHelper.MaxRowNumber)
+            throw new ArgumentOutOfRangeException(nameof(row));
+
+        if (BottomRow < row)
+        {
+            above = this;
+            below = null;
+            return true;
+        }
+
+        if (TopRow >= row)
+        {
+            above = null;
+            below = this;
+            return false;
+        }
+
+        above = new XLSheetRange(TopRow, LeftColumn, row - 1, RightColumn);
+        below = new XLSheetRange(row, LeftColumn, BottomRow, RightColumn);
+        return true;
+    }
+
+    /// <summary>
+    /// Split the range below <paramref name="row"/>, into <paramref name="below"/> (rows after
+    /// <paramref name="row"/>) and <paramref name="above"/> (up to and including <paramref name="row"/>).
+    /// </summary>
+    /// <returns><c>true</c> if <paramref name="below"/> is not null.</returns>
+    internal bool SplitBelow(int row, [NotNullWhen(true)] out XLSheetRange? below, out XLSheetRange? above)
+    {
+        if (row is < XLHelper.MinRowNumber or > XLHelper.MaxRowNumber)
+            throw new ArgumentOutOfRangeException(nameof(row));
+
+        if (TopRow > row)
+        {
+            below = this;
+            above = null;
+            return true;
+        }
+
+        if (BottomRow <= row)
+        {
+            below = null;
+            above = this;
+            return false;
+        }
+
+        below = new XLSheetRange(row + 1, LeftColumn, BottomRow, RightColumn);
+        above = new XLSheetRange(TopRow, LeftColumn, row, RightColumn);
+        return true;
+    }
+
+    /// <summary>
+    /// Split the range before <paramref name="column"/>, into <paramref name="left"/> (columns
+    /// before <paramref name="column"/>) and <paramref name="right"/> (from <paramref name="column"/> right).
+    /// </summary>
+    /// <returns><c>true</c> if <paramref name="left"/> is not null.</returns>
+    internal bool SplitBefore(int column, [NotNullWhen(true)] out XLSheetRange? left, out XLSheetRange? right)
+    {
+        if (column is < XLHelper.MinColumnNumber or > XLHelper.MaxColumnNumber)
+            throw new ArgumentOutOfRangeException(nameof(column));
+
+        if (RightColumn < column)
+        {
+            left = this;
+            right = null;
+            return true;
+        }
+
+        if (LeftColumn >= column)
+        {
+            left = null;
+            right = this;
+            return false;
+        }
+
+        left = new XLSheetRange(TopRow, LeftColumn, BottomRow, column - 1);
+        right = new XLSheetRange(TopRow, column, BottomRow, RightColumn);
+        return true;
+    }
+
+    /// <summary>
+    /// Split the range after <paramref name="column"/>, into <paramref name="right"/> (columns
+    /// after <paramref name="column"/>) and <paramref name="left"/> (up to and including <paramref name="column"/>).
+    /// </summary>
+    /// <returns><c>true</c> if <paramref name="right"/> is not null.</returns>
+    internal bool SplitAfter(int column, [NotNullWhen(true)] out XLSheetRange? right, out XLSheetRange? left)
+    {
+        if (column is < XLHelper.MinColumnNumber or > XLHelper.MaxColumnNumber)
+            throw new ArgumentOutOfRangeException(nameof(column));
+
+        if (LeftColumn > column)
+        {
+            right = this;
+            left = null;
+            return true;
+        }
+
+        if (RightColumn <= column)
+        {
+            right = null;
+            left = this;
+            return false;
+        }
+
+        right = new XLSheetRange(TopRow, column + 1, BottomRow, RightColumn);
+        left = new XLSheetRange(TopRow, LeftColumn, BottomRow, column);
+        return true;
+    }
+
+    /// <summary>
+    /// Wrap this single range in a one-element <see cref="XLAreaList"/>.
+    /// </summary>
+    internal XLAreaList ToAreaList()
+    {
+        return new XLAreaList(this);
     }
 }

--- a/XLibur/Excel/Ranges/XLRangeConditionalFormatHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeConditionalFormatHelper.cs
@@ -1,6 +1,7 @@
-﻿using System.Linq;
+using System.Collections.Generic;
+using System.Linq;
+using XLibur.Excel.ConditionalFormats;
 using XLibur.Excel.Coordinates;
-using XLibur.Extensions;
 
 namespace XLibur.Excel;
 
@@ -8,98 +9,87 @@ namespace XLibur.Excel;
 /// Contains the conditional-format removal algorithm.
 /// <see cref="XLRangeBase"/> delegates <c>RemoveConditionalFormatting</c> here.
 /// </summary>
+/// <remarks>
+/// Coverage is only cut when the cleared range fully spans a format area's width or height;
+/// a partial (corner) overlap preserves the area unchanged. Operates on the value-typed
+/// <see cref="XLConditionalFormat.Areas"/> and writes results back via <see cref="XLConditionalFormat.SetAreas"/>.
+/// </remarks>
 internal static class XLRangeConditionalFormatHelper
 {
     internal static void RemoveConditionalFormatting(XLRangeBase range)
     {
+        var remove = XLSheetRange.FromRangeAddress(range.RangeAddress);
+
         var affectedFormats = range.Worksheet.ConditionalFormats
-            .Where(x => x.Ranges.GetIntersectedRanges(range.RangeAddress).Any())
+            .Cast<XLConditionalFormat>()
+            .Where(cf => cf.Areas.IntersectsWith(remove))
             .ToList();
 
         foreach (var format in affectedFormats)
         {
-            SplitFormatRanges(format, range);
-
-            if (format.Ranges.Count == 0)
-                range.Worksheet.ConditionalFormats.Remove(x => x == format);
-        }
-    }
-
-    private static void SplitFormatRanges(IXLConditionalFormat format, XLRangeBase removeRange)
-    {
-        var cfRanges = format.Ranges.ToList();
-        format.Ranges.RemoveAll();
-
-        foreach (var cfRange in cfRanges)
-        {
-            if (!cfRange.Intersects(removeRange))
+            var result = new List<XLSheetRange>();
+            foreach (var cfArea in format.Areas)
             {
-                format.Ranges.Add(cfRange);
-                continue;
+                if (cfArea.Intersect(remove) is null)
+                {
+                    result.Add(cfArea);
+                    continue;
+                }
+
+                AddRemainderAreas(result, cfArea, remove);
             }
 
-            AddRemainderRanges(format, cfRange, removeRange);
+            if (result.Count == 0)
+                range.Worksheet.ConditionalFormats.Remove(x => x == format);
+            else
+                format.SetAreas(new XLAreaList(result));
         }
     }
 
-    private static void AddRemainderRanges(
-        IXLConditionalFormat format,
-        IXLRange cfRange,
-        XLRangeBase removeRange)
+    private static void AddRemainderAreas(List<XLSheetRange> result, XLSheetRange cf, XLSheetRange remove)
     {
-        var mf = removeRange.RangeAddress.FirstAddress;
-        var ml = removeRange.RangeAddress.LastAddress;
-        var f = cfRange.RangeAddress.FirstAddress;
-        var l = cfRange.RangeAddress.LastAddress;
-
-        var splitByWidth = TrySplitByWidth(format, removeRange.Worksheet, mf, ml, f, l);
-        var splitByHeight = TrySplitByHeight(format, removeRange.Worksheet, mf, ml, f, l);
+        var splitByWidth = TrySplitByWidth(result, remove, cf);
+        var splitByHeight = TrySplitByHeight(result, remove, cf);
 
         if (!splitByWidth && !splitByHeight)
-            format.Ranges.Add(cfRange); // Not split, preserve original
+            result.Add(cf); // Not split, preserve original
     }
 
-    private static bool TrySplitByWidth(
-        IXLConditionalFormat format,
-        IXLWorksheet worksheet,
-        XLAddress mf, XLAddress ml,
-        IXLAddress f, IXLAddress l)
+    private static bool TrySplitByWidth(List<XLSheetRange> result, XLSheetRange remove, XLSheetRange cf)
     {
-        if (mf.ColumnNumber > f.ColumnNumber || ml.ColumnNumber < l.ColumnNumber)
+        if (remove.LeftColumn > cf.LeftColumn || remove.RightColumn < cf.RightColumn)
             return false;
 
-        if (!mf.RowNumber.Between(f.RowNumber, l.RowNumber) && !ml.RowNumber.Between(f.RowNumber, l.RowNumber))
-            return true; // Spans full width, but no row overlap produces a remainder — still counts as "by width"
+        // Spans full width, but no row overlap produces a remainder — still counts as "by width".
+        if (!Between(remove.TopRow, cf.TopRow, cf.BottomRow) && !Between(remove.BottomRow, cf.TopRow, cf.BottomRow))
+            return true;
 
-        if (mf.RowNumber > f.RowNumber)
-            format.Ranges.Add(worksheet.Range(f.RowNumber, f.ColumnNumber, mf.RowNumber - 1, l.ColumnNumber));
+        if (remove.TopRow > cf.TopRow)
+            result.Add(new XLSheetRange(cf.TopRow, cf.LeftColumn, remove.TopRow - 1, cf.RightColumn));
 
-        if (ml.RowNumber < l.RowNumber)
-            format.Ranges.Add(worksheet.Range(ml.RowNumber + 1, f.ColumnNumber, l.RowNumber, l.ColumnNumber));
+        if (remove.BottomRow < cf.BottomRow)
+            result.Add(new XLSheetRange(remove.BottomRow + 1, cf.LeftColumn, cf.BottomRow, cf.RightColumn));
 
         return true;
     }
 
-    private static bool TrySplitByHeight(
-        IXLConditionalFormat format,
-        IXLWorksheet worksheet,
-        XLAddress mf, XLAddress ml,
-        IXLAddress f, IXLAddress l)
+    private static bool TrySplitByHeight(List<XLSheetRange> result, XLSheetRange remove, XLSheetRange cf)
     {
-        if (mf.RowNumber > f.RowNumber || ml.RowNumber < l.RowNumber)
+        if (remove.TopRow > cf.TopRow || remove.BottomRow < cf.BottomRow)
             return false;
 
-        if (!mf.ColumnNumber.Between(f.ColumnNumber, l.ColumnNumber) && !ml.ColumnNumber.Between(f.ColumnNumber, l.ColumnNumber))
-            return true; // Spans full height but no column overlap produces the remainder
+        // Spans full height but no column overlap produces the remainder.
+        if (!Between(remove.LeftColumn, cf.LeftColumn, cf.RightColumn) && !Between(remove.RightColumn, cf.LeftColumn, cf.RightColumn))
+            return true;
 
-        if (mf.ColumnNumber > f.ColumnNumber)
-            format.Ranges.Add(worksheet.Range(f.RowNumber, f.ColumnNumber, l.RowNumber, mf.ColumnNumber - 1));
+        if (remove.LeftColumn > cf.LeftColumn)
+            result.Add(new XLSheetRange(cf.TopRow, cf.LeftColumn, cf.BottomRow, remove.LeftColumn - 1));
 
-        if (ml.ColumnNumber < l.ColumnNumber)
-        {
-            format.Ranges.Add(worksheet.Range(f.RowNumber, ml.ColumnNumber + 1, l.RowNumber, l.ColumnNumber));
-        }
+        if (remove.RightColumn < cf.RightColumn)
+            result.Add(new XLSheetRange(cf.TopRow, remove.RightColumn + 1, cf.BottomRow, cf.RightColumn));
 
         return true;
     }
+
+    private static bool Between(int value, int low, int high) => value >= low && value <= high;
 }

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -1254,23 +1254,22 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
     }
 
     /// <summary>
-    /// Collects the range instances currently owned by conditional formats and data validations.
-    /// These are repositioned explicitly during a row/column shift; because the range repository
-    /// deduplicates by address, an explicit replacement can be the very same instance the blanket
-    /// shift in <see cref="NotifyRangeShiftedRows"/> / <see cref="NotifyRangeShiftedColumns"/> is
-    /// about to move, which would double the offset (ClosedXML issue #2850). Callers use the
-    /// returned set to shift each range exactly once. Reference identity is required because
-    /// distinct range instances may share an address.
+    /// Collects the range instances currently owned by data validations. These are repositioned
+    /// explicitly during a row/column shift; because the range repository deduplicates by address,
+    /// an explicit replacement can be the very same instance the blanket shift in
+    /// <see cref="NotifyRangeShiftedRows"/> / <see cref="NotifyRangeShiftedColumns"/> is about to
+    /// move, which would double the offset (ClosedXML issue #2850). Callers use the returned set to
+    /// shift each range exactly once. Reference identity is required because distinct range
+    /// instances may share an address.
     /// </summary>
+    /// <remarks>
+    /// Conditional formats are no longer included: their coverage is stored as a value-typed
+    /// <c>XLAreaList</c> (not live repository ranges), so the shift can never alias — see
+    /// <see cref="XLibur.Excel.ConditionalFormats.XLConditionalFormat.Areas"/>.
+    /// </remarks>
     private HashSet<object> GetExplicitlyShiftedRanges()
     {
         var handled = new HashSet<object>(ReferenceEqualityComparer.Instance);
-
-        foreach (var cf in ConditionalFormats)
-        {
-            foreach (var cfRange in cf.Ranges)
-                handled.Add(cfRange);
-        }
 
         foreach (var dv in DataValidations)
         {

--- a/XLibur/Excel/XLWorksheetRangeShifter.cs
+++ b/XLibur/Excel/XLWorksheetRangeShifter.cs
@@ -127,10 +127,6 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
     {
         if (columnsShifted == 0 || !worksheet.ConditionalFormats.Any()) return;
         var first = range.RangeAddress.FirstAddress;
-        // A first-column insert has no column to the left to extend into, so the explicit shift
-        // is skipped and the blanket auto-shift handles CF ranges (see XLWorksheet.NotifyRangeShiftedColumns).
-        if (first.ColumnNumber == 1) return;
-
         var last = range.RangeAddress.LastAddress;
         // The affected region spans the range's rows and the inserted/deleted columns.
         var affected = columnsShifted > 0
@@ -147,7 +143,7 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
             if (newAreas.Count == 0)
                 worksheet.ConditionalFormats.Remove(f => f == cf);
             else
-                xlCf.SetAreas(newAreas, worksheet);
+                xlCf.SetAreas(newAreas);
         }
     }
 
@@ -155,10 +151,6 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
     {
         if (rowsShifted == 0 || !worksheet.ConditionalFormats.Any()) return;
         var first = range.RangeAddress.FirstAddress;
-        // A first-row insert has no row above to extend into, so the explicit shift is skipped and
-        // the blanket auto-shift handles CF ranges (see XLWorksheet.NotifyRangeShiftedRows).
-        if (first.RowNumber == 1) return;
-
         var last = range.RangeAddress.LastAddress;
         // The affected region spans the range's columns and the inserted/deleted rows, mirroring
         // the inserted range in XLRangeInsertHelper. Structural shifts run on the value-typed
@@ -177,7 +169,7 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
             if (newAreas.Count == 0)
                 worksheet.ConditionalFormats.Remove(f => f == cf);
             else
-                xlCf.SetAreas(newAreas, worksheet);
+                xlCf.SetAreas(newAreas);
         }
     }
 

--- a/XLibur/Excel/XLWorksheetRangeShifter.cs
+++ b/XLibur/Excel/XLWorksheetRangeShifter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using XLibur.Excel.ConditionalFormats;
 using XLibur.Excel.Coordinates;
 using XLibur.Extensions;
 
@@ -124,56 +125,59 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
 
     private void ShiftConditionalFormattingColumns(XLRange range, int columnsShifted)
     {
-        if (!worksheet.ConditionalFormats.Any()) return;
-        var firstCol = range.RangeAddress.FirstAddress.ColumnNumber;
-        if (firstCol == 1) return;
+        if (columnsShifted == 0 || !worksheet.ConditionalFormats.Any()) return;
+        var first = range.RangeAddress.FirstAddress;
+        // A first-column insert has no column to the left to extend into, so the explicit shift
+        // is skipped and the blanket auto-shift handles CF ranges (see XLWorksheet.NotifyRangeShiftedColumns).
+        if (first.ColumnNumber == 1) return;
 
-        var colNum = columnsShifted > 0 ? firstCol - 1 : firstCol;
-        var model = worksheet.Column(colNum).AsRange();
+        var last = range.RangeAddress.LastAddress;
+        // The affected region spans the range's rows and the inserted/deleted columns.
+        var affected = columnsShifted > 0
+            ? new XLSheetRange(first.RowNumber, first.ColumnNumber, last.RowNumber, first.ColumnNumber + columnsShifted - 1)
+            : new XLSheetRange(first.RowNumber, first.ColumnNumber, last.RowNumber, first.ColumnNumber - columnsShifted - 1);
 
         foreach (var cf in worksheet.ConditionalFormats.ToList())
         {
-            var cfRanges = cf.Ranges.ToList();
-            cf.Ranges.RemoveAll();
+            var xlCf = (XLConditionalFormat)cf;
+            var newAreas = columnsShifted > 0
+                ? xlCf.Areas.InsertAndShiftRight(affected)
+                : xlCf.Areas.DeleteAndShiftLeft(affected);
 
-            foreach (var cfRange in cfRanges)
-            {
-                var newRange = ShiftRangeColumns(cfRange, model, firstCol, columnsShifted);
-                if (newRange.RangeAddress.IsValid &&
-                    newRange.RangeAddress.FirstAddress.ColumnNumber <=
-                    newRange.RangeAddress.LastAddress.ColumnNumber)
-                    cf.Ranges.Add(newRange);
-            }
-
-            if (cf.Ranges.Count == 0)
+            if (newAreas.Count == 0)
                 worksheet.ConditionalFormats.Remove(f => f == cf);
+            else
+                xlCf.SetAreas(newAreas, worksheet);
         }
     }
 
     private void ShiftConditionalFormattingRows(XLRange range, int rowsShifted)
     {
-        if (!worksheet.ConditionalFormats.Any()) return;
-        var firstRow = range.RangeAddress.FirstAddress.RowNumber;
-        if (firstRow == 1) return;
+        if (rowsShifted == 0 || !worksheet.ConditionalFormats.Any()) return;
+        var first = range.RangeAddress.FirstAddress;
+        // A first-row insert has no row above to extend into, so the explicit shift is skipped and
+        // the blanket auto-shift handles CF ranges (see XLWorksheet.NotifyRangeShiftedRows).
+        if (first.RowNumber == 1) return;
 
-        var rowNum = rowsShifted > 0 ? firstRow - 1 : firstRow;
-        var model = worksheet.Row(rowNum).AsRange();
+        var last = range.RangeAddress.LastAddress;
+        // The affected region spans the range's columns and the inserted/deleted rows, mirroring
+        // the inserted range in XLRangeInsertHelper. Structural shifts run on the value-typed
+        // XLAreaList so overlapping/adjacent coverage can never alias or double-shift (issue #2850).
+        var affected = rowsShifted > 0
+            ? new XLSheetRange(first.RowNumber, first.ColumnNumber, first.RowNumber + rowsShifted - 1, last.ColumnNumber)
+            : new XLSheetRange(first.RowNumber, first.ColumnNumber, first.RowNumber - rowsShifted - 1, last.ColumnNumber);
 
         foreach (var cf in worksheet.ConditionalFormats.ToList())
         {
-            var cfRanges = cf.Ranges.ToList();
-            cf.Ranges.RemoveAll();
+            var xlCf = (XLConditionalFormat)cf;
+            var newAreas = rowsShifted > 0
+                ? xlCf.Areas.InsertAndShiftDown(affected)
+                : xlCf.Areas.DeleteAndShiftUp(affected);
 
-            foreach (var cfRange in cfRanges)
-            {
-                var newRange = ShiftRangeRows(cfRange, model, firstRow, rowsShifted);
-                if (newRange.RangeAddress.IsValid &&
-                    newRange.RangeAddress.FirstAddress.RowNumber <= newRange.RangeAddress.LastAddress.RowNumber)
-                    cf.Ranges.Add(newRange);
-            }
-
-            if (cf.Ranges.Count == 0)
+            if (newAreas.Count == 0)
                 worksheet.ConditionalFormats.Remove(f => f == cf);
+            else
+                xlCf.SetAreas(newAreas, worksheet);
         }
     }
 

--- a/XLibur/Excel/XLWorksheetRangeShifter.cs
+++ b/XLibur/Excel/XLWorksheetRangeShifter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel.ConditionalFormats;
 using XLibur.Excel.Coordinates;
@@ -175,53 +176,61 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
 
     private void ShiftDataValidationColumns(XLRange range, int columnsShifted)
     {
-        if (!worksheet.DataValidations.Any()) return;
-        var firstCol = range.RangeAddress.FirstAddress.ColumnNumber;
-        if (firstCol == 1) return;
+        if (columnsShifted == 0 || !worksheet.DataValidations.Any()) return;
+        var first = range.RangeAddress.FirstAddress;
+        if (first.ColumnNumber == 1) return;
 
-        var colNum = columnsShifted > 0 ? firstCol - 1 : firstCol;
-        var model = worksheet.Column(colNum).AsRange();
+        var last = range.RangeAddress.LastAddress;
+        var affected = columnsShifted > 0
+            ? new XLSheetRange(first.RowNumber, first.ColumnNumber, last.RowNumber, first.ColumnNumber + columnsShifted - 1)
+            : new XLSheetRange(first.RowNumber, first.ColumnNumber, last.RowNumber, first.ColumnNumber - columnsShifted - 1);
 
-        foreach (var dv in worksheet.DataValidations.ToList())
+        ShiftDataValidations(dv =>
         {
-            var dvRanges = dv.Ranges.ToList();
-            dv.ClearRanges();
-
-            foreach (var dvRange in dvRanges)
-            {
-                var newRange = ShiftRangeColumns(dvRange, model, firstCol, columnsShifted);
-                if (newRange.RangeAddress.IsValid &&
-                    newRange.RangeAddress.FirstAddress.ColumnNumber <=
-                    newRange.RangeAddress.LastAddress.ColumnNumber)
-                    dv.AddRange(newRange);
-            }
-
-            if (!dv.Ranges.Any())
-                worksheet.DataValidations.Delete(v => v == dv);
-        }
+            var areas = XLAreaList.FromRanges(dv.Ranges);
+            return columnsShifted > 0 ? areas.InsertAndShiftRight(affected) : areas.DeleteAndShiftLeft(affected);
+        });
     }
 
     private void ShiftDataValidationRows(XLRange range, int rowsShifted)
     {
-        if (!worksheet.DataValidations.Any()) return;
-        var firstRow = range.RangeAddress.FirstAddress.RowNumber;
-        if (firstRow == 1) return;
+        if (rowsShifted == 0 || !worksheet.DataValidations.Any()) return;
+        var first = range.RangeAddress.FirstAddress;
+        if (first.RowNumber == 1) return;
 
-        var rowNum = rowsShifted > 0 ? firstRow - 1 : firstRow;
-        var model = worksheet.Row(rowNum).AsRange();
+        var last = range.RangeAddress.LastAddress;
+        var affected = rowsShifted > 0
+            ? new XLSheetRange(first.RowNumber, first.ColumnNumber, first.RowNumber + rowsShifted - 1, last.ColumnNumber)
+            : new XLSheetRange(first.RowNumber, first.ColumnNumber, first.RowNumber - rowsShifted - 1, last.ColumnNumber);
 
-        foreach (var dv in worksheet.DataValidations.ToList())
+        ShiftDataValidations(dv =>
         {
-            var dvRanges = dv.Ranges.ToList();
-            dv.ClearRanges();
+            var areas = XLAreaList.FromRanges(dv.Ranges);
+            return rowsShifted > 0 ? areas.InsertAndShiftDown(affected) : areas.DeleteAndShiftUp(affected);
+        });
+    }
 
-            foreach (var dvRange in dvRanges)
-            {
-                var newRange = ShiftRangeRows(dvRange, model, firstRow, rowsShifted);
-                if (newRange.RangeAddress.IsValid &&
-                    newRange.RangeAddress.FirstAddress.RowNumber <= newRange.RangeAddress.LastAddress.RowNumber)
-                    dv.AddRange(newRange);
-            }
+    /// <summary>
+    /// Applies a value-typed area transform to every data-validation rule in two phases: compute
+    /// each rule's new coverage and clear all rules first, then re-add. Interleaving clear and add
+    /// per rule would let an extended range split a not-yet-shifted rule it transiently overlaps,
+    /// wiping it (the data-validation drop-on-insert bug). Coverage is still materialized as ranges,
+    /// so validations remain in the shift skip-set (see XLWorksheet.NotifyRangeShiftedRows).
+    /// </summary>
+    private void ShiftDataValidations(Func<XLDataValidation, XLAreaList> transform)
+    {
+        var pending = new List<(XLDataValidation Dv, XLAreaList Areas)>();
+        foreach (var dv in worksheet.DataValidations.OfType<XLDataValidation>().ToList())
+        {
+            var newAreas = transform(dv);
+            dv.ClearRanges();
+            pending.Add((dv, newAreas));
+        }
+
+        foreach (var (dv, areas) in pending)
+        {
+            foreach (var area in areas)
+                dv.AddRange(worksheet.Range(area.TopRow, area.LeftColumn, area.BottomRow, area.RightColumn));
 
             if (!dv.Ranges.Any())
                 worksheet.DataValidations.Delete(v => v == dv);
@@ -273,50 +282,6 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
                     dv.MaxValue = XLCellFormulaShifter.ShiftFormulaRows(dv.MaxValue, ws, range, rowsShifted);
             }
         });
-    }
-
-    private IXLRange ShiftRangeColumns(IXLRange range, IXLRange model, int firstCol, int columnsShifted)
-    {
-        var address = range.RangeAddress;
-        if (range.Intersects(model))
-        {
-            return worksheet.Range(address.FirstAddress.RowNumber,
-                address.FirstAddress.ColumnNumber,
-                address.LastAddress.RowNumber,
-                Math.Min(XLHelper.MaxColumnNumber, address.LastAddress.ColumnNumber + columnsShifted));
-        }
-
-        if (address.FirstAddress.ColumnNumber >= firstCol)
-        {
-            return worksheet.Range(address.FirstAddress.RowNumber,
-                Math.Max(address.FirstAddress.ColumnNumber + columnsShifted, firstCol),
-                address.LastAddress.RowNumber,
-                Math.Min(XLHelper.MaxColumnNumber, address.LastAddress.ColumnNumber + columnsShifted));
-        }
-
-        return range;
-    }
-
-    private IXLRange ShiftRangeRows(IXLRange range, IXLRange model, int firstRow, int rowsShifted)
-    {
-        var address = range.RangeAddress;
-        if (range.Intersects(model))
-        {
-            return worksheet.Range(address.FirstAddress.RowNumber,
-                address.FirstAddress.ColumnNumber,
-                Math.Min(XLHelper.MaxRowNumber, address.LastAddress.RowNumber + rowsShifted),
-                address.LastAddress.ColumnNumber);
-        }
-
-        if (address.FirstAddress.RowNumber >= firstRow)
-        {
-            return worksheet.Range(Math.Max(address.FirstAddress.RowNumber + rowsShifted, firstRow),
-                address.FirstAddress.ColumnNumber,
-                Math.Min(XLHelper.MaxRowNumber, address.LastAddress.RowNumber + rowsShifted),
-                address.LastAddress.ColumnNumber);
-        }
-
-        return range;
     }
 
     private void RemoveInvalidSparklines()


### PR DESCRIPTION
## Summary

Adopts ClosedXML's value-typed `XLAreaList` / `sqref` model for conditional-format (and data-validation) coverage, then migrates conditional formats onto it as their source of truth. This **structurally eliminates the ClosedXML [#2850](https://github.com/ClosedXML/ClosedXML/issues/2850) double-shift class for conditional formats** and **fixes a data-validation drop-on-insert defect**.

Five self-contained, individually-green commits. Full test suite passes at every step (**6202 passed, 0 failed**).

## Why

CF/DV coverage was stored as live, repository-backed `XLRange` objects. The range repository deduplicates by address, so on a row/column insert the blanket auto-shift could move the *same* aliased instance twice (#2850), and the data-validation shift could wipe a rule whose extended neighbour transiently overlapped it. Modelling coverage as immutable value-typed areas transformed by pure functions makes both failure modes impossible.

## What changed

### 1. `XLAreaList` value-typed `sqref` model
Immutable list of rectangular `XLSheetRange` areas with pure structural transforms: `InsertAndShiftDown/Right`, `DeleteAndShiftUp/Left`, `DeleteWithoutShift`, `Excluding`, `IntersectingWith`, `TryCopyAreaTo`. `XLSheetRange` already carried most of the needed `Area` surface; this adds the missing primitives (`HasFullRowWidth/ColumnHeight`, `ShiftRowsAndClip/ColumnsAndClip/ShiftAndClip`, `Exclude`, `ShiftOrExtend*`, `ShiftOrShrink*`, `SplitAbove/Below/Before/After`, `ToAreaList`). Ported from ClosedXML `develop` with its self-contained tests.

### 2. Area consolidation
`XLAreaConsolidator` — a sweep-line bitmask consolidator merging overlapping/adjacent areas into maximal blocks — wired up as `XLAreaList.GetConsolidated()`. Left the existing `IXLRanges`-based engine untouched. Tests include the known-good expected output ported from ClosedXML's `RangesConsolidationTests` baseline.

### 3. CF shifting on the area model
The range shifter computes each conditional format's new coverage with the `sqref` transforms instead of the bespoke model-row arithmetic. Overlapping/adjacent multi-area coverage extends and shifts in one pass.

### 4. CF area-based **source of truth**
`XLConditionalFormat.Areas` (an `XLAreaList`) is now the stored source of truth; `Ranges`/`Range` are projections materialized on demand. CF coverage no longer lives in the range repository, so the blanket shift can never alias it — **CF is dropped from the #2850 skip-set workaround**, and the first-row/column short-circuit is removed. Coverage mutators (constructors, consolidation, cell-copy extension, the removal helper) all write via `Areas`/`SetAreas`; the removal helper keeps its original "cut only on full width/height overlap" semantics.

> **API note:** `IXLConditionalFormat.Ranges` is now a read-only projection. Mutating the returned collection no longer changes coverage — set `Range`, or construct/copy with the desired ranges.

### 5. Data-validation drop-on-insert fix
The DV shift now runs the area transforms in **two phases** (compute + clear all rules, then re-add). The old per-rule interleaved clear-then-add let an extended range split a not-yet-shifted rule it transiently overlapped, wiping it. Removes the now-dead model-row helpers.

## Tests

- `XLAreaListTests`, `XLAreaConsolidatorTests` — the value-typed model (incl. ClosedXML baselines).
- `ConditionalFormatRangeShiftTests` — #2850 row/column regressions (now on the area engine) + a multi-area CF that extends one area while shifting another.
- `DataValidationDropOnInsertTests` — row/column drop-on-insert regressions.

## Follow-up (not in this PR)

The skip-set still handles **data validations**, because DV coverage remains repository-backed. Fully retiring it needs DV moved onto an area-based source of truth **and** its address-keyed spatial rule-range index reworked — tracked separately.

Tracked in #160.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conditional formatting now remains correctly aligned when rows or columns are inserted, including multi-area formats.
  * Data validation rules are preserved and shifted correctly during row and column insertions.
  * Copying cells no longer loses or misplaces related conditional formatting.
  * Removing part of a conditional format now preserves the remaining coverage accurately.

* **Tests**
  * Added comprehensive coverage for range shifting, consolidation, deletion, copying, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->