### PR TITLE
refactor: resolve cell value once per cell in the sheet writer

### DIFF
--- a/XLibur/Excel/IO/SheetDataWriter.cs
+++ b/XLibur/Excel/IO/SheetDataWriter.cs
@@ -80,7 +80,10 @@ internal static class SheetDataWriter
 
             WriteIntermediateRows(xml, xlWorksheet, rows, currentRowNumber, maxColumn, context, ref rowState);
 
-            if (IsBlankAndEmpty(cellCtx.CellsCollection, point))
+            // Resolve the value and its share-string flag once for both the blank-and-empty check
+            // and the value write below, avoiding a second ValueSlice traversal per cell.
+            var cellValue = cellCtx.CellsCollection.ValueSlice.GetCellValueAndShareString(point, out var shareString);
+            if (IsBlankAndEmpty(cellValue, cellCtx.CellsCollection, point))
                 continue;
 
             if (rowState.OpenedRowNumber != currentRowNumber)
@@ -100,7 +103,7 @@ internal static class SheetDataWriter
             var cellStyleId =
                 ResolveCellStyleId(xlWorksheet, point, ref lastCachedStyle, ref lastCachedStyleId, context);
 
-            WriteCellAtPoint(xml, ref cellCtx, point, rowStyleId, cellStyleId);
+            WriteCellAtPoint(xml, ref cellCtx, point, rowStyleId, cellStyleId, cellValue, shareString);
         }
 
         if (rowState.IsRowOpened)
@@ -175,9 +178,8 @@ internal static class SheetDataWriter
                xlRow.OutlineLevel > 0;
     }
 
-    private static bool IsBlankAndEmpty(XLCellsCollection cellsCollection, XLSheetPoint point)
+    private static bool IsBlankAndEmpty(XLCellValue cellValue, XLCellsCollection cellsCollection, XLSheetPoint point)
     {
-        var cellValue = cellsCollection.ValueSlice.GetCellValue(point);
         if (cellValue.Type != XLDataType.Blank)
             return false;
 
@@ -213,7 +215,7 @@ internal static class SheetDataWriter
     }
 
     private static void WriteCellAtPoint(XmlWriter xml, ref CellWriteContext ctx,
-        XLSheetPoint point, uint rowStyleId, uint cellStyleId)
+        XLSheetPoint point, uint rowStyleId, uint cellStyleId, XLCellValue cellValue, bool shareString)
     {
         var formula = ctx.CellsCollection.FormulaSlice.Get(point);
         if (formula is not null)
@@ -228,9 +230,8 @@ internal static class SheetDataWriter
             return;
         }
 
-        // Single slice lookup for both value and share-string flag, avoiding a
-        // second Lut traversal that GetShareString would require separately.
-        var cellValue = ctx.CellsCollection.ValueSlice.GetCellValueAndShareString(point, out var shareString);
+        // Value and share-string flag were already resolved by the caller (and reused for the
+        // blank-and-empty check), so no second ValueSlice traversal is needed here.
         if (cellValue.Type != XLDataType.Blank)
         {
             WriteValueOnlyCell(xml, ref ctx, point, cellStyleId, cellValue, shareString);


### PR DESCRIPTION
## What

The sheet-data save loop looked up the `ValueSlice` **twice** for every non-blank cell: once in `IsBlankAndEmpty` and again in `WriteCellAtPoint`. This resolves the value and its share-string flag once at the top of the loop and threads them through, so each cell touches the `ValueSlice` a single time.

## Honest framing — this is a cleanup, not a measured perf win

I investigated this as a save-path optimization but measured it end-to-end and it makes **no measurable difference**: on `CreateFormattedAndSave` (50K rows × 10 styled columns, 500K cells) before/after are within noise (~1.10 s vs ~1.11 s, StdDev ~0.016 s). Slice descents are cheap (flat `RowData` struct) and save time is dominated by XML serialization. Two premises from the original idea also didn't hold:

- `IsBlankAndEmpty` masks out `ConditionalFormats`, so there's no per-cell CF scan to remove.
- The `XLCell` allocation in the blank probe only fires for value-blank cells, which are ~0 in a fully-valued sheet.

So this PR is offered purely as a small readability/redundancy cleanup — one fewer `ValueSlice` traversal per cell — with **no performance claim**.

## Verification

- Full suite green: **6203 passed / 0 failed** (net10.0); save/round-trip tests included.
- Byte-for-byte output is unchanged (the value written is identical; formula cells still re-read their cached value after evaluation).
- Clean build under `TreatWarningsAsErrors` across net8.0/net9.0/net10.0.