### PR TITLE
perf: cut load allocations by 61% (SST reader, cell value/attribute reads, style cache)

### DIFF
--- a/XLibur.Tests/Excel/Loading/SheetDataValueReadingTests.cs
+++ b/XLibur.Tests/Excel/Loading/SheetDataValueReadingTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Loading;
+
+/// <summary>
+/// Covers reading of cell attribute and <c>&lt;v&gt;</c> content that does not fit the fixed-size
+/// scratch buffer the sheet-data reader uses to avoid a string allocation per cell. Well-formed
+/// files never exceed it, so without these tests the fallback path would be unexercised.
+/// </summary>
+[TestFixture]
+public class SheetDataValueReadingTests
+{
+    private static XLWorkbook SaveAndReload(XLWorkbook workbook)
+    {
+        var ms = new MemoryStream();
+        workbook.SaveAs(ms);
+        ms.Position = 0;
+        return new XLWorkbook(ms);
+    }
+
+    private static XLWorkbook SaveAndReload(XLWorkbook workbook, SaveOptions options)
+    {
+        var ms = new MemoryStream();
+        workbook.SaveAs(ms, options);
+        ms.Position = 0;
+        return new XLWorkbook(ms);
+    }
+
+    [TestCase(10)]
+    [TestCase(63)]
+    [TestCase(64)]
+    [TestCase(65)]
+    [TestCase(200)]
+    [TestCase(5000)]
+    public void Text_of_any_length_round_trips(int length)
+    {
+        var text = string.Concat(Enumerable.Repeat("abcdefghij", (length / 10) + 1))[..length];
+
+        using var original = new XLWorkbook();
+        var ws = original.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = text;
+
+        using var reloaded = SaveAndReload(original);
+
+        Assert.That(reloaded.Worksheet("Sheet1").Cell("A1").GetString(), Is.EqualTo(text));
+    }
+
+    [Test]
+    public void Formula_string_result_longer_than_the_scratch_buffer_round_trips()
+    {
+        // A cached formula result is written as t="str" with the text inline in <v>, so it goes
+        // through the same buffered read as a normal value but is not a shared string.
+        var text = new string('x', 300);
+
+        using var original = new XLWorkbook();
+        var ws = original.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = text;
+        ws.Cell("A2").FormulaA1 = "A1";
+
+        // Cached formula values are only written when explicitly requested; without this the
+        // formula cell would carry no <v> and the t="str" read path would not be exercised.
+        using var reloaded = SaveAndReload(original, new SaveOptions { EvaluateFormulasBeforeSaving = true });
+
+        Assert.That(reloaded.Worksheet("Sheet1").Cell("A2").CachedValue.GetText(), Is.EqualTo(text));
+    }
+
+    /// <remarks>
+    /// Restricted to values of at most 15 significant digits. Saving formats doubles with
+    /// <c>"G15"</c> by deliberate policy (see <c>ObjectExtensions.ToInvariantString</c>), so wider
+    /// values — and the extremes of <see cref="double"/> — lose precision on the way out. That is a
+    /// property of the write path; what is asserted here is that the read path reconstructs exactly
+    /// what was written.
+    /// </remarks>
+    [Test]
+    public void High_precision_numbers_round_trip()
+    {
+        double[] numbers =
+        [
+            0d, 1d, -1d, 0.1d, -0.1d, 0.3d,
+            1234567890.12345d,
+            -123456.789012345d,
+            1e-300, 1e300,
+            123456789012345d,
+            0.000123456789012d
+        ];
+
+        using var original = new XLWorkbook();
+        var ws = original.AddWorksheet("Sheet1");
+        for (var i = 0; i < numbers.Length; i++)
+            ws.Cell(i + 1, 1).Value = numbers[i];
+
+        using var reloaded = SaveAndReload(original);
+
+        var loaded = reloaded.Worksheet("Sheet1");
+        for (var i = 0; i < numbers.Length; i++)
+        {
+            Assert.That(loaded.Cell(i + 1, 1).GetDouble(), Is.EqualTo(numbers[i]),
+                $"number at row {i + 1} did not round-trip");
+        }
+    }
+
+    [Test]
+    public void Shared_string_indexes_beyond_the_scratch_buffer_width_round_trip()
+    {
+        // Forces six-digit shared string indexes, so the <v> content of later cells is longer
+        // than a short value but still well inside the buffer — guards the index parse path.
+        const int count = 200_000;
+
+        using var original = new XLWorkbook();
+        var ws = original.AddWorksheet("Sheet1");
+        for (var i = 0; i < count; i++)
+            ws.Cell(i + 1, 1).Value = "s" + i;
+
+        using var reloaded = SaveAndReload(original);
+
+        var loaded = reloaded.Worksheet("Sheet1");
+        Assert.Multiple(() =>
+        {
+            Assert.That(loaded.Cell(1, 1).GetString(), Is.EqualTo("s0"));
+            Assert.That(loaded.Cell(count / 2, 1).GetString(), Is.EqualTo("s" + (count / 2 - 1)));
+            Assert.That(loaded.Cell(count, 1).GetString(), Is.EqualTo("s" + (count - 1)));
+        });
+    }
+
+    [Test]
+    public void Whitespace_only_and_padded_text_is_preserved()
+    {
+        // <t xml:space="preserve"> content must survive the shared-string reader verbatim.
+        string[] texts = ["   ", " leading", "trailing ", " both ", "\ttab\t", new string(' ', 100)];
+
+        using var original = new XLWorkbook();
+        var ws = original.AddWorksheet("Sheet1");
+        for (var i = 0; i < texts.Length; i++)
+            ws.Cell(i + 1, 1).Value = texts[i];
+
+        using var reloaded = SaveAndReload(original);
+
+        var loaded = reloaded.Worksheet("Sheet1");
+        for (var i = 0; i < texts.Length; i++)
+        {
+            Assert.That(loaded.Cell(i + 1, 1).GetString(), Is.EqualTo(texts[i]),
+                $"text at row {i + 1} was not preserved");
+        }
+    }
+
+    [Test]
+    public void Escaped_control_characters_are_decoded_once()
+    {
+        // _xHHHH_ escapes are decoded by the shared-string reader; a literal underscore run
+        // must not be mistaken for an escape.
+        string[] texts = ["ab", "_x0018_literal", "_Xceed_Something", "plain_underscore"];
+
+        using var original = new XLWorkbook();
+        var ws = original.AddWorksheet("Sheet1");
+        for (var i = 0; i < texts.Length; i++)
+            ws.Cell(i + 1, 1).Value = texts[i];
+
+        using var reloaded = SaveAndReload(original);
+
+        var loaded = reloaded.Worksheet("Sheet1");
+        for (var i = 0; i < texts.Length; i++)
+        {
+            Assert.That(loaded.Cell(i + 1, 1).GetString(), Is.EqualTo(texts[i]),
+                $"text at row {i + 1} was not decoded correctly");
+        }
+    }
+
+    [Test]
+    public void Rich_text_and_plain_text_can_share_one_table()
+    {
+        using var original = new XLWorkbook();
+        var ws = original.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = "plain before";
+
+        var rich = ws.Cell("A2").GetRichText();
+        rich.AddText("bold").Bold = true;
+        rich.AddText(new string('n', 120));
+
+        ws.Cell("A3").Value = "plain after";
+
+        using var reloaded = SaveAndReload(original);
+
+        var loaded = reloaded.Worksheet("Sheet1");
+        Assert.Multiple(() =>
+        {
+            Assert.That(loaded.Cell("A1").GetString(), Is.EqualTo("plain before"));
+            Assert.That(loaded.Cell("A3").GetString(), Is.EqualTo("plain after"));
+            Assert.That(loaded.Cell("A2").GetString(), Is.EqualTo("bold" + new string('n', 120)));
+
+            var loadedRich = loaded.Cell("A2").GetRichText();
+            Assert.That(loadedRich.Count, Is.EqualTo(2));
+            Assert.That(loadedRich.First().Bold, Is.True);
+        });
+    }
+}

