### PR TITLE
feat: add AVERAGEIF, AVERAGEIFS, MAXIFS and MINIFS

### DIFF
--- a/XLibur.Tests/Excel/CalcEngine/CriteriaAggregateFunctionTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/CriteriaAggregateFunctionTests.cs
@@ -1,0 +1,128 @@
+using NUnit.Framework;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+// AVERAGEIF / AVERAGEIFS / MAXIFS / MINIFS — the criteria aggregate functions built on the same
+// TallyCriteria machinery as SUMIFS / COUNTIFS.
+[TestFixture]
+public class CriteriaAggregateFunctionTests
+{
+    private const double Tolerance = 1e-9;
+
+    // Region | Category | Sales
+    // North  | A        | 100
+    // South  | B        | 200
+    // North  | A        | 300
+    // West   | B        | 400
+    // North  | B        | 500
+    private static XLWorkbook CreateSampleWorkbook()
+    {
+        var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        string[] regions = { "North", "South", "North", "West", "North" };
+        string[] categories = { "A", "B", "A", "B", "B" };
+        double[] sales = { 100, 200, 300, 400, 500 };
+        for (var i = 0; i < regions.Length; i++)
+        {
+            ws.Cell(i + 1, 1).Value = regions[i];
+            ws.Cell(i + 1, 2).Value = categories[i];
+            ws.Cell(i + 1, 3).Value = sales[i];
+        }
+
+        return wb;
+    }
+
+    [Test]
+    public void AverageIf_WithSeparateAverageRange()
+    {
+        using var wb = CreateSampleWorkbook();
+        var ws = wb.Worksheet("Data");
+
+        // Average of Sales where Region = North -> (100 + 300 + 500) / 3
+        Assert.AreEqual(300d, (double)ws.Evaluate("AVERAGEIF(A1:A5, \"North\", C1:C5)"), Tolerance);
+    }
+
+    [Test]
+    public void AverageIf_WithoutAverageRange_AveragesTheCriteriaRange()
+    {
+        using var wb = CreateSampleWorkbook();
+        var ws = wb.Worksheet("Data");
+
+        // Average of the values in C1:C5 that are > 150 -> (200 + 300 + 400 + 500) / 4
+        Assert.AreEqual(350d, (double)ws.Evaluate("AVERAGEIF(C1:C5, \">150\")"), Tolerance);
+    }
+
+    [Test]
+    public void AverageIf_NoMatch_ReturnsDivisionByZero()
+    {
+        using var wb = CreateSampleWorkbook();
+        var ws = wb.Worksheet("Data");
+
+        Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("AVERAGEIF(A1:A5, \"East\", C1:C5)"));
+    }
+
+    [Test]
+    public void AverageIfs_MultipleCriteria()
+    {
+        using var wb = CreateSampleWorkbook();
+        var ws = wb.Worksheet("Data");
+
+        // Average of Sales where Region = North AND Category = A -> (100 + 300) / 2
+        Assert.AreEqual(200d, (double)ws.Evaluate("AVERAGEIFS(C1:C5, A1:A5, \"North\", B1:B5, \"A\")"), Tolerance);
+    }
+
+    [Test]
+    public void AverageIfs_NoMatch_ReturnsDivisionByZero()
+    {
+        using var wb = CreateSampleWorkbook();
+        var ws = wb.Worksheet("Data");
+
+        Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("AVERAGEIFS(C1:C5, A1:A5, \"East\")"));
+    }
+
+    [Test]
+    public void MaxIfs_ReturnsMaxOfMatchingCells()
+    {
+        using var wb = CreateSampleWorkbook();
+        var ws = wb.Worksheet("Data");
+
+        Assert.AreEqual(500d, (double)ws.Evaluate("MAXIFS(C1:C5, A1:A5, \"North\")"), Tolerance);
+        // Region = North AND Category = A -> max(100, 300)
+        Assert.AreEqual(300d, (double)ws.Evaluate("MAXIFS(C1:C5, A1:A5, \"North\", B1:B5, \"A\")"), Tolerance);
+    }
+
+    [Test]
+    public void MinIfs_ReturnsMinOfMatchingCells()
+    {
+        using var wb = CreateSampleWorkbook();
+        var ws = wb.Worksheet("Data");
+
+        Assert.AreEqual(100d, (double)ws.Evaluate("MINIFS(C1:C5, A1:A5, \"North\")"), Tolerance);
+        // Region = North AND Category = A -> min(100, 300)
+        Assert.AreEqual(100d, (double)ws.Evaluate("MINIFS(C1:C5, A1:A5, \"North\", B1:B5, \"A\")"), Tolerance);
+    }
+
+    [Test]
+    public void MaxIfs_And_MinIfs_NoMatch_ReturnZero()
+    {
+        using var wb = CreateSampleWorkbook();
+        var ws = wb.Worksheet("Data");
+
+        // Excel returns 0 (not an error) when no cell satisfies the criteria.
+        Assert.AreEqual(0d, (double)ws.Evaluate("MAXIFS(C1:C5, A1:A5, \"East\")"), Tolerance);
+        Assert.AreEqual(0d, (double)ws.Evaluate("MINIFS(C1:C5, A1:A5, \"East\")"), Tolerance);
+    }
+
+    [Test]
+    public void CriteriaAndValueRangeSizeMismatch_ReturnsValueError()
+    {
+        using var wb = CreateSampleWorkbook();
+        var ws = wb.Worksheet("Data");
+
+        // Value range (5 rows) and criteria range (4 rows) differ in size.
+        Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("AVERAGEIFS(C1:C5, A1:A4, \"North\")"));
+        Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("MAXIFS(C1:C5, A1:A4, \"North\")"));
+        Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("MINIFS(C1:C5, A1:A4, \"North\")"));
+    }
+}

