### PR TITLE
refactor: make data-validation coverage area-based source of truth (#160)

### DIFF
--- a/XLibur/Excel/DataValidation/XLDataValidation.cs
+++ b/XLibur/Excel/DataValidation/XLDataValidation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using XLibur.Excel.Coordinates;
 using XLibur.Extensions;
 
 namespace XLibur.Excel;
@@ -17,7 +18,6 @@ internal sealed class RangeEventArgs : EventArgs
 
 internal sealed class XLDataValidation : IXLDataValidation
 {
-    private readonly XLRanges _ranges;
     private readonly XLWorksheet _worksheet;
 
     public XLDataValidation(IXLRange range)
@@ -36,13 +36,38 @@ internal sealed class XLDataValidation : IXLDataValidation
     private XLDataValidation(XLWorksheet worksheet)
     {
         _worksheet = worksheet ?? throw new ArgumentNullException(nameof(worksheet));
-        _ranges = new XLRanges();
+        Areas = XLAreaList.Empty;
         Initialize();
     }
 
+    /// <summary>
+    /// Raised when a single range is appended to the coverage. The container uses it to split any
+    /// pre-existing overlapping rule (one validation per cell) and add the matching index entry.
+    /// </summary>
     internal event EventHandler<RangeEventArgs>? RangeAdded;
 
+    /// <summary>
+    /// Raised when a single range is removed from the coverage. The container uses it to drop the
+    /// matching index entry.
+    /// </summary>
     internal event EventHandler<RangeEventArgs>? RangeRemoved;
+
+    /// <summary>
+    /// Raised when the whole coverage is replaced in one step (a structural shift or consolidation
+    /// writing back a value-typed area transform via <see cref="SetAreas"/>). The container reindexes
+    /// this rule from its <see cref="Areas"/>. Unlike <see cref="RangeAdded"/> it performs no
+    /// split-on-add: a shift preserves the disjointness the rules already had.
+    /// </summary>
+    internal event EventHandler? CoverageReplaced;
+
+    /// <summary>
+    /// The rule's coverage, as a value-typed <see cref="XLAreaList"/>. This is the source of truth:
+    /// coverage lives here rather than as live repository ranges, so structural (row/column insert
+    /// &amp; delete) shifts run as pure area transforms and can never alias or double-shift (ClosedXML
+    /// issue #2850). <see cref="Ranges"/> is a projection of it. Mirrors
+    /// <see cref="XLibur.Excel.ConditionalFormats.XLConditionalFormat.Areas"/>.
+    /// </summary>
+    internal XLAreaList Areas { get; private set; }
 
     internal XLWorksheet Worksheet => _worksheet;
 
@@ -55,7 +80,7 @@ internal sealed class XLDataValidation : IXLDataValidation
     {
         if (dataValidation == this) return;
 
-        if (_ranges.Count == 0)
+        if (Areas.Count == 0)
             AddRanges(dataValidation.Ranges);
 
         IgnoreBlanks = dataValidation.IgnoreBlanks;
@@ -83,15 +108,27 @@ internal sealed class XLDataValidation : IXLDataValidation
                 (!string.IsNullOrWhiteSpace(ErrorTitle) || !string.IsNullOrWhiteSpace(ErrorMessage)));
     }
 
+    /// <summary>
+    /// Carve <paramref name="rangeAddress"/> out of the coverage, keeping the non-overlapping
+    /// remainder. Each intersecting area is replaced by its remainder pieces one at a time (via
+    /// <see cref="RemoveRange"/> / <see cref="AddRange"/>) so the container maintains its index
+    /// incrementally — the same granular flow the range-based implementation used, which keeps the
+    /// index enumeration order (and therefore copy order) stable. Remainder pieces are emitted in
+    /// reading order (top-to-bottom, then left-to-right).
+    /// </summary>
     internal void SplitBy(IXLRangeAddress rangeAddress)
     {
-        var rangesToSplit = _ranges.GetIntersectedRanges(rangeAddress).ToList();
+        var excludedArea = XLSheetRange.FromRangeAddress(rangeAddress);
 
-        foreach (var rangeToSplit in rangesToSplit)
+        foreach (var area in Areas.IntersectingWith(excludedArea).ToList())
         {
-            var newRanges = ((XLRange)rangeToSplit).Split(rangeAddress, includeIntersection: false);
-            RemoveRange(rangeToSplit);
-            newRanges.ForEach(AddRange);
+            var pieces = new List<XLSheetRange>();
+            area.Exclude(excludedArea, pieces);
+            pieces.Sort((a, b) => a.TopRow != b.TopRow ? a.TopRow - b.TopRow : a.LeftColumn - b.LeftColumn);
+
+            RemoveRange(MaterializeRange(area));
+            foreach (var piece in pieces)
+                AddRange(MaterializeRange(piece));
         }
     }
 
@@ -147,7 +184,30 @@ internal sealed class XLDataValidation : IXLDataValidation
     public string MaxValue { get => maxValue; set => maxValue = value; }
     public string MinValue { get => minValue; set => minValue = value; }
     public XLOperator Operator { get; set; }
-    public IEnumerable<IXLRange> Ranges => _ranges.AsEnumerable();
+
+    /// <summary>
+    /// Coverage materialized as ranges on the owning worksheet, in reading order (top-to-bottom,
+    /// then left-to-right) — the same ordering the range-backed <see cref="XLRanges"/> collection
+    /// enumerated in, which callers (the sqref writer, copy) depend on. A fresh snapshot each call —
+    /// mutating a returned range has no effect on the rule; change coverage via <see cref="AddRange"/>,
+    /// <see cref="RemoveRange"/>, <see cref="ClearRanges"/>, or <see cref="SetAreas"/>. Projection of
+    /// <see cref="Areas"/>, the source of truth.
+    /// </summary>
+    public IEnumerable<IXLRange> Ranges =>
+        Areas.OrderBy(a => a.TopRow).ThenBy(a => a.LeftColumn).Select(MaterializeRange);
+
+    private XLRange MaterializeRange(XLSheetRange area)
+        => _worksheet.Range(area.TopRow, area.LeftColumn, area.BottomRow, area.RightColumn);
+
+    /// <summary>
+    /// Replace the coverage in one step. Used by the range shifter and consolidation to write back a
+    /// value-typed area transform. Signals <see cref="CoverageReplaced"/> so the container reindexes.
+    /// </summary>
+    internal void SetAreas(XLAreaList areas)
+    {
+        Areas = areas;
+        CoverageReplaced?.Invoke(this, EventArgs.Empty);
+    }
 
     public bool ShowErrorMessage { get; set; }
 
@@ -199,7 +259,7 @@ internal sealed class XLDataValidation : IXLDataValidation
         if (range.Worksheet != Worksheet)
             range = Worksheet.Range(((XLRangeAddress)range.RangeAddress).WithoutWorksheet());
 
-        _ranges.Add(range);
+        Areas = Areas.With(XLSheetRange.FromRangeAddress(range.RangeAddress));
 
         RangeAdded?.Invoke(this, new RangeEventArgs(range));
     }
