### PR TITLE
feat: add dynamic-array functions (SEQUENCE, UNIQUE, SORT, SORTBY, FILTER, XLOOKUP, XMATCH)

### DIFF
--- a/XLibur.Tests/Excel/CalcEngine/DynamicArrayFunctionTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DynamicArrayFunctionTests.cs
@@ -1,0 +1,221 @@
+using NUnit.Framework;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+// SEQUENCE / UNIQUE / SORT / SORTBY / FILTER / XLOOKUP / XMATCH.
+// Array results are exercised through legacy CSE array formulas (FormulaArrayA1) over a correctly
+// sized range; scalar results (and the top-left collapse) through ws.Evaluate.
+[TestFixture]
+public class DynamicArrayFunctionTests
+{
+    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    {
+        wb = new XLWorkbook();
+        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+    }
+
+    [Test]
+    public void Sequence_FillsRowMajor()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("A1:B3").FormulaArrayA1 = "SEQUENCE(3, 2)";
+            Assert.AreEqual(1, ws.Cell("A1").Value);
+            Assert.AreEqual(2, ws.Cell("B1").Value);
+            Assert.AreEqual(3, ws.Cell("A2").Value);
+            Assert.AreEqual(4, ws.Cell("B2").Value);
+            Assert.AreEqual(5, ws.Cell("A3").Value);
+            Assert.AreEqual(6, ws.Cell("B3").Value);
+
+            // Start and step.
+            ws.Range("D1:D3").FormulaArrayA1 = "SEQUENCE(3, 1, 10, 5)";
+            Assert.AreEqual(10, ws.Cell("D1").Value);
+            Assert.AreEqual(15, ws.Cell("D2").Value);
+            Assert.AreEqual(20, ws.Cell("D3").Value);
+        }
+    }
+
+    [Test]
+    public void Sequence_ScalarContext_ReturnsTopLeft()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            Assert.AreEqual(1, ws.Evaluate("SEQUENCE(3, 2)"));
+        }
+    }
+
+    [Test]
+    public void Unique_ReturnsDistinctValuesInOrder()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 2;
+            ws.Cell("A3").Value = 2;
+            ws.Cell("A4").Value = 3;
+            ws.Cell("A5").Value = 1;
+
+            ws.Range("C1:C3").FormulaArrayA1 = "UNIQUE(A1:A5)";
+            Assert.AreEqual(1, ws.Cell("C1").Value);
+            Assert.AreEqual(2, ws.Cell("C2").Value);
+            Assert.AreEqual(3, ws.Cell("C3").Value);
+        }
+    }
+
+    [Test]
+    public void Unique_ExactlyOnce_KeepsValuesAppearingOnce()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 2;
+            ws.Cell("A3").Value = 2;
+            ws.Cell("A4").Value = 3;
+
+            // by_col FALSE, exactly_once TRUE -> only 1 and 3.
+            ws.Range("C1:C2").FormulaArrayA1 = "UNIQUE(A1:A4, FALSE, TRUE)";
+            Assert.AreEqual(1, ws.Cell("C1").Value);
+            Assert.AreEqual(3, ws.Cell("C2").Value);
+        }
+    }
+
+    [Test]
+    public void Sort_OrdersRows()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 3;
+            ws.Cell("A2").Value = 1;
+            ws.Cell("A3").Value = 4;
+            ws.Cell("A4").Value = 1;
+
+            ws.Range("C1:C4").FormulaArrayA1 = "SORT(A1:A4)";
+            Assert.AreEqual(1, ws.Cell("C1").Value);
+            Assert.AreEqual(1, ws.Cell("C2").Value);
+            Assert.AreEqual(3, ws.Cell("C3").Value);
+            Assert.AreEqual(4, ws.Cell("C4").Value);
+
+            // Descending.
+            ws.Range("D1:D4").FormulaArrayA1 = "SORT(A1:A4, 1, -1)";
+            Assert.AreEqual(4, ws.Cell("D1").Value);
+            Assert.AreEqual(3, ws.Cell("D2").Value);
+            Assert.AreEqual(1, ws.Cell("D3").Value);
+            Assert.AreEqual(1, ws.Cell("D4").Value);
+        }
+    }
+
+    [Test]
+    public void SortBy_OrdersBySeparateKey()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = "c";
+            ws.Cell("A2").Value = "a";
+            ws.Cell("A3").Value = "b";
+            ws.Cell("B1").Value = 3;
+            ws.Cell("B2").Value = 1;
+            ws.Cell("B3").Value = 2;
+
+            ws.Range("C1:C3").FormulaArrayA1 = "SORTBY(A1:A3, B1:B3)";
+            Assert.AreEqual("a", ws.Cell("C1").Value);
+            Assert.AreEqual("b", ws.Cell("C2").Value);
+            Assert.AreEqual("c", ws.Cell("C3").Value);
+        }
+    }
+
+    [Test]
+    public void Filter_KeepsMatchingRows()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 10;
+            ws.Cell("A2").Value = 20;
+            ws.Cell("A3").Value = 30;
+            ws.Cell("A4").Value = 40;
+
+            ws.Range("C1:C2").FormulaArrayA1 = "FILTER(A1:A4, A1:A4>25)";
+            Assert.AreEqual(30, ws.Cell("C1").Value);
+            Assert.AreEqual(40, ws.Cell("C2").Value);
+        }
+    }
+
+    [Test]
+    public void Filter_NoMatch_ReturnsIfEmpty()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 2;
+            Assert.AreEqual("none", ws.Evaluate("FILTER(A1:A2, A1:A2>9, \"none\")"));
+        }
+    }
+
+    [Test]
+    public void XLookup_ExactMatch()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = "apple";
+            ws.Cell("A2").Value = "banana";
+            ws.Cell("A3").Value = "cherry";
+            ws.Cell("B1").Value = 10;
+            ws.Cell("B2").Value = 20;
+            ws.Cell("B3").Value = 30;
+
+            Assert.AreEqual(20, ws.Evaluate("XLOOKUP(\"banana\", A1:A3, B1:B3)"));
+            // Not found with a provided fallback.
+            Assert.AreEqual("missing", ws.Evaluate("XLOOKUP(\"kiwi\", A1:A3, B1:B3, \"missing\")"));
+            // Not found without fallback -> #N/A.
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("XLOOKUP(\"kiwi\", A1:A3, B1:B3)"));
+        }
+    }
+
+    [Test]
+    public void XLookup_NextSmallerMatchMode()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 3;
+            ws.Cell("A3").Value = 5;
+            ws.Cell("B1").Value = "low";
+            ws.Cell("B2").Value = "mid";
+            ws.Cell("B3").Value = "high";
+
+            // 4 has no exact match; match mode -1 falls back to the next smaller (3 -> "mid").
+            Assert.AreEqual("mid", ws.Evaluate("XLOOKUP(4, A1:A3, B1:B3, , -1)"));
+        }
+    }
+
+    [Test]
+    public void XMatch_ReturnsPosition()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = "apple";
+            ws.Cell("A2").Value = "banana";
+            ws.Cell("A3").Value = "cherry";
+
+            Assert.AreEqual(2, ws.Evaluate("XMATCH(\"banana\", A1:A3)"));
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("XMATCH(\"kiwi\", A1:A3)"));
+
+            ws.Cell("D1").Value = 1;
+            ws.Cell("D2").Value = 3;
+            ws.Cell("D3").Value = 5;
+            // Next-smaller: 4 -> position of 3.
+            Assert.AreEqual(2, ws.Evaluate("XMATCH(4, D1:D3, -1)"));
+        }
+    }
+}

