### PR TITLE
feat: dynamic-array spill engine (Phase B)

### DIFF
--- a/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -339,6 +339,71 @@ public class ArrayFormulaTests
     }
 
     [Test]
+    public void DynamicArrayFormulaSavesAsArrayFormulaWithSpillRef()
+    {
+        // A spilled dynamic array serialises as an array formula whose ref is the spill
+        // footprint, on the anchor cell, plus the cm dynamic-array metadata link.
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("S");
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(3)");
+            wb.RecalculateAllFormulas(); // spills A1:A3
+
+            wb.SaveAs(ms, validate: false);
+        }
+
+        using var zip = new System.IO.Compression.ZipArchive(new MemoryStream(ms.ToArray()), System.IO.Compression.ZipArchiveMode.Read);
+        var sheetEntry = zip.Entries.First(e => e.FullName.Contains("sheet1.xml", StringComparison.OrdinalIgnoreCase));
+        using var sheetReader = new StreamReader(sheetEntry.Open());
+        var sheetXml = sheetReader.ReadToEnd();
+
+        Assert.That(sheetXml, Does.Contain("t=\"array\""), "Dynamic array must serialise as an array formula");
+        Assert.That(sheetXml, Does.Contain("ref=\"A1:A3\""), "Spill footprint must be written as the array ref");
+        Assert.That(sheetXml, Does.Contain("cm=\"1\""), "Dynamic-array cell metadata (cm) missing");
+    }
+
+    [Test]
+    public void DynamicArrayFormulaRoundTripsAndReSpills()
+    {
+        // Full round-trip: save a spilled dynamic array, load it back, and confirm it is
+        // reconstructed as a dynamic array (not a legacy CSE array) that re-spills correctly.
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("S");
+            ws.Cell("D1").Value = 5;
+            ws.Cell("D2").Value = 6;
+            ws.Cell("D3").Value = 7;
+            ws.Cell("A1").SetDynamicFormulaA1("UNIQUE(D1:D3)");
+            wb.RecalculateAllFormulas(); // spills A1:A3 = {5;6;7}
+
+            wb.SaveAs(ms, validate: false);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var ws = wb.Worksheet("S");
+            var anchor = (XLCell)ws.Cell("A1");
+
+            Assert.IsTrue(anchor.HasFormula);
+            Assert.IsTrue(anchor.Formula!.IsDynamicArray, "Loaded formula must be a dynamic array, not a CSE array");
+            Assert.IsFalse(((XLCell)ws.Cell("A2")).HasFormula, "Spilled cell must load formula-less");
+
+            // The spill re-evaluates and fills the footprint from the cached child values
+            // without a #SPILL! collision.
+            Assert.AreEqual(5, ws.Cell("A1").Value);
+            Assert.AreEqual(7, ws.Cell("A3").Value);
+
+            // Changing a source re-spills the loaded formula.
+            ws.Cell("D3").Value = 8;
+            wb.RecalculateAllFormulas();
+            Assert.AreEqual(8, ws.Cell("A3").Value);
+        }
+    }
+
+    [Test]
     public void DeletingRowsThroughArrayDoesNotCorruptRange()
     {
         // Deleting rows that overlap an array used to push the stored range past row 1, producing

--- a/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -404,6 +404,62 @@ public class ArrayFormulaTests
     }
 
     [Test]
+    public void DynamicArrayAndCseArrayLoadDistinctly()
+    {
+        // A dynamic array (cm metadata) and a legacy CSE array (no cm) both serialise with
+        // t="array"; on load only the one whose cm references XLDAPR becomes dynamic.
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("S");
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(2)"); // dynamic, A1:A2
+            ws.Range("C1:C2").FormulaArrayA1 = "TRANSPOSE({10,20})"; // CSE array, C1:C2
+            wb.RecalculateAllFormulas();
+
+            wb.SaveAs(ms, validate: false);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var ws = wb.Worksheet("S");
+
+            Assert.IsTrue(((XLCell)ws.Cell("A1")).Formula!.IsDynamicArray, "SEQUENCE must load as a dynamic array");
+            Assert.IsFalse(((XLCell)ws.Cell("A2")).HasFormula, "Dynamic spill cell is formula-less");
+
+            Assert.IsFalse(((XLCell)ws.Cell("C1")).Formula!.IsDynamicArray, "CSE array must not load as dynamic");
+            Assert.IsTrue(ws.Cell("C1").HasArrayFormula, "CSE array keeps its array formula");
+            Assert.IsTrue(ws.Cell("C2").HasArrayFormula, "CSE array child keeps the shared array formula");
+        }
+    }
+
+    [Test]
+    public void DynamicArraySpillErrorRoundTrips()
+    {
+        // A blocked dynamic array (#SPILL! anchor) round-trips: the error value survives save/load
+        // (exercising the XLError.SpillRange save/parse path) and stays blocked after reload.
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("S");
+            ws.Cell("A2").Value = "block";
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(3)");
+            wb.RecalculateAllFormulas();
+            Assert.AreEqual(XLError.SpillRange, ws.Cell("A1").Value);
+
+            wb.SaveAs(ms, validate: false);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var ws = wb.Worksheet("S");
+            Assert.AreEqual("block", ws.Cell("A2").Value);
+            Assert.AreEqual(XLError.SpillRange, ws.Cell("A1").Value);
+        }
+    }
+
+    [Test]
     public void DeletingRowsThroughArrayDoesNotCorruptRange()
     {
         // Deleting rows that overlap an array used to push the stored range past row 1, producing

--- a/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -288,7 +288,12 @@ public class FormulaParserTests
     [TestCase]
     public void Reference_function_call_can_be_reference_with_spill_range_operator()
     {
-        AssertCanParseButNotEvaluate("=A1#", "Evaluation of spill range operator is not implemented.");
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+
+        // A1 is not a spill anchor, so the spill-range operator resolves to a #REF! error
+        // (it parses and evaluates rather than throwing).
+        Assert.AreEqual(XLError.CellReference, ws.Evaluate("=A1#"));
     }
 
     #endregion

--- a/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
@@ -28,6 +28,8 @@ public class InformationTests
     [TestCase("#NUM!", 6)]
     [TestCase("#N/A", 7)]
     //[TestCase("#GETTING_DATA", 8)] OLAP Cube not supported
+    // #SPILL! (ERROR.TYPE 9) can't be written as a literal — the parser doesn't tokenize it —
+    // so it is covered against a real spilled #SPILL! cell in SpillEvaluationTests.
     public void ErrorType_ReturnsNumberForError(string error, int expectedNumber)
     {
         Assert.AreEqual(expectedNumber, XLWorkbook.EvaluateExpr($"ERROR.TYPE({error})"));

--- a/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
@@ -118,6 +118,58 @@ public class SpillEvaluationTests
     }
 
     [Test]
+    public void Spill_DependentOfSpilledCell_RecalculatesWhenSourceChanges()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("D1").Value = 1;
+            ws.Cell("D2").Value = 2;
+            ws.Cell("D3").Value = 3;
+            ws.Cell("A1").SetDynamicFormulaA1("UNIQUE(D1:D3)"); // spills A1:A3 = {1;2;3}
+            ws.Cell("C1").FormulaA1 = "A3*10";                  // depends on the spilled A3
+
+            wb.CalcEngine.Recalculate(wb, null);
+            Assert.AreEqual(30, ws.Cell("C1").Value);
+
+            // Change a source cell so the spilled A3 becomes 5.
+            ws.Cell("D3").Value = 5;
+            Assert.IsTrue(ws.Cell("C1").NeedsRecalculation,
+                "A dependent of a spilled (non-anchor) cell must be invalidated when the array's source changes");
+
+            wb.CalcEngine.Recalculate(wb, null);
+            Assert.AreEqual(50, ws.Cell("C1").Value);
+        }
+    }
+
+    [Test]
+    [Ignore("Recalc ordering when a dependent is positioned before the spill anchor is a known " +
+            "limitation. Spilled cells are formula-less, so a read of one does not trigger the calc " +
+            "chain to evaluate the anchor first; on the very first evaluation the footprint is also " +
+            "unknown until the anchor runs. Closing this needs the spill-owner lookup (B3/B5).")]
+    public void Spill_DependentBeforeAnchor_RecalcOrdering()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("D1").Value = 1;
+            ws.Cell("D2").Value = 2;
+            ws.Cell("D3").Value = 3;
+            // Anchor at C1 spills C1:C3; the dependent at A1 sits positionally BEFORE the anchor
+            // and reads the spilled C3.
+            ws.Cell("C1").SetDynamicFormulaA1("UNIQUE(D1:D3)");
+            ws.Cell("A1").FormulaA1 = "C3*10";
+
+            wb.CalcEngine.Recalculate(wb, null);
+            Assert.AreEqual(30, ws.Cell("A1").Value);
+
+            ws.Cell("D3").Value = 5;
+            wb.CalcEngine.Recalculate(wb, null);
+            Assert.AreEqual(50, ws.Cell("A1").Value);
+        }
+    }
+
+    [Test]
     public void Spill_PastSheetEdge_ProducesSpillError()
     {
         var ws = NewSheet(out var wb);

--- a/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
@@ -143,11 +143,7 @@ public class SpillEvaluationTests
     }
 
     [Test]
-    [Ignore("Recalc ordering when a dependent is positioned before the spill anchor is a known " +
-            "limitation. Spilled cells are formula-less, so a read of one does not trigger the calc " +
-            "chain to evaluate the anchor first; on the very first evaluation the footprint is also " +
-            "unknown until the anchor runs. Closing this needs the spill-owner lookup (B3/B5).")]
-    public void Spill_DependentBeforeAnchor_RecalcOrdering()
+    public void Spill_DependentBeforeAnchor_RecalculatesAfterInitialSpill()
     {
         var ws = NewSheet(out var wb);
         using (wb)
@@ -156,16 +152,40 @@ public class SpillEvaluationTests
             ws.Cell("D2").Value = 2;
             ws.Cell("D3").Value = 3;
             // Anchor at C1 spills C1:C3; the dependent at A1 sits positionally BEFORE the anchor
-            // and reads the spilled C3.
+            // and reads the spilled (non-anchor) C3 directly.
+            ws.Cell("C1").SetDynamicFormulaA1("UNIQUE(D1:D3)");
+            ws.Cell("A1").FormulaA1 = "C3*10";
+
+            // Establish the spill so the spill-owner lookup knows C3 belongs to C1.
+            wb.CalcEngine.Recalculate(wb, null);
+
+            // A later source change must recompute the dependent with the fresh spilled value:
+            // reading C3 now forces the dirty anchor C1 to evaluate first.
+            ws.Cell("D3").Value = 5;
+            wb.CalcEngine.Recalculate(wb, null);
+            Assert.AreEqual(50, ws.Cell("A1").Value);
+        }
+    }
+
+    [Test]
+    [Ignore("Remaining limitation: on the VERY FIRST evaluation the spill footprint is unknown " +
+            "until the anchor runs, so a dependent positioned before a not-yet-spilled anchor still " +
+            "reads a blank cell. Full ordering here needs a calc-chain pre-pass that sizes arrays " +
+            "before evaluation. Post-first-spill ordering is covered by " +
+            nameof(Spill_DependentBeforeAnchor_RecalculatesAfterInitialSpill) + ".")]
+    public void Spill_DependentBeforeAnchor_FirstEvaluationOrdering()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("D1").Value = 1;
+            ws.Cell("D2").Value = 2;
+            ws.Cell("D3").Value = 3;
             ws.Cell("C1").SetDynamicFormulaA1("UNIQUE(D1:D3)");
             ws.Cell("A1").FormulaA1 = "C3*10";
 
             wb.CalcEngine.Recalculate(wb, null);
             Assert.AreEqual(30, ws.Cell("A1").Value);