@@ -225,10 +285,10 @@ internal sealed class XLDataValidation : IXLDataValidation
     /// </summary>
     public void ClearRanges()
     {
-        var allRanges = _ranges.ToList();
-        _ranges.RemoveAll();
+        var removedRanges = Ranges.ToList();
+        Areas = XLAreaList.Empty;
 
-        foreach (var range in allRanges)
+        foreach (var range in removedRanges)
         {
             RangeRemoved?.Invoke(this, new RangeEventArgs(range));
         }
@@ -286,14 +346,14 @@ internal sealed class XLDataValidation : IXLDataValidation
         if (range == null)
             return false;
 
-        var res = _ranges.Remove(range);
+        var area = XLSheetRange.FromRangeAddress(range.RangeAddress);
+        var newAreas = Areas.Without(area);
+        if (newAreas.Count == Areas.Count)
+            return false;
 
-        if (res)
-        {
-            RangeRemoved?.Invoke(this, new RangeEventArgs(range));
-        }
-
-        return res;
+        Areas = newAreas;
+        RangeRemoved?.Invoke(this, new RangeEventArgs(range));
+        return true;
     }
 
     #endregion IXLDataValidation Members

--- a/XLibur/Excel/DataValidation/XLDataValidations.cs
+++ b/XLibur/Excel/DataValidation/XLDataValidations.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using XLibur.Excel.Coordinates;
 using XLibur.Excel.Ranges.Index;
 using XLibur.Extensions;
 