--- a/XLibur/Excel/CalcEngine/FormulaParser.cs
+++ b/XLibur/Excel/CalcEngine/FormulaParser.cs
@@ -289,6 +289,13 @@ internal sealed class FormulaParser
             if (!foundFunction && functionName.StartsWith($"{DefaultFunctionNameSpace}."))
             {
                 functionName = functionName.Substring(DefaultFunctionNameSpace.Length + 1);
+
+                // Worksheet-only future functions carry a further "_xlws." namespace
+                // (e.g. FILTER/SORT are stored as "_xlfn._xlws.FILTER"). Strip it too.
+                const string worksheetNameSpace = "_xlws.";
+                if (functionName.StartsWith(worksheetNameSpace, StringComparison.Ordinal))
+                    functionName = functionName.Substring(worksheetNameSpace.Length);
+
                 foundFunction = _functionRegistry.TryGetFunc(functionName, out minParams, out maxParams);
             }
 

--- a/XLibur/Excel/CalcEngine/Functions/DynamicArray.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DynamicArray.cs
@@ -1,0 +1,479 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using XLibur.Excel.CalcEngine.Functions;
+
+namespace XLibur.Excel.CalcEngine;
+
+/// <summary>
+/// Modern dynamic-array worksheet functions (SEQUENCE, UNIQUE, SORT, SORTBY, FILTER, XLOOKUP,
+/// XMATCH). They are registered as <see cref="FunctionFlags.ReturnsArray"/> so the array-formula
+/// engine (see <c>FunctionDefinition.CallAsArray</c>) uses their whole array output. In a plain
+/// (non-array) formula the result collapses to its top-left element, matching Excel's implicit-
+/// intersection behaviour for pre-spill hosts; entered as an array formula the full result is
+/// written across the range. Actual grid <em>spilling</em> is a separate, later piece of work.
+/// </summary>
+internal static class DynamicArray
+{
+    public static void Register(FunctionRegistry ce)
+    {
+        ce.RegisterFunction("SEQUENCE", 1, 4, Sequence, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Generates a list of sequential numbers
+        ce.RegisterFunction("UNIQUE", 1, 3, Unique, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Returns the distinct values from a range or array
+        ce.RegisterFunction("SORT", 1, 4, Sort, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Sorts the contents of a range or array
+        ce.RegisterFunction("SORTBY", 2, 255, SortBy, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Sorts a range or array based on the values in a corresponding range or array
+        ce.RegisterFunction("FILTER", 2, 3, Filter, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Filters a range or array based on criteria
+        ce.RegisterFunction("XLOOKUP", 3, 6, XLookup, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Searches a range or array and returns the matching item(s)
+        ce.RegisterFunction("XMATCH", 2, 4, XMatch, FunctionFlags.Range, AllowRange.All); // Returns the relative position of an item in a range or array
+    }
+
+    private static AnyValue Sequence(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryIntArg(ctx, args[0], out var rows, out var rowsError))
+            return rowsError;
+
+        var columns = 1;
+        if (args.Length > 1 && !TryIntArg(ctx, args[1], out columns, out var columnsError))
+            return columnsError;
+
+        double start = 1;
+        if (args.Length > 2 && !TryNumberArg(ctx, args[2], out start, out var startError))
+            return startError;
+
+        double step = 1;
+        if (args.Length > 3 && !TryNumberArg(ctx, args[3], out step, out var stepError))
+            return stepError;
+
+        if (rows < 1 || columns < 1 || rows > XLHelper.MaxRowNumber || columns > XLHelper.MaxColumnNumber)
+            return XLError.NumberInvalid;
+
+        var data = new ScalarValue[rows, columns];
+        var current = start;
+        for (var r = 0; r < rows; r++)
+        {
+            for (var c = 0; c < columns; c++)
+            {
+                data[r, c] = current;
+                current += step;
+            }
+        }
+
+        return new ConstArray(data);
+    }
+
+    private static AnyValue Unique(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!args[0].TryPickCollectionArray(out var array, ctx))
+            return XLError.IncompatibleValue;
+
+        var byColumn = false;
+        if (args.Length > 1 && !TryBoolArg(ctx, args[1], out byColumn, out var byColumnError))
+            return byColumnError;
+
+        var exactlyOnce = false;
+        if (args.Length > 2 && !TryBoolArg(ctx, args[2], out exactlyOnce, out var exactlyOnceError))
+            return exactlyOnceError;
+
+        // Work row-wise; when comparing columns, operate on the transpose and transpose back.
+        var source = byColumn ? new TransposedArray(array!) : array!;
+        var width = source.Width;
+
+        var representatives = new List<int>();
+        var counts = new List<int>();
+        for (var r = 0; r < source.Height; r++)
+        {
+            var matched = -1;
+            for (var k = 0; k < representatives.Count; k++)
+            {
+                if (RowsEqual(source, r, representatives[k], width))
+                {
+                    matched = k;
+                    break;
+                }
+            }
+
+            if (matched == -1)
+            {
+                representatives.Add(r);
+                counts.Add(1);
+            }
+            else
+            {
+                counts[matched]++;
+            }
+        }
+
+        var kept = new List<int>();
+        for (var k = 0; k < representatives.Count; k++)
+        {
+            if (!exactlyOnce || counts[k] == 1)
+                kept.Add(representatives[k]);
+        }
+
+        if (kept.Count == 0)
+            return XLError.NoValueAvailable;
+
+        var result = new ScalarValue[kept.Count, width];
+        for (var i = 0; i < kept.Count; i++)
+        {
+            for (var c = 0; c < width; c++)
+                result[i, c] = source[kept[i], c];
+        }
+
+        return Orient(new ConstArray(result), byColumn);
+    }
+
+    private static AnyValue Sort(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!args[0].TryPickCollectionArray(out var array, ctx))
+            return XLError.IncompatibleValue;
+
+        var sortIndex = 1;
+        if (args.Length > 1 && !TryIntArg(ctx, args[1], out sortIndex, out var sortIndexError))
+            return sortIndexError;
+
+        var sortOrder = 1;
+        if (args.Length > 2 && !TryIntArg(ctx, args[2], out sortOrder, out var sortOrderError))
+            return sortOrderError;
+
+        var byColumn = false;
+        if (args.Length > 3 && !TryBoolArg(ctx, args[3], out byColumn, out var byColumnError))
+            return byColumnError;
+
+        if (sortOrder != 1 && sortOrder != -1)
+            return XLError.IncompatibleValue;
+
+        var source = byColumn ? new TransposedArray(array!) : array!;
+        var width = source.Width;
+        if (sortIndex < 1 || sortIndex > width)
+            return XLError.IncompatibleValue;
+
+        var key = sortIndex - 1;
+        var comparer = ScalarValueComparer.SortIgnoreCase;
+        // OrderBy is a stable sort, so equal keys keep their original order (Excel behaviour).
+        var order = Enumerable.Range(0, source.Height)
+            .OrderBy(r => r, Comparer<int>.Create((a, b) => sortOrder * comparer.Compare(source[a, key], source[b, key])))
+            .ToList();
+
+        return Orient(BuildRows(source, order), byColumn);
+    }
+
+    private static AnyValue SortBy(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!args[0].TryPickCollectionArray(out var array, ctx))
+            return XLError.IncompatibleValue;
+
+        var height = array!.Height;
+
+        // Parse (by_array, [order]) groups. A range/array argument starts a new key; a following
+        // scalar argument is that key's sort order (1 ascending, -1 descending).
+        var keys = new List<(Array By, int Order)>();
+        var i = 1;
+        while (i < args.Length)
+        {
+            if (!args[i].TryPickCollectionArray(out var by, ctx))
+                return XLError.IncompatibleValue;
+            if (by!.Width != 1 || by.Height != height)
+                return XLError.IncompatibleValue;
+            i++;
+
+            var order = 1;
+            if (i < args.Length && args[i].TryPickScalar(out _, out _))
+            {
+                if (!TryIntArg(ctx, args[i], out order, out var orderError))
+                    return orderError;
+                if (order != 1 && order != -1)
+                    return XLError.IncompatibleValue;
+                i++;
+            }
+
+            keys.Add((by, order));
+        }
+
+        var comparer = ScalarValueComparer.SortIgnoreCase;
+        var indices = Enumerable.Range(0, height)
+            .OrderBy(r => r, Comparer<int>.Create((a, b) =>
+            {
+                foreach (var (by, order) in keys)
+                {
+                    var cmp = order * comparer.Compare(by[a, 0], by[b, 0]);
+                    if (cmp != 0)
+                        return cmp;
+                }
+
+                return 0;
+            }))
+            .ToList();
+
+        return BuildRows(array, indices);
+    }
+
+    private static AnyValue Filter(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!args[0].TryPickCollectionArray(out var array, ctx))
+            return XLError.IncompatibleValue;
+        if (!args[1].TryPickCollectionArray(out var include, ctx))
+            return XLError.IncompatibleValue;
+
+        var height = array!.Height;
+        var width = array.Width;
+
+        // The mask selects rows when it's a column vector matching the height, or columns when it's
+        // a row vector matching the width.
+        bool filterRows;
+        if (include!.Width == 1 && include.Height == height)
+            filterRows = true;
+        else if (include.Height == 1 && include.Width == width)
+            filterRows = false;
+        else
+            return XLError.IncompatibleValue;
+
+        var kept = new List<int>();
+        var count = filterRows ? height : width;
+        for (var i = 0; i < count; i++)
+        {
+            var mask = filterRows ? include[i, 0] : include[0, i];
+            if (!mask.TryCoerceLogicalOrBlankOrNumberOrText(out var flag, out var maskError))
+                return maskError;
+            if (flag)
+                kept.Add(i);
+        }
+
+        if (kept.Count == 0)
+            return args.Length > 2 ? args[2] : XLError.CellReference;
+
+        if (filterRows)
+        {
+            var rows = new ScalarValue[kept.Count, width];
+            for (var i = 0; i < kept.Count; i++)
+            {
+                for (var c = 0; c < width; c++)
+                    rows[i, c] = array[kept[i], c];
+            }
+
+            return new ConstArray(rows);
+        }
+
+        var columns = new ScalarValue[height, kept.Count];
+        for (var i = 0; i < kept.Count; i++)
+        {
+            for (var r = 0; r < height; r++)
+                columns[r, i] = array[r, kept[i]];
+        }
+
+        return new ConstArray(columns);
+    }
+
+    private static AnyValue XLookup(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryScalarArg(ctx, args[0], out var lookupValue))
+            return XLError.IncompatibleValue;
+        if (lookupValue.TryPickError(out var lookupError))
+            return lookupError;
+
+        if (!args[1].TryPickCollectionArray(out var lookupArray, ctx))
+            return XLError.IncompatibleValue;
+        if (!args[2].TryPickCollectionArray(out var returnArray, ctx))
+            return XLError.IncompatibleValue;
+
+        var matchMode = 0;
+        if (args.Length > 4 && !TryIntArg(ctx, args[4], out matchMode, out var matchModeError))
+            return matchModeError;
+
+        var searchMode = 1;
+        if (args.Length > 5 && !TryIntArg(ctx, args[5], out searchMode, out var searchModeError))
+            return searchModeError;
+
+        var vertical = !(lookupArray!.Height == 1 && lookupArray.Width > 1);
+        var length = vertical ? lookupArray.Height : lookupArray.Width;
+
+        var index = FindMatch(lookupArray, vertical, lookupValue, matchMode, searchMode);
+        if (index < 0)
+            return args.Length > 3 ? args[3] : XLError.NoValueAvailable;
+
+        // Return the matching row (vertical lookup) or column (horizontal lookup) of return_array.
+        if (vertical)
+        {
+            if (returnArray!.Height != length)
+                return XLError.IncompatibleValue;
+            if (returnArray.Width == 1)
+                return returnArray[index, 0].ToAnyValue();
+
+            var row = new ScalarValue[1, returnArray.Width];
+            for (var c = 0; c < returnArray.Width; c++)
+                row[0, c] = returnArray[index, c];
+            return new ConstArray(row);
+        }
+
+        if (returnArray!.Width != length)
+            return XLError.IncompatibleValue;
+        if (returnArray.Height == 1)
+            return returnArray[0, index].ToAnyValue();
+
+        var column = new ScalarValue[returnArray.Height, 1];
+        for (var r = 0; r < returnArray.Height; r++)
+            column[r, 0] = returnArray[r, index];
+        return new ConstArray(column);
+    }
+
+    private static AnyValue XMatch(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryScalarArg(ctx, args[0], out var lookupValue))
+            return XLError.IncompatibleValue;
+        if (lookupValue.TryPickError(out var lookupError))
+            return lookupError;
+
+        if (!args[1].TryPickCollectionArray(out var lookupArray, ctx))
+            return XLError.IncompatibleValue;
+
+        var matchMode = 0;
+        if (args.Length > 2 && !TryIntArg(ctx, args[2], out matchMode, out var matchModeError))
+            return matchModeError;
+
+        var searchMode = 1;
+        if (args.Length > 3 && !TryIntArg(ctx, args[3], out searchMode, out var searchModeError))
+            return searchModeError;
+
+        var vertical = !(lookupArray!.Height == 1 && lookupArray.Width > 1);
+        var index = FindMatch(lookupArray, vertical, lookupValue, matchMode, searchMode);
+        return index < 0 ? XLError.NoValueAvailable : index + 1;
+    }
+
+    /// <summary>
+    /// Find the index of <paramref name="target"/> within a one-dimensional lookup array, honouring
+    /// XLOOKUP/XMATCH match modes (0 exact, -1 exact-or-next-smaller, 1 exact-or-next-larger,
+    /// 2 wildcard) and search modes (1 first-to-last, -1 last-to-first; binary modes fall back to a
+    /// linear scan, which is correct if slower).
+    /// </summary>
+    private static int FindMatch(Array array, bool vertical, ScalarValue target, int matchMode, int searchMode)
+    {
+        var length = vertical ? array.Height : array.Width;
+        var comparer = ScalarValueComparer.SortIgnoreCase;
+
+        if (matchMode == 2 && target.TryPickText(out var pattern, out _))
+        {
+            var wildcard = new Wildcard(pattern!);
+            foreach (var i in SearchOrder(length, searchMode))
+            {
+                if (Element(array, vertical, i).TryPickText(out var text, out _) && wildcard.Matches(text!.AsSpan()))
+                    return i;
+            }
+
+            return -1;
+        }
+
+        var best = -1;
+        var bestValue = ScalarValue.Blank;
+        foreach (var i in SearchOrder(length, searchMode))
+        {
+            var value = Element(array, vertical, i);
+            if (!target.HaveSameType(value))
+                continue;
+
+            var compare = comparer.Compare(value, target);
+            if (compare == 0)
+                return i;
+
+            if (matchMode == -1 && compare < 0 && (best == -1 || comparer.Compare(value, bestValue) > 0))
+            {
+                best = i;
+                bestValue = value;
+            }
+            else if (matchMode == 1 && compare > 0 && (best == -1 || comparer.Compare(value, bestValue) < 0))
+            {
+                best = i;
+                bestValue = value;
+            }
+        }
+
+        return best;
+    }
+
+    private static ScalarValue Element(Array array, bool vertical, int index)
+        => vertical ? array[index, 0] : array[0, index];
+
+    private static IEnumerable<int> SearchOrder(int length, int searchMode)
+    {
+        if (searchMode == -1)
+        {
+            for (var i = length - 1; i >= 0; i--)
+                yield return i;
+        }
+        else
+        {
+            for (var i = 0; i < length; i++)
+                yield return i;
+        }
+    }
+
+    private static bool RowsEqual(Array array, int rowA, int rowB, int width)
+    {
+        for (var c = 0; c < width; c++)
+        {
+            if (ScalarValueComparer.SortIgnoreCase.Compare(array[rowA, c], array[rowB, c]) != 0)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static ConstArray BuildRows(Array source, IReadOnlyList<int> rowOrder)
+    {
+        var result = new ScalarValue[rowOrder.Count, source.Width];
+        for (var i = 0; i < rowOrder.Count; i++)
+        {
+            for (var c = 0; c < source.Width; c++)
+                result[i, c] = source[rowOrder[i], c];
+        }
+
+        return new ConstArray(result);
+    }
+
+    private static AnyValue Orient(Array array, bool transposed)
+        => transposed ? new TransposedArray(array) : array;
+
+    private static bool TryScalarArg(CalcContext ctx, in AnyValue arg, out ScalarValue scalar)
+    {
+        if (arg.TryPickScalar(out scalar, out _))
+            return true;
+
+        return arg.ImplicitIntersection(ctx).TryPickScalar(out scalar, out _);
+    }
+
+    private static bool TryNumberArg(CalcContext ctx, in AnyValue arg, out double number, out XLError error)
+    {
+        error = default;
+        if (!TryScalarArg(ctx, arg, out var scalar))
+        {
+            number = 0;
+            error = XLError.IncompatibleValue;
+            return false;
+        }
+
+        return scalar.ToNumber(ctx.Culture).TryPickT0(out number, out error);
+    }
+
+    private static bool TryIntArg(CalcContext ctx, in AnyValue arg, out int value, out XLError error)
+    {
+        if (!TryNumberArg(ctx, arg, out var number, out error))
+        {
+            value = 0;
+            return false;
+        }
+
+        value = (int)Math.Truncate(number);
+        return true;
+    }
+
+    private static bool TryBoolArg(CalcContext ctx, in AnyValue arg, out bool value, out XLError error)
+    {
+        error = default;
+        if (!TryScalarArg(ctx, arg, out var scalar))
+        {
+            value = false;
+            error = XLError.IncompatibleValue;
+            return false;
+        }
+
+        return scalar.TryCoerceLogicalOrBlankOrNumberOrText(out value, out error);
+    }
+}

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -412,6 +412,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
         Statistical.Register(fr);
         DateAndTime.Register(fr);
         Financial.Register(fr);
+        DynamicArray.Register(fr);
 
         return fr;
     }