--- a/XLibur/Excel/IO/LoadContext.cs
+++ b/XLibur/Excel/IO/LoadContext.cs
@@ -94,10 +94,18 @@ internal sealed class LoadContext
         return XLNumberFormatValue.FromKey(ref predefinedFormatKey);
     }
 
+    private StyleValueCache? _styleCache;
+
     /// <summary>
     /// The stylesheet and its sub-collections, populated once from the workbook styles part.
     /// </summary>
     internal StylesheetData Styles { get; set; } = null!;
+
+    /// <summary>
+    /// Per-workbook cache of style values resolved from <c>cellXfs</c> indexes. Shared by every
+    /// worksheet because <see cref="Styles"/> is workbook-global.
+    /// </summary>
+    internal StyleValueCache StyleCache => _styleCache ??= new StyleValueCache(Styles);
 
     /// <summary>
     /// Maps 1-based vm (value metadata) index to cell image info loaded from rich data parts.

--- a/XLibur/Excel/IO/SharedStringReader.cs
+++ b/XLibur/Excel/IO/SharedStringReader.cs
@@ -1,5 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Utils;
@@ -31,69 +34,214 @@ internal readonly struct SharedStringEntry
 }
 
 /// <summary>
-/// Reads the shared string table from an SST part. For plain text entries (the vast majority),
-/// only the decoded text string is retained and the DOM element is released for GC. For rich
-/// text entries (with runs or phonetic data), the <see cref="SharedStringItem"/> is kept for
-/// later formatting extraction via <see cref="WorksheetSheetDataReader.SetCellText"/>.
+/// Reads the shared string table from an SST part with a raw <see cref="XmlReader"/>.
+/// <para>
+/// The overwhelmingly common entry is a plain <c>&lt;si&gt;&lt;t&gt;text&lt;/t&gt;&lt;/si&gt;</c>, for which only
+/// the decoded string is retained — no DOM node is ever built. Materializing the whole
+/// <see cref="SharedStringTablePart.SharedStringTable"/> DOM instead costs two OpenXml elements plus an
+/// attribute collection per entry, all of which become garbage immediately after the text is extracted;
+/// for a string-heavy workbook the table can hold hundreds of thousands of entries.
+/// </para>
+/// <para>
+/// Entries with runs or phonetic data are rare and still need the DOM for formatting extraction via
+/// <see cref="WorksheetSheetDataReader.SetCellText"/>, so their subtree is rebuilt into a
+/// <see cref="SharedStringItem"/>. Richness can only be established after the first child has been consumed
+/// (a leading <c>&lt;t&gt;</c> may be followed by <c>&lt;rPh&gt;</c>), hence the re-serialization in
+/// <see cref="ReadRichItem"/> rather than a plain <c>ReadOuterXml</c>.
+/// </para>
 /// </summary>
 internal static class SharedStringReader
 {
+    private const string XmlNs = "http://www.w3.org/XML/1998/namespace";
+
     internal static SharedStringEntry[] Read(SharedStringTablePart part)
     {
-        var sst = part.SharedStringTable;
-        if (sst is null)
-            return [];
-
-        // Pre-allocate from the SST's UniqueCount attribute to avoid
-        // List<T> resize+copy overhead for large shared string tables.
-        // Only use UniqueCount (number of unique <si> entries), not Count
-        // (total reference count including duplicates) which would over-allocate.
-        var uniqueCount = sst.UniqueCount?.Value;
-        if (uniqueCount is not null and > 0)
+        using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
+        using var reader = XmlReader.Create(stream, new XmlReaderSettings
         {
-            var entries = new SharedStringEntry[(int)uniqueCount.Value];
-            var idx = 0;
-            foreach (var item in sst.Elements<SharedStringItem>())
+            // Whitespace must NOT be ignored: a <t> holding only spaces is legitimate text content.
+            IgnoreWhitespace = false,
+            IgnoreComments = true,
+            IgnoreProcessingInstructions = true,
+            CloseInput = false
+        });
+
+        while (reader.Read())
+        {
+            if (reader.NodeType == XmlNodeType.Element
+                && reader.LocalName == "sst"
+                && reader.NamespaceURI == OpenXmlConst.Main2006SsNs)
             {
-                var entry = ReadEntry(item);
-                if (idx < entries.Length)
-                    entries[idx++] = entry;
-                else
-                {
-                    // Count attribute was wrong — fall back to growing
-                    Array.Resize(ref entries, entries.Length * 2);
-                    entries[idx++] = entry;
-                }
+                return ReadSst(reader);
             }
-
-            // Trim if the declared count was larger than actual entries
-            if (idx < entries.Length)
-                Array.Resize(ref entries, idx);
-
-            return entries;
         }
 
-        // Fallback: no count attribute, use list
-        var list = new List<SharedStringEntry>();
-        foreach (var item in sst.Elements<SharedStringItem>())
-            list.Add(ReadEntry(item));
-
-        return list.ToArray();
+        return [];
     }
 
-    private static SharedStringEntry ReadEntry(SharedStringItem item)
+    private static SharedStringEntry[] ReadSst(XmlReader reader)
     {
-        // Schema: <si> contains either (t, rPh*, phoneticPr?) or (r+, rPh*, phoneticPr?).
-        // Pure plain text: a single <t> child with no runs and no phonetic data.
-        var text = item.Text;
-        if (text is not null && text == item.FirstChild && text == item.LastChild)
+        // Pre-allocate from the sst's uniqueCount attribute to avoid resize+copy for large tables.
+        // Only uniqueCount (number of unique <si> entries) is usable here, not count (total reference
+        // count including duplicates), which would over-allocate.
+        var uniqueCount = ReadUniqueCount(reader);
+
+        if (reader.IsEmptyElement)
+            return [];
+
+        var entries = uniqueCount > 0 ? new SharedStringEntry[uniqueCount] : [];
+        var count = 0;
+
+        reader.Read(); // Move into <sst> (first child or </sst>).
+
+        while (true)
         {
-            // Decode _xHHHH_ escapes (e.g. _x0018_ → \u0018) matching the original
-            // SetCellText code path.
-            var decoded = XmlEncoder.DecodeString(text.InnerText);
-            return SharedStringEntry.Plain(decoded);
+            if (reader.NodeType == XmlNodeType.Element)
+            {
+                if (reader.LocalName == "si" && reader.NamespaceURI == OpenXmlConst.Main2006SsNs)
+                {
+                    var entry = ReadSharedStringItem(reader); // Leaves reader after </si>.
+
+                    if (count == entries.Length)
+                    {
+                        // uniqueCount was absent or understated — grow geometrically.
+                        Array.Resize(ref entries, entries.Length == 0 ? 16 : entries.Length * 2);
+                    }
+
+                    entries[count++] = entry;
+                    continue;
+                }
+
+                reader.Skip(); // Unknown element (e.g. <extLst>).
+                continue;
+            }
+
+            if (reader.NodeType == XmlNodeType.EndElement || reader.EOF)
+                break;
+
+            if (!reader.Read())
+                break;
         }
 
-        return SharedStringEntry.Rich(item);
+        if (count != entries.Length)
+            Array.Resize(ref entries, count);
+
+        return entries;
+    }
+
+    private static int ReadUniqueCount(XmlReader reader)
+    {
+        var uniqueCount = 0;
+        if (reader.HasAttributes)
+        {
+            var value = reader.GetAttribute("uniqueCount");
+            if (value is not null && int.TryParse(value, out var parsed) && parsed > 0)
+                uniqueCount = parsed;
+
+            reader.MoveToElement();
+        }
+
+        return uniqueCount;
+    }
+
+    /// <summary>
+    /// Reads a single <c>&lt;si&gt;</c>. The reader enters positioned on the start element and returns
+    /// positioned on the node immediately after <c>&lt;/si&gt;</c>.
+    /// </summary>
+    private static SharedStringEntry ReadSharedStringItem(XmlReader reader)
+    {
+        if (reader.IsEmptyElement)
+        {
+            reader.Read(); // Move past <si/>.
+            return SharedStringEntry.Plain(string.Empty);
+        }
+
+        reader.Read(); // Move into <si> (first child or </si>).
+        SkipToContent(reader);
+
+        string? plainText = null;
+        if (IsMainElement(reader, "t"))
+        {
+            plainText = reader.ReadElementContentAsString(); // Reads <t> text and moves past </t>.
+            SkipToContent(reader);
+        }
+
+        // A lone <t> is the plain case; anything left before </si> means runs or phonetic data.
+        if (reader.NodeType != XmlNodeType.Element)
+        {
+            reader.Read(); // Move past </si>.
+
+            // Decode _xHHHH_ escapes (e.g. _x0018_ → ), matching the SetCellText path.
+            return SharedStringEntry.Plain(XmlEncoder.DecodeString(plainText ?? string.Empty));
+        }
+
+        var rich = ReadRichItem(reader, plainText);
+        reader.Read(); // Move past </si>.
+        return rich;
+    }
+
+    /// <summary>
+    /// Rebuilds the remainder of an <c>&lt;si&gt;</c> subtree (plus any <c>&lt;t&gt;</c> already consumed)
+    /// into a <see cref="SharedStringItem"/> DOM element. The reader enters on the first remaining child
+    /// element and returns on <c>&lt;/si&gt;</c>.
+    /// </summary>
+    private static SharedStringEntry ReadRichItem(XmlReader reader, string? leadingText)
+    {
+        var sb = new StringBuilder();
+        using (var writer = XmlWriter.Create(sb, new XmlWriterSettings
+        {
+            OmitXmlDeclaration = true,
+            ConformanceLevel = ConformanceLevel.Fragment,
+            CheckCharacters = false
+        }))
+        {
+            writer.WriteStartElement("si", OpenXmlConst.Main2006SsNs);
+
+            if (leadingText is not null)
+            {
+                writer.WriteStartElement("t", OpenXmlConst.Main2006SsNs);
+                writer.WriteAttributeString("space", XmlNs, "preserve");
+                writer.WriteString(leadingText);
+                writer.WriteEndElement();
+            }
+
+            while (true)
+            {
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    // ReadOuterXml emits the in-scope default namespace and moves past the child.
+                    writer.WriteRaw(reader.ReadOuterXml());
+                    continue;
+                }
+
+                if (reader.NodeType == XmlNodeType.EndElement || reader.EOF)
+                    break;
+
+                if (!reader.Read())
+                    break;
+            }
+
+            writer.WriteEndElement();
+        }
+
+        return SharedStringEntry.Rich(new SharedStringItem(sb.ToString()));
+    }
+
+    private static bool IsMainElement(XmlReader reader, string localName)
+        => reader.NodeType == XmlNodeType.Element
+           && reader.LocalName == localName
+           && reader.NamespaceURI == OpenXmlConst.Main2006SsNs;
+
+    /// <summary>
+    /// Advances over whitespace and other non-structural nodes so the reader lands on the next
+    /// element start or end tag.
+    /// </summary>
+    private static void SkipToContent(XmlReader reader)
+    {
+        while (reader.NodeType is not (XmlNodeType.Element or XmlNodeType.EndElement))
+        {
+            if (reader.EOF || !reader.Read())
+                return;
+        }
     }
 }