@@ -64,11 +65,9 @@ internal sealed class XLDataValidations : IXLDataValidations
         var xlDataValidation = (XLDataValidation)dataValidation;
         xlDataValidation.RangeAdded -= OnRangeAdded;
         xlDataValidation.RangeRemoved -= OnRangeRemoved;
+        xlDataValidation.CoverageReplaced -= OnCoverageReplaced;
 
-        foreach (var range in dataValidation.Ranges)
-        {
-            ProcessRangeRemoved(range);
-        }
+        _dataValidationIndex.RemoveAll(e => ReferenceEquals(e.DataValidation, xlDataValidation));
     }
 
     public void Delete(IXLRange range)
@@ -151,6 +150,7 @@ internal sealed class XLDataValidations : IXLDataValidations
 
         xlDataValidation.RangeAdded += OnRangeAdded;
         xlDataValidation.RangeRemoved += OnRangeRemoved;
+        xlDataValidation.CoverageReplaced += OnCoverageReplaced;
 
         foreach (var range in xlDataValidation.Ranges)
         {
@@ -166,13 +166,6 @@ internal sealed class XLDataValidations : IXLDataValidations
 
     public void Consolidate()
     {
-        // Make sure the rule-range index reflects the current rule ranges before we
-        // start tearing down and rebuilding rules. After column/row shifts the
-        // address-keyed index can hold stale entries, and the split-on-add logic
-        // would otherwise interpret a rule's own out-of-date entry as a competing
-        // rule and wipe its ranges.
-        ReconcileIndex();
-
         Func<IXLDataValidation, IXLDataValidation, bool> areEqual = (dv1, dv2) =>
         {
             return
@@ -200,15 +193,13 @@ internal sealed class XLDataValidations : IXLDataValidations
             var similarRules = rules.Where(r => areEqual(rules[0], r)).ToList();
             rules.RemoveAll(similarRules.Contains);
 
-            var consRule = similarRules[0];
-            var ranges = similarRules.SelectMany(dv => dv.Ranges).ToList();
+            var consRule = (XLDataValidation)similarRules[0];
 
-            IXLRanges consolidatedRanges = new XLRanges();
-            ranges.ForEach(r => consolidatedRanges.Add(r));
-            consolidatedRanges = consolidatedRanges.Consolidate();
-
-            consRule.ClearRanges();
-            consRule.AddRanges(consolidatedRanges);
+            // Merge every similar rule's coverage and collapse adjacent/overlapping blocks with the
+            // value-typed area model (mirrors XLConditionalFormats.ConsolidateItem). Add() reindexes.
+            var mergedAreas = new XLAreaList(
+                similarRules.Cast<XLDataValidation>().SelectMany(dv => dv.Areas).ToList());
+            consRule.SetAreas(mergedAreas.GetConsolidated());
             Add(consRule);
         }
     }
@@ -221,6 +212,11 @@ internal sealed class XLDataValidations : IXLDataValidations
     private void OnRangeRemoved(object? sender, RangeEventArgs e)
     {
         ProcessRangeRemoved(e.Range);
+    }
+
+    private void OnCoverageReplaced(object? sender, EventArgs e)
+    {
+        ReindexRule((XLDataValidation)sender!);
     }
 
     private void ProcessRangeAdded(IXLRange range, XLDataValidation dataValidation, bool skipIntersectionCheck)
@@ -242,22 +238,20 @@ internal sealed class XLDataValidations : IXLDataValidations
     }
 
     /// <summary>