-
-            ws.Cell("D3").Value = 5;
-            wb.CalcEngine.Recalculate(wb, null);
-            Assert.AreEqual(50, ws.Cell("A1").Value);
         }
     }
 
@@ -231,6 +251,28 @@ public class SpillEvaluationTests
 
             wb.CalcEngine.Recalculate(wb, null);
             Assert.AreEqual(6, ws.Cell("A1").Value);
+        }
+    }
+
+    [Test]
+    public void Spill_SurvivesRowInsertAndReSpills()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(3)"); // spills A1:A3
+            wb.RecalculateAllFormulas();
+            Assert.AreEqual(3, ws.Cell("A3").Value);
+
+            // A structural insert relocates the anchor A1 -> A2. It stays a dynamic array and
+            // re-spills over the shifted footprint A2:A4 after recalculation.
+            ws.Row(1).InsertRowsAbove(1);
+            wb.RecalculateAllFormulas();
+
+            Assert.IsTrue(ws.Cell("A2").HasFormula, "Anchor must stay dynamic after the shift");
+            Assert.AreEqual(1, ws.Cell("A2").Value);
+            Assert.AreEqual(3, ws.Cell("A4").Value);
+            Assert.IsFalse(ws.Cell("A3").HasFormula, "Spilled cell stays formula-less after the shift");
         }
     }
 

--- a/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
@@ -289,4 +289,124 @@ public class SpillEvaluationTests
             Assert.AreEqual(XLError.SpillRange, anchor.Value);
         }
     }
+
+    [Test]
+    public void Spill_HorizontalVector_FillsRow()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(1, 3)"); // spills A1:C1
+
+            Assert.AreEqual(1, ws.Cell("A1").Value);
+            Assert.AreEqual(2, ws.Cell("B1").Value);
+            Assert.AreEqual(3, ws.Cell("C1").Value);
+        }
+    }
+
+    [Test]
+    public void Spill_GrowingResult_FillsNewCells()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("D1").Value = 1;
+            ws.Cell("D2").Value = 2;
+            ws.Cell("D3").Value = 2;
+            ws.Cell("A1").SetDynamicFormulaA1("UNIQUE(D1:D3)"); // {1;2} -> A1:A2
+
+            Assert.AreEqual(1, ws.Cell("A1").Value); // trigger the spill
+            Assert.AreEqual(2, ws.Cell("A2").Value);
+            Assert.IsTrue(ws.Cell("A3").IsEmpty(), "Only two distinct values initially");
+
+            // A third distinct value grows the footprint into the previously-empty A3.
+            ws.Cell("D3").Value = 3;
+            Assert.AreEqual(1, ws.Cell("A1").Value);
+            Assert.AreEqual(3, ws.Cell("A3").Value);
+        }
+    }
+
+    [Test]
+    public void Spill_ErrorIsReportedByErrorFunctions()
+    {
+        // A real #SPILL! cell reports through ERROR.TYPE (9) and ISERROR — exercising the
+        // XLError.SpillRange enum member end to end (the literal can't be parsed).
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A2").Value = "block";
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(3)");
+            Assert.AreEqual(XLError.SpillRange, ws.Cell("A1").Value);
+
+            ws.Cell("C1").FormulaA1 = "ERROR.TYPE(A1)";
+            ws.Cell("C2").FormulaA1 = "ISERROR(A1)";
+            Assert.AreEqual(9, ws.Cell("C1").Value);
+            Assert.AreEqual(true, ws.Cell("C2").Value);
+        }
+    }
+
+    [Test]
+    public void Spill_RecoversAfterBlockerClearedAndAnchorReevaluates()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("D1").Value = 1;
+            ws.Cell("D2").Value = 2;
+            ws.Cell("D3").Value = 3;
+            ws.Cell("A2").Value = "block";
+            ws.Cell("A1").SetDynamicFormulaA1("UNIQUE(D1:D3)");
+            Assert.AreEqual(XLError.SpillRange, ws.Cell("A1").Value);
+
+            // Clear the blocker and change a source so the anchor re-evaluates: the spill recovers.
+            ws.Cell("A2").Value = Blank.Value;
+            ws.Cell("D3").Value = 4;
+            Assert.AreEqual(1, ws.Cell("A1").Value);
+            Assert.AreEqual(2, ws.Cell("A2").Value);
+            Assert.AreEqual(4, ws.Cell("A3").Value);
+        }
+    }
+
+    [Test]
+    public void Spill_SurvivesColumnInsertAndReSpills()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(1, 3)"); // spills A1:C1
+            wb.RecalculateAllFormulas();
+            Assert.AreEqual(3, ws.Cell("C1").Value);
+
+            // A column insert relocates the anchor A1 -> B1; it re-spills over B1:D1.
+            ws.Column(1).InsertColumnsBefore(1);
+            wb.RecalculateAllFormulas();
+
+            Assert.IsTrue(ws.Cell("B1").HasFormula, "Anchor must stay dynamic after the shift");
+            Assert.AreEqual(1, ws.Cell("B1").Value);
+            Assert.AreEqual(3, ws.Cell("D1").Value);
+        }
+    }
+
+    [Test]
+    public void Spill_DependentBeforeAnchor_OrdersCorrectlyOnInteractiveRead()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("D1").Value = 1;
+            ws.Cell("D2").Value = 2;
+            ws.Cell("D3").Value = 3;
+            ws.Cell("C1").SetDynamicFormulaA1("UNIQUE(D1:D3)");
+            ws.Cell("A1").FormulaA1 = "C3*10";
+
+            // Establish the spill by reading the anchor, then the dependent.
+            Assert.AreEqual(1, ws.Cell("C1").Value);
+            Assert.AreEqual(30, ws.Cell("A1").Value);
+
+            // A plain .Value read of the dependent after a source change must order the dirty
+            // anchor first (via the fallback to a full, dependency-ordered recalculation).
+            ws.Cell("D3").Value = 5;
+            Assert.AreEqual(50, ws.Cell("A1").Value);
+        }
+    }
 }

--- a/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
@@ -289,6 +289,28 @@ public class SpillEvaluationTests
     }
 
     [Test]
+    public void Spill_SurvivesRowDeleteAndReSpills()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A2").SetDynamicFormulaA1("SEQUENCE(3)"); // spills A2:A4
+            wb.RecalculateAllFormulas();
+            Assert.AreEqual(3, ws.Cell("A4").Value);
+
+            // Deleting the empty row above relocates the anchor A2 -> A1 (negative shift); it
+            // re-spills over A1:A3.
+            ws.Row(1).Delete();
+            wb.RecalculateAllFormulas();
+
+            Assert.IsTrue(ws.Cell("A1").HasFormula, "Anchor must stay dynamic after the delete");
+            Assert.AreEqual(1, ws.Cell("A1").Value);
+            Assert.AreEqual(3, ws.Cell("A3").Value);
+            Assert.IsFalse(ws.Cell("A2").HasFormula, "Spilled cell stays formula-less after the delete");
+        }
+    }
+
+    [Test]
     public void Spill_PastSheetEdge_ProducesSpillError()
     {
         var ws = NewSheet(out var wb);
@@ -396,6 +418,27 @@ public class SpillEvaluationTests
             Assert.IsTrue(ws.Cell("B1").HasFormula, "Anchor must stay dynamic after the shift");
             Assert.AreEqual(1, ws.Cell("B1").Value);
             Assert.AreEqual(3, ws.Cell("D1").Value);
+        }
+    }
+
+    [Test]
+    public void Spill_SurvivesColumnDeleteAndReSpills()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("B1").SetDynamicFormulaA1("SEQUENCE(1, 3)"); // spills B1:D1
+            wb.RecalculateAllFormulas();
+            Assert.AreEqual(3, ws.Cell("D1").Value);
+
+            // Deleting the empty column to the left relocates the anchor B1 -> A1 (negative
+            // shift); it re-spills over A1:C1.
+            ws.Column(1).Delete();
+            wb.RecalculateAllFormulas();
+
+            Assert.IsTrue(ws.Cell("A1").HasFormula, "Anchor must stay dynamic after the delete");
+            Assert.AreEqual(1, ws.Cell("A1").Value);
+            Assert.AreEqual(3, ws.Cell("C1").Value);
         }
     }
 

--- a/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
@@ -1,0 +1,133 @@
+using NUnit.Framework;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+// Phase B1 — in-memory spilling of dynamic-array formulas.
+// A dynamic-array formula in a single anchor cell auto-fills its computed footprint into the
+// neighbouring cells, which stay formula-less. A blocked footprint (existing content) or one that
+// runs past the sheet edge collapses to a #SPILL! error on the anchor. Re-evaluating to a smaller
+// footprint clears the cells the previous result no longer covers.
+[TestFixture]
+public class SpillEvaluationTests
+{
+    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    {
+        wb = new XLWorkbook();
+        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+    }
+
+    [Test]
+    public void Spill_ColumnVector_FillsFootprint()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(3)");
+
+            // Reading the anchor evaluates the formula and spills into A2:A3.
+            Assert.AreEqual(1, ws.Cell("A1").Value);
+            Assert.AreEqual(2, ws.Cell("A2").Value);
+            Assert.AreEqual(3, ws.Cell("A3").Value);
+        }
+    }
+
+    [Test]
+    public void Spill_TwoDimensional_FillsGrid()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(2, 3)");
+
+            Assert.AreEqual(1, ws.Cell("A1").Value);
+            Assert.AreEqual(2, ws.Cell("B1").Value);
+            Assert.AreEqual(3, ws.Cell("C1").Value);
+            Assert.AreEqual(4, ws.Cell("A2").Value);
+            Assert.AreEqual(5, ws.Cell("B2").Value);
+            Assert.AreEqual(6, ws.Cell("C2").Value);
+        }
+    }
+
+    [Test]
+    public void Spill_AnchorHoldsFormula_SpilledCellsDoNot()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(3)");
+            Assert.AreEqual(1, ws.Cell("A1").Value); // trigger the spill
+
+            Assert.IsTrue(ws.Cell("A1").HasFormula, "Anchor must keep the formula");
+            Assert.IsFalse(ws.Cell("A2").HasFormula, "Spilled cell must be formula-less");
+            Assert.IsFalse(ws.Cell("A3").HasFormula, "Spilled cell must be formula-less");
+        }
+    }
+
+    [Test]
+    public void Spill_BlockedByExistingValue_ProducesSpillErrorAndPreservesBlocker()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A2").Value = "block";
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(3)");
+
+            // The footprint A1:A3 collides with A2, so only the anchor is written.
+            Assert.AreEqual(XLError.SpillRange, ws.Cell("A1").Value);
+            Assert.AreEqual("block", ws.Cell("A2").Value, "Blocking value must be untouched");
+            Assert.IsTrue(ws.Cell("A3").IsEmpty(), "No value is written to blocked-spill cells");
+        }
+    }
+
+    [Test]
+    public void Spill_BlockedByFormula_ProducesSpillError()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A3").FormulaA1 = "1+1";
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(3)");
+
+            Assert.AreEqual(XLError.SpillRange, ws.Cell("A1").Value);
+            Assert.IsTrue(ws.Cell("A2").IsEmpty(), "No value is written to blocked-spill cells");
+        }
+    }
+
+    [Test]
+    public void Spill_ShrinkingResult_ClearsStaleCells()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("B1").Value = 1;
+            ws.Cell("B2").Value = 2;
+            ws.Cell("B3").Value = 3;
+            ws.Cell("A1").SetDynamicFormulaA1("UNIQUE(B1:B3)");
+
+            Assert.AreEqual(1, ws.Cell("A1").Value); // spills A1:A3 = {1;2;3}
+            Assert.AreEqual(3, ws.Cell("A3").Value);
+
+            // Collapse a source value so only two distinct values remain: the same formula
+            // instance now spills A1:A2 only and must clear the stale A3.
+            ws.Cell("B3").Value = 2;
+            Assert.AreEqual(1, ws.Cell("A1").Value);
+            Assert.AreEqual(2, ws.Cell("A2").Value);
+            Assert.IsTrue(ws.Cell("A3").IsEmpty(), "Stale cell of the previous footprint must be cleared");
+        }
+    }
+
+    [Test]
+    public void Spill_PastSheetEdge_ProducesSpillError()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            // Anchor on the last row: a 2-row result would need a row beyond the sheet.
+            var anchor = ws.Cell(XLHelper.MaxRowNumber, 1);
+            anchor.SetDynamicFormulaA1("SEQUENCE(2)");
+
+            Assert.AreEqual(XLError.SpillRange, anchor.Value);
+        }
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
@@ -215,6 +215,18 @@ public class SpillEvaluationTests
     }
 
     [Test]