--- a/XLibur/Excel/IO/StyleValueCache.cs
+++ b/XLibur/Excel/IO/StyleValueCache.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Caches the <see cref="XLStyleValue"/> resolved for each <c>cellXfs</c> style index encountered
+/// while loading cells.
+/// <para>
+/// Style indexes are dense and bounded by the number of <c>cellXfs</c> entries, so the cache is a
+/// flat array rather than a dictionary: resolving a cell's style is a bounds check and an array read
+/// instead of a hash and probe, and every cell in a sheet performs one such lookup. Indexes outside
+/// the declared range (malformed files) fall back to a lazily created dictionary so behaviour is
+/// unchanged for them.
+/// </para>
+/// <para>
+/// The cache is workbook-scoped: <c>styles.xml</c> is workbook-global and
+/// <see cref="WorksheetSheetDataReader.ResolveStyleValue"/> is a pure function of the style index,
+/// so entries resolved for one worksheet are reused by the rest.
+/// </para>
+/// </summary>
+internal sealed class StyleValueCache
+{
+    private readonly StylesheetData _styles;
+    private readonly XLStyleValue?[] _byIndex;
+    private Dictionary<int, XLStyleValue>? _outOfRange;
+
+    internal StyleValueCache(StylesheetData styles)
+    {
+        _styles = styles;
+
+        // ChildElements.Count is the actual number of <xf> elements; CellFormats.Count is the
+        // declared count attribute, which is not authoritative.
+        var cellFormatCount = styles.Stylesheet?.CellFormats?.ChildElements.Count ?? 0;
+        _byIndex = cellFormatCount > 0 ? new XLStyleValue?[cellFormatCount] : [];
+    }
+
+    internal XLStyleValue Resolve(int styleIndex)
+    {
+        if ((uint)styleIndex < (uint)_byIndex.Length)
+        {
+            var cached = _byIndex[styleIndex];
+            if (cached is not null)
+                return cached;
+
+            var resolved = WorksheetSheetDataReader.ResolveStyleValue(styleIndex, _styles);
+            _byIndex[styleIndex] = resolved;
+            return resolved;
+        }
+
+        return ResolveOutOfRange(styleIndex);
+    }
+
+    /// <summary>
+    /// Handles a style index beyond the declared <c>cellXfs</c> range. This happens for workbooks
+    /// with no stylesheet at all (every index resolves to the default style) and for malformed
+    /// files; <see cref="WorksheetSheetDataReader.ResolveStyleValue"/> keeps whatever behaviour
+    /// those cases had before.
+    /// </summary>
+    private XLStyleValue ResolveOutOfRange(int styleIndex)
+    {
+        _outOfRange ??= new Dictionary<int, XLStyleValue>();
+        if (_outOfRange.TryGetValue(styleIndex, out var cached))
+            return cached;
+
+        var resolved = WorksheetSheetDataReader.ResolveStyleValue(styleIndex, _styles);
+        _outOfRange[styleIndex] = resolved;
+        return resolved;
+    }
+}

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Xml;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -28,7 +29,7 @@ internal static class WorksheetSheetDataReader
         XLWorksheet worksheet,
         SharedStringEntry[]? sharedStrings,
         Dictionary<uint, string> sharedFormulasR1C1,