-    /// Rebuild the internal rule-range spatial index from the current ranges of every
-    /// rule. Address-keyed index entries can fall out of sync with their backing
-    /// <see cref="XLRange"/> instances after column/row inserts that mutate addresses
-    /// in place (the shifter updates each <c>XLRange.RangeAddress</c> but does not
-    /// re-key the index entry). A stale index causes <see cref="SplitExistingRanges"/>
-    /// to split rules against their own outdated entries, wiping their range collection.
+    /// Rebuild a single rule's spatial-index entries from its <see cref="XLDataValidation.Areas"/>.
+    /// Called when a rule replaces its whole coverage in one step (a structural shift or
+    /// consolidation via <see cref="XLDataValidation.SetAreas"/>, signalled by
+    /// <see cref="XLDataValidation.CoverageReplaced"/>). Entries are keyed off immutable area values
+    /// (never a live repository range), so a subsequent blanket range shift cannot desync them —
+    /// which is what let the old defensive full-index rebuild (ReconcileIndex) go.
     /// </summary>
-    internal void ReconcileIndex()
+    private void ReindexRule(XLDataValidation dataValidation)
     {
-        _dataValidationIndex.RemoveAll();
-        foreach (var dv in _dataValidations.OfType<XLDataValidation>())
+        _dataValidationIndex.RemoveAll(e => ReferenceEquals(e.DataValidation, dataValidation));
+        foreach (var area in dataValidation.Areas)
         {
-            foreach (var range in dv.Ranges)
-            {
-                _dataValidationIndex.Add(new XLDataValidationIndexEntry(range.RangeAddress, dv));
-            }
+            var address = XLRangeAddress.FromSheetRange(_worksheet, area);
+            _dataValidationIndex.Add(new XLDataValidationIndexEntry(address, dataValidation));
         }
     }
 

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -1172,20 +1172,11 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
 
         WorksheetRangeShiftedRows(range, rowsShifted);
 