+    public void SpillOperator_MultiCellOperand_ReturnsRefError()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            // The spill operator requires a single-cell anchor; a multi-cell operand is #REF!.
+            wb.DefinedNames.Add("Rng", "Sheet1!A1:B2");
+            Assert.AreEqual(XLError.CellReference, ws.Evaluate("Rng#"));
+        }
+    }
+
+    [Test]
     public void SpillOperator_TracksFootprintWhenItShrinks()
     {
         var ws = NewSheet(out var wb);

--- a/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
@@ -170,6 +170,71 @@ public class SpillEvaluationTests
     }
 
     [Test]
+    public void SpillOperator_ReferencesWholeFootprint()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").SetDynamicFormulaA1("SEQUENCE(3)"); // spills A1:A3 = {1;2;3}
+            ws.Cell("C1").FormulaA1 = "SUM(A1#)";
+
+            wb.CalcEngine.Recalculate(wb, null);
+            Assert.AreEqual(6, ws.Cell("C1").Value);
+        }
+    }
+
+    [Test]
+    public void SpillOperator_NonAnchorCell_ReturnsRefError()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            // A1 holds no dynamic array, so A1# is #REF!.
+            Assert.AreEqual(XLError.CellReference, ws.Evaluate("A1#"));
+        }
+    }
+
+    [Test]
+    public void SpillOperator_TracksFootprintWhenItShrinks()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("D1").Value = 1;
+            ws.Cell("D2").Value = 2;
+            ws.Cell("D3").Value = 3;
+            ws.Cell("A1").SetDynamicFormulaA1("UNIQUE(D1:D3)"); // spills A1:A3
+            ws.Cell("C1").FormulaA1 = "SUM(A1#)";
+
+            wb.CalcEngine.Recalculate(wb, null);
+            Assert.AreEqual(6, ws.Cell("C1").Value); // 1+2+3
+
+            // Collapse to two distinct values: A1# now covers A1:A2 only.
+            ws.Cell("D3").Value = 1;
+            wb.CalcEngine.Recalculate(wb, null);
+            Assert.AreEqual(3, ws.Cell("C1").Value); // 1+2
+        }
+    }
+
+    [Test]
+    public void SpillOperator_EvaluatesAnchorFirst_EvenWhenDependentComesBefore()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            // The dependent A1=SUM(C1#) sits positionally BEFORE its anchor C1. Because the
+            // spill operator's range includes the anchor cell (which holds the dirty formula),
+            // reading it forces the anchor to evaluate first — so this orders correctly, unlike
+            // a plain read of a non-anchor spilled cell.
+            ws.Cell("C1").SetDynamicFormulaA1("SEQUENCE(3)"); // spills C1:C3
+            ws.Cell("A1").FormulaA1 = "SUM(C1#)";
+
+            wb.CalcEngine.Recalculate(wb, null);
+            Assert.AreEqual(6, ws.Cell("A1").Value);
+        }
+    }
+
+    [Test]
     public void Spill_PastSheetEdge_ProducesSpillError()
     {
         var ws = NewSheet(out var wb);

--- a/XLibur/Excel/CalcEngine/CalcContext.cs
+++ b/XLibur/Excel/CalcEngine/CalcContext.cs
@@ -114,7 +114,27 @@ internal sealed class CalcContext
         var formula = sheet.Internals.CellsCollection.FormulaSlice.Get(point);
 
         if (formula is null)
+        {
+            // A formula-less cell may still be a spilled cell of a dynamic array. If its owning
+            // anchor is dirty, the stored value is stale — force the anchor to evaluate first.
+            if (CalcEngine.HasSpillOwners &&
+                CalcEngine.TryGetDirtySpillOwner(sheet.SheetId, point, Workbook, out var spillAnchor))
+            {
+                if (RecalculateSheetId is not null && sheet.SheetId != RecalculateSheetId.Value)
+                    return valueSlice.GetCellValue(point);
+
+                if (_recursive)
+                {
+                    // Evaluate the anchor recursively so it spills current values into this cell.
+                    _ = GetCellValue(sheet, spillAnchor.Row, spillAnchor.Column);
+                    return valueSlice.GetCellValue(point);
+                }
+
+                throw new GettingDataException(new XLBookPoint(sheet.SheetId, spillAnchor));
+            }
+
             return valueSlice.GetCellValue(point);
+        }
 
         if (formula.IsClean(Workbook))
             return valueSlice.GetCellValue(point);

--- a/XLibur/Excel/CalcEngine/CalculationVisitor.cs
+++ b/XLibur/Excel/CalcEngine/CalculationVisitor.cs
@@ -51,9 +51,14 @@ internal sealed class CalculationVisitor : IFormulaVisitor<CalcContext, AnyValue
     /// </summary>
     private static AnyValue EvaluateSpillRange(CalcContext context, AnyValue operand)
     {
-        // The operand of `#` must resolve to a single-cell reference: the spill anchor.
+        // The operand of `#` must resolve to a single-cell reference: the spill anchor. A
+        // multi-cell area (e.g. A1:B3#) is not a valid anchor, so it is a #REF!.
         if (!operand.TryPickArea(out var anchorArea, out var error))
             return error;
+
+        if (anchorArea.FirstAddress.RowNumber != anchorArea.LastAddress.RowNumber ||
+            anchorArea.FirstAddress.ColumnNumber != anchorArea.LastAddress.ColumnNumber)
+            return XLError.CellReference;
 
         var sheet = anchorArea.Worksheet as XLWorksheet ?? context.Worksheet;
         var anchorRow = anchorArea.FirstAddress.RowNumber;

--- a/XLibur/Excel/CalcEngine/CalculationVisitor.cs
+++ b/XLibur/Excel/CalcEngine/CalculationVisitor.cs
@@ -37,12 +37,45 @@ internal sealed class CalculationVisitor : IFormulaVisitor<CalcContext, AnyValue
             UnaryOp.Add => arg.UnaryPlus(),
             UnaryOp.Subtract => arg.UnaryMinus(context),
             UnaryOp.Percentage => arg.UnaryPercent(context),
-            UnaryOp.SpillRange => throw new NotImplementedException(
-                "Evaluation of spill range operator is not implemented."),
+            UnaryOp.SpillRange => EvaluateSpillRange(context, arg),
             UnaryOp.ImplicitIntersection => throw new NotImplementedException(
                 "Excel 2016 implicit intersection is different from @ intersection of E2019+"),
             _ => throw new NotSupportedException($"Unknown operator {node.Operation}.")
         };
+    }
+
+    /// <summary>
+    /// Evaluates the <c>#</c> spill-range operator (e.g. <c>A1#</c>): resolves the operand to a
+    /// spill anchor and returns a <see cref="Reference"/> to that dynamic array's current
+    /// footprint. Returns <c>#REF!</c> when the operand cell is not a spill anchor.
+    /// </summary>
+    private static AnyValue EvaluateSpillRange(CalcContext context, AnyValue operand)
+    {
+        // The operand of `#` must resolve to a single-cell reference: the spill anchor.
+        if (!operand.TryPickArea(out var anchorArea, out var error))
+            return error;
+
+        var sheet = anchorArea.Worksheet as XLWorksheet ?? context.Worksheet;
+        var anchorRow = anchorArea.FirstAddress.RowNumber;
+        var anchorColumn = anchorArea.FirstAddress.ColumnNumber;
+
+        // Force the anchor to be current before reading its footprint: for a dirty anchor this
+        // throws GettingDataException so the calc chain evaluates the anchor (spilling it and
+        // updating its Range) before this formula. The returned value itself is unused.
+        _ = context.GetCellValue(sheet, anchorRow, anchorColumn);
+
+        var formula = sheet.Internals.CellsCollection.FormulaSlice.Get(new XLSheetPoint(anchorRow, anchorColumn));
+        if (formula is null || !formula.IsDynamicArray)
+            return XLError.CellReference; // #REF! — the cell is not a spill anchor.
+
+        var footprint = formula.Range;
+        if (footprint == default)
+            return XLError.CellReference; // Anchor exists but hasn't produced a footprint yet.
+
+        var rangeAddress = new XLRangeAddress(
+            new XLAddress(sheet, footprint.TopRow, footprint.LeftColumn, true, true),
+            new XLAddress(sheet, footprint.BottomRow, footprint.RightColumn, true, true));
+        return new Reference(rangeAddress);
     }
 
     public AnyValue Visit(CalcContext context, BinaryNode node)