-        Dictionary<int, XLStyleValue> styleList,
+        StyleValueCache styleCache,
         Dictionary<XLNumberFormatValue, XLDataType> numberDataTypeCache,
         bool use1904DateSystem,
         HashSet<uint>? dynamicArrayCmIndexes = null)
@@ -37,7 +38,7 @@ internal static class WorksheetSheetDataReader
         public readonly XLWorksheet Worksheet = worksheet;
         public readonly SharedStringEntry[]? SharedStrings = sharedStrings;
         public readonly Dictionary<uint, string> SharedFormulasR1C1 = sharedFormulasR1C1;
-        public readonly Dictionary<int, XLStyleValue> StyleList = styleList;
+        public readonly StyleValueCache StyleCache = styleCache;
 
         /// <summary>
         /// Memoizes the <see cref="XLDataType"/> derived from a cell's number format
@@ -63,6 +64,14 @@ internal static class WorksheetSheetDataReader
         /// between context construction and the first <c>&lt;row&gt;</c>.
         /// </summary>
         public bool HasColumnStyles => Worksheet.Internals.ColumnsCollection.Count > 0;
+
+        /// <summary>
+        /// Scratch buffer for reading cell attribute values and <c>&lt;v&gt;</c> content as characters
+        /// rather than strings. Every cell carries an <c>r</c> attribute and most carry a value, so
+        /// materializing them would cost several short-lived strings per cell — millions on a large
+        /// sheet — that are parsed to a number or point and immediately discarded.
+        /// </summary>
+        public readonly char[] ValueBuffer = new char[ValueBufferLength];
     }
 
     /// <summary>