-        // When the insertion is below row 1, the worksheet-level shift above already
-        // repositioned conditional-format and data-validation ranges
-        // (ShiftConditionalFormattingRows / ShiftDataValidationRows). Those handlers obtain
-        // replacement ranges through the range repository, which deduplicates by address — so
-        // when a shifted target lands on an address that already owns a stored range, they
-        // receive that pre-existing instance, which is also present in rangesToShift. Re-applying
-        // the blanket shift below would move it a second time (the "doubled" offset in ClosedXML
-        // issue #2850). Exclude those ranges so each is shifted exactly once. For a first-row
-        // insert the explicit handlers short-circuit and delegate to the blanket shift, so no
-        // exclusion applies.
-        var alreadyShifted = range.RangeAddress.FirstAddress.RowNumber != 1
-            ? GetExplicitlyShiftedRanges()
-            : null;
-
+        // Conditional-format and data-validation coverage was already repositioned by the
+        // worksheet-level shift above (ShiftConditionalFormattingRows / ShiftDataValidationRows).
+        // Both store coverage as the value-typed XLAreaList — not live repository ranges — so the
+        // blanket shift below can never alias and double-shift them (ClosedXML issue #2850); no
+        // skip-set is needed.
         var collapsed = false;
         foreach (var storedRange in rangesToShift)
         {
@@ -1193,9 +1184,6 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
                 continue;
 
             if (ReferenceEquals(range, storedRange))
-                continue;
-
-            if (alreadyShifted?.Contains(storedRange) == true)
                 continue;
 
             storedRange.WorksheetRangeShiftedRows(range, rowsShifted);
@@ -1220,14 +1208,9 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
 
         WorksheetRangeShiftedColumns(range, columnsShifted);
 
-        // See NotifyRangeShiftedRows: for inserts past the first column, CF/DV ranges are
-        // repositioned explicitly and can alias a stored range at the shifted target address, so
-        // exclude them from the blanket shift to avoid the doubled offset (ClosedXML issue #2850).
-        // A first-column insert short-circuits the explicit handlers, so no exclusion applies.
-        var alreadyShifted = range.RangeAddress.FirstAddress.ColumnNumber != 1
-            ? GetExplicitlyShiftedRanges()
-            : null;
-
+        // See NotifyRangeShiftedRows: CF/DV coverage is the value-typed XLAreaList, not live
+        // repository ranges, so the blanket shift can never alias and double-shift it (ClosedXML
+        // issue #2850); no skip-set is needed.
         var collapsed = false;
         foreach (var storedRange in rangesToShift)
         {
@@ -1235,9 +1218,6 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
                 continue;
 
             if (ReferenceEquals(range, storedRange))
-                continue;
-
-            if (alreadyShifted?.Contains(storedRange) == true)
                 continue;
 
             storedRange.WorksheetRangeShiftedColumns(range, columnsShifted);
@@ -1251,33 +1231,6 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
         {
             range.WorksheetRangeShiftedColumns(range, columnsShifted);
         }
-    }
-
-    /// <summary>
-    /// Collects the range instances currently owned by data validations. These are repositioned
-    /// explicitly during a row/column shift; because the range repository deduplicates by address,
-    /// an explicit replacement can be the very same instance the blanket shift in
-    /// <see cref="NotifyRangeShiftedRows"/> / <see cref="NotifyRangeShiftedColumns"/> is about to
-    /// move, which would double the offset (ClosedXML issue #2850). Callers use the returned set to
-    /// shift each range exactly once. Reference identity is required because distinct range
-    /// instances may share an address.
-    /// </summary>
-    /// <remarks>
-    /// Conditional formats are no longer included: their coverage is stored as a value-typed
-    /// <c>XLAreaList</c> (not live repository ranges), so the shift can never alias — see
-    /// <see cref="XLibur.Excel.ConditionalFormats.XLConditionalFormat.Areas"/>.
-    /// </remarks>
-    private HashSet<object> GetExplicitlyShiftedRanges()
-    {
-        var handled = new HashSet<object>(ReferenceEqualityComparer.Instance);
-
-        foreach (var dv in DataValidations)
-        {
-            foreach (var dvRange in dv.Ranges)
-                handled.Add(dvRange);
-        }
-
-        return handled;
     }
 
     public XLRow Row(int rowNumber, bool pingCells)

--- a/XLibur/Excel/XLWorksheetRangeShifter.cs
+++ b/XLibur/Excel/XLWorksheetRangeShifter.cs
@@ -178,62 +178,51 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
     {
         if (columnsShifted == 0 || !worksheet.DataValidations.Any()) return;
         var first = range.RangeAddress.FirstAddress;
-        if (first.ColumnNumber == 1) return;
-
         var last = range.RangeAddress.LastAddress;
+        // The area model handles every insert, including a first-column insert. (The old range-based
+        // path short-circuited here and let the blanket range shifter move the validation ranges;
+        // area-based coverage is no longer a repository range, so it must be shifted here.)
         var affected = columnsShifted > 0
             ? new XLSheetRange(first.RowNumber, first.ColumnNumber, last.RowNumber, first.ColumnNumber + columnsShifted - 1)
             : new XLSheetRange(first.RowNumber, first.ColumnNumber, last.RowNumber, first.ColumnNumber - columnsShifted - 1);
 
         ShiftDataValidations(dv =>
-        {
-            var areas = XLAreaList.FromRanges(dv.Ranges);
-            return columnsShifted > 0 ? areas.InsertAndShiftRight(affected) : areas.DeleteAndShiftLeft(affected);
-        });
+            columnsShifted > 0 ? dv.Areas.InsertAndShiftRight(affected) : dv.Areas.DeleteAndShiftLeft(affected));
     }
 
     private void ShiftDataValidationRows(XLRange range, int rowsShifted)
     {
         if (rowsShifted == 0 || !worksheet.DataValidations.Any()) return;
         var first = range.RangeAddress.FirstAddress;
-        if (first.RowNumber == 1) return;
-
         var last = range.RangeAddress.LastAddress;
+        // The area model handles every insert, including a first-row insert. (The old range-based
+        // path short-circuited here and let the blanket range shifter move the validation ranges;
+        // area-based coverage is no longer a repository range, so it must be shifted here.)
         var affected = rowsShifted > 0
             ? new XLSheetRange(first.RowNumber, first.ColumnNumber, first.RowNumber + rowsShifted - 1, last.ColumnNumber)
             : new XLSheetRange(first.RowNumber, first.ColumnNumber, first.RowNumber - rowsShifted - 1, last.ColumnNumber);
 
         ShiftDataValidations(dv =>
-        {
-            var areas = XLAreaList.FromRanges(dv.Ranges);
-            return rowsShifted > 0 ? areas.InsertAndShiftDown(affected) : areas.DeleteAndShiftUp(affected);
-        });
+            rowsShifted > 0 ? dv.Areas.InsertAndShiftDown(affected) : dv.Areas.DeleteAndShiftUp(affected));
     }
 
     /// <summary>