### PR DESCRIPTION
First phase of dynamic-array support (item 4 of the roadmap). Adds the seven modern dynamic-array worksheet functions, which previously existed **only as `_xlfn` name-remap entries for saving** and could not be evaluated at all.

## Approach

They're registered as `ReturnsArray`, so the **existing** array-formula engine (`FunctionDefinition.CallAsArray`) uses their whole array output — no changes to the evaluation/recalc core. Consequences:

- Entered as a CSE array formula (`FormulaArrayA1` over a sized range), the **full result** is written across the range.
- In a plain formula, the result collapses to its top-left element — Excel's implicit-intersection (`@`) behaviour on pre-spill hosts. `XLOOKUP`/`XMATCH` single-value lookups work fully this way.

## Functions

- **`SEQUENCE`**`(rows,[cols],[start],[step])` — row-major generated array.
- **`UNIQUE`**`(array,[by_col],[exactly_once])` — distinct rows/columns in first-seen order.
- **`SORT`**`(array,[index],[order],[by_col])` / **`SORTBY`**`(array, by1,[order1], …)` — stable ordering by a key column/row or by separate key arrays.
- **`FILTER`**`(array, include, [if_empty])` — keep rows/columns where the mask is TRUE.
- **`XLOOKUP`**`(lookup, lookup_array, return_array, [if_not_found], [match_mode], [search_mode])` — exact / next-smaller / next-larger / wildcard; first- or last-to-first; returns the matching row or column (scalar or array). **`XMATCH`** returns the position.

Also a small parser fix: strip the `_xlws.` worksheet-only namespace so `_xlfn._xlws.FILTER`/`SORT` resolve to the registered `FILTER`/`SORT`.

## Not in this PR (later phase)

The actual grid **spilling** — dynamic result-sizing, the `#` spill-range operator, `#SPILL!` collision detection, dependency-tree coverage of the spilled region, and save/load round-trip of spilled formulas. That touches the recalc core and is scoped as a separate follow-up.

## Tests

New `DynamicArrayFunctionTests` (11 cases): SEQUENCE fill + start/step, UNIQUE with exactly-once, SORT asc/desc, SORTBY, FILTER + if-empty, XLOOKUP exact/not-found/next-smaller, XMATCH position/next-smaller — array results via CSE array formulas, scalars via `ws.Evaluate`.

## Verification

- Full suite green: **6214 passed / 0 failed** (net10.0).
- Clean build under `TreatWarningsAsErrors` across net8.0/net9.0/net10.0; no PublicAPI change.