### PR TITLE
feat: add IFS and SWITCH logical functions

### DIFF
--- a/XLibur.Tests/Excel/CalcEngine/IfsSwitchTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/IfsSwitchTests.cs
@@ -1,0 +1,114 @@
+using NUnit.Framework;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+// IFS and SWITCH — scalar logical selectors added alongside IF.
+[TestFixture]
+public class IfsSwitchTests
+{
+    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    {
+        wb = new XLWorkbook();
+        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+    }
+
+    [Test]
+    public void Ifs_ReturnsValueOfFirstTrueCondition()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 2;
+            Assert.AreEqual("two", ws.Evaluate(@"IFS(A1=1, ""one"", A1=2, ""two"", A1=3, ""three"")"));
+            // First TRUE wins even if a later condition also matches.
+            Assert.AreEqual("first", ws.Evaluate(@"IFS(TRUE, ""first"", TRUE, ""second"")"));
+            // A numeric (non-zero) condition is truthy.
+            Assert.AreEqual("y", ws.Evaluate(@"IFS(0, ""x"", 5, ""y"")"));
+        }
+    }
+
+    [Test]
+    public void Ifs_NoTrueCondition_ReturnsNotAvailable()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"IFS(FALSE, 1, FALSE, 2)"));
+            // Odd trailing argument with no earlier match -> #N/A.
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"IFS(FALSE, 1, 2)"));
+        }
+    }
+
+    [Test]
+    public void Ifs_OddTrailingArgument_IgnoredWhenEarlierConditionMatches()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            Assert.AreEqual(1, ws.Evaluate(@"IFS(TRUE, 1, 2)"));
+        }
+    }
+
+    [Test]
+    public void Ifs_ErrorConditionIsPropagated()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate(@"IFS(1/0, ""x"", TRUE, ""y"")"));
+        }
+    }
+
+    [Test]
+    public void Switch_ReturnsResultOfFirstMatch()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            Assert.AreEqual("b", ws.Evaluate(@"SWITCH(2, 1, ""a"", 2, ""b"", 3, ""c"")"));
+            // First match wins.
+            Assert.AreEqual("a", ws.Evaluate(@"SWITCH(1, 1, ""a"", 1, ""b"")"));
+        }
+    }
+
+    [Test]
+    public void Switch_TextMatchIsCaseInsensitive()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            Assert.AreEqual("match", ws.Evaluate(@"SWITCH(""red"", ""RED"", ""match"", ""no"")"));
+        }
+    }
+
+    [Test]
+    public void Switch_NoMatch_UsesDefaultWhenPresent()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            Assert.AreEqual("none", ws.Evaluate(@"SWITCH(9, 1, ""a"", 2, ""b"", ""none"")"));
+        }
+    }
+
+    [Test]
+    public void Switch_NoMatch_NoDefault_ReturnsNotAvailable()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"SWITCH(9, 1, ""a"", 2, ""b"")"));
+        }
+    }
+
+    [Test]
+    public void Switch_ErrorExpressionIsPropagated()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate(@"SWITCH(1/0, 1, ""a"", ""default"")"));
+        }
+    }
+}

--- a/XLibur/Excel/CalcEngine/Functions/Logical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Logical.cs
@@ -12,8 +12,10 @@ internal static class Logical
         ce.RegisterFunction("FALSE", 0, 0, Adapt(False), FunctionFlags.Scalar);
         ce.RegisterFunction("IF", 2, 3, AdaptLastOptional(If, false), FunctionFlags.Range, AllowRange.Only, 1, 2);
         ce.RegisterFunction("IFERROR", 2, 2, Adapt(IfError), FunctionFlags.Scalar);
+        ce.RegisterFunction("IFS", 2, 254, Ifs, FunctionFlags.Scalar); // Returns the value for the first TRUE condition
         ce.RegisterFunction("NOT", 1, 1, AdaptCoerced(Not), FunctionFlags.Scalar);
         ce.RegisterFunction("OR", 1, int.MaxValue, Or, FunctionFlags.Range, AllowRange.All);
+        ce.RegisterFunction("SWITCH", 3, 254, Switch, FunctionFlags.Scalar); // Matches an expression against a list of values
         ce.RegisterFunction("TRUE", 0, 0, Adapt(True), FunctionFlags.Scalar);
     }
 
@@ -60,6 +62,51 @@ internal static class Logical
             return potentialError.ToAnyValue();
 
         return alternative.ToAnyValue();
+    }
+
+    private static AnyValue Ifs(CalcContext ctx, Span<AnyValue> args)
+    {
+        // IFS(condition1, value1, [condition2, value2], ...). Return the value paired with the first
+        // condition that is TRUE. Iterate whole pairs only, so a dangling trailing argument (odd
+        // count) simply can't match — matching Excel, which then returns #N/A.
+        for (var i = 0; i + 1 < args.Length; i += 2)
+        {
+            if (!args[i].TryPickScalar(out var conditionScalar, out _))
+                return XLError.IncompatibleValue;
+
+            if (!conditionScalar.TryCoerceLogicalOrBlankOrNumberOrText(out var condition, out var error))
+                return error;
+
+            if (condition)
+                return args[i + 1];
+        }
+
+        // No condition evaluated to TRUE.
+        return XLError.NoValueAvailable;
+    }
+
+    private static AnyValue Switch(CalcContext ctx, Span<AnyValue> args)
+    {
+        // SWITCH(expression, value1, result1, [value2, result2], ..., [default]).
+        ref var expression = ref args[0];
+        if (expression.TryPickError(out var expressionError))
+            return expressionError;
+
+        int i;
+        for (i = 1; i + 1 < args.Length; i += 2)
+        {
+            // Compare with Excel '=' semantics (case-insensitive text, numeric coercion, ...).
+            var comparison = AnyValue.IsEqual(expression, args[i], ctx);
+            if (comparison.TryPickError(out var comparisonError))
+                return comparisonError;
+
+            if (comparison.TryPickScalar(out var scalar, out _) &&
+                scalar.TryPickLogical(out var isMatch) && isMatch)
+                return args[i + 1];
+        }
+
+        // An odd trailing argument (no result to pair with) is the default value.
+        return i < args.Length ? args[i] : XLError.NoValueAvailable;
     }
 
     private static AnyValue Not(bool value)


### PR DESCRIPTION
## What

Adds the two modern conditional selectors that were missing (`IF` was the only one). Both are scalar variadic functions registered with `AllowRange.None`, so each argument is reduced to a scalar via implicit intersection before the function runs.

- **`IFS(cond1, val1, [cond2, val2], ...)`** — returns the value paired with the first TRUE condition, coercing each condition exactly as `IF` does. Iterates whole pairs, so a dangling trailing argument can't match; `#N/A` when no condition is TRUE. Errors in a condition propagate.
- **`SWITCH(expr, val1, res1, [val2, res2], ..., [default])`** — returns the result of the first value equal to `expr` using Excel `=` semantics (case-insensitive text, numeric coercion) via `AnyValue.IsEqual`. An odd trailing argument is the default; otherwise `#N/A`. Errors in the expression or a comparison propagate.

## Tests

New `IfsSwitchTests` (9 cases): first-match, no-match (`#N/A`), numeric truthiness, first-TRUE-wins, case-insensitive text match, default handling, odd-argument handling, and error propagation for both functions.

## Verification

- Full suite green: **6212 passed / 0 failed** (net10.0).
- Clean build under `TreatWarningsAsErrors` across net8.0/net9.0/net10.0; no PublicAPI change.