-    /// Applies a value-typed area transform to every data-validation rule in two phases: compute
-    /// each rule's new coverage and clear all rules first, then re-add. Interleaving clear and add
-    /// per rule would let an extended range split a not-yet-shifted rule it transiently overlaps,
-    /// wiping it (the data-validation drop-on-insert bug). Coverage is still materialized as ranges,
-    /// so validations remain in the shift skip-set (see XLWorksheet.NotifyRangeShiftedRows).
+    /// Applies a value-typed area transform to every data-validation rule and writes the result back
+    /// with <see cref="XLDataValidation.SetAreas"/>. Because coverage is the area model (not live
+    /// repository ranges) the shift is a pure transform that can never alias or double-shift (ClosedXML
+    /// issue #2850), and the write-back reindexes without split-on-add — so an extended range can no
+    /// longer split a not-yet-shifted rule it transiently overlaps (the drop-on-insert bug). A rule
+    /// whose coverage transforms to nothing is deleted. Mirrors ShiftConditionalFormatting*.
     /// </summary>
     private void ShiftDataValidations(Func<XLDataValidation, XLAreaList> transform)
     {
-        var pending = new List<(XLDataValidation Dv, XLAreaList Areas)>();
         foreach (var dv in worksheet.DataValidations.OfType<XLDataValidation>().ToList())
         {
             var newAreas = transform(dv);
-            dv.ClearRanges();
-            pending.Add((dv, newAreas));
-        }
-
-        foreach (var (dv, areas) in pending)
-        {
-            foreach (var area in areas)
-                dv.AddRange(worksheet.Range(area.TopRow, area.LeftColumn, area.BottomRow, area.RightColumn));
-
-            if (!dv.Ranges.Any())
+            if (newAreas.Count == 0)
                 worksheet.DataValidations.Delete(v => v == dv);
+            else
+                dv.SetAreas(newAreas);
         }
     }
 
@@ -246,8 +235,7 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
     /// mirroring <see cref="MoveDefinedNamesColumns"/>. Every worksheet's validations are visited
     /// (not just the mutated sheet's) so a formula on one sheet that references the mutated sheet is
     /// re-pointed too; <see cref="XLCellFormulaShifter.ShiftFormulaColumns"/> only touches references