@@ -100,6 +109,14 @@ internal static class WorksheetSheetDataReader
             Height is not null || DyDescent is not null || Hidden || Collapsed
             || OutlineLevel > 0 || ShowPhonetic || CustomFormat;
     }
+
+    /// <summary>
+    /// Capacity of <see cref="SheetDataReadContext.ValueBuffer"/>. Comfortably exceeds every value
+    /// read through it: a cell reference is at most 10 characters (<c>XFD1048576</c>), a style or
+    /// metadata index at most 10 digits, and a round-tripped double at most 24. Longer content still
+    /// reads correctly — it just falls back to a materialized string.
+    /// </summary>
+    private const int ValueBufferLength = 64;
 
     private static readonly string[] DateCellFormats =
     [
@@ -159,37 +176,52 @@ internal static class WorksheetSheetDataReader
 
         if (reader.HasAttributes)
         {
+            var buffer = context.ValueBuffer;
             while (reader.MoveToNextAttribute())
             {
                 var ns = reader.NamespaceURI;
-                switch (reader.LocalName)
+                var localName = reader.LocalName;
+
+                var isKnown = ns.Length == 0
+                    ? localName is "r" or "ht" or "hidden" or "collapsed" or "outlineLevel"
+                        or "ph" or "customFormat" or "s"
+                    : localName == "dyDescent" && ns == OpenXmlConst.X14Ac2009SsNs;
+
+                if (!isKnown)
+                    continue;
+
+                // Read as characters — none of these attributes is retained as a string.
+                var length = ReadValueIntoBuffer(reader, buffer, out var overflow);
+                var value = length >= 0 ? buffer.AsSpan(0, length) : overflow.AsSpan();
+
+                switch (localName)
                 {
-                    case "r" when ns.Length == 0:
-                        TryParseOoxmlNonNegativeInt(reader.Value, out rowIndex);
+                    case "r":
+                        TryParseOoxmlNonNegativeInt(value, out rowIndex);
                         break;
-                    case "ht" when ns.Length == 0:
-                        height = double.Parse(reader.Value, NumberStyles.Float, XLHelper.ParseCulture);
+                    case "ht":
+                        height = double.Parse(value, NumberStyles.Float, XLHelper.ParseCulture);
                         break;
-                    case "dyDescent" when ns == OpenXmlConst.X14Ac2009SsNs:
-                        dyDescent = double.Parse(reader.Value, NumberStyles.Float, XLHelper.ParseCulture);
+                    case "dyDescent":
+                        dyDescent = double.Parse(value, NumberStyles.Float, XLHelper.ParseCulture);
                         break;
-                    case "hidden" when ns.Length == 0:
-                        hidden = ParseXmlBool(reader.Value);
+                    case "hidden":
+                        hidden = ParseXmlBool(value);
                         break;
-                    case "collapsed" when ns.Length == 0:
-                        collapsed = ParseXmlBool(reader.Value);
+                    case "collapsed":
+                        collapsed = ParseXmlBool(value);
                         break;
-                    case "outlineLevel" when ns.Length == 0:
-                        outlineLevel = int.Parse(reader.Value);
+                    case "outlineLevel":
+                        outlineLevel = int.Parse(value, CultureInfo.InvariantCulture);
                         break;
-                    case "ph" when ns.Length == 0:
-                        showPhonetic = ParseXmlBool(reader.Value);
+                    case "ph":
+                        showPhonetic = ParseXmlBool(value);
                         break;
-                    case "customFormat" when ns.Length == 0:
-                        customFormat = ParseXmlBool(reader.Value);
+                    case "customFormat":
+                        customFormat = ParseXmlBool(value);
                         break;
-                    case "s" when ns.Length == 0:
-                        styleIndex = int.Parse(reader.Value);
+                    case "s":
+                        styleIndex = int.Parse(value, CultureInfo.InvariantCulture);
                         break;
                 }
             }
@@ -238,7 +270,7 @@ internal static class WorksheetSheetDataReader
 
         int styleIndex = 0;
         XLSheetPoint? cellRef = null;
-        string? typeAttr = null;
+        var dataType = CellValues.Number; // Matches an absent t attribute.
         bool showPhonetic = false;
         uint? cellMetaIndex = null;
         uint? valueMetaIndex = null;
@@ -247,32 +279,42 @@ internal static class WorksheetSheetDataReader
 
         if (reader.HasAttributes)
         {
+            var buffer = context.ValueBuffer;
             while (reader.MoveToNextAttribute())
             {
                 if (reader.NamespaceURI.Length != 0)
                     continue;
 
-                switch (reader.LocalName)
+                // LocalName comes from the reader's name table, so it costs nothing; the value is
+                // read as characters because none of these attributes is retained as a string.
+                var localName = reader.LocalName;
+                if (localName is not ("r" or "s" or "t" or "ph" or "cm" or "vm"))
+                    continue;
+
+                var length = ReadValueIntoBuffer(reader, buffer, out var overflow);
+                var value = length >= 0 ? buffer.AsSpan(0, length) : overflow.AsSpan();
+
+                switch (localName)
                 {
                     case "r":
-                        cellRef = XLSheetPoint.Parse(reader.Value);
+                        cellRef = XLSheetPoint.Parse(value);
                         break;
                     case "s":
-                        TryParseOoxmlNonNegativeInt(reader.Value, out styleIndex);
+                        TryParseOoxmlNonNegativeInt(value, out styleIndex);
                         break;
                     case "t":
-                        typeAttr = reader.Value;
+                        dataType = ParseCellDataType(value);
                         break;
                     case "ph":
-                        showPhonetic = ParseXmlBool(reader.Value);
+                        showPhonetic = ParseXmlBool(value);
                         if (showPhonetic) hasMisc = true;
                         break;
                     case "cm":
-                        cellMetaIndex = uint.Parse(reader.Value);
+                        cellMetaIndex = uint.Parse(value, CultureInfo.InvariantCulture);
                         hasMisc = true;
                         break;
                     case "vm":
-                        valueMetaIndex = uint.Parse(reader.Value);
+                        valueMetaIndex = uint.Parse(value, CultureInfo.InvariantCulture);
                         hasMisc = true;
                         break;
                 }
@@ -283,9 +325,8 @@ internal static class WorksheetSheetDataReader
 
         var cellAddress = cellRef ?? new XLSheetPoint(rowIndex, state.LastColumnNumber + 1);
         state.LastColumnNumber = cellAddress.Column;
-        var dataType = ParseCellDataType(typeAttr);
 
-        var cellStyleValue = ResolveCachedStyleValue(styleIndex, context.Styles, context.StyleList);
+        var cellStyleValue = context.StyleCache.Resolve(styleIndex);
 
         var ws = context.Worksheet;
         var cellsCollection = ws.Internals.CellsCollection;
@@ -342,7 +383,12 @@ internal static class WorksheetSheetDataReader
         var cellWasSetWithEmptyValue = false;
         if (cellHasValue)
         {
-            var text = reader.ReadElementContentAsString(); // Reads <v> text and moves past </v>.
+            // Reads <v> content and moves past </v>, without a string for the numeric and
+            // shared-string cases that dominate a sheet.
+            var buffer = context.ValueBuffer;
+            var length = ReadElementContentIntoBuffer(reader, buffer, out var overflow);
+            var text = length >= 0 ? buffer.AsSpan(0, length) : overflow.AsSpan();
+
             SetCellValue(dataType, text, cellsCollection, cellAddress, cellStyleValue, ws,
                 context.SharedStrings, formulaInline, context.NumberDataTypeCache);
         }
@@ -503,8 +549,91 @@ internal static class WorksheetSheetDataReader
         }
     }
 
-    private static bool ParseXmlBool(string value)
-        => value == "1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+    private static bool ParseXmlBool(ReadOnlySpan<char> value)
+        => value.SequenceEqual("1") || value.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Copies the value of the node the reader is positioned on (an attribute or a text node) into
+    /// <paramref name="buffer"/> without materializing a string, returning the number of characters
+    /// written. When the value does not fit, the whole value is materialized into
+    /// <paramref name="overflow"/> instead and -1 is returned; the reader is fully drained either
+    /// way, so callers must never fall back to <see cref="XmlReader.Value"/>.
+    /// </summary>
+    private static int ReadValueIntoBuffer(XmlReader reader, char[] buffer, out string? overflow)
+    {
+        overflow = null;
+
+        var length = 0;
+        int read;
+        while ((read = reader.ReadValueChunk(buffer, length, buffer.Length - length)) > 0)
+        {
+            length += read;
+            if (length < buffer.Length)
+                continue;
+
+            var builder = new StringBuilder(buffer.Length * 2).Append(buffer, 0, length);
+            while ((read = reader.ReadValueChunk(buffer, 0, buffer.Length)) > 0)
+                builder.Append(buffer, 0, read);
+
+            overflow = builder.ToString();
+            return -1;
+        }
+
+        return length;
+    }
+
+    /// <summary>
+    /// Reads the text content of the element the reader is positioned on into
+    /// <paramref name="buffer"/>, following the same contract as
+    /// <see cref="ReadValueIntoBuffer"/>. This is the allocation-free counterpart of
+    /// <see cref="XmlReader.ReadElementContentAsString()"/>. The reader returns positioned on the
+    /// node immediately after the element's end tag.
+    /// </summary>
+    private static int ReadElementContentIntoBuffer(XmlReader reader, char[] buffer, out string? overflow)
+    {
+        overflow = null;
+
+        if (reader.IsEmptyElement)
+        {
+            reader.Read(); // Move past <v/>.
+            return 0;
+        }
+
+        reader.Read(); // Move into the element's content.
+
+        var length = 0;
+        StringBuilder? builder = null;
+
+        while (reader.NodeType is XmlNodeType.Text or XmlNodeType.CDATA
+               or XmlNodeType.SignificantWhitespace or XmlNodeType.Whitespace)
+        {
+            int read;
+            while ((read = reader.ReadValueChunk(buffer, length, buffer.Length - length)) > 0)
+            {
+                length += read;
+                if (length < buffer.Length)
+                    continue;
+
+                // Content longer than the scratch buffer: spill into a builder and keep going.
+                builder ??= new StringBuilder(buffer.Length * 2);
+                builder.Append(buffer, 0, length);
+                length = 0;
+            }
+
+            reader.Read(); // Move past the text node.
+        }
+
+        reader.Read(); // Move past the element's end tag.
+
+        if (builder is null)
+            return length;
+
+        if (length > 0)
+            builder.Append(buffer, 0, length);
+
+        overflow = builder.ToString();
+        return -1;
+    }
 
     /// <summary>
     /// Fast inherited style lookup using pre-cached row style. When the worksheet has no
@@ -524,32 +653,39 @@ internal static class WorksheetSheetDataReader
         return XLStyleValue.Combine(sheetStyle, rowStyle, colStyle);
     }
 
-    private static CellValues ParseCellDataType(string? typeAttribute)
+    /// <summary>
+    /// Maps the <c>t</c> attribute to a data type. Dispatches on length first so the single-character
+    /// forms — which is all Excel writes for the bulk of a sheet — avoid any sequence comparison.
+    /// An absent attribute is handled by the caller's <see cref="CellValues.Number"/> default.
+    /// </summary>
+    private static CellValues ParseCellDataType(ReadOnlySpan<char> typeAttribute)
     {
-        return typeAttribute switch
+        switch (typeAttribute.Length)
         {
-            "b" => CellValues.Boolean,
-            "n" => CellValues.Number,
-            "e" => CellValues.Error,
-            "s" => CellValues.SharedString,
-            "str" => CellValues.String,
-            "inlineStr" => CellValues.InlineString,
-            "d" => CellValues.Date,
-            null => CellValues.Number,
-            _ => throw new FormatException("Unknown cell type.")
-        };
-    }
+            case 1:
+                switch (typeAttribute[0])
+                {
+                    case 's': return CellValues.SharedString;
+                    case 'n': return CellValues.Number;
+                    case 'b': return CellValues.Boolean;
+                    case 'e': return CellValues.Error;
+                    case 'd': return CellValues.Date;
+                }
 
-    private static XLStyleValue ResolveCachedStyleValue(int styleIndex, StylesheetData styles,
-        Dictionary<int, XLStyleValue> styleList)
-    {
-        if (!styleList.TryGetValue(styleIndex, out var cellStyleValue))
-        {
-            cellStyleValue = ResolveStyleValue(styleIndex, styles);
-            styleList[styleIndex] = cellStyleValue;
+                break;
+
+            case 3:
+                if (typeAttribute.SequenceEqual("str"))
+                    return CellValues.String;
+                break;
+
+            case 9:
+                if (typeAttribute.SequenceEqual("inlineStr"))
+                    return CellValues.InlineString;
+                break;
         }
 
-        return cellStyleValue;
+        throw new FormatException("Unknown cell type.");
     }
 
     /// <summary>
@@ -557,31 +693,26 @@ internal static class WorksheetSheetDataReader
     /// bypassing <see cref="XLCell"/> allocation and <c>CalcEngine.MarkDirty</c>.
     /// An <see cref="XLCell"/> is only created for the rare rich-text shared-string path.
     /// </summary>
-    internal static void SetCellValue(CellValues dataType, string? cellValue,
+    internal static void SetCellValue(CellValues dataType, ReadOnlySpan<char> cellValue,
         XLCellsCollection cellsCollection, XLSheetPoint cellAddress, XLStyleValue cellStyleValue,
         XLWorksheet ws, SharedStringEntry[]? sharedStrings, bool inline,
         Dictionary<XLNumberFormatValue, XLDataType>? numberDataTypeCache = null)
     {
-        // Only String writes an empty value when v is null.
-        if (cellValue is null)
-        {
-            if (dataType == CellValues.String)
-                cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty, inline);
-            return;
-        }
-
+        // Number and SharedString are the bulk of any sheet and parse straight from the characters.
+        // String keeps the text, so it materializes one either way. Error and Date are rare enough
+        // that materializing a string for them is not worth a span-based parser.
         if (dataType == CellValues.Number)
             SetNumberCellValue(cellValue, cellsCollection, cellAddress, cellStyleValue, inline, numberDataTypeCache);
         else if (dataType == CellValues.SharedString)
             SetSharedStringCellValue(cellValue, cellsCollection, cellAddress, ws, sharedStrings, inline);
         else if (dataType == CellValues.String)
-            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, cellValue, inline);
+            cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, cellValue.ToString(), inline);
         else if (dataType == CellValues.Boolean)
             SetBooleanCellValue(cellValue, cellsCollection, cellAddress, inline);
         else if (dataType == CellValues.Error)