--- a/XLibur/Excel/CalcEngine/Functions/Statistical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Statistical.cs
@@ -8,11 +8,19 @@ namespace XLibur.Excel.CalcEngine;
 
 internal static class Statistical
 {
+    // Argument positions that may be ranges in *IFS functions that take a leading value range:
+    // the value range at position 0, then the criteria ranges at odd positions (criteria values,
+    // at even positions, are scalars). Mirrors MathTrig.SumIfsAllowedRangeParams.
+    private static readonly int[] ValueAndCriteriaRangeParams =
+        new[] { 0 }.Concat(Enumerable.Range(0, 128).Select(x => x * 2 + 1)).ToArray();
+
     public static void Register(FunctionRegistry ce)
     {
         //ce.RegisterFunction("AVEDEV", AveDev, 1, int.MaxValue);
         ce.RegisterFunction("AVERAGE", 1, int.MaxValue, Average, FunctionFlags.Range, AllowRange.All); // Returns the average (arithmetic mean) of the arguments
         ce.RegisterFunction("AVERAGEA", 1, int.MaxValue, AverageA, FunctionFlags.Range, AllowRange.All);
+        ce.RegisterFunction("AVERAGEIF", 2, 3, AdaptLastOptional(AverageIf), FunctionFlags.Range, AllowRange.Only, 0, 2); // Returns the average of cells that meet a criterion
+        ce.RegisterFunction("AVERAGEIFS", 3, 255, AdaptIfs(AverageIfs), FunctionFlags.Range, AllowRange.Only, ValueAndCriteriaRangeParams); // Returns the average of cells that meet multiple criteria
         //BETADIST	Returns the beta cumulative distribution function
         //BETAINV   Returns the inverse of the cumulative distribution function for a specified beta distribution
         ce.RegisterFunction("BINOMDIST", 4, 4, Adapt(BinomDist), FunctionFlags.Scalar); //BINOMDIST	Returns the individual term binomial distribution probability
@@ -55,9 +63,11 @@ internal static class Statistical
         //LOGNORMDIST	Returns the cumulative lognormal distribution
         ce.RegisterFunction("MAX", 1, 255, Max, FunctionFlags.Range, AllowRange.All);
         ce.RegisterFunction("MAXA", 1, int.MaxValue, MaxA, FunctionFlags.Range, AllowRange.All);
+        ce.RegisterFunction("MAXIFS", 3, 255, AdaptIfs(MaxIfs), FunctionFlags.Range, AllowRange.Only, ValueAndCriteriaRangeParams); // Returns the maximum of cells that meet multiple criteria
         ce.RegisterFunction("MEDIAN", 1, int.MaxValue, Median, FunctionFlags.Range, AllowRange.All);
         ce.RegisterFunction("MIN", 1, int.MaxValue, Min, FunctionFlags.Range, AllowRange.All);
         ce.RegisterFunction("MINA", 1, int.MaxValue, MinA, FunctionFlags.Range, AllowRange.All);
+        ce.RegisterFunction("MINIFS", 3, 255, AdaptIfs(MinIfs), FunctionFlags.Range, AllowRange.Only, ValueAndCriteriaRangeParams); // Returns the minimum of cells that meet multiple criteria
         //MODE	Returns the most common value in a data set
         //NEGBINOMDIST	Returns the negative binomial distribution
         //NORMDIST	Returns the normal cumulative distribution
@@ -250,6 +260,95 @@ internal static class Statistical
             return error;
 
         return state.TallyCount;
+    }
+
+    private static AnyValue AverageIf(CalcContext ctx, AnyValue range, ScalarValue selectionCriteria, AnyValue averageRange)
+    {
+        // Average range is optional. If not specified, use the criteria range as the average range.
+        if (averageRange.IsBlank)
+            averageRange = range;
+
+        if (!range.TryPickArea(out var area, out var areaError))
+            return areaError;
+
+        if (!averageRange.TryPickArea(out _, out var averageAreaError))
+            return averageAreaError;
+
+        var tally = new TallyCriteria();
+        tally.Add(area, Criteria.Create(selectionCriteria, ctx.Culture));
+
+        // Average returns #DIV/0! when no cell satisfies the criterion, matching Excel.
+        return Average(ctx, new[] { averageRange }, tally);
+    }
+
+    private static AnyValue AverageIfs(CalcContext ctx, AnyValue averageRange, List<(AnyValue Range, ScalarValue Criteria)> criteriaRanges)
+    {
+        if (!TryBuildCriteriaTally(ctx, averageRange, criteriaRanges, out var tally, out var error))
+            return error;
+
+        // #DIV/0! when nothing matches, matching Excel.
+        return Average(ctx, new[] { averageRange }, tally);
+    }
+
+    private static AnyValue MaxIfs(CalcContext ctx, AnyValue maxRange, List<(AnyValue Range, ScalarValue Criteria)> criteriaRanges)
+    {
+        if (!TryBuildCriteriaTally(ctx, maxRange, criteriaRanges, out var tally, out var error))
+            return error;
+
+        // Max returns 0 when nothing matches, matching Excel.
+        return Max(ctx, new[] { maxRange }, tally);
+    }
+
+    private static AnyValue MinIfs(CalcContext ctx, AnyValue minRange, List<(AnyValue Range, ScalarValue Criteria)> criteriaRanges)
+    {
+        if (!TryBuildCriteriaTally(ctx, minRange, criteriaRanges, out var tally, out var error))
+            return error;
+
+        // Min returns 0 when nothing matches, matching Excel.
+        return Min(ctx, new[] { minRange }, tally);
+    }
+
+    /// <summary>
+    /// Build a <see cref="TallyCriteria"/> for the <c>{AVERAGE,MAX,MIN}IFS</c> family: every
+    /// criteria area must match the size of the leading value area (Excel invariant), unlike the
+    /// single-criteria <c>*IF</c> forms. Returns <c>false</c> with <paramref name="error"/> set when
+    /// an argument isn't an area or the sizes disagree.
+    /// </summary>
+    private static bool TryBuildCriteriaTally(
+        CalcContext ctx,
+        AnyValue valueRange,
+        List<(AnyValue Range, ScalarValue Criteria)> criteriaRanges,
+        out TallyCriteria tally,
+        out AnyValue error)
+    {
+        tally = new TallyCriteria();
+        error = default;
+
+        if (!valueRange.TryPickArea(out var valueArea, out var valueAreaError))
+        {
+            error = valueAreaError;
+            return false;
+        }
+
+        foreach (var (selectionRange, selectionCriteria) in criteriaRanges)
+        {
+            if (!selectionRange.TryPickArea(out var selectionArea, out var selectionAreaError))
+            {
+                error = selectionAreaError;
+                return false;
+            }
+
+            if (valueArea.RowSpan != selectionArea.RowSpan ||
+                valueArea.ColumnSpan != selectionArea.ColumnSpan)
+            {
+                error = XLError.IncompatibleValue;
+                return false;
+            }
+
+            tally.Add(selectionArea, Criteria.Create(selectionCriteria, ctx.Culture));
+        }
+
+        return true;
     }
 
     private static AnyValue DevSq(CalcContext ctx, Span<AnyValue> args)


### PR DESCRIPTION
## What

Adds four common criteria-aggregate worksheet functions that were missing, even though all supporting machinery already existed for `SUMIFS`/`COUNTIFS`:

- **`AVERAGEIF`** — mirrors `SUMIF` (optional average range; averages the criteria range when omitted).
- **`AVERAGEIFS`**, **`MAXIFS`**, **`MINIFS`** — mirror `SUMIFS` (leading value range + criteria pairs; all areas must be the same size), via a shared `TryBuildCriteriaTally` helper.

All four reuse the existing `TallyCriteria` / `Criteria` engine and the already-`internal` `Average` / `Max` / `Min` tally overloads — no calc-engine changes.

## Excel-accurate semantics

- `AVERAGEIF` / `AVERAGEIFS` return `#DIV/0!` when no cell matches.
- `MAXIFS` / `MINIFS` return `0` when no cell matches.
- A value/criteria range size mismatch returns `#VALUE!`.

## Tests

New `CriteriaAggregateFunctionTests` (9 cases): separate vs. omitted average range, multi-criteria, no-match for each family, and the size-mismatch error path.

## Verification

- Full suite green: **6212 passed / 0 failed** (net10.0).
- Clean build under `TreatWarningsAsErrors` across net8.0/net9.0/net10.0; no PublicAPI change.