-    /// to the sheet being shifted, so unrelated references pass through. Run unconditionally because
-    /// the range shifter short-circuits for first-column inserts.
+    /// to the sheet being shifted, so unrelated references pass through.
     /// </summary>
     private void ShiftDataValidationFormulaColumns(XLRange range, int columnsShifted)
     {
@@ -267,8 +255,7 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
     /// Shifts cell references inside data-validation criteria formulas (formula1/formula2,
     /// stored in <see cref="IXLDataValidation.MinValue"/> / <see cref="IXLDataValidation.MaxValue"/>)
     /// when rows are inserted or deleted. The row counterpart of
-    /// <see cref="ShiftDataValidationFormulaColumns"/>; run unconditionally because the range
-    /// shifter short-circuits for first-row inserts.
+    /// <see cref="ShiftDataValidationFormulaColumns"/>.
     /// </summary>
     private void ShiftDataValidationFormulaRows(XLRange range, int rowsShifted)
     {

--- a/XLibur/Excel/XLWorksheetRangeShifter.cs
+++ b/XLibur/Excel/XLWorksheetRangeShifter.cs
@@ -134,18 +134,8 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
             ? new XLSheetRange(first.RowNumber, first.ColumnNumber, last.RowNumber, first.ColumnNumber + columnsShifted - 1)
             : new XLSheetRange(first.RowNumber, first.ColumnNumber, last.RowNumber, first.ColumnNumber - columnsShifted - 1);
 
-        foreach (var cf in worksheet.ConditionalFormats.ToList())
-        {
-            var xlCf = (XLConditionalFormat)cf;
-            var newAreas = columnsShifted > 0
-                ? xlCf.Areas.InsertAndShiftRight(affected)
-                : xlCf.Areas.DeleteAndShiftLeft(affected);
-
-            if (newAreas.Count == 0)
-                worksheet.ConditionalFormats.Remove(f => f == cf);
-            else
-                xlCf.SetAreas(newAreas);
-        }
+        ShiftConditionalFormats(cf =>
+            columnsShifted > 0 ? cf.Areas.InsertAndShiftRight(affected) : cf.Areas.DeleteAndShiftLeft(affected));
     }
 
     private void ShiftConditionalFormattingRows(XLRange range, int rowsShifted)
@@ -160,17 +150,26 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
             ? new XLSheetRange(first.RowNumber, first.ColumnNumber, first.RowNumber + rowsShifted - 1, last.ColumnNumber)
             : new XLSheetRange(first.RowNumber, first.ColumnNumber, first.RowNumber - rowsShifted - 1, last.ColumnNumber);
 
-        foreach (var cf in worksheet.ConditionalFormats.ToList())
-        {
-            var xlCf = (XLConditionalFormat)cf;
-            var newAreas = rowsShifted > 0
-                ? xlCf.Areas.InsertAndShiftDown(affected)
-                : xlCf.Areas.DeleteAndShiftUp(affected);
+        ShiftConditionalFormats(cf =>
+            rowsShifted > 0 ? cf.Areas.InsertAndShiftDown(affected) : cf.Areas.DeleteAndShiftUp(affected));
+    }
 
+    /// <summary>
+    /// Applies a value-typed area transform to every conditional-format rule and writes the result back
+    /// with <see cref="XLConditionalFormat.SetAreas"/>. Because coverage is the value-typed
+    /// <see cref="XLAreaList"/> (not live repository ranges) the shift is a pure transform that can never
+    /// alias or double-shift, even across overlapping/adjacent coverage (ClosedXML issue #2850). A rule
+    /// whose coverage transforms to nothing is removed. Mirrors <see cref="ShiftDataValidations"/>.
+    /// </summary>
+    private void ShiftConditionalFormats(Func<XLConditionalFormat, XLAreaList> transform)
+    {
+        foreach (var cf in worksheet.ConditionalFormats.OfType<XLConditionalFormat>().ToList())
+        {
+            var newAreas = transform(cf);
             if (newAreas.Count == 0)
                 worksheet.ConditionalFormats.Remove(f => f == cf);
             else
-                xlCf.SetAreas(newAreas);
+                cf.SetAreas(newAreas);
         }
     }
 


### PR DESCRIPTION
Closes #160.

Completes the data-validation half of the `XLAreaList` migration begun for conditional formats (#159, now merged). Rebased onto `main`; the diff is a single commit.

## What

`XLDataValidation` now stores coverage in a value-typed `XLAreaList` (source of truth); `Ranges` is a read-only, reading-order projection of it. Structural (row/column insert & delete) shifts run as pure area transforms written back via `SetAreas`, so validation coverage can never alias or double-shift (ClosedXML issue #2850).

## Changes

- **Spatial index** (`_dataValidationIndex`) is rebuilt per-rule from **immutable area values** on coverage replacement (`ReindexRule`), so a blanket range shift can no longer desync it. The defensive `ReconcileIndex()` full rebuild is removed.
- **Skip-set eliminated** — data validations are removed from the `NotifyRangeShifted*` machinery; with CF already gone, `GetExplicitlyShiftedRanges()` is deleted entirely.
- **Shift handlers** no longer short-circuit first-row/first-column inserts — the area model shifts them directly, exactly as conditional formats already do.
- **`Consolidate()`** uses `XLAreaList.GetConsolidated()` (mirrors `XLConditionalFormats.ConsolidateItem`).
- Split-on-add keeps its incremental remove/add-pieces flow to preserve index enumeration (and therefore copy) order.

## Acceptance criteria (#160)

- [x] Coverage is the area-based source of truth
- [x] Skip-set and `ReconcileIndex()` workaround eliminated
- [x] All tests pass, including drop-on-insert and shift/consolidation scenarios

## Verification

Full solution builds clean (0 warnings under `TreatWarningsAsErrors`). Full test suite: **6203 passed / 0 failed** (net10.0), including drop-on-insert, shift/consolidation, formula-shift, save round-trip, and copy scenarios.