--- a/XLibur/Excel/CalcEngine/DependenciesVisitor.cs
+++ b/XLibur/Excel/CalcEngine/DependenciesVisitor.cs
@@ -54,10 +54,11 @@ internal sealed class DependenciesVisitor : IFormulaVisitor<DependenciesContext,
         // Operand is a reference
         if (node.Operation is UnaryOp.ImplicitIntersection or UnaryOp.SpillRange)
         {
-            // Both operators are ignored for now, because *spill* operators
-            // are part of dynamic arrays (=ignore until they are implemented)
-            // and *Implicit intersection* only makes the area smaller and is pretty
-            // rare operators = also skip for now (won't affect correctness).
+            // The operand's area is propagated as-is: for `#` that is the spill anchor cell,
+            // which is enough for dirty propagation because spilled cells only change when the
+            // anchor re-evaluates (and the anchor's whole footprint is registered as its formula
+            // area — see DependencyTree.CreateFrom). Implicit intersection only ever shrinks the
+            // area, so propagating the operand is a safe over-approximation there too.
 
             // The reference must be propagated upward, because there could be
             // a range operator (e.g. `B7:@A1:A5`)

--- a/XLibur/Excel/CalcEngine/DependencyTree.cs
+++ b/XLibur/Excel/CalcEngine/DependencyTree.cs
@@ -68,7 +68,19 @@ internal sealed class DependencyTree
             {
                 var formula = enumerator.Current;
                 var point = enumerator.Point;
-                if (formula.Type == FormulaType.Normal)
+                if (formula.IsDynamicArray)
+                {
+                    // A dynamic-array formula lives only in its anchor cell (spilled cells are
+                    // formula-less), so it appears exactly once. Register the whole spill
+                    // footprint so a change to the array's precedents invalidates dependents of
+                    // ANY spilled cell, not just the anchor. Before the first spill the footprint
+                    // is unknown (default) — register the 1x1 anchor; the spill re-registers the
+                    // formula once its size is known (see XLCalcEngine.SpillDynamicArray).
+                    var footprint = formula.Range == default ? new XLSheetRange(point, point) : formula.Range;
+                    var bookArea = new XLBookArea(sheet.Name, footprint);
+                    tree.AddFormula(bookArea, formula, workbook);
+                }
+                else if (formula.Type == FormulaType.Normal)
                 {
                     var bookArea = new XLBookArea(sheet.Name, new XLSheetRange(point, point));
                     tree.AddFormula(bookArea, formula, workbook);
@@ -118,6 +130,18 @@ internal sealed class DependencyTree
         }
 
         return precedents;
+    }
+
+    /// <summary>
+    /// Re-register a dynamic-array formula under a new spill footprint. Called after a spill
+    /// grows, shrinks, or collapses to a <c>#SPILL!</c> anchor so the tree keeps invalidating
+    /// dependents of every currently-spilled cell. Safe to call whether or not the formula is
+    /// already in the tree.
+    /// </summary>
+    internal void UpdateSpillFootprint(XLBookArea formulaArea, XLCellFormula formula, XLWorkbook workbook)
+    {
+        RemoveFormula(formula);
+        AddFormula(formulaArea, formula, workbook);
     }
 
     /// <summary>

--- a/XLibur/Excel/CalcEngine/Functions/Information.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Information.cs
@@ -33,6 +33,11 @@ internal static class Information
         if (!value.TryPickError(out var error))
             return XLError.NoValueAvailable;
 
+        // ERROR.TYPE numbering matches the enum order (off by one) up to #N/A, but the
+        // modern errors are non-contiguous in Excel: #SPILL! is 9, not 8.
+        if (error == XLError.SpillRange)
+            return 9;
+
         return (int)error + 1;
     }
 

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -32,6 +32,21 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
     /// </summary>
     private bool _needsDependencyTree;
 
+    /// <summary>
+    /// Maps each spilled (non-anchor) cell of every dynamic-array formula to the anchor formula
+    /// that owns it. Spilled cells are formula-less, so this lets a read of one (during recalc)
+    /// force the owning anchor to evaluate first — see <see cref="TryGetDirtySpillOwner"/>.
+    /// Rebuilt when the dependency tree is (re)built and kept in sync by
+    /// <see cref="SpillDynamicArray"/>. Empty for workbooks without dynamic arrays.
+    /// </summary>
+    private readonly Dictionary<XLBookPoint, XLCellFormula> _spillOwners = new();
+
+    /// <summary>
+    /// Whether any dynamic-array formula currently has spilled cells. Used to keep the
+    /// spill-owner lookup out of the hot cell-read path for the common no-dynamic-array case.
+    /// </summary>
+    internal bool HasSpillOwners => _spillOwners.Count > 0;
+
     public XLCalcEngine(CultureInfo culture)
     {
         _culture = culture;
@@ -129,6 +144,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
         _dependencyTree = null;
         _chain = null;
         _needsDependencyTree = false;
+        _spillOwners.Clear();
 
         // Mark everything as dirty, because there can be stale values
         foreach (var sheet in sheets)
@@ -147,6 +163,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
         if (_dependencyTree is null && _needsDependencyTree)
         {
             _dependencyTree = DependencyTree.CreateFrom(sheet.Workbook);
+            RebuildSpillOwners(sheet.Workbook);
         }
 
         if (_dependencyTree is not null)
@@ -231,6 +248,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
         {
             _chain = XLCalculationChain.CreateFrom(wb);
             _dependencyTree = DependencyTree.CreateFrom(wb);
+            RebuildSpillOwners(wb);
         }
 
         var sheetIdMap = wb.WorksheetsInternal
@@ -448,6 +466,10 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
 
         formula.Range = newFootprint;
 
+        // Keep the spill-owner lookup in sync so a read of any spilled cell can force this
+        // anchor to evaluate first during recalc.
+        UpdateSpillOwners(sheet.SheetId, formula, previousRange, newFootprint);
+
         // Keep the dependency tree's area for this formula in sync with the footprint, so a
         // later change to the array's precedents invalidates dependents of every spilled cell
         // (not just the anchor). Only needed once the tree exists and the footprint changed.
@@ -456,6 +478,70 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
             var formulaArea = new XLBookArea(sheet.Name, newFootprint);
             _dependencyTree.UpdateSpillFootprint(formulaArea, formula, sheet.Workbook);
         }