-            SetErrorCellValue(cellValue, cellsCollection, cellAddress, inline);
+            SetErrorCellValue(cellValue.ToString(), cellsCollection, cellAddress, inline);
         else if (dataType == CellValues.Date)
-            SetDateCellValue(cellValue, cellsCollection, cellAddress, inline);
+            SetDateCellValue(cellValue.ToString(), cellsCollection, cellAddress, inline);
     }
 
     /// <summary>
@@ -915,7 +1046,7 @@ internal static class WorksheetSheetDataReader
         return formula;
     }
 
-    private static void SetNumberCellValue(string cellValue, XLCellsCollection cellsCollection,
+    private static void SetNumberCellValue(ReadOnlySpan<char> cellValue, XLCellsCollection cellsCollection,
         XLSheetPoint cellAddress, XLStyleValue cellStyleValue, bool inline,
         Dictionary<XLNumberFormatValue, XLDataType>? numberDataTypeCache = null)
     {
@@ -930,7 +1061,7 @@ internal static class WorksheetSheetDataReader
         cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, cellNumber, inline);
     }
 
-    private static void SetSharedStringCellValue(string cellValue, XLCellsCollection cellsCollection,
+    private static void SetSharedStringCellValue(ReadOnlySpan<char> cellValue, XLCellsCollection cellsCollection,
         XLSheetPoint cellAddress, XLWorksheet ws, SharedStringEntry[]? sharedStrings, bool inline)
     {
         if (TryParseOoxmlNonNegativeInt(cellValue, out var sharedStringId)
@@ -949,11 +1080,11 @@ internal static class WorksheetSheetDataReader
             cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, string.Empty, inline);
     }
 
-    private static void SetBooleanCellValue(string cellValue, XLCellsCollection cellsCollection,
+    private static void SetBooleanCellValue(ReadOnlySpan<char> cellValue, XLCellsCollection cellsCollection,
         XLSheetPoint cellAddress, bool inline)
     {
-        var isTrue = string.Equals(cellValue, "1", StringComparison.Ordinal) ||
-                     string.Equals(cellValue, "TRUE", StringComparison.OrdinalIgnoreCase);
+        var isTrue = cellValue.SequenceEqual("1") ||
+                     cellValue.Equals("TRUE", StringComparison.OrdinalIgnoreCase);
         cellsCollection.ValueSlice.SetCellValueDuringLoad(cellAddress, isTrue, inline);
     }
 
@@ -1099,7 +1230,7 @@ internal static class WorksheetSheetDataReader
     /// Falls back to <see cref="double.TryParse(string, NumberStyles, IFormatProvider, out double)"/>
     /// for exponents, leading whitespace, leading '+', overflow, or any non-standard format.
     /// </summary>
-    private static bool TryParseOoxmlDouble(string s, out double result)
+    private static bool TryParseOoxmlDouble(ReadOnlySpan<char> s, out double result)
     {
         var len = s.Length;
         if (len == 0)
@@ -1158,7 +1289,7 @@ internal static class WorksheetSheetDataReader
     /// <paramref name="mantissa"/>. Advances <paramref name="i"/> past the digits and returns the
     /// number of digits consumed.
     /// </summary>
-    private static int ScanDigits(string s, ref int i, ref long mantissa)
+    private static int ScanDigits(ReadOnlySpan<char> s, ref int i, ref long mantissa)
     {
         var start = i;
         var len = s.Length;
@@ -1178,13 +1309,13 @@ internal static class WorksheetSheetDataReader
     /// <summary>
     /// Parse a row index attribute value. Row indices in OOXML are always positive integers.
     /// </summary>
-    private static int ParseRowIndex(string s)
+    private static int ParseRowIndex(ReadOnlySpan<char> s)
     {
         TryParseOoxmlNonNegativeInt(s, out var result);
         return result;
     }
 
-    private static bool TryParseOoxmlNonNegativeInt(string s, out int result)
+    private static bool TryParseOoxmlNonNegativeInt(ReadOnlySpan<char> s, out int result)
     {
         result = 0;
         var len = s.Length;

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -328,11 +328,10 @@ public partial class XLWorkbook
     {
         var styles = context.Styles;
         var sharedFormulasR1C1 = new Dictionary<uint, string>();
-        var styleList = new Dictionary<int, XLStyleValue>();
         var numberDataTypeCache = new Dictionary<XLNumberFormatValue, XLDataType>();
         PageSetupProperties? pageSetupProperties = null;
         var sheetDataContext = new WorksheetSheetDataReader.SheetDataReadContext(
-            styles, ws, sharedStrings, sharedFormulasR1C1, styleList, numberDataTypeCache,
+            styles, ws, sharedStrings, sharedFormulasR1C1, context.StyleCache, numberDataTypeCache,
             Use1904DateSystem, context.DynamicArrayCmIndexes);
         var sheetDataState = new WorksheetSheetDataReader.SheetDataReadState();
 


### PR DESCRIPTION
## Summary

Follows #171, which moved `<sheetData>` off `OpenXmlPartReader`. Three remaining sources of per-cell and per-entry garbage on the load path are removed, cutting allocations by **61%** and wall time by **16.5%** on the 250K x 15 load benchmark.

`XLiburReadBenchmarks.LoadWorkbook`, 250K rows x 15 cols, net8.0, `InProcessEmitToolchain`, Ryzen 9 5950X:

|                       | Mean    | Allocated  |
|-----------------------|--------:|-----------:|
| before                | 4.750 s | 1020.92 MB |
| SST + style cache     | 3.897 s |  775.78 MB |
| + chunked value reads | **3.968 s** | **392.88 MB** |

The final time is within noise of the intermediate reading (Error +/-0.03 s); the chunked reads buy allocation, not CPU. No save-path code is touched.

## Changes

- **Shared string table (`SharedStringReader`)** — read `<si>` entries with a raw `XmlReader` instead of materializing the whole `SharedStringTable` DOM. A plain `<si><t>text</t></si>` now yields just the decoded string; previously every entry cost two OpenXml elements plus an attribute collection that became garbage as soon as the text was extracted. Entries with runs or phonetic data still need the DOM for formatting extraction, so their subtree is rebuilt into a `SharedStringItem`. Richness is only knowable after the first child is consumed (a leading `<t>` may be followed by `<rPh>`), hence the re-serialization rather than a plain `ReadOuterXml`.
- **Cell and row attributes, and `<v>` content (`WorksheetSheetDataReader`)** — read values through `XmlReader.ReadValueChunk` into a reusable 64-char buffer and parse from the span. Every cell carries an `r` attribute and most carry a value, none of which is retained as a string, so these were millions of short-lived strings parsed to a point or number and immediately discarded. Content wider than the buffer still reads correctly via a `StringBuilder` fallback. `String`, `Error` and `Date` values still materialize a string, either because the text *is* the value or because the type is too rare to warrant a span parser.
- **Style resolution (`StyleValueCache`, new)** — replace the per-worksheet `Dictionary<int, XLStyleValue>` with a flat array indexed by `cellXfs` index, scoped to the workbook since `styles.xml` is workbook-global and resolution is a pure function of the index.

### Note on the approach

`ReadValueChunk` was verified with a throwaway allocation probe before being built on, rather than assumed: it works on **attribute** nodes as well as text, and removes **99.8%** of the allocation for that work (103.8 -> 0.2 bytes/cell).

A fourth candidate — remapping file-SST ids to workbook-SST ids to skip the `Dictionary<Text,int>` probe in `SharedStringTable.IncreaseRef` — was **deliberately not implemented**. Measured, it is ~750K probes at ~25-30 ns on the benchmark sheet: under 1% of load time and zero allocations, which does not justify the risk to shared-string reference counting (it drives `DecreaseRef`, free-list reuse, and what gets written back to the SST on save).

## Related Issues

<!-- none -->

## Testing

- [x] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually

Adds `SheetDataValueReadingTests` (12 cases) covering the buffer-overflow fallback that well-formed files never reach: long text and formula string results, high-precision numbers, whitespace-only and padded text, `_xHHHH_` escapes, and a shared string table mixing rich and plain entries.

Full suite green on **both** target frameworks: 6,290 passed / 0 failed on net8.0 and net10.0.

One new test initially failed; I stashed the change and re-ran it against unmodified `main`, where it failed identically. The cause is pre-existing and on the *write* path: doubles are serialized with `"G15"` by deliberate policy in `ObjectExtensions.ToInvariantString`, so values wider than 15 significant digits already lose precision on save. The test was narrowed accordingly and documents why. Worth knowing before anyone rewrites `WriteNumberValue` with a span-based `TryFormat` — it must target `G15`, not `"R"`/shortest-round-trip, or output changes for every workbook.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