+    }
+
+    /// <summary>
+    /// Rebuilds <see cref="_spillOwners"/> from every dynamic-array formula's current footprint.
+    /// Called whenever the dependency tree is (re)built so the lookup reflects spills produced in
+    /// earlier sessions/recalcs or restored from a loaded file.
+    /// </summary>
+    private void RebuildSpillOwners(XLWorkbook wb)
+    {
+        _spillOwners.Clear();
+        foreach (var sheet in wb.WorksheetsInternal)
+        {
+            using var enumerator = sheet.Internals.CellsCollection.FormulaSlice.GetForwardEnumerator(XLSheetRange.Full);
+            while (enumerator.MoveNext())
+            {
+                var formula = enumerator.Current;
+                if (formula.IsDynamicArray && formula.Range != default)
+                    RegisterSpillOwners(sheet.SheetId, formula, formula.Range);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Updates <see cref="_spillOwners"/> after a spill: unregisters cells the new footprint no
+    /// longer covers and registers the non-anchor cells of the new footprint.
+    /// </summary>
+    private void UpdateSpillOwners(uint sheetId, XLCellFormula formula, XLSheetRange previousRange, XLSheetRange newFootprint)
+    {
+        if (previousRange != default)
+        {
+            foreach (var point in previousRange)
+            {
+                if (!newFootprint.Contains(point))
+                    _spillOwners.Remove(new XLBookPoint(sheetId, point));
+            }
+        }
+
+        RegisterSpillOwners(sheetId, formula, newFootprint);
+    }
+
+    private void RegisterSpillOwners(uint sheetId, XLCellFormula formula, XLSheetRange footprint)
+    {
+        var anchor = footprint.FirstPoint;
+        foreach (var point in footprint)
+        {
+            if (point != anchor)
+                _spillOwners[new XLBookPoint(sheetId, point)] = formula;
+        }
+    }
+
+    /// <summary>
+    /// If <paramref name="point"/> is a spilled (non-anchor) cell of a dynamic array whose anchor
+    /// is dirty, returns the anchor point so the caller can force the anchor to evaluate first.
+    /// </summary>
+    internal bool TryGetDirtySpillOwner(uint sheetId, XLSheetPoint point, XLWorkbook wb, out XLSheetPoint anchor)
+    {
+        if (_spillOwners.TryGetValue(new XLBookPoint(sheetId, point), out var owner) && owner.IsDirty(wb))
+        {
+            anchor = owner.Range.FirstPoint;
+            return true;
+        }
+
+        anchor = default;
+        return false;
     }
 
     /// <summary>

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -175,7 +175,11 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
         try
         {
             var valueSlice = sheet.Internals.CellsCollection.ValueSlice;
-            if (formula.Type == FormulaType.Normal)
+            if (formula.IsDynamicArray)
+            {
+                SpillDynamicArray(formula, point, sheet, recalculateSheetId: null);
+            }
+            else if (formula.Type == FormulaType.Normal)
             {
                 var result = EvaluateFormula(
                     formula.A1,
@@ -288,7 +292,13 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
     private void ApplyFormula(XLCellFormula formula, XLSheetPoint appliedPoint, XLWorksheet sheet, ValueSlice valueSlice, uint? recalculateSheetId)
     {
         var formulaText = formula.A1;
-        if (formula.Type == FormulaType.Normal)
+        if (formula.IsDynamicArray)
+        {
+            // The formula lives only in the anchor cell (spilled cells are formula-less),
+            // so the applied point is always the anchor.
+            SpillDynamicArray(formula, appliedPoint, sheet, recalculateSheetId);
+        }
+        else if (formula.Type == FormulaType.Normal)
         {
             var single = EvaluateFormula(
                 formulaText,
@@ -381,6 +391,105 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
             return new ScalarArray(single, 1, 1);
 
         return multi!;
+    }
+
+    /// <summary>
+    /// Evaluates a dynamic-array formula and spills its result across the anchor's
+    /// footprint. Only the anchor holds the <see cref="XLCellFormula"/>; the remaining
+    /// footprint cells receive values only. The computed footprint is stored back on
+    /// <see cref="XLCellFormula.Range"/> so a later evaluation can clear a stale region.
+    /// </summary>
+    /// <remarks>
+    /// The spill is blocked — the anchor gets <see cref="XLError.SpillRange"/> (<c>#SPILL!</c>)
+    /// and nothing is written to the footprint — when the result would run past the sheet
+    /// edge, or when any footprint cell (other than the anchor, and other than a cell owned by
+    /// this formula's previous footprint) already holds a formula or a non-blank value.
+    /// </remarks>
+    private void SpillDynamicArray(XLCellFormula formula, XLSheetPoint anchor, XLWorksheet sheet, uint? recalculateSheetId)
+    {
+        var cells = sheet.Internals.CellsCollection;
+        var valueSlice = cells.ValueSlice;
+        var formulaSlice = cells.FormulaSlice;
+
+        var masterCell = sheet.Cell(anchor.Row, anchor.Column);
+        var array = EvaluateArrayFormula(formula.A1, masterCell, recalculateSheetId);
+
+        var lastRow = anchor.Row + array.Height - 1;
+        var lastColumn = anchor.Column + array.Width - 1;
+
+        var previousRange = formula.Range;
+        var anchorRange = new XLSheetRange(anchor);
+
+        var outOfBounds = lastRow > XLHelper.MaxRowNumber || lastColumn > XLHelper.MaxColumnNumber;
+        if (outOfBounds || HasSpillCollision(anchor, lastRow, lastColumn, previousRange, valueSlice, formulaSlice))
+        {
+            ClearSpillFootprint(previousRange, anchorRange, valueSlice);
+            valueSlice.SetCellValue(anchor, XLError.SpillRange);
+            formula.Range = anchorRange;
+            return;
+        }
+
+        var footprint = new XLSheetRange(anchor, new XLSheetPoint(lastRow, lastColumn));
+
+        // Erase any cell of the previous footprint that the new one no longer covers
+        // (the array shrank or moved) before writing the fresh result.
+        ClearSpillFootprint(previousRange, footprint, valueSlice);
+
+        for (var rowOffset = 0; rowOffset < array.Height; ++rowOffset)
+        {
+            for (var colOffset = 0; colOffset < array.Width; ++colOffset)
+            {
+                var point = new XLSheetPoint(anchor.Row + rowOffset, anchor.Column + colOffset);
+                valueSlice.SetCellValue(point, array[rowOffset, colOffset].ToCellValue());
+            }
+        }
+
+        formula.Range = footprint;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if any cell of the prospective footprint blocks the spill.
+    /// The anchor itself and any cell within <paramref name="ownedRange"/> (this formula's
+    /// previous footprint, which will be overwritten) never block; any other cell holding a
+    /// formula or a non-blank value does.
+    /// </summary>
+    private static bool HasSpillCollision(XLSheetPoint anchor, int lastRow, int lastColumn, XLSheetRange ownedRange, ValueSlice valueSlice, FormulaSlice formulaSlice)
+    {
+        for (var row = anchor.Row; row <= lastRow; ++row)
+        {
+            for (var column = anchor.Column; column <= lastColumn; ++column)
+            {
+                var point = new XLSheetPoint(row, column);
+                if (point == anchor || ownedRange.Contains(point))
+                    continue;
+
+                if (formulaSlice.Get(point) is not null)
+                    return true;
+
+                if (!valueSlice.GetCellValue(point).IsBlank)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Blanks every cell of <paramref name="previousRange"/> that falls outside
+    /// <paramref name="keepRange"/>. Used to erase a stale footprint when a dynamic array
+    /// shrinks, moves, or collapses to a <c>#SPILL!</c> anchor. A <c>default</c> previous
+    /// range (never spilled) clears nothing.
+    /// </summary>
+    private static void ClearSpillFootprint(XLSheetRange previousRange, XLSheetRange keepRange, ValueSlice valueSlice)
+    {
+        if (previousRange == default)
+            return;
+
+        foreach (var point in previousRange)
+        {
+            if (!keepRange.Contains(point))
+                valueSlice.SetCellValue(point, Blank.Value);
+        }
     }
 
     internal AnyValue EvaluateName(string nameFormula, XLWorksheet ws)

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -33,16 +33,27 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
     private bool _needsDependencyTree;
 
     /// <summary>
-    /// Maps each spilled (non-anchor) cell of every dynamic-array formula to the anchor formula
-    /// that owns it. Spilled cells are formula-less, so this lets a read of one (during recalc)
-    /// force the owning anchor to evaluate first — see <see cref="TryGetDirtySpillOwner"/>.
-    /// Rebuilt when the dependency tree is (re)built and kept in sync by
-    /// <see cref="SpillDynamicArray"/>. Empty for workbooks without dynamic arrays.
+    /// The spill footprint of every dynamic-array formula, one entry per formula (a rectangle,
+    /// not one entry per spilled cell). Spilled cells are formula-less, so this lets a read of one
+    /// (during recalc) find the owning anchor and force it to evaluate first — see
+    /// <see cref="TryGetDirtySpillOwner"/>. Rebuilt when the dependency tree is (re)built and kept
+    /// in sync by <see cref="SpillDynamicArray"/>. Empty for workbooks without dynamic arrays.
     /// </summary>
-    private readonly Dictionary<XLBookPoint, XLCellFormula> _spillOwners = new();
+    private readonly List<SpillFootprint> _spillOwners = new();
 
     /// <summary>
-    /// Whether any dynamic-array formula currently has spilled cells. Used to keep the
+    /// A dynamic array's spill footprint (including the anchor at <see cref="Range"/>'s first
+    /// point) together with the owning formula.
+    /// </summary>
+    private readonly struct SpillFootprint(uint sheetId, XLSheetRange range, XLCellFormula owner)
+    {
+        internal readonly uint SheetId = sheetId;
+        internal readonly XLSheetRange Range = range;
+        internal readonly XLCellFormula Owner = owner;
+    }
+
+    /// <summary>
+    /// Whether any dynamic-array formula currently has a spill footprint. Used to keep the
     /// spill-owner lookup out of the hot cell-read path for the common no-dynamic-array case.
     /// </summary>
     internal bool HasSpillOwners => _spillOwners.Count > 0;
@@ -468,7 +479,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
 
         // Keep the spill-owner lookup in sync so a read of any spilled cell can force this
         // anchor to evaluate first during recalc.
-        UpdateSpillOwners(sheet.SheetId, formula, previousRange, newFootprint);
+        SetSpillFootprint(sheet.SheetId, formula, newFootprint);
 
         // Keep the dependency tree's area for this formula in sync with the footprint, so a
         // later change to the array's precedents invalidates dependents of every spilled cell
@@ -495,49 +506,43 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
             {
                 var formula = enumerator.Current;
                 if (formula.IsDynamicArray && formula.Range != default)
-                    RegisterSpillOwners(sheet.SheetId, formula, formula.Range);
+                    _spillOwners.Add(new SpillFootprint(sheet.SheetId, formula.Range, formula));
             }
         }
     }
 
     /// <summary>
-    /// Updates <see cref="_spillOwners"/> after a spill: unregisters cells the new footprint no
-    /// longer covers and registers the non-anchor cells of the new footprint.
+    /// Records a dynamic-array formula's current spill footprint, replacing any prior footprint
+    /// for the same formula (footprints never overlap, so one rectangle per formula is enough).
     /// </summary>
-    private void UpdateSpillOwners(uint sheetId, XLCellFormula formula, XLSheetRange previousRange, XLSheetRange newFootprint)
+    private void SetSpillFootprint(uint sheetId, XLCellFormula formula, XLSheetRange footprint)
     {
-        if (previousRange != default)
+        for (var i = 0; i < _spillOwners.Count; i++)
         {
-            foreach (var point in previousRange)
+            if (ReferenceEquals(_spillOwners[i].Owner, formula))
             {
-                if (!newFootprint.Contains(point))
-                    _spillOwners.Remove(new XLBookPoint(sheetId, point));
+                _spillOwners[i] = new SpillFootprint(sheetId, footprint, formula);
+                return;
             }
         }
 
-        RegisterSpillOwners(sheetId, formula, newFootprint);
-    }
-
-    private void RegisterSpillOwners(uint sheetId, XLCellFormula formula, XLSheetRange footprint)
-    {
-        var anchor = footprint.FirstPoint;
-        foreach (var point in footprint)
-        {
-            if (point != anchor)
-                _spillOwners[new XLBookPoint(sheetId, point)] = formula;
-        }
+        _spillOwners.Add(new SpillFootprint(sheetId, footprint, formula));
     }
 
     /// <summary>
     /// If <paramref name="point"/> is a spilled (non-anchor) cell of a dynamic array whose anchor
     /// is dirty, returns the anchor point so the caller can force the anchor to evaluate first.
+    /// The anchor cell itself holds a formula, so it never reaches this lookup.
     /// </summary>
     internal bool TryGetDirtySpillOwner(uint sheetId, XLSheetPoint point, XLWorkbook wb, out XLSheetPoint anchor)
     {
-        if (_spillOwners.TryGetValue(new XLBookPoint(sheetId, point), out var owner) && owner.IsDirty(wb))
+        foreach (var footprint in _spillOwners)
         {
-            anchor = owner.Range.FirstPoint;
-            return true;
+            if (footprint.SheetId == sheetId && footprint.Range.Contains(point) && footprint.Owner.IsDirty(wb))
+            {
+                anchor = footprint.Range.FirstPoint;
+                return true;
+            }
         }
 
         anchor = default;

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -420,31 +420,42 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
         var previousRange = formula.Range;
         var anchorRange = new XLSheetRange(anchor);
 
+        XLSheetRange newFootprint;
         var outOfBounds = lastRow > XLHelper.MaxRowNumber || lastColumn > XLHelper.MaxColumnNumber;
         if (outOfBounds || HasSpillCollision(anchor, lastRow, lastColumn, previousRange, valueSlice, formulaSlice))
         {
             ClearSpillFootprint(previousRange, anchorRange, valueSlice);
             valueSlice.SetCellValue(anchor, XLError.SpillRange);
-            formula.Range = anchorRange;
-            return;
+            newFootprint = anchorRange;
         }
-
-        var footprint = new XLSheetRange(anchor, new XLSheetPoint(lastRow, lastColumn));
-
-        // Erase any cell of the previous footprint that the new one no longer covers
-        // (the array shrank or moved) before writing the fresh result.
-        ClearSpillFootprint(previousRange, footprint, valueSlice);
-
-        for (var rowOffset = 0; rowOffset < array.Height; ++rowOffset)
+        else
         {
-            for (var colOffset = 0; colOffset < array.Width; ++colOffset)
+            newFootprint = new XLSheetRange(anchor, new XLSheetPoint(lastRow, lastColumn));
+
+            // Erase any cell of the previous footprint that the new one no longer covers
+            // (the array shrank or moved) before writing the fresh result.
+            ClearSpillFootprint(previousRange, newFootprint, valueSlice);
+
+            for (var rowOffset = 0; rowOffset < array.Height; ++rowOffset)
             {
-                var point = new XLSheetPoint(anchor.Row + rowOffset, anchor.Column + colOffset);
-                valueSlice.SetCellValue(point, array[rowOffset, colOffset].ToCellValue());
+                for (var colOffset = 0; colOffset < array.Width; ++colOffset)
+                {
+                    var point = new XLSheetPoint(anchor.Row + rowOffset, anchor.Column + colOffset);
+                    valueSlice.SetCellValue(point, array[rowOffset, colOffset].ToCellValue());
+                }
             }
         }
 
-        formula.Range = footprint;
+        formula.Range = newFootprint;
+
+        // Keep the dependency tree's area for this formula in sync with the footprint, so a
+        // later change to the array's precedents invalidates dependents of every spilled cell
+        // (not just the anchor). Only needed once the tree exists and the footprint changed.
+        if (_dependencyTree is not null && newFootprint != previousRange)
+        {
+            var formulaArea = new XLBookArea(sheet.Name, newFootprint);
+            _dependencyTree.UpdateSpillFootprint(formulaArea, formula, sheet.Workbook);
+        }
     }
 
     /// <summary>

--- a/XLibur/Excel/CalcEngine/XLError.cs
+++ b/XLibur/Excel/CalcEngine/XLError.cs
@@ -52,5 +52,16 @@ public enum XLError
     /// <c>#N/A</c> - Intended to indicate when a designated value is not available.
     /// </summary>
     /// <example>The value is used for extra cells of an array formula that is applied on an array of a smaller size that the array formula.</example>
-    NoValueAvailable = 6
+    NoValueAvailable = 6,
+
+    /// <summary>
+    /// <c>#SPILL!</c> - a dynamic array formula's result can't be written because the
+    /// spill range isn't empty (blocked by other content) or would fall outside the sheet.
+    /// </summary>
+    /// <remarks>
+    /// This member breaks the "value + 1 equals <c>ERROR.TYPE</c>" convention that holds for
+    /// the members above: <c>ERROR.TYPE(#SPILL!)</c> is <c>9</c>, not <c>8</c>, so the
+    /// <c>ERROR.TYPE</c> function special-cases it.
+    /// </remarks>
+    SpillRange = 7
 }

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -1090,8 +1090,16 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         if (formula.Type == FormulaType.Normal)
         {
             var shiftedNormal = XLCellFormulaShifter.ShiftFormulaRows(formula.A1, Worksheet, shiftedRange, rowsShifted);
+
+            if (formula.IsDynamicArray)
+            {
+                ShiftDynamicArrayFormula(formula, shiftedNormal, ReferenceEquals(Worksheet, shiftedRange.Worksheet),
+                    () => ShiftArrayRangeRows(formula.Range, shiftedRange, rowsShifted));
+                return;
+            }
+
             if (!string.Equals(shiftedNormal, formula.A1, StringComparison.Ordinal))
-                SetShiftedNormalFormula(formula, shiftedNormal);
+                FormulaA1 = shiftedNormal;
             return;
         }
 
@@ -1126,8 +1134,16 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         if (formula.Type == FormulaType.Normal)
         {
             var shiftedNormal = XLCellFormulaShifter.ShiftFormulaColumns(formula.A1, Worksheet, shiftedRange, columnsShifted);
+
+            if (formula.IsDynamicArray)
+            {
+                ShiftDynamicArrayFormula(formula, shiftedNormal, ReferenceEquals(Worksheet, shiftedRange.Worksheet),
+                    () => ShiftArrayRangeColumns(formula.Range, shiftedRange, columnsShifted));
+                return;
+            }
+
             if (!string.Equals(shiftedNormal, formula.A1, StringComparison.Ordinal))
-                SetShiftedNormalFormula(formula, shiftedNormal);
+                FormulaA1 = shiftedNormal;
             return;
         }
 
@@ -1146,18 +1162,26 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
     }
 
     /// <summary>
-    /// Reassigns a shifted normal-formula text, preserving the dynamic-array designation.
-    /// A dynamic array is stored as a normal formula with <see cref="XLCellFormula.IsDynamicArray"/>
-    /// set; routing it through the plain <see cref="FormulaA1"/> setter would rebuild it as a
-    /// regular formula and drop that flag, so on save it would lose its <c>cm</c> dynamic-array
-    /// metadata and Excel would apply implicit intersection (e.g. <c>=@UNIQUE(...)</c>).
+    /// Applies a shift to a dynamic-array formula in place: updates the shifted formula text on
+    /// the existing instance and relocates its spill footprint. Recreating it through the plain
+    /// <see cref="FormulaA1"/> or <see cref="SetDynamicFormulaA1"/> setters would rebuild the
+    /// formula and reset its <see cref="XLCellFormula.Range"/> — a later re-spill would then see
+    /// the (already-moved) spilled values as a <c>#SPILL!</c> collision, and the plain setter
+    /// would also drop the dynamic-array flag (losing the <c>cm</c> metadata on save).
     /// </summary>
-    private void SetShiftedNormalFormula(XLCellFormula formula, string shiftedA1)
+    private static void ShiftDynamicArrayFormula(XLCellFormula formula, string shiftedA1, bool sameSheet, Func<XLSheetRange> shiftRange)
     {
-        if (formula.IsDynamicArray)
-            SetDynamicFormulaA1(shiftedA1);
-        else
-            FormulaA1 = shiftedA1;
+        if (!string.Equals(shiftedA1, formula.A1, StringComparison.Ordinal))
+            formula.UpdateShiftedA1(shiftedA1);
+
+        // Only a same-sheet insert/delete physically relocates the anchor and its spilled cells,
+        // so the stored footprint must move with them.
+        if (!sameSheet)
+            return;
+
+        var newRange = shiftRange();
+        if (newRange != formula.Range)
+            formula.Range = newRange;
     }
 
     /// <summary>

--- a/XLibur/Excel/IO/LoadContext.cs
+++ b/XLibur/Excel/IO/LoadContext.cs
@@ -105,6 +105,47 @@ internal sealed class LoadContext
     /// </summary>
     internal Dictionary<uint, XLCellImage>? RichValueImages { get; set; }
 
+    /// <summary>
+    /// The set of 1-based cell-metadata (<c>cm</c>) indexes that reference the <c>XLDAPR</c>
+    /// dynamic-array future-metadata type. A cell whose <c>cm</c> is in this set carries a
+    /// dynamic-array formula (as opposed to a legacy CSE array). <c>null</c> when the workbook
+    /// has no dynamic-array metadata. Populated once from the cell-metadata part.
+    /// </summary>
+    internal HashSet<uint>? DynamicArrayCmIndexes { get; set; }
+
+    /// <summary>
+    /// Populate <see cref="DynamicArrayCmIndexes"/> from the workbook's cell-metadata part by
+    /// finding every cell-metadata record that references the <c>XLDAPR</c> type.
+    /// </summary>
+    internal void LoadDynamicArrayMetadata(Metadata? metadata)
+    {
+        if (metadata?.MetadataTypes is not { } metadataTypes)
+            return;
+
+        uint typeIndex = 0;
+        uint xldaprTypeIndex = 0;
+        foreach (var metadataType in metadataTypes.Elements<MetadataType>())
+        {
+            typeIndex++;
+            if (metadataType.Name?.Value == "XLDAPR")
+            {
+                xldaprTypeIndex = typeIndex;
+                break;
+            }
+        }
+
+        if (xldaprTypeIndex == 0 || metadata.GetFirstChild<CellMetadata>() is not { } cellMetadata)
+            return;
+
+        uint cmIndex = 0;
+        foreach (var block in cellMetadata.Elements<MetadataBlock>())
+        {
+            cmIndex++;
+            if (block.GetFirstChild<MetadataRecord>()?.TypeIndex?.Value == xldaprTypeIndex)
+                (DynamicArrayCmIndexes ??= new HashSet<uint>()).Add(cmIndex);
+        }
+    }
+
     private static Exception PivotCfNotFoundException(string sheetName, int priority)
     {
         return PartStructureException.ExpectedElementNotFound($"conditional formatting for pivot table in sheet {sheetName} with priority {priority}");

--- a/XLibur/Excel/IO/LoadContext.cs
+++ b/XLibur/Excel/IO/LoadContext.cs
@@ -141,8 +141,17 @@ internal sealed class LoadContext
         foreach (var block in cellMetadata.Elements<MetadataBlock>())
         {
             cmIndex++;
-            if (block.GetFirstChild<MetadataRecord>()?.TypeIndex?.Value == xldaprTypeIndex)
-                (DynamicArrayCmIndexes ??= new HashSet<uint>()).Add(cmIndex);
+
+            // A block may hold several records; it is a dynamic-array cell if any of them
+            // references the XLDAPR type (add the block index at most once).
+            foreach (var record in block.Elements<MetadataRecord>())
+            {
+                if (record.TypeIndex?.Value == xldaprTypeIndex)
+                {
+                    (DynamicArrayCmIndexes ??= new HashSet<uint>()).Add(cmIndex);
+                    break;
+                }
+            }
         }
     }
 

--- a/XLibur/Excel/IO/SheetDataWriter.cs
+++ b/XLibur/Excel/IO/SheetDataWriter.cs
@@ -279,6 +279,21 @@ internal static class SheetDataWriter
         {
             WriteDataTableFormula(xml, formula);
         }
+        else if (formula.IsDynamicArray)
+        {
+            // A dynamic-array formula lives only in its anchor cell (spilled cells are
+            // formula-less and round-trip as plain cached values). Excel serialises it as an
+            // array formula whose ref is the spill footprint, paired with the cm dynamic-array
+            // metadata (written above). Before the first spill the footprint is unknown, so use
+            // the 1x1 anchor.
+            xml.WriteStartElement("f", Main2006SsNs);
+            xml.WriteAttributeString("t", "array");
+            var spillRange = formula.Range == default ? new XLSheetRange(point) : formula.Range;
+            var spillAddress = XLRangeAddress.FromSheetRange(xlWorksheet, spillRange);
+            xml.WriteAttributeString("ref", spillAddress.ToStringRelative());
+            xml.WriteString(formula.A1);
+            xml.WriteEndElement(); // f
+        }
         else if (formula.Type == FormulaType.Array)
         {
             var isMasterCell = formula.Range.FirstPoint == point;

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -28,7 +28,8 @@ internal static class WorksheetSheetDataReader
         SharedStringEntry[]? sharedStrings,
         Dictionary<uint, string> sharedFormulasR1C1,
         Dictionary<int, XLStyleValue> styleList,
-        bool use1904DateSystem)
+        bool use1904DateSystem,
+        HashSet<uint>? dynamicArrayCmIndexes = null)
     {
         public readonly StylesheetData Styles = styles;
         public readonly XLWorksheet Worksheet = worksheet;
@@ -36,6 +37,12 @@ internal static class WorksheetSheetDataReader
         public readonly Dictionary<uint, string> SharedFormulasR1C1 = sharedFormulasR1C1;
         public readonly Dictionary<int, XLStyleValue> StyleList = styleList;
         public readonly bool Use1904DateSystem = use1904DateSystem;
+
+        /// <summary>
+        /// 1-based cell-metadata (<c>cm</c>) indexes that mark a formula as a dynamic array.
+        /// <c>null</c> when the workbook has no dynamic-array metadata.
+        /// </summary>
+        public readonly HashSet<uint>? DynamicArrayCmIndexes = dynamicArrayCmIndexes;
 
         /// <summary>
         /// Whether the worksheet has any custom column styles. When <c>false</c>,
@@ -256,7 +263,7 @@ internal static class WorksheetSheetDataReader
         // Move from the cell start element onwards.
         reader.MoveAhead();
 
-        LoadCellContent(in context, reader, dataType, cellAddress, cellStyleValue, ws, cellsCollection);
+        LoadCellContent(in context, reader, dataType, cellAddress, cellStyleValue, ws, cellsCollection, cellMetaIndex);
 
         if (styleMatchesInherited)
             EnsureStyleForBlankCell(cellsCollection, cellAddress, cellStyleValue);
@@ -314,9 +321,10 @@ internal static class WorksheetSheetDataReader
     /// </summary>
     private static void LoadCellContent(in SheetDataReadContext context, OpenXmlPartReader reader,
         CellValues dataType, XLSheetPoint cellAddress, XLStyleValue cellStyleValue,
-        XLWorksheet ws, XLCellsCollection cellsCollection)
+        XLWorksheet ws, XLCellsCollection cellsCollection, uint? cellMetaIndex)
     {
-        var formula = LoadCellFormula(ws, cellAddress, reader, context.SharedFormulasR1C1);
+        var formula = LoadCellFormula(ws, cellAddress, reader, context.SharedFormulasR1C1,
+            cellMetaIndex, context.DynamicArrayCmIndexes);
 
         // Formula results are stored inline (not in the shared string table).
         var formulaInline = formula is not null;
@@ -357,18 +365,19 @@ internal static class WorksheetSheetDataReader
     /// If the reader is positioned at an 'f' element, loads the formula and advances past it.
     /// </summary>
     private static XLCellFormula? LoadCellFormula(XLWorksheet ws, XLSheetPoint cellAddress,
-        OpenXmlPartReader reader, Dictionary<uint, string> sharedFormulasR1C1)
+        OpenXmlPartReader reader, Dictionary<uint, string> sharedFormulasR1C1,
+        uint? cellMetaIndex, HashSet<uint>? dynamicArrayCmIndexes)
     {
         if (!reader.IsStartElement("f"))
             return null;
 
-        var formula = SetCellFormula(ws, cellAddress, reader, sharedFormulasR1C1);
+        var formula = SetCellFormula(ws, cellAddress, reader, sharedFormulasR1C1, cellMetaIndex, dynamicArrayCmIndexes);
         reader.MoveAhead();
         return formula;
     }
 
     private static XLCellFormula? SetCellFormula(XLWorksheet ws, XLSheetPoint cellAddress, OpenXmlPartReader reader,
-        Dictionary<uint, string> sharedFormulasR1C1)
+        Dictionary<uint, string> sharedFormulasR1C1, uint? cellMetaIndex, HashSet<uint>? dynamicArrayCmIndexes)
     {
         var attributes = reader.Attributes;
         var formulaSlice = ws.Internals.CellsCollection.FormulaSlice;
@@ -398,12 +407,29 @@ internal static class WorksheetSheetDataReader
         {
         } arrayArea) // Child cells of an array may have an array type, but not ref, that is reserved for the master cell
         {
-            var aca = attributes.GetBoolAttribute("aca", false);
+            var isDynamicArray = cellMetaIndex is { } cm &&
+                                 dynamicArrayCmIndexes is not null &&
+                                 dynamicArrayCmIndexes.Contains(cm);
+            if (isDynamicArray)
+            {
+                // A dynamic array is serialised as an array formula whose ref is the spill
+                // footprint, marked by the cm XLDAPR metadata. Only the anchor holds the
+                // formula (spilled cells load as plain cached values); storing the footprint on
+                // Range marks those cells as owned so the first re-spill doesn't see them as a
+                // #SPILL! collision.
+                formula = XLCellFormula.DynamicArrayA1(formulaText);
+                formula.Range = arrayArea;
+                formulaSlice.SetDuringLoad(cellAddress, formula);
+            }
+            else
+            {
+                var aca = attributes.GetBoolAttribute("aca", false);
 
-            // Because cells are read from top-to-bottom, from left-to-right, none of child cells have
-            // a formula yet. Also, Excel doesn't allow change of array data, only through the parent formula.
-            formula = XLCellFormula.Array(formulaText, arrayArea, aca);
-            formulaSlice.SetArray(arrayArea, formula);
+                // Because cells are read from top-to-bottom, from left-to-right, none of child cells have
+                // a formula yet. Also, Excel doesn't allow change of array data, only through the parent formula.
+                formula = XLCellFormula.Array(formulaText, arrayArea, aca);
+                formulaSlice.SetArray(arrayArea, formula);
+            }
         }
         else if (formulaType == CellFormulaValues.Shared && attributes.GetUintAttribute("si") is { } sharedIndex)
         {

--- a/XLibur/Excel/XLCellValue.cs
+++ b/XLibur/Excel/XLCellValue.cs
@@ -61,7 +61,7 @@ public readonly struct XLCellValue : IEquatable<XLCellValue>, IEquatable<Blank>,
 
     private XLCellValue(XLError error) : this()
     {
-        if (error < XLError.NullValue || error > XLError.NoValueAvailable)
+        if (error < XLError.NullValue || error > XLError.SpillRange)
             throw new ArgumentOutOfRangeException(nameof(error));
 
         Type = XLDataType.Error;

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -109,6 +109,8 @@ public partial class XLWorkbook
 
         RichDataReader.LoadRichData(workbookPart, this, context);
 
+        context.LoadDynamicArrayMetadata(workbookPart.CellMetadataPart?.Metadata);
+
         LoadCustomFileProperties(dSpreadsheet);
 
         if (workbookPart.Workbook!.WorkbookProperties is { } wbProps)
@@ -328,7 +330,8 @@ public partial class XLWorkbook
         var styleList = new Dictionary<int, XLStyleValue>();
         PageSetupProperties? pageSetupProperties = null;
         var sheetDataContext = new WorksheetSheetDataReader.SheetDataReadContext(
-            styles, ws, sharedStrings, sharedFormulasR1C1, styleList, Use1904DateSystem);
+            styles, ws, sharedStrings, sharedFormulasR1C1, styleList, Use1904DateSystem,
+            context.DynamicArrayCmIndexes);
         var sheetDataState = new WorksheetSheetDataReader.SheetDataReadState();
 
         using var reader = new OpenXmlPartReader(worksheetPart);

--- a/XLibur/Extensions/XLErrorExtensions.cs
+++ b/XLibur/Extensions/XLErrorExtensions.cs
@@ -16,6 +16,7 @@ internal static class XLErrorExtensions
             XLError.NoValueAvailable => "#N/A",
             XLError.NullValue => "#NULL!",
             XLError.NumberInvalid => "#NUM!",
+            XLError.SpillRange => "#SPILL!",
             _ => throw new ArgumentOutOfRangeException(nameof(error), error, "Unknown XLError value.")
         };
 }
@@ -30,7 +31,8 @@ internal static class XLErrorParser
         ["#NAME?"] = XLError.NameNotRecognized,
         ["#N/A"] = XLError.NoValueAvailable,
         ["#NULL!"] = XLError.NullValue,
-        ["#NUM!"] = XLError.NumberInvalid
+        ["#NUM!"] = XLError.NumberInvalid,
+        ["#SPILL!"] = XLError.SpillRange
     };
 
     public static bool TryParseError(string input, out XLError error)

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -103,3 +103,4 @@ static XLibur.Excel.XLAlignmentKey.operator ==(XLibur.Excel.XLAlignmentKey left,
 static XLibur.Excel.XLAlignmentKey.operator !=(XLibur.Excel.XLAlignmentKey left, XLibur.Excel.XLAlignmentKey right) -> bool
 static XLibur.AttributeExtensions.GetMethod<T>(this T instance, System.Linq.Expressions.Expression<System.Func<T, object!>!>! methodSelector) -> System.Reflection.MethodInfo!
 static XLibur.AttributeExtensions.GetMethod<T>(this T instance, System.Linq.Expressions.Expression<System.Action<T>!>! methodSelector) -> System.Reflection.MethodInfo!
+XLibur.Excel.XLError.SpillRange = 7 -> XLibur.Excel.XLError

--- a/docs/dynamic-array-spill-phase-b.md
+++ b/docs/dynamic-array-spill-phase-b.md
@@ -1,0 +1,158 @@
+# Dynamic Arrays — Phase B: the spill engine
+
+Status: **implemented** (PR [XLibur#169](https://github.com/XLibur/XLibur/pull/169)). This document
+was the implementation plan; it has been updated to record what actually shipped, the deviations
+from the plan, and the remaining limitations.
+
+**Phase A** (PR #168) added the modern functions (`SEQUENCE`, `UNIQUE`, `SORT`, `SORTBY`, `FILTER`,
+`XLOOKUP`, `XMATCH`) as `ReturnsArray` functions. **Phase B** is the actual *spilling*: a
+dynamic-array formula in a single cell auto-fills its computed footprint into neighbouring empty
+cells, growing/shrinking with the result, participates in dependency-driven recalculation, and
+round-trips through save/load.
+
+Only the **anchor** cell holds the `XLCellFormula`; spilled cells stay formula-less (matching
+Excel), which preserves the "only the anchor has `<f>`" serialization model.
+
+---
+
+## 1. What already existed (reused)
+
+- **Array evaluation.** `CalcContext.IsArrayCalculation` flips `CalculationVisitor.Visit(FunctionNode)`
+  to `FunctionDefinition.CallAsArray`, returning the whole array for a `ReturnsArray | AllowRange.All`
+  function. `XLCalcEngine.EvaluateArrayFormula` evaluates a formula to a full `Array` without the
+  scalar collapse. **Reused as-is** by the spill path.
+- **Array types.** `Array` (`Width`, `Height`, `this[y,x]`, `Broadcast`), `ConstArray`,
+  `AnyValue.GetArraySize()`.
+- **Multi-cell writeback loop.** The `FormulaType.Array` branches in `TryEvaluateSingleCell` and
+  `ApplyFormula` were the template for the new `SpillDynamicArray` path.
+- **Formula model.** `XLCellFormula` stores no cached value; cleanliness is an epoch. A dynamic array
+  is `Type = Normal` **plus** `IsDynamicArray = true` (`DynamicArrayA1` factory), with a settable
+  `Range` (`XLSheetRange`) used to hold the computed footprint.
+- **Public entry point.** `XLCell.SetDynamicFormulaA1` → `DynamicArrayA1`.
+- **Save metadata plumbing.** `XLWorkbook_Save.EnsureDynamicArrayMetadata`,
+  `SaveContext.DynamicArrayMetaIndex`, and the `cm` attribute in `SheetDataWriter`.
+- **Parser.** `A1#` parses to `UnaryOp.SpillRange`.
+
+## 2. The gaps — and how each was closed
+
+1. **`UnaryOp.SpillRange` evaluation** — implemented in `CalculationVisitor` (B3). `ImplicitIntersection`
+   and `BinaryOp.Intersection` remain `NotImplementedException` (out of scope).
+2. **Dynamic sizing** — `SpillDynamicArray` derives the footprint from `array.Width/Height` (B1).
+3. **`IsDynamicArray` formulas spill** — a dedicated `SpillDynamicArray` path in both
+   `TryEvaluateSingleCell` and `ApplyFormula` (taken before the `Normal` branch) evaluates via the
+   array path and never applies the `[0,0]` scalar collapse (B1).
+4. **Spill range stored / persisted** — the footprint is stored on `formula.Range`; save writes
+   `<f t="array" ref="…">` + `cm`, and load reconstructs `IsDynamicArray` from the `cm`→XLDAPR
+   metadata (B4).
+5. **Dependency tree covers the spill region** — `DependencyTree.CreateFrom` registers the whole
+   footprint as the `FormulaArea`; `UpdateSpillFootprint` re-registers on grow/shrink (B2).
+6. **`#SPILL!` error + collision detection** — `XLError.SpillRange` added; collision and
+   out-of-bounds detection in `SpillDynamicArray` (B1).
+7. **Stale-footprint clearing** — `ClearSpillFootprint` blanks cells the new footprint no longer
+   covers (B1).
+8. **Structural shifts** — a dynamic array is now shifted **in place** (text + footprint) like an
+   array formula, instead of being rebuilt (which reset `Range`). `Purge` + re-spill remains the
+   safety net (B5).
+
+## 3. Design decisions (as resolved)
+
+- **Where the footprint is stored.** On `formula.Range`, keeping `Type = Normal,
+  IsDynamicArray = true`. The anchor is `Range.FirstPoint`.
+- **Anchor vs spilled cells.** Spilled cells are **formula-less**; only the anchor holds the
+  formula. A per-workbook spill-owner map (`point → anchor formula`) lets a read of a spilled cell
+  find its anchor.
+- **Array semantics.** Dynamic arrays evaluate with `IsArrayCalculation = true` (via
+  `EvaluateArrayFormula`); the scalar `[0,0]` collapse is bypassed.
+- **`#SPILL!` representation.** `XLError.SpillRange = 7`. **Note the deviation:** `ERROR.TYPE(#SPILL!)`
+  is **9**, not `value + 1`, because the modern errors are non-contiguous — so `ERROR.TYPE`
+  special-cases it, and `XLCellValue`'s bounds check was widened to include it.
+
+## 4. Implementation order (as shipped)
+
+Each step landed as a separate commit on `feat/dynamic-array-spill-b1`.
+
+### B1 — Spill an in-memory dynamic-array formula
+`SpillDynamicArray` in `XLCalcEngine`: evaluate → size → collision-check (every non-anchor footprint
+cell not owned by the previous footprint that holds a formula or non-blank value blocks the spill) →
+clear the stale footprint → write the array → store `formula.Range`. Blocked footprint or
+out-of-bounds → `#SPILL!` on the anchor only. Added the `XLError.SpillRange` member and its four
+touch-points (enum, display/parse, `XLCellValue` bound, `ERROR.TYPE`).
+
+### B2 — Dependency tree covers the spill region
+`DependencyTree.CreateFrom` registers `IsDynamicArray` formulas with `formula.Range` as the
+`FormulaArea` (1×1 anchor before the first spill). `UpdateSpillFootprint` re-registers when the
+footprint changes, so dependents of any spilled cell are invalidated.
+
+### B3 — The `A1#` spill-range operator
+`CalculationVisitor.EvaluateSpillRange` resolves the operand to a spill anchor, forces the anchor to
+evaluate first (so its footprint is current), and returns a `Reference` to `formula.Range`. A
+non-anchor cell yields `#REF!`. Because the operator's range **includes the anchor**, `SUM(A1#)`
+orders correctly even when the referencing formula precedes the anchor.
+
+### B4 — Save/load round-trip
+Save: a dynamic-array anchor is written as `<f t="array" ref="footprint">` + the `cm` XLDAPR
+metadata; spilled cells round-trip as plain cached values. Load: `LoadContext.LoadDynamicArrayMetadata`
+parses the cell-metadata part to collect the `cm` indexes referencing XLDAPR; an array formula whose
+`cm` is in that set is reconstructed as a dynamic array (`Range = ref`), while other array formulas
+stay CSE arrays. Storing the footprint on `Range` marks the cached child values as owned so the first
+re-spill after load doesn't misfire a `#SPILL!` collision.
+
+### B5 — Robustness & polish
+- **Recalc ordering.** A per-workbook spill-owner map (rebuilt when the dependency tree is (re)built,
+  kept in sync by `SpillDynamicArray`, cleared on `Purge`) lets `CalcContext.GetCellValue` throw
+  `GettingDataException` at the owning anchor when a formula-less spilled cell of a dirty anchor is
+  read — so the chain evaluates the anchor first. Gated on `HasSpillOwners`.
+- **Shift preserves the footprint.** `ShiftDynamicArrayFormula` updates the text in place and
+  relocates `Range`, fixing a spurious `#SPILL!` on re-spill after a row/column insert.
+- **Out-of-bounds `#SPILL!`** — landed in B1.
+
+## 5. Deviations & gotchas discovered during implementation
+
+- **`ERROR.TYPE(#SPILL!)` is 9, not 8.** The naive `(int)error + 1` breaks for the new member;
+  `ERROR.TYPE` special-cases it and the `XLCellValue` error-bounds check was widened.
+- **The `#SPILL!` *literal* can't be parsed.** The external `ClosedXML.Parser` doesn't tokenize
+  `#SPILL!` (it errors with *Unexpected token SPILL*). It can only appear as a computed value, so
+  `ERROR.TYPE(#SPILL!)` is tested against a real spilled cell rather than a literal.
+- **`SEQUENCE(cell-reference)` returns `#VALUE!`** in array mode (literal arguments work). This is an
+  orthogonal argument-coercion issue, not a spill bug; tests use `UNIQUE(range)` where a
+  reference-driven size is needed.
+- **The old "split-into-`@` on shift" behaviour was already gone** — the shift path kept the dynamic
+  flag but reset `Range`, which is what B5 fixed.
+
+## 6. Known limitations (documented, with tests)
+
+- **First-evaluation ordering.** When a dependent is positioned *before* a not-yet-spilled anchor and
+  reads a spilled non-anchor cell, the footprint is unknown until the anchor runs — a genuine circular
+  dependency that would need a calc-chain pre-pass to size arrays before evaluation. Captured by the
+  `[Ignore]`d `Spill_DependentBeforeAnchor_FirstEvaluationOrdering` test. Post-first-spill ordering
+  works; the `A1#` operator is unaffected and is the recommended way to reference a spill.
+- **`#SPILL!` auto-recovery.** Clearing a cell that blocks a spill does not by itself re-spill the
+  anchor (the desired footprint of a `#SPILL!` anchor isn't tracked); recovery happens on the next
+  anchor re-evaluation. Editing a live spilled cell is transient (overwritten on next recalc),
+  consistent with Excel treating spill cells as read-only.
+
+## 7. Files touched
+
+- `XLibur/Excel/CalcEngine/XLCalcEngine.cs` — spill path, footprint sizing/collision/clearing,
+  spill-owner map.
+- `XLibur/Excel/CalcEngine/CalculationVisitor.cs` — `UnaryOp.SpillRange`.
+- `XLibur/Excel/CalcEngine/DependenciesVisitor.cs` — `SpillRange` precedent propagation (comment).
+- `XLibur/Excel/CalcEngine/DependencyTree.cs` — footprint `FormulaArea` + `UpdateSpillFootprint`.
+- `XLibur/Excel/CalcEngine/CalcContext.cs` — spill-owner lookup on cell reads.
+- `XLibur/Excel/CalcEngine/XLError.cs` (+ `XLErrorExtensions`, `Information.ErrorType`, `XLCellValue`)
+  — `#SPILL!`.
+- `XLibur/Excel/Cells/XLCell.cs` — in-place dynamic-array shift.
+- `XLibur/Excel/IO/SheetDataWriter.cs` — write the spill `ref`.
+- `XLibur/Excel/IO/WorksheetSheetDataReader.cs` + `LoadContext.cs` + `XLWorkbook_Load.cs` —
+  reconstruct `IsDynamicArray` from `cm`/XLDAPR.
+- Tests: `SpillEvaluationTests`, plus `ArrayFormulaTests`, `FormulaParserTests`, `InformationTests`.
+
+## 8. Verification
+
+```
+dotnet build XLibur/XLibur.csproj -c Release --no-restore -v q
+dotnet test XLibur.Tests/XLibur.Tests.csproj -c Release -f net10.0 --filter "FullyQualifiedName~Spill|FullyQualifiedName~ArrayFormula|FullyQualifiedName~DynamicArray"
+dotnet test XLibur.Tests/XLibur.Tests.csproj -c Release -f net10.0   # full suite
+```
+
+Result after Phase B: full suite **6275 passed / 0 failed** on net8.0 and net10.0.


### PR DESCRIPTION
## Dynamic Arrays — Phase B: the spill engine

Phase A (#168) added the modern array functions (`SEQUENCE`, `UNIQUE`, `SORT`, `SORTBY`, `FILTER`, `XLOOKUP`, `XMATCH`) as `ReturnsArray` functions. **Phase B is the actual spilling**: a dynamic-array formula in a single cell now auto-fills its computed footprint into neighbouring cells, growing/shrinking with the result, and round-trips through save/load.

Only the **anchor** cell holds the `XLCellFormula`; spilled cells stay formula-less (matching Excel), which keeps the "only the anchor has `<f>`" serialization model.

### What's included

| Commit | Delivers |
|---|---|
| **B1** | In-memory spilling — derive the footprint from the result, collision-check, clear stale cells, write the array. Blocked footprint (existing content) or one past the sheet edge collapses to `#SPILL!` on the anchor. Adds the `XLError.SpillRange` (`#SPILL!`) member (enum, display/parse, `XLCellValue` bound, and the `ERROR.TYPE` → 9 special-case). |
| **B2** | Dependency-tree coverage — a dynamic array registers its **whole footprint** (not just the anchor), so a change to its precedents invalidates dependents of any spilled cell. Re-registers when the footprint grows/shrinks. |
| **B3** | The `A1#` spill-range operator — resolves to a `Reference` over the anchor's current footprint; `#REF!` when the cell isn't a spill anchor. Because the range includes the anchor, `SUM(A1#)` orders correctly regardless of layout. |
| **B4** | Save/load round-trip — a dynamic array serialises as `<f t="array" ref="…">` + the `cm` XLDAPR metadata; on load the cell-metadata part is parsed to reconstruct `IsDynamicArray` (distinguished from a legacy CSE array by its `cm`). |
| **B5** | Recalc ordering via a spill-owner lookup (a read of a spilled cell forces its dirty anchor to evaluate first), and preservation of the spill footprint across row/column shifts (previously reset, causing a spurious `#SPILL!` on re-spill). |

### Testing

- New `SpillEvaluationTests` (23 tests) plus extensions to `ArrayFormulaTests`, `FormulaParserTests`, and `InformationTests`.
- Covers: column/row/2-D spill, grow & shrink, value/formula collisions, out-of-bounds, `#SPILL!` recovery, `A1#` (incl. shrink-tracking and ordering), dependency invalidation, interactive & full-recalc ordering, row/column shift + re-spill, `ERROR.TYPE`/`ISERROR` on a real `#SPILL!`, CSE-vs-dynamic load distinction, and a `#SPILL!` save/load round-trip.
- **Full suite: 6275 passed / 0 failed on net8.0 and net10.0.**

### Known limitations (documented, with tests)

- **First-evaluation ordering** when a dependent is positioned *before* a never-spilled anchor: the footprint is unknown until the anchor runs (a genuine circular dependency needing a calc-chain pre-pass). Captured by an `[Ignore]`d regression test. The `A1#` operator is unaffected and is the recommended way to reference a spill.
- **`#SPILL!` auto-recovery** when a user *clears* a cell blocking a spill without otherwise re-triggering the anchor — recovers on the next anchor re-evaluation. Editing a live spilled cell is transient (overwritten on next recalc), consistent with Excel treating spill cells as read-only.
- The external `ClosedXML.Parser` doesn't tokenize the `#SPILL!` **literal**, so `ERROR.TYPE(#SPILL!)` is tested against a real spilled cell rather than a literal.

Design and file-level plan: `docs/dynamic-array-spill-phase-b.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full dynamic-array spill support (vertical, horizontal, and 2D), including the spill-range operator.
  * Improved save/load so spilled dynamic-array formulas serialize with the correct array footprint and metadata, and load distinctly from legacy array formulas.
  * Added `#SPILL!` parsing/display with correct error-function behavior (including numeric reporting).

* **Bug Fixes**
  * Fixed spilled-value recalculation (including anchor-first ordering), spill collision handling, stale spill clearing on shrink, and persistence/recovery of blocked `#SPILL!` states.

* **Tests / Documentation**
  * Added extensive spill and save/load regression coverage and updated the dynamic-array spill-phase documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->