### PR TITLE
docs: add top-10 improvement roadmap specs (perf, features, compat, architecture)

### DIFF
--- a/docs/specs/01-streaming-write-api.md
+++ b/docs/specs/01-streaming-write-api.md
@@ -1,0 +1,106 @@
+# Spec 01 — Streaming (Forward-Only) Write API for Large Workbooks
+
+**Area:** Feature + Architecture + Performance (memory)
+**Effort:** L (2–4 weeks)
+**Dependencies:** None (but coordinate with Spec 03 — both touch `SheetDataWriter`)
+**Status:** Proposed
+
+## Summary
+
+Add a forward-only, row-at-a-time streaming writer (analogous to POI's SXSSF or OpenXmlWriter) so callers can produce arbitrarily large .xlsx files with bounded memory. Today the entire workbook must be materialized in the in-memory slice model before `SaveAs` runs; a 5M-row export costs GBs of resident memory even though the write path itself is already streaming XML.
+
+## Motivation
+
+- `SheetDataWriter.StreamSheetData` already streams `<sheetData>` via raw `XmlWriter` — but it can only read from a fully materialized `XLWorksheet`. The storage, not the serializer, is the memory ceiling.
+- Benchmarks: 50K rows × 3 cols save allocates ~543 MB; resident slice memory is ~16–32 bytes/cell plus styles. At 5M+ rows the in-memory model is the blocker, not CPU.
+- Competing libraries (EPPlus streaming, MiniExcel, POI SXSSF) win large-export scenarios on this feature alone.
+
+## Current state (file pointers)
+
+- `XLibur/Excel/IO/SheetDataWriter.cs` (750 lines) — hot loop; takes concrete `XLWorksheet`, `SaveContext`, `SaveOptions`. Signature: `StreamSheetData(XmlWriter, XLWorksheet, SaveContext, SaveOptions)`. No abstraction seam.
+- `XLibur/Excel/IO/WorksheetPartWriter.cs` — builds detached OpenXML DOM for non-sheetData elements, then re-emits via its own `XmlWriter` over the part stream, splicing in `StreamSheetData`.
+- `XLibur/Excel/Cells/SharedStringTable.cs` (232 lines) — workbook-global, refcounted; SST is written after sheets by `SharedStringTableWriter.cs`.
+- `XLibur/Excel/XLWorkbook_Save.cs` (1002 lines) — `CreateParts` orchestration.
+- All IO classes are `internal static`. No async, no `CompressionLevel` control (zip goes through the OpenXML SDK / `System.IO.Packaging`).
+
+## Design
+
+### Phase 1 — Extract the data-source seam (internal refactor)
+
+Introduce an internal interface consumed by `SheetDataWriter`:
+
+```csharp
+internal interface IXLSheetDataSource
+{
+    // Forward-only enumeration of non-empty rows in ascending row order.
+    IEnumerable<XLRowData> EnumerateRows();
+}
+```
+
+where `XLRowData` exposes row number, row properties (height/style/hidden), and a forward-only cell enumerator yielding `(column, XLCellValue value, styleId, formula?)`. Adapt the existing `SlicesEnumerator` path into an implementation backed by `XLWorksheet`. **Zero behavior change; all existing tests must pass unchanged.** Benchmark `CreateAndSave` before/after — regression budget ≤ 2% time, 0% allocation.
+
+### Phase 2 — Public streaming writer
+
+New public entry point (new file area `XLibur/Excel/Streaming/`):
+
+```csharp
+public sealed class XLStreamingWorkbook : IDisposable
+{
+    public static XLStreamingWorkbook Create(Stream output, XLStreamingOptions? options = null);
+    public XLStreamingWorksheet AddWorksheet(string name);
+    public void Finish();   // writes SST, styles, workbook part, closes package
+}
+
+public sealed class XLStreamingWorksheet
+{
+    public IXLStyle RowStyle { get; }           // style applied to next appended row
+    public void AppendRow(params XLCellValue[] values);
+    public void AppendRow(ReadOnlySpan<XLCellValue> values, IXLStyle? style = null);
+    public void SkipRows(int count);
+    public void Complete();                      // closes the worksheet part
+}
+```
+
+Constraints (document clearly): rows append-only in ascending order; one worksheet open at a time; no formula recalculation (formula strings pass through verbatim); no reading back.
+
+Implementation notes:
+- Reuse `SheetDataWriter` cell-serialization internals via the Phase-1 seam — a streaming worksheet is just another `IXLSheetDataSource` whose enumeration is driven by the caller.
+- SST strategy is an option: `SharedStrings` (default, dictionary built incrementally, written at `Finish()`) or `InlineStrings` (zero SST memory, larger files). The dictionary is the only unbounded memory in shared mode — call this out in docs.
+- Styles: accept `IXLStyle` and intern to `XLStyleValue` via the existing repositories; styles part written at `Finish()`.
+- Worksheet parts must be written before the workbook part is finalized — the OpenXML SDK supports adding parts incrementally; if part-stream lifetime under `System.IO.Packaging` proves awkward, fall back to writing sheet XML to temp `FileStream`s and copying into the package at `Finish()` (POI approach). Prototype this risk first (task P2.1).
+
+### Phase 3 (stretch) — `CompressionLevel` + async save
+
+While in this area: expose `SaveOptions.CompressionLevel` if feasible via the SDK, and add `SaveAsAsync`/`FinishAsync`. If `System.IO.Packaging` blocks both, record findings in the spec and split into a follow-up.
+
+## Work plan
+
+| # | Task | Size |
+|---|------|------|
+| P1.1 | Define `IXLSheetDataSource`/`XLRowData`, adapt `SheetDataWriter` to consume it | M |
+| P1.2 | `XLWorksheet`-backed implementation over `SlicesEnumerator`; benchmark parity | M |
+| P2.1 | Spike: incremental part writing under OpenXML SDK 3.x (or temp-file fallback) | S |
+| P2.2 | `XLStreamingWorkbook`/`XLStreamingWorksheet` public API + options | M |
+| P2.3 | SST incremental build + inline-strings mode | S |
+| P2.4 | Style interning for streaming rows | S |
+| P2.5 | Tests: round-trip via full `XLWorkbook.Load`, Excel-opens-clean validation, 1M-row memory test (assert peak working set bound) | M |
+| P2.6 | Benchmark class `StreamingWriteBenchmarks` (vs `CreateAndSave` and vs raw OpenXML SDK) | S |
+| P3.1 | CompressionLevel / async spike + implementation or writeup | M |
+
+## Acceptance criteria
+
+1. Writing 1,000,000 rows × 10 cols via the streaming API stays under **150 MB peak managed heap** (measure with the `MemoryProfile.cs` harness pattern).
+2. Output opens in Excel with no repair dialog; `XLWorkbook.Load` round-trips values, styles, and formula strings.
+3. Streaming write of the 50K-row benchmark scenario is ≥ as fast as `CreateAndSave` and allocates ≤ 25% of it.
+4. No public-API breaks; `PublicApiAnalyzers` updated for additions only.
+5. Existing test suite green; new tests in `XLibur.Tests/Excel/Streaming/`.
+
+## Risks
+
+- OpenXML SDK part-stream lifetime may force the temp-file fallback (adds disk I/O; still bounded memory). De-risk with task P2.1 first.
+- API design is permanent — keep surface minimal (append-only) for v1; no cell-level random access.
+
+## References
+
+- Architecture survey: `SheetDataWriter` has no seam; `ISlice` is a shift contract, not a data-source abstraction.
+- Benchmarks: `XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs`, results under `BenchmarkDotNet.Artifacts/results/`.

--- a/docs/specs/02-load-path-allocations.md
+++ b/docs/specs/02-load-path-allocations.md
@@ -1,0 +1,70 @@
+# Spec 02 — Load-Path Allocation Elimination (sheetData, SST, styles)
+
+**Area:** Performance (read time + memory)
+**Effort:** M (1–2 weeks, three independent sub-tasks)
+**Dependencies:** None. Builds on PR #171 (raw `XmlReader` sheetData pass).
+**Status:** Proposed
+
+## Summary
+
+PR #171 moved `<sheetData>` parsing off `OpenXmlPartReader` (load: 6504 ms / 2357 MB → 4218 ms / 1017 MB on the 250K×15 benchmark). Three large allocation sources remain, each independently fixable: (1) per-cell transient strings for attributes and `<v>` content, (2) the shared-string table still being read through the full OpenXML DOM, and (3) per-cell dictionary probes for shared-string re-interning and style resolution. Target: **load ≤ 3.2 s / ≤ 600 MB** on the 250K×15 benchmark.
+
+## Current state (verify before starting — line numbers drift)
+
+- `XLibur/Excel/IO/WorksheetSheetDataReader.cs` (~1232 lines):
+  - `LoadCellXml` (~line 234): reads `reader.Value` (string alloc) for attributes `r`, `s`, `t`, `ph`, `cm`, `vm` — `r`/`s`/`cm`/`vm` are immediately parsed to ints and discarded.
+  - `LoadCellContentXml` (~line 340): `reader.ReadElementContentAsString()` on `<v>` allocates a string per numeric cell, parsed to `double` and thrown away. ~3.75M transient strings on the benchmark sheet. **This is the single biggest remaining load allocation.**
+  - `SetSharedStringCellValue` (~line 933): parses SST index from the `<v>` string, then `SetCellValueDuringLoad` → `_sst.IncreaseRef(text)` — a `Dictionary<string,int>` probe per cell to re-intern a string already unique in the file's SST.
+  - `ResolveCachedStyleValue` (~line 543): `Dictionary<int, XLStyleValue>` probe per styled cell; `GetInheritedStyleFast` (~line 514) runs per cell. styleIndex is dense and small — an array fits.
+- `XLibur/Excel/IO/SharedStringReader.cs`: builds the entire `SharedStringTablePart.SharedStringTable` OpenXML DOM, then iterates `Elements<SharedStringItem>()`. Pre-sized `SharedStringEntry[]` exists, but the DOM is still fully materialized and discarded.
+
+## Design
+
+### Task A — SST via raw `XmlReader` (biggest bang for string-heavy files)
+
+Rewrite `SharedStringReader` with the same raw-`XmlReader` treatment as PR #171:
+- Stream `<si>` items; plain `<t>` items → `string` direct; rich-text `<si>` (has `<r>` runs) → fall back to parsing runs into `XLImmutableRichText` (keep existing rare-path behavior; if complex, `ReadOuterXml` + DOM for rich items only is acceptable).
+- Honor `uniqueCount` for pre-sizing (already done — keep).
+
+### Task B — File-SST → workbook-SST id remap
+
+Build an `int[] sstRemap` once after reading the file SST: `sstRemap[fileId] = workbookSstId`, populated via one `IncreaseRef` pass over unique strings (refcount 0 initially, incremented per cell reference by array math instead of dictionary probes). Then `SetSharedStringCellValue` becomes: parse index → `sstRemap[index]` → store id + bump refcount directly. Replaces ~3.75M dictionary probes with array lookups.
+- Requires an internal `SharedStringTable` API to increase refcount by id (exists conceptually — check `IncreaseRef` overloads) and to bulk-reserve capacity.
+
+### Task C — Dense style array + numeric `<v>` without string
+
+1. Replace `Dictionary<int, XLStyleValue> StyleList` with `XLStyleValue?[]` indexed by styleIndex (size = cellXfs count, known up front).
+2. Attributes: for integer-valued attributes use `reader.MoveToAttribute` + a small helper that parses via `XmlReader.ReadContentAsInt()` where the implementation avoids the intermediate string, or parse `reader.Value` once into a reused position. Measure — if `ReadContentAsInt` still allocates internally on this reader, keep strings for attributes (they're smaller than `<v>`) and document why.
+3. `<v>` numeric content: try `reader.ReadElementContentAsDouble()` first and measure allocations (it may bypass the string on `XmlTextReaderImpl`). If it doesn't, the fallback design is a UTF-8 side-parse: read the raw part stream through a custom minimal scanner only for the `<v>` hot path. **Do not build a full custom XML parser in this task** — if `ReadElementContentAsDouble` doesn't pay off, record measurements and stop; the UTF-8 tokenizer becomes its own follow-up spec.
+
+## Work plan
+
+| # | Task | Size | Independent? |
+|---|------|------|--------------|
+| A | SST raw-XmlReader rewrite | M | Yes |
+| B | SST id remap array (needs A's entry array, coordinate) | S | After A |
+| C1 | Dense style array | S | Yes |
+| C2 | `ReadElementContentAsDouble` / attribute-alloc measurements + fixes | M | Yes |
+| D | Update `XLiburReadBenchmarks` results + `MemoryProfile` snapshots; record before/after in PR | S | Last |
+
+## Measurement protocol (required for every PR)
+
+1. `dotnet run -c Release --project XLibur.Benchmarks/XLibur.Benchmarks.csproj -- --filter '*XLiburReadBenchmarks*'`
+2. dotMemory snapshots via `dotnet run -c Release --project XLibur.Benchmarks/XLibur.Benchmarks.csproj -- profile` (writes `.dmw` to `C:\profiles\`).
+3. Report time + allocated + peak in the PR description, per the format used in PR #171.
+
+## Acceptance criteria
+
+1. 250K×15 `LoadAndReadAllCells`: load phase allocations reduced ≥ 35% from current main; wall time reduced ≥ 15%. No regression in `CreateAndSave`.
+2. All existing tests green, including rich-text SST round-trip tests, phonetics, and inline-string tests.
+3. Behavior identical for: missing `uniqueCount`, out-of-range SST index (must keep current error/tolerance behavior — check tests first), duplicate strings in file SST (legal per spec).
+
+## Risks
+
+- File SSTs can legally contain duplicate strings; the remap must map two file ids to one workbook id without breaking refcounts.
+- `XmlReader` typed-content methods differ across reader implementations — measure, don't assume.
+
+## References
+
+- PR #171 (`bcb180b4`) for the established pattern and PR-description format.
+- Perf survey notes: SST DOM, per-cell probes, `<v>` string allocs identified as the top three remaining load costs.

--- a/docs/specs/03-save-path-allocations.md
+++ b/docs/specs/03-save-path-allocations.md
@@ -1,0 +1,52 @@
+# Spec 03 — Save-Path Allocation Reduction (543 MB → target ≤ 350 MB)
+
+**Area:** Performance (write time + memory)
+**Effort:** M (1–2 weeks, mostly independent small tasks)
+**Dependencies:** Coordinate with Spec 01 (both touch `SheetDataWriter`); land this first or rebase.
+**Status:** Proposed
+
+## Summary
+
+The 50K-row formatted save (`CreateFormattedAndSave`) allocates ~543 MB and has barely moved while wall time halved — allocation is the remaining lever on the write path. The cell loop itself is already tuned (single slice pass, reusable cell-ref buffer, style memo); the remaining costs are number→string formatting, per-cell inherited-style resolution, style-key hashing, and a handful of known small items.
+
+## Current state (verify line numbers before starting)
+
+- `XLibur/Extensions/XmlWriterExtensions.cs` — `WriteNumberValue` formats doubles via `double.ToInvariantString()`, one string per numeric/date cell (~100K+ per benchmark save).
+- `XLibur/Excel/XLWorksheet.cs` (~line 1671) — `GetStyleValue(point)` falls through to `GetInheritedStyleValue` for every cell without an explicit style; runs **before** `SheetDataWriter.ResolveCellStyleId`'s last-value memo can help.
+- `XLibur/Excel/IO/SheetDataWriter.cs` — `CollectTableTotalCells` allocates a `HashSet<XLSheetPoint>` and probes it per cell whenever any table has a totals row.
+- `XLibur/Excel/Style/XLStyleKey.cs` — `StyleKey_GetHashCode` benchmark: 40.7 ms/100K vs 12.0 ms for its worst component (`BorderKey`), 4.6/4.2/1.2 for Fill/Font/Color. The composite hash does redundant work.
+- `XLibur/Excel/Cells/SharedStringTable.cs` — no `EnsureCapacity`; 50K unique strings rehash the dictionary repeatedly during save/populate.
+- Benchmarks: `XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs` (`CreateAndSave`, `CreateFormattedAndSave`), `StyleKeyHashCodeBenchmarks.cs`, `AllocationBenchmarks.cs`.
+
+## Work plan (each task = one small PR, benchmark before/after in description)
+
+| # | Task | Detail | Size |
+|---|------|--------|------|
+| 1 | Span-based number write | In `WriteNumberValue`: `Span<char> buf = stackalloc char[24]; value.TryFormat(buf, out int len, "R"/G17-equivalent, CultureInfo.InvariantCulture)` then `WriteRaw(char[], ...)` via a reusable `char[]` (XmlWriter.WriteRaw has no span overload — reuse a cached buffer). **Must produce byte-identical output** to `ToInvariantString` for round-trip stability — add a property-based test comparing both formatters over random doubles, ints, dates. | S |
+| 2 | Inherited-style memo | In the save loop, memoize `GetStyleValue` results per (row-style, column-style) pair — for a typical sheet most cells inherit the same worksheet/column style. Cache last row's resolved inherited value; invalidate on row change. Profile first to confirm this is the hot allocation (dotMemory `profile` harness). | M |
+| 3 | StyleKey hash caching | `XLStyleValue` is immutable — compute the full hash once in the constructor and store it (`_cachedHashCode`), or fix `XLStyleKey.GetHashCode` to combine pre-computed component hashes instead of re-hashing all fields. Verify with `StyleKeyHashCodeBenchmarks`. | S |
+| 4 | Table-totals guard | Skip `CollectTableTotalCells` + per-cell `Contains` entirely when `worksheet.Tables.All(t => !t.ShowTotalsRow)` (or count == 0). | XS |
+| 5 | SST `EnsureCapacity` | Add `internal void EnsureCapacity(int)` to `SharedStringTable`; call from bulk populate paths and from the SST load path (Spec 02 Task B uses it too). | XS |
+| 6 | Repository dead-entry sweep | `XLRepositoryBase` (`XLibur/Excel/Caching/`) uses non-generic `WeakReference` per entry and never prunes dead ones. Switch to `WeakReference<T>` and add an opportunistic prune (e.g., every N misses). Long-lived processes creating many workbooks currently accumulate shells. | S |
+| 7 | Profile-verify remainder | After 1–6, take a fresh dotMemory snapshot of `CreateFormattedAndSave`; file follow-up issues for anything ≥ 5% of remaining allocations (likely `XmlWriter` internals and `System.IO.Packaging` — note but don't chase; that's Spec 01 Phase 3 territory). | S |
+
+## Measurement protocol
+
+Same as Spec 02: BenchmarkDotNet filter `'*XLiburWorkbookBenchmarks*'` + dotMemory `profile` harness; before/after table in every PR description.
+
+## Acceptance criteria
+
+1. `CreateFormattedAndSave` allocated bytes reduced ≥ 30% total across the task series (543 MB → ≤ 380 MB; stretch ≤ 350 MB); wall time not regressed.
+2. Saved output byte-identical (or semantically identical — same values after reload) versus main for the full test corpus; number formatting round-trip test added (task 1).
+3. `StyleKey_GetHashCode` benchmark ≤ 15 ms/100K (from 40.7).
+4. All tests green; no public API changes.
+
+## Risks
+
+- Task 1 formatting parity: `double.ToInvariantString` may use shortest-round-trip ("R"-like) semantics — match exactly; Excel files store shortest-round-trip doubles. The property test is mandatory, not optional.
+- Task 2 can add complexity for marginal gain if the profile doesn't confirm — profile first, implement second.
+
+## References
+
+- Memory notes: prior allocation plan identified items 1, 4, 5 plus the (already-landed) cell-loop optimizations.
+- Perf survey: 543 MB headline, StyleKey hash numbers, repository WeakReference accumulation.

--- a/docs/specs/04-demand-driven-formula-eval.md
+++ b/docs/specs/04-demand-driven-formula-eval.md
@@ -1,0 +1,81 @@
+# Spec 04 — Demand-Driven Formula Evaluation (kill the full-recalc cliff)
+
+**Area:** Performance (read time + memory) + Architecture (calc engine)
+**Effort:** L (2–3 weeks; subtle correctness work)
+**Dependencies:** None. Read `docs/dynamic-array-spill-phase-b.md` first — spill ownership interacts with recalc.
+**Status:** Proposed
+
+## Summary
+
+Reading `cell.Value` on a dirty formula cell can trigger **full-workbook recalculation**: `XLCell.Evaluate` tries `TryEvaluateSingleCell` and, on any `GettingDataException` (formula references another dirty cell), falls back to `CalcEngine.Recalculate(wb, null)` — which lazily builds the full `XLCalculationChain` + `DependencyTree` (~176 MB for 250K formulas) and iterates every formula in the workbook. The fix: evaluate the *precedent closure* of the requested cell recursively instead of falling back to everything.
+
+## Current state
+
+- `XLibur/Excel/CalcEngine/XLCalcEngine.cs` (670 lines) — `TryEvaluateSingleCell` (single-cell fast path, no tree), `Recalculate` (full chain), `MarkDirty` (builds `DependencyTree` lazily when `_needsDependencyTree`).
+- `XLibur/Excel/Cells/XLCell.cs` — `Evaluate(force)` (~line 338): clean-check via `Formula.IsDirty(workbook)` is cheap (epoch compare); dirty → `TryEvaluateSingleCell` → fallback `Recalculate(wb, null)`.
+- `XLibur/Excel/CalcEngine/DependencyTree.cs` (404 lines) — real dependency graph; per-sheet `RBush<AreaDependents>` R-trees; built by full workbook scan in `CreateFrom`.
+- `XLibur/Excel/CalcEngine/XLCalculationChain.cs` (411 lines) — intrusive linked chain + `Dictionary<XLBookPoint, Link>`; uses `GettingDataException` to reorder evaluation when a formula reads a dirty precedent.
+- Dirty tracking is epoch-based: `XLCellFormula._evalEpoch` vs `XLWorkbook.EditEpoch` — any edit conceptually dirties the whole book; RBush + explicit-dirty flags refine it.
+- Known history: an earlier attempt to lazily build the tree inside `MarkDirty` failed on unparseable formulas (external workbook refs, legacy TABLE) and unexpected build timing (`Mark_dirty_wont_crash_on_cycle`). Design around this: **the demand-driven path must not require the tree at all.**
+
+## Design
+
+### Core: recursive demand evaluation with cycle guard
+
+Replace the `TryEvaluateSingleCell`-or-full-recalc dichotomy with:
+
+```
+EvaluateOnDemand(cell):
+    if formula is clean → return cached
+    push cell onto evaluation stack (detect cycles → #REF!/circular handling per existing semantics)
+    evaluate AST; when the evaluator reads another cell:
+        if that cell has a dirty formula → EvaluateOnDemand(it) first (recurse)
+        else → read its slice value directly
+    store result, stamp _evalEpoch, pop stack
+```
+
+This is textbook demand-driven recalc (what `GettingDataException` + chain-reordering approximates globally, done locally). Concretely:
+
+1. Add an evaluation-stack (reused `List<XLBookPoint>` + `HashSet<XLBookPoint>` on the engine, cleared per top-level call) for cycle detection. On cycle: match Excel semantics already implemented for the chain (see how `XLCalculationChain` + cycle tests handle it — `Mark_dirty_wont_crash_on_cycle` and friends define expected behavior).
+2. The hook point is where `CalculationVisitor`/`CalcContext` dereferences a cell value and currently throws `GettingDataException` for dirty cells. Instead of throwing, call back into demand evaluation. Keep the exception path intact for the full-`Recalculate` chain mode — add a mode flag on `CalcContext` rather than changing global behavior.
+3. Depth limit (e.g. 10_000) to avoid stack issues on pathological chains — it's an explicit iterative stack, not CPU recursion, so the limit is about runaway work, not StackOverflow. On hitting the limit, fall back to full `Recalculate` (current behavior) — correctness is preserved.
+4. **Unparseable formulas** (external refs, TABLE): if a precedent's formula can't be parsed, treat as current behavior (its cached value is used / full-recalc fallback). Never let demand evaluation crash where full recalc wouldn't.
+
+### Secondary: don't build the dependency tree for read-only workloads
+
+`MarkDirty` currently wants the tree. For the load-then-read pattern there are no edits, so the tree is never needed — verify that plain `Load` + `Value` reads with this change never construct `DependencyTree`/`XLCalculationChain` (assert via test with an internal counter or by checking `_dependencyTree is null` after the read pass).
+
+Edits after reads must still propagate dirtiness correctly: the epoch mechanism already dirties everything on edit, so post-edit reads re-evaluate via the demand path. Confirm the two historically-failing scenarios are covered by tests: `EditCellInvalidatesDependentCells`, `RecalculateAllFormulas_recalculates_all_formulas_in_sheet_and_leaves_rest_dirty`.
+
+### Interaction with spill (dynamic arrays)
+
+A dirty spill-owner formula must be evaluated as a whole (its footprint cells derive from it). When demand evaluation hits a cell inside a spill footprint, resolve to the owner formula and evaluate that. See `TryGetDirtySpillOwner` in `XLCalcEngine` — reuse it. Add tests: read a cell in the middle of a dirty spill range.
+
+## Work plan
+
+| # | Task | Size |
+|---|------|------|
+| 1 | Read the chain/`GettingDataException` flow end-to-end; write a short design note in the PR confirming/adjusting the hook point | S |
+| 2 | Demand-evaluation with explicit stack + cycle detection behind `CalcContext` mode flag | L |
+| 3 | Wire `XLCell.Evaluate` to demand path; remove full-recalc fallback except for depth-limit/parse-failure cases | S |
+| 4 | Spill-owner resolution in demand path + tests | M |
+| 5 | Tests: cycles, cross-sheet precedents, dirty ranges (`SUM(A:A)` with dirty cells in area), post-edit invalidation, unparseable precedents | M |
+| 6 | Benchmark: 250K×15 `LoadAndReadAllCells` read phase; add a formula-heavy read benchmark (e.g. 100K formula cells, read 100 random) demonstrating O(precedents) not O(workbook) | S |
+
+## Acceptance criteria
+
+1. Reading one dirty formula whose precedents are plain values: no `DependencyTree`, no `XLCalculationChain` construction, no workbook-wide iteration.
+2. Reading 100 random formula cells out of 100K dirty formulas evaluates ≤ (100 × average precedent closure) formulas — verified with an internal evaluation counter in a test.
+3. All existing calc-engine tests green, including cycle tests and the two dirty-propagation tests named above.
+4. 250K×15 read-phase time and allocations improve or hold (the earlier prototype suggested large wins when formulas reference values; formula-chain sheets are the new win).
+5. Full `Recalculate()`/`RecalculateAllFormulas()` public behavior unchanged.
+
+## Risks
+
+- Correctness. This is the highest-risk spec in the set: evaluation order and cycle semantics must match Excel/current behavior. Mitigate by keeping the chain-based full recalc untouched and diffing results: add a test harness that evaluates a corpus of workbooks both ways and compares every cached value.
+- Volatile functions (NOW, RAND, OFFSET/INDIRECT dependencies): check how `DependenciesVisitor` flags them today; demand evaluation must not cache-and-skip volatiles differently than full recalc. Add explicit tests.
+
+## References
+
+- Prior in-progress work (`TryEvaluateSingleCell`) and its two failing tests — that attempt is the starting point, this spec is its completion with a sounder strategy.
+- `docs/dynamic-array-spill-phase-b.md` for spill architecture.

--- a/docs/specs/05-structural-edit-scalability.md
+++ b/docs/specs/05-structural-edit-scalability.md
@@ -1,0 +1,77 @@
+# Spec 05 — Structural-Edit & Bulk-Style Scalability (rows insert, range shift, style propagation)
+
+**Area:** Architecture + Performance
+**Effort:** L (2–3 weeks; can split into 3 independent PRs)
+**Dependencies:** None.
+**Status:** Proposed
+
+## Summary
+
+Row/column insert-delete and range-wide style changes are the two operations most at odds with the otherwise-excellent slice architecture. Inserting N rows one at a time is O(N × liveRanges·log(liveRanges)) because every insert materializes and sorts **every live range in the worksheet**; a range-wide style change materializes an `XLCell` object **per cell**. Both should be index-driven and slice-driven respectively.
+
+## Current state
+
+1. **Range-shift notification** — `XLibur/Excel/XLWorksheet.cs` (~lines 1166–1234), `NotifyRangeShiftedRows`/`NotifyRangeShiftedColumns`:
+   ```csharp
+   var rangesToShift = _rangeRepository
+       .Where(r => r.RangeAddress.IsValid)
+       .OrderBy(r => r.RangeAddress.FirstAddress.RowNumber * -Math.Sign(rowsShifted))
+       .ToList();
+   ```
+   Full materialize + sort of every live range per single insert/delete, then a virtual dispatch per range.
+2. **Per-cell formula shifting** — `XLRangeBase.Delete` loops cells calling `ShiftFormulaRows` per cell; `AllocationBenchmarks` shows `ShiftFormulaRows` as the worst micro-benchmark (2.61 ms / 3.6 MB per 1000 iterations).
+3. **Style propagation** — `XLibur/Excel/Style/XLStylizedBase.cs` (145 lines): `ModifyStyle` → `GetChildrenRecursively` builds a `HashSet<XLStylizedBase>` of every descendant then `.GroupBy(...)` — one `XLCell` per cell in the range. `SetStyle(..., propagate: true)` recursive-walks `Children`.
+4. **Two independent spatial indexes** — `XLibur/Excel/Ranges/Index/XLRangeIndex.cs` (265 lines) uses a QuadTree (`XLibur/Excel/Patterns/`, 391 lines) with a `MinimumCountForIndexing` threshold, below which `Contains`/`GetIntersectedRanges` degrade to linear `Any(...)` scans. The calc engine separately uses `RBush<AreaDependents>` (RBush.Signed package) in `DependencyTree`. Two structures, two maintenance paths.
+5. **Misc:** `XLRanges.Ranges` re-enumerates `_indexes.Values.SelectMany(...)` on every access; `XLCellsCollection.FindUsedColumn` (~lines 340–368) builds a LINQ `Concat×4 → Where → Distinct → OrderBy` chain per `FirstColumnUsed`/`LastColumnUsed` call.
+
+## Design — three independent workstreams
+
+### A. Batch + index-driven range shift
+
+1. **Index-driven query:** replace the `_rangeRepository.Where(...).OrderBy(...).ToList()` scan with a query against `XLRangeIndex`: only ranges intersecting or below/right of the shift line can be affected. Ranges fully above an inserted row don't need visiting at all.
+2. **Batch semantics:** `InsertRowsAbove(n)` and worksheet-level bulk operations must notify **once** with the full shift delta, not n times. Audit call sites: `XLRow.InsertRowsAbove/Below`, `XLRangeBase.InsertRowsAbove`, delete equivalents, and column twins. If the public API already passes `numberOfRows` down, verify a single notification happens (write a counting test first — it may partially work already).
+3. **Formula shifting:** `ShiftFormulaRows` per cell → shift at the `FormulaSlice` level: enumerate formulas in the affected region once, use `ClosedXML.Parser`-based transformation (see `CalcEngine/Visitors/FormulaTransformation.cs`, which already rents `ArrayPool<char>`) and skip formulas with no row-relative references cheaply.
+
+### B. Slice-level bulk style application
+
+`range.Style.Font.Bold = true` over 1M cells should not create 1M `XLCell` facades.
+
+1. Add an internal bulk path on the style machinery: for a rectangular target, iterate `StyleSlice` positions directly (existing `Slice` enumerators), applying the transition `XLStyleValue → XLStyleValue` via the existing 8-slot transition cache on `XLStyleValue`. Cells with no explicit style entry get the (single, computed-once) transitioned inherited style — only written to the slice if it differs from the new inherited value.
+2. Rework `XLStylizedBase.ModifyStyle`/`GetChildrenRecursively` so ranges/rows/columns/worksheets dispatch to the bulk path instead of materializing children. Non-cell stylized children (tables, CF) keep the object path.
+3. Benchmark: new `BulkStyleBenchmarks` (style 100K×10 range; assert allocations don't scale with cell count).
+
+### C. Spatial-index consolidation (evaluate, then do or document)
+
+Evaluate replacing the QuadTree in `XLRangeIndex` with `RBush.Signed` (already a dependency, already proven in `DependencyTree`):
+- Prototype `XLRangeIndex` on RBush; run range-heavy tests + a micro-benchmark (insert/query/remove 10K ranges).
+- If RBush wins or ties: delete `XLibur/Excel/Patterns/` QuadTree (~391 lines) — one structure to maintain. If it loses (RBush removal cost is a known weakness): write the finding into this spec and keep QuadTree.
+- Also fix `XLRanges.Ranges` re-enumeration (cache or expose a count-only path) and de-LINQ `XLCellsCollection.FindUsedColumn` (fold the 4-slice merge into a simple loop like the existing `ColumnsUsedKeys` cache did).
+
+## Work plan
+
+| # | Task | Size | PR |
+|---|------|------|----|
+| A1 | Counting test: notifications per `InsertRowsAbove(5)`; fix to single batch notify | S | 1 |
+| A2 | Index-driven `NotifyRangeShifted*` | M | 1 |
+| A3 | Slice-level formula shift | M | 2 |
+| B1 | Bulk style application path + rework `ModifyStyle` | L | 3 |
+| B2 | `BulkStyleBenchmarks` | S | 3 |
+| C1 | RBush-vs-QuadTree prototype + decision | M | 4 |
+| C2 | `FindUsedColumn` / `XLRanges.Ranges` de-LINQ | S | 4 |
+
+## Acceptance criteria
+
+1. Inserting 1,000 rows one-by-one into a sheet with 1,000 live ranges: ≥ 10× faster than main (add a benchmark demonstrating it).
+2. `InsertRowsAbove(1000)` (batch) triggers exactly one shift notification pass.
+3. Styling a 100K-cell range allocates O(distinct styles), not O(cells) — asserted in benchmark, and `GetChildrenRecursively` no longer enumerates cells for range targets.
+4. Zero behavior change: full test suite green, especially `XLibur.Tests` range/insert/delete/named-range/CF-shift tests (recent fixes #158, #142, #303e27c0 are the regression corpus — do not break them).
+5. If C1 consolidates: QuadTree deleted, RBush index passes all range-index tests.
+
+## Risks
+
+- Range-shift ordering matters (the `OrderBy` with `-Math.Sign(rowsShifted)` exists so overlapping ranges shift in the right order) — the index-driven replacement must preserve processing order semantics. Characterize with tests before changing.
+- `ModifyStyle` rework touches a base class used by everything stylized — do B behind thorough tests; consider a temporary internal feature flag for A/B validation in tests.
+
+## References
+
+- Architecture survey §5 (pain points), `AllocationBenchmarks.cs` (`ShiftFormulaRows`), recent regression-relevant fixes: #158 (CF shift), #142 (named range shrink), #157 (page break extents).

--- a/docs/specs/06-workbook-encryption.md
+++ b/docs/specs/06-workbook-encryption.md
@@ -1,0 +1,94 @@
+# Spec 06 — Password-Protected Workbook Support (ECMA-376 Encryption)
+
+**Area:** Feature + Compatibility
+**Effort:** L (3–4 weeks including interop testing)
+**Dependencies:** None.
+**Status:** Proposed
+
+## Summary
+
+XLibur cannot open or save password-encrypted Excel files — a hard blocker for users handling files from regulated environments. Encrypted .xlsx files are OLE Compound File Binary (CFB) containers holding an `EncryptionInfo` stream and an `EncryptedPackage` stream (the real .xlsx, AES-encrypted). Zero encryption code exists in the repo today (repo-wide grep for encrypt/agile/CryptoAPI: no hits). Note: this is distinct from sheet/workbook *protection* (password hashes controlling edit permissions), which already exists in `XLibur/Excel/Protection/`.
+
+**Authorization context:** this implements the documented ECMA-376 / MS-OFFCRYPTO standard so users can open/save their own password-protected spreadsheets — the same capability EPPlus, NPOI, and Aspose ship.
+
+## Scope
+
+| Capability | In scope |
+|---|---|
+| Read: **Agile Encryption** (Office 2010+, AES-128/256-CBC, SHA-512 key derivation) | ✅ required |
+| Read: **Standard Encryption** (Office 2007, AES-128-ECB derivation) | ✅ required (still common in the wild) |
+| Write: Agile Encryption (AES-256, SHA-512, Excel-default parameters) | ✅ required |
+| Write: Standard Encryption | ❌ no (obsolete; Excel hasn't written it since 2007) |
+| XOR-obfuscation / RC4 (legacy .xls-era) | ❌ no |
+| VBA project password, sheet protection | ❌ out of scope (different mechanisms) |
+
+## Design
+
+### Container layer: CFB (MS-CFB)
+
+Decision required up front (task 1): **evaluate OpenMcdf** (mature .NET CFB library, MPL-2.0) vs writing a minimal in-house CFB reader/writer.
+- OpenMcdf pro: battle-tested, fast. Con: MPL-2.0 dependency in an MIT project (MPL is file-level copyleft — legally compatible as a dependency, but the project has been conservative about licenses; flag to maintainer for sign-off before proceeding).
+- In-house pro: no dependency; encrypted-workbook CFB usage is a narrow subset (2 streams, small directory). MS-CFB is well documented; a read+write implementation limited to what Office emits is ~600–900 lines. Reference implementations to study (clean-room, don't copy GPL code): EPPlus (PolyForm), NPOI (Apache-2.0 — safe to study), msoffcrypto-tool (MIT).
+
+Recommendation: in-house minimal CFB (`XLibur/Excel/IO/Encryption/CompoundFile/`), unless maintainer approves the dependency.
+
+### Crypto layer (MS-OFFCRYPTO)
+
+All primitives exist in `System.Security.Cryptography` (Aes, SHA1/SHA512, HMACSHA*, RandomNumberGenerator) — no new packages.
+
+- **Agile read/write** (`EncryptionInfo` version 4.4, XML descriptor):
+  - Parse/emit the `<encryption>` XML (keyData, dataIntegrity, keyEncryptors/password).
+  - Key derivation: iterated SHA-512 spin (spinCount, default 100,000) over password (UTF-16LE) + salt; block-key variants for verifier hash input/value, key value, HMAC key/value.
+  - Package encryption: AES-CBC in 4096-byte segments, IV = H(keyData.salt ‖ segmentIndex).
+  - Integrity: HMAC over the encrypted package, verified on read, emitted on write.
+- **Standard read** (version 3.2/4.2 binary descriptor): AES key from SHA-1 iterated 50,000× + block index; verify via encryptedVerifier/Hash; package decrypted ECB (per spec, with the stream-size prefix).
+- Wrong password → throw a dedicated `XLInvalidPasswordException` (distinguish from corrupt-file errors).
+
+### API surface
+
+```csharp
+// Load
+new XLWorkbook(path, new LoadOptions { Password = "secret" });
+new XLWorkbook(stream, new LoadOptions { Password = "secret" });
+// Save
+workbook.SaveAs(path, new SaveOptions { Password = "secret" });  // Agile AES-256
+```
+
+- `LoadOptions.Password` (`string?`); `SaveOptions.Password` (`string?`).
+- Load flow: sniff CFB signature (`D0 CF 11 E0 ...`) → if encrypted and no password, throw `XLInvalidPasswordException` with a clear message → decrypt `EncryptedPackage` into a `MemoryStream` → existing load path unchanged.
+- Save flow: existing save into `MemoryStream` → encrypt → write CFB container. (Streaming encryption is possible later; MemoryStream first — files that fit in memory are the 99% case and the whole workbook is in memory anyway.)
+- Re-saving a workbook loaded with a password does **not** silently re-encrypt — password must be given explicitly on save (matches EPPlus behavior; least surprise, documented).
+
+## Work plan
+
+| # | Task | Size |
+|---|------|------|
+| 1 | CFB decision spike (OpenMcdf license sign-off vs in-house); if in-house: CFB reader | M |
+| 2 | CFB writer (only what Office needs: header, FAT, directory, 2 streams, mini-FAT) | M |
+| 3 | Agile `EncryptionInfo` XML parse/emit + key derivation + verifier | M |
+| 4 | Agile package decrypt/encrypt (segmented AES-CBC) + HMAC integrity | M |
+| 5 | Standard-encryption read path | S |
+| 6 | `LoadOptions.Password` / `SaveOptions.Password` wiring + `XLInvalidPasswordException` | S |
+| 7 | Test corpus: files encrypted by real Excel (agile AES-256 default, long/unicode/empty-edge passwords), by LibreOffice, by EPPlus; wrong-password, truncated-container, tampered-HMAC cases | M |
+| 8 | Round-trip: save-encrypted → open in Excel manually once + automated reopen via XLibur; document in PR | S |
+
+Tasks 1–2 and 3–4 can run in parallel (container vs crypto). Test files go in `XLibur.Tests/Resource/Encrypted/` with a generation README (which Excel version produced each).
+
+## Acceptance criteria
+
+1. Opens agile- and standard-encrypted files produced by Excel 2007–2024 and LibreOffice; wrong password throws `XLInvalidPasswordException`.
+2. Files saved with a password open in Excel (manual verification, recorded in PR) and in EPPlus/openpyxl (automated where licensing permits — openpyxl via a CI-optional script is fine to skip; EPPlus test project already references EPPlus for benchmarks, check license mode).
+3. Tampered ciphertext (flipped byte) fails the HMAC check with a clear error, not garbage data.
+4. No new NuGet dependency without maintainer license sign-off.
+5. Passwords handled as `string` per API convention but never logged; derived keys zeroed where practical (`CryptographicOperations.ZeroMemory`).
+
+## Risks
+
+- MS-OFFCRYPTO has many optional knobs; Excel only emits a narrow profile — implement to the profile, validate against the corpus, and reject unknown cipher/hash combinations explicitly rather than guessing.
+- CFB writer subtleties (mini-stream cutoff at 4096 bytes, sector chains) — the reopen-in-Excel test is the gate.
+
+## References
+
+- MS-OFFCRYPTO, MS-CFB (Microsoft open specifications).
+- NPOI `POIFS`/`CryptoAPI` (Apache-2.0) as a study reference.
+- Existing (different) feature: `XLibur/Excel/Protection/` — password *hashes* for edit protection, untouched by this spec.

--- a/docs/specs/07-formula-function-coverage.md
+++ b/docs/specs/07-formula-function-coverage.md
@@ -1,0 +1,58 @@
+# Spec 07 — Formula Function Coverage Expansion (257 → ~420 functions)
+
+**Area:** Feature
+**Effort:** L total, but **highly parallelizable** — 6 independent waves, each a self-contained PR assignable to a different agent/model.
+**Dependencies:** None (waves are independent). LET/LAMBDA are explicitly **excluded** — see Spec 08 (they need parser/scoping work, not registration).
+**Status:** Proposed
+
+## Summary
+
+The calc engine registers 257 functions vs Excel's ~500. The registry (`XLibur/Excel/CalcEngine/FunctionRegistry.cs`) is a single clean extension point, and recent PRs (#163–#168) established the pattern: implement in the matching `CalcEngine/Functions/*.cs` file, register with a signature adapter, test with Excel-verified values. This spec batches the missing functions into waves by category.
+
+## Pattern to follow (read these PRs first)
+
+- #165 (SMALL, RANK, PERCENTILE, QUARTILE, MODE), #166 (PV, NPV, IRR, RATE, NPER, PPMT), #163 (AVERAGEIF/S, MAXIFS, MINIFS), #168 (dynamic-array set).
+- Implementation files: `XLibur/Excel/CalcEngine/Functions/{MathTrig,Statistical,Text,DateAndTime,Lookup,Information,Database,Engineering,Logical,Financial,DynamicArray}.cs`.
+- Signature marshalling: `Functions/SignatureAdapter.cs` (1026 lines) — reuse existing adapters; add new arities only when unavoidable.
+- Value model: `ScalarValue`/`AnyValue` discriminated unions; error propagation must match Excel (e.g. #NUM! vs #VALUE! distinctions matter and are tested).
+- Tests: mirror existing test layout in `XLibur.Tests/Excel/CalcEngine/`; every function needs Excel-verified expected values (state in the test comment how values were verified), edge cases (empty args, wrong types, error propagation), and at least one in-worksheet evaluation test.
+
+## Waves (each = one PR, independently assignable)
+
+### Wave A — Financial (~28 functions) — file: `Financial.cs`
+`XIRR, XNPV, MIRR, FV (verify exists), IPMT, SLN, SYD, DB, DDB, VDB, ISPMT, CUMIPMT, CUMPRINC, EFFECT, NOMINAL, RRI, PDURATION, DOLLARDE, DOLLARFR, TBILLEQ, TBILLPRICE, TBILLYIELD, DISC, INTRATE, RECEIVED, FVSCHEDULE`
+Notes: XIRR/IRR-family use Newton–Raphson with bisection fallback — study the existing IRR/RATE implementations from #166 for the established root-finding approach. Day-count-basis functions (PRICE, YIELD, DURATION, MDURATION, ACCRINT, COUP*) are a **separate optional wave A2** — the 30/360 & actual/actual basis engine is its own chunk of work; don't block Wave A on it.
+
+### Wave B — Statistical, modern dotted set (~48) — file: `Statistical.cs`
+`NORM.DIST, NORM.INV, NORM.S.DIST, NORM.S.INV, LOGNORM.DIST, LOGNORM.INV, CHISQ.DIST, CHISQ.DIST.RT, CHISQ.INV, CHISQ.INV.RT, CHISQ.TEST, F.DIST, F.DIST.RT, F.INV, F.INV.RT, F.TEST, T.DIST, T.DIST.2T, T.DIST.RT, T.INV, T.INV.2T, T.TEST, Z.TEST, EXPON.DIST, POISSON.DIST, WEIBULL.DIST, GAMMA.DIST, GAMMA.INV, GAMMA, GAMMALN.PRECISE, BETA.DIST, BETA.INV, HYPGEOM.DIST, NEGBINOM.DIST, BINOM.DIST (verify), BINOM.INV, CONFIDENCE.NORM, CONFIDENCE.T, PERCENTILE.EXC, PERCENTILE.INC, QUARTILE.EXC, QUARTILE.INC, RANK.AVG, RANK.EQ, MODE.SNGL, MODE.MULT, PERCENTRANK.INC, PERCENTRANK.EXC` plus legacy aliases (`NORMDIST, NORMINV, NORMSDIST, NORMSINV, CHIDIST, CHIINV, CHITEST, FDIST, FINV, FTEST, TDIST, TINV, TTEST, ZTEST, EXPONDIST, POISSON, WEIBULL, GAMMADIST, GAMMAINV, BETADIST, BETAINV, HYPGEOMDIST, NEGBINOMDIST, CONFIDENCE, CRITBINOM`) which are thin aliases of the dotted implementations.
+Notes: needs an internal special-functions helper (incomplete gamma/beta, erf) — implement once in a shared internal static class with accuracy tests against published values (≥ 1e-10 relative where Excel achieves it). Check what MODE/PERCENTILE/QUARTILE from #165 map to and alias accordingly.
+
+### Wave C — Regression & descriptive statistics (~22) — file: `Statistical.cs`
+`FREQUENCY, LINEST, LOGEST, TREND, GROWTH, FORECAST, FORECAST.LINEAR, CORREL, PEARSON, COVARIANCE.P, COVARIANCE.S, COVAR, SLOPE, INTERCEPT, RSQ, STEYX, SKEW, SKEW.P, KURT, PROB, TRIMMEAN, HARMEAN, GEOMEAN (verify), AVEDEV (verify), DEVSQ (verify)`
+Notes: FREQUENCY/LINEST/TREND return arrays — they must integrate with the spill engine (see `Functions/DynamicArray.cs` and `docs/dynamic-array-spill-phase-b.md` for how array-returning functions spill).
+
+### Wave D — Engineering (~35) — file: `Engineering.cs`
+`COMPLEX, IMABS, IMAGINARY, IMARGUMENT, IMCONJUGATE, IMCOS, IMCOSH, IMCOT, IMCSC, IMCSCH, IMDIV, IMEXP, IMLN, IMLOG10, IMLOG2, IMPOWER, IMPRODUCT, IMREAL, IMSEC, IMSECH, IMSIN, IMSINH, IMSQRT, IMSUB, IMSUM, IMTAN, CONVERT, BESSELI, BESSELJ, BESSELK, BESSELY, ERF, ERF.PRECISE, ERFC, ERFC.PRECISE, DELTA, GESTEP, BITAND, BITOR, BITXOR, BITLSHIFT, BITRSHIFT`
+Notes: complex numbers are strings in Excel ("3+4i") — parse/format helper first. CONVERT needs the full unit table from Excel docs (large but mechanical). BIT* validate 48-bit ranges.
+
+### Wave E — Modern text + array shaping (~22) — files: `Text.cs`, `DynamicArray.cs`
+Text: `TEXTSPLIT, TEXTBEFORE, TEXTAFTER, VALUETOTEXT, ARRAYTOTEXT, UNICHAR, UNICODE, DBCS (stub per locale rules or document omission), ENCODEURL`
+Array shaping: `VSTACK, HSTACK, TOROW, TOCOL, WRAPROWS, WRAPCOLS, CHOOSEROWS, CHOOSECOLS, TAKE, DROP, EXPAND`
+Notes: array-shaping functions are pure array→array transforms on the existing `Array` type and spill like the #168 set — this wave is the natural follow-on for whoever did #168. TEXTSPLIT returns 2-D arrays and spills.
+
+### Wave F — Date/time + misc (~8) — files: `DateAndTime.cs`, `MathTrig.cs`
+`NETWORKDAYS.INTL, WORKDAY.INTL (weekend-string/number parameter engine, shared helper), DAYS (verify), ISOWEEKNUM (exists — skip), AGGREGATE (option-driven dispatch to existing functions, ignore-error/hidden modes; hidden-row awareness can defer with a documented limitation), SUBTOTAL (verify completeness of 101–111 hidden-row variants)`
+
+## Per-wave acceptance criteria
+
+1. Every function registered, implemented, and covered by tests with Excel-verified values including error cases; `FunctionRegistry` count increases accordingly.
+2. Excel parity on error types (#NUM!, #VALUE!, #DIV/0!, #N/A) for the tested cases.
+3. Array-returning functions spill correctly (Waves C, E) — at least one spill test each.
+4. No regressions: full `XLibur.Tests` green; build with `TreatWarningsAsErrors` clean.
+5. PR description lists functions added and any deliberate deviations/limitations (e.g. DBCS, AGGREGATE hidden-row mode) — these also go in the changelog.
+
+## Coordination notes for parallel execution
+
+- Waves B and C both edit `Statistical.cs` — run them sequentially or have C branch from B.
+- All waves touch `FunctionRegistry.cs` — keep registrations grouped by category in the file to minimize merge conflicts; rebase order A → D → E → F → B → C is conflict-minimal.
+- Shared special-functions helper (Wave B) should land before or within B; C may reuse it.

--- a/docs/specs/08-let-lambda.md
+++ b/docs/specs/08-let-lambda.md
@@ -1,0 +1,63 @@
+# Spec 08 — LET, LAMBDA, and Lambda-Helper Functions
+
+**Area:** Feature (calc engine core)
+**Effort:** L (2–4 weeks; parser/scoping work, not bulk registration)
+**Dependencies:** Independent of Spec 07, but land LET before LAMBDA. Interacts with the spill engine (`docs/dynamic-array-spill-phase-b.md`).
+**Status:** Proposed
+
+## Summary
+
+`LET` (named intermediate values) and `LAMBDA` (user-defined functions) plus the helper set (`MAP, REDUCE, SCAN, BYROW, BYCOL, MAKEARRAY, ISOMITTED`) are the most-requested modern Excel capabilities not coverable by simple function registration: they introduce **lexical scoping and function values** into a calc engine that currently has neither. Files using LET/LAMBDA today evaluate to errors in XLibur.
+
+## Current state
+
+- Evaluation: `XLibur/Excel/CalcEngine/CalculationVisitor.cs` (315 lines) walks the AST from ClosedXML.Parser; values are `AnyValue`/`ScalarValue` discriminated unions (`AnyValue.cs` 680 lines — cases: logical, number, text, error, Array, Reference).
+- Context: `CalcContext` carries workbook/sheet/address state per evaluation.
+- Functions dispatch through `FunctionRegistry` + `SignatureAdapter` — args are eagerly evaluated before the function body runs. **LET/LAMBDA cannot use this path**: LET binds names sequentially with later value-exprs referencing earlier names; LAMBDA's body must not evaluate at definition time.
+- Parser: ClosedXML.Parser 2.0 — **task 1 is verifying** it parses `LET(x, 1, x+1)` and `LAMBDA(x, x*2)(3)` (nested-call syntax where a function call's target is itself an expression) and how `_xlpm.`-prefixed parameter names surface in the AST. Excel stores lambda parameters as `_xlpm.x` and wraps names in `_xlfn.LET`/`_xlfn.LAMBDA` — check `FormulaConverter`/name-handling for how `_xlfn.` prefixes are already handled for other modern functions.
+
+## Design
+
+### Phase 1 — LET
+
+1. **Special-form evaluation.** Add a special-cases hook in `CalculationVisitor` for LET (bypass `SignatureAdapter` eager evaluation): evaluate value-exprs left to right, binding each name in an environment, then evaluate the body expression in that environment.
+2. **Environment.** A small immutable-ish scope chain on `CalcContext`: `sealed class XLNameEnvironment { XLNameEnvironment? Parent; Dictionary<string, AnyValue> Bindings; }` — lookups walk the chain; name resolution in the visitor consults the environment **before** defined-names/sheet names (Excel gives LET names precedence within scope). Case-insensitive comparer matching Excel name rules.
+3. **Name references in the AST**: LET names arrive as name/identifier nodes (likely with `_xlpm.` prefix from files, bare when typed via API). Normalize both.
+4. Round-trip: formulas containing LET must save/load verbatim (they already round-trip as strings — verify `_xlfn./_xlpm.` prefixes are preserved on save and hidden in the user-facing `Formula.A1` the same way existing `_xlfn` functions are handled).
+
+### Phase 2 — LAMBDA + invocation
+
+1. **Function values.** Add a `Lambda` case to `AnyValue` (parameters: `IReadOnlyList<string>`, body AST node reference, captured `XLNameEnvironment`). This is the deep cut — audit every `Match`/`TryPick` switch over `AnyValue` (compiler will find them once the case is added; the union is hand-rolled so follow the existing pattern for adding a case, see how `Array` is threaded through).
+2. **Definition:** LAMBDA as a special form returns the function value without evaluating the body. A LAMBDA evaluated as a cell's final result yields `#CALC!` (Excel behavior) unless invoked.
+3. **Invocation:** support call-on-expression `LAMBDA(...)(args)` and — the common storage form — lambdas bound via LET or **defined names** (a defined name whose refersTo is `=LAMBDA(...)` acts as a UDF). Defined-name lambda invocation is the highest-value entry point: check how `DefinedNames` resolution feeds the evaluator and allow a name to resolve to a lambda value that a call node can apply.
+4. **Recursion:** named lambdas may self-reference; guard with the calc engine's existing cycle/depth protections (coordinate with Spec 04 if it lands first — its evaluation stack is the natural place for the depth limit).
+
+### Phase 3 — Helpers
+
+`MAP, REDUCE, SCAN, BYROW, BYCOL, MAKEARRAY, ISOMITTED` — regular registered functions that take a lambda argument (now representable as `AnyValue.Lambda`) and apply it element-/row-/column-wise, producing arrays that spill via the existing engine. `ISOMITTED` requires optional-parameter plumbing in lambda invocation (omitted args bind a distinct "omitted" marker).
+
+## Work plan
+
+| # | Task | Size |
+|---|------|------|
+| 1 | Parser capability spike: LET/LAMBDA/call-on-expression/`_xlpm.` through ClosedXML.Parser; write findings in PR (if parser lacks support, file upstream issue — parser is a sibling ClosedXML project — and stop) | S |
+| 2 | `XLNameEnvironment` + LET special form + tests | M |
+| 3 | LET round-trip (`_xlfn`/`_xlpm` save/load) + tests with a real Excel-authored file in `XLibur.Tests/Resource/` | S |
+| 4 | `AnyValue.Lambda` case + exhaustive-switch audit | M |
+| 5 | LAMBDA definition/invocation incl. defined-name UDFs + `#CALC!` semantics | L |
+| 6 | Helper functions + spill integration + `ISOMITTED` | M |
+| 7 | Test corpus: Excel-authored workbook exercising LET/LAMBDA/helpers with cached values — assert XLibur recomputes identical values | M |
+
+## Acceptance criteria
+
+1. `LET(x, 2, y, x*3, x+y)` = 8; sequential binding, shadowing, and name-precedence tests pass.
+2. A workbook authored in Excel using LET/LAMBDA/MAP/BYROW loads, recalculates to the same values Excel cached, and saves back openable in Excel with formulas intact.
+3. LAMBDA via defined name is invocable from cell formulas; bare LAMBDA in a cell yields `#CALC!`.
+4. Recursion terminates with Excel-like error (not stack overflow) at depth limit.
+5. No regression across the calc-engine suite; spill tests for MAP/BYROW/MAKEARRAY.
+
+## Risks
+
+- Parser support is the go/no-go gate — that's why task 1 is a spike with a stop condition.
+- Adding a case to a hand-rolled discriminated union touches many switches; lean on the compiler (the union's Match methods) and the nullable/warnings-as-errors build to find them all.
+- Volatile semantics inside lambdas and dirty-tracking of lambda-invoked references: ensure `DependenciesVisitor` treats a lambda body's references as precedents of the calling cell (add tests: edit a cell referenced only inside a lambda body → dependent recalculates).

--- a/docs/specs/09-threaded-comments-roundtrip.md
+++ b/docs/specs/09-threaded-comments-roundtrip.md
@@ -1,0 +1,91 @@
+# Spec 09 — Threaded Comments: Full Model + Write Path (and Round-Trip Fidelity)
+
+**Area:** Feature + Compatibility
+**Effort:** M (1–2 weeks)
+**Dependencies:** None.
+**Status:** Proposed
+
+## Summary
+
+Threaded comments (Office 365's reply-style comments) are currently read **lossily**: the whole thread is flattened into the legacy note's text joined by newlines, discarding authors, timestamps, reply structure, and mentions — and there is no write path, so saving a file that contained threaded comments silently downgrades them to a legacy note. This spec adds a first-class threaded-comment model with full round-trip, plus a small fidelity audit for other silently-dropped content.
+
+## Current state
+
+- Read: `LoadThreadedComments` / `ApplyThreadedCommentsToCell` in `XLibur/Excel/XLWorkbook_Load.cs` (~lines 736–786) — flattens thread → legacy note text.
+- Write: nothing. No `WorksheetThreadedCommentsPart`, no `PersonPart`/`personList` anywhere in the codebase.
+- Legacy notes are complete: `XLibur/Excel/Comments/` + `IO/CommentPartWriter.cs` + `IO/VmlDrawingPartWriter.cs`.
+- Related fidelity gaps (audit scope, task 6): chartsheets/dialog sheets/macro sheets land in `XLWorkbook.UnsupportedSheet` (`XLWorkbook.cs` ~line 784, `XLWorkbook_Load.cs` ~line 261) and are **dropped on save**; form controls/ActiveX are dropped; slicers/timelines are dropped.
+
+## OOXML background (what Excel writes)
+
+- `xl/threadedComments/threadedComment{N}.xml` (one per sheet with threads): `<threadedComment ref="A1" dT="..." personId="{guid}" id="{guid}" [parentId="{guid}"]>` with `<text>`; replies reference the root via `parentId`.
+- `xl/persons/person.xml` (workbook-level `PersonPart`): `<person displayName="..." id="{guid}" userId="..." providerId="..."/>`.
+- **Compatibility pairing:** Excel also writes a legacy comment (+ VML) fallback for each thread root, whose text is prefixed with `[Threaded comment]` boilerplate. Older Excel shows the fallback; 365 shows the thread. XLibur must write both, like Excel does, and must **hide the fallback note from the user model** when the threaded part is present (current reader already prefers the threaded content — keep that, but stop flattening).
+
+## Design
+
+### Public API (new files under `XLibur/Excel/Comments/Threaded/`)
+
+```csharp
+public interface IXLThreadedComment
+{
+    string Text { get; set; }
+    IXLPerson Author { get; }
+    DateTime CreatedUtc { get; }
+    IXLThreadedComment? Parent { get; }                 // null for thread root
+    IReadOnlyList<IXLThreadedComment> Replies { get; }
+    IXLThreadedComment AddReply(IXLPerson author, string text);
+    bool Resolved { get; set; }                          // root only ('done' flag)
+}
+
+public interface IXLPerson { string DisplayName { get; } string? UserId { get; } string? ProviderId { get; } Guid Id { get; } }
+
+// IXLCell additions:
+IXLThreadedComment? GetThreadedComment();
+IXLThreadedComment CreateThreadedComment(IXLPerson author, string text);
+bool HasThreadedComment { get; }
+
+// IXLWorkbook addition:
+IXLPersons Persons { get; }   // Add(displayName), lookup by id
+```
+
+Design rules:
+- A cell has *either* a legacy note *or* a threaded comment as its user-visible annotation; creating a threaded comment on a cell with a legacy note throws (or converts — decide and document; **recommend throw** for v1, explicit `ConvertToThread()` later).
+- Storage: extend the comment slot in the misc slice area. `XLMiscSliceContent` (`XLibur/Excel/Cells/XLMiscSliceContent.cs`) holds `XLComment?` today; either widen the type to a shared base/`object` holding note-or-thread, or add a per-worksheet side dictionary keyed by `XLSheetPoint` (threads are rare — a side dictionary avoids fattening the misc struct for every cell; **recommend side dictionary**, consistent with how rare data should be stored per the architecture's slice philosophy).
+- Mentions (`<mention>` runs): **out of scope v1** — preserve raw XML for round-trip (store the original `<text>` payload when unmodified) but no mention API.
+
+### Read path rework
+
+`LoadThreadedComments`: build the model (persons, roots, replies ordered by `dT`), attach to cells, and **do not** create the flattened legacy text. The paired legacy fallback note is detected (same ref as a thread root) and suppressed from `cell.GetComment()`.
+
+### Write path
+
+New `ThreadedCommentPartWriter` + `PersonPartWriter` in `XLibur/Excel/IO/`:
+1. Emit `person.xml` for all referenced persons.
+2. Emit per-sheet `threadedComment{N}.xml` with stable GUIDs (persist loaded ids; generate for new).
+3. Emit the legacy fallback note + VML for each thread root (reuse `CommentPartWriter`/`VmlDrawingPartWriter` with the `[Threaded comment]` boilerplate text Excel uses).
+4. Wire into `XLWorkbook_Save.cs` part orchestration + content types/relationships.
+
+## Work plan
+
+| # | Task | Size |
+|---|------|------|
+| 1 | Model + API (`IXLThreadedComment`, `IXLPerson`, cell/workbook surface) + side-dictionary storage | M |
+| 2 | Reader rework (structure-preserving; fallback-note suppression) | M |
+| 3 | Writers (persons, threads, legacy fallback pairing) + save orchestration | M |
+| 4 | Tests: Excel-authored file with threads/replies/resolved flags in `XLibur.Tests/Resource/` → load asserts structure; round-trip byte-level part comparison where stable; new-thread-from-scratch opens in Excel (manual check recorded in PR) | M |
+| 5 | Editing semantics tests: delete thread root deletes replies; copy/move cell behavior (match legacy-note behavior); `CopyTo` across workbooks maps persons | S |
+| 6 | **Fidelity audit (separate PR):** enumerate content dropped on round-trip (chartsheets, form controls, slicers, timelines, custom XML). For each: document, and where cheap, **preserve the raw part** through load→save instead of dropping (part pass-through for unmodified sheets is often near-free with the OpenXML SDK since unknown parts stay in the package when not removed — verify what XLibur's save actually removes vs preserves, and stop deleting what it doesn't understand). Deliverable: `docs/round-trip-fidelity.md` + pass-through fixes where trivial. | M |
+
+## Acceptance criteria
+
+1. Excel-authored threaded comments load with authors, UTC timestamps, reply order, and resolved state intact; `GetComment()` no longer returns flattened thread text.
+2. Round-trip: load → save → open in Excel 365 shows identical threads; open in Excel 2016 shows the fallback notes.
+3. Threads created via API from scratch open correctly in Excel 365 (manual verification recorded in PR).
+4. Legacy-note behavior unchanged for files without threads (full existing comment test suite green).
+5. Fidelity audit doc merged; at least chartsheet part pass-through evaluated with a clear do/can't-do conclusion.
+
+## Risks
+
+- Excel is picky about person/thread GUID and relationship wiring — the manual open-in-Excel check is the gate, automate reopen-via-XLibur for CI.
+- The legacy-fallback pairing is underdocumented; copy exactly what current Excel emits (author a sample file, inspect parts, mirror it).

--- a/docs/specs/10-chart-formatting-depth.md
+++ b/docs/specs/10-chart-formatting-depth.md
@@ -1,0 +1,101 @@
+# Spec 10 — Chart Formatting Depth (series styling, data labels, legend, axes)
+
+**Area:** Feature (flagship differentiator — upstream ClosedXML has no charts at all)
+**Effort:** L total, but splits into 4 independent PRs
+**Dependencies:** None.
+**Status:** Proposed
+
+## Summary
+
+XLibur's chart support (a fork addition) covers ~75 classic chart types plus 5 ChartEx types, combo charts, anchoring, and title/series/axis emission — but `IXLChartSeries` exposes only name/category/value refs + index/order. Users cannot set a series color, add data labels, control the legend, or title/scale/format an axis. This spec adds the formatting layer that makes generated charts presentation-ready, plus two reader gaps.
+
+## Current state
+
+- Model: `XLibur/Excel/Charts/` (`IXLChart`, `IXLChartSeries`, `XLCharts`, `XLChartType` enum with ~75 values, `SecondaryChartType`/`SecondarySeries` for combos).
+- IO: `XLibur/Excel/IO/ChartWriter.cs` (1151 lines), `ChartReader.cs` (549 lines). ChartEx defaults bundled as `ChartExDefaultColors.xml`/`ChartExDefaultStyle.xml`.
+- Gaps: no per-series fill/line/marker; no data labels; no legend API; no axis title/scale/number-format; no trendlines/error bars; charts anchored via `OneCellAnchor`/`AbsoluteAnchor` are **skipped on read** (only `TwoCellAnchor` handled); no chart sheets (they fall into `UnsupportedSheets`); no per-series secondary-axis binding.
+
+## Design
+
+Keep the API deliberately smaller than DrawingML: expose the ~15 properties that cover 95% of real chart styling; everything else remains writer defaults. Unknown/unsupported chart XML read from existing files must be **preserved on round-trip** (verify the reader/writer round-trips untouched chart parts rather than regenerating them — if the writer regenerates, preserving loaded raw XML for properties the model doesn't understand is part of PR 1's groundwork; state the finding in the PR).
+
+### PR 1 — Series formatting
+
+```csharp
+public interface IXLChartSeries // additions
+{
+    XLColor? FillColor { get; set; }          // solid fill; null = automatic
+    XLColor? LineColor { get; set; }
+    double? LineWidthPt { get; set; }
+    XLMarkerStyle MarkerStyle { get; set; }    // None/Circle/Square/Diamond/Triangle/X/Auto
+    double? MarkerSize { get; set; }
+    XLColor? MarkerFillColor { get; set; }
+    bool Smooth { get; set; }                  // line charts
+    bool UseSecondaryAxis { get; set; }        // binds series to secondary value axis
+    IXLDataLabels DataLabels { get; }          // see PR 2
+}
+```
+Writer: emit `c:spPr` (a:solidFill/a:ln) per series, `c:marker`, `c:smooth`; secondary-axis binding moves the series into the secondary plot group (the combo plumbing for `SecondarySeries` exists — generalize it). Reader: parse the same back.
+
+### PR 2 — Data labels
+
+```csharp
+public interface IXLDataLabels
+{
+    bool ShowValue { get; set; }
+    bool ShowCategoryName { get; set; }
+    bool ShowSeriesName { get; set; }
+    bool ShowPercentage { get; set; }          // pie/doughnut
+    string? NumberFormat { get; set; }
+    XLDataLabelPosition Position { get; set; } // Center/InsideEnd/OutsideEnd/BestFit...
+}
+```
+Per-series (`c:dLbls` under `c:ser`) and chart-level defaults. Position enum validity varies by chart type — validate and throw a clear message for invalid combos (mirror Excel's rules for bar/line/pie only; others accept Center).
+
+### PR 3 — Legend + axis API
+
+```csharp
+public interface IXLChartLegend { bool Visible { get; set; } XLLegendPosition Position { get; set; } bool Overlay { get; set; } }
+public interface IXLChartAxis
+{
+    string? Title { get; set; }
+    string? NumberFormat { get; set; }
+    double? Min { get; set; } double? Max { get; set; }
+    double? MajorUnit { get; set; } double? MinorUnit { get; set; }
+    bool Visible { get; set; }
+    bool MajorGridlines { get; set; }
+    XLAxisOrientation Orientation { get; set; }   // MinMax / MaxMin (reversed)
+    bool LogScale { get; set; } double LogBase { get; set; }
+}
+// IXLChart additions: Legend, CategoryAxis, ValueAxis, SecondaryValueAxis (created on demand)
+```
+The writer already emits axes — this PR parameterizes what it emits (`c:title`, `c:numFmt`, `c:scaling` min/max/orientation/logBase, `c:majorUnit`, `c:majorGridlines`, `c:delete` for hidden) and the reader parses it back.
+
+### PR 4 — Reader gaps
+
+1. Read charts anchored via `OneCellAnchor` and `AbsoluteAnchor` (currently skipped) — map to the existing anchor model; if the model only supports two-cell anchors, add the other anchor kinds to the drawing model (pictures may already have `FreeFloating` placement — reuse that pattern from `XLibur/Excel/Drawings/`).
+2. Trendlines/error bars: **round-trip preservation only** (no API) — do not drop them when rewriting a chart whose other properties were edited.
+
+## Work plan
+
+| PR | Content | Size |
+|----|---------|------|
+| 1 | Series formatting + secondary-axis binding + round-trip-preservation groundwork | L |
+| 2 | Data labels | M |
+| 3 | Legend + axes | M |
+| 4 | Anchor reader gaps + trendline/error-bar preservation | M |
+
+PRs 2 and 3 are independent of each other once PR 1's groundwork lands.
+
+## Acceptance criteria (each PR)
+
+1. Every new property: set via API → save → **open in Excel renders as expected** (manual matrix recorded once per PR) and → reload via XLibur reads the same value back (automated).
+2. Excel-authored charts using these features load with correct property values (test resources authored in Excel, checked into `XLibur.Tests/Resource/Charts/`).
+3. Round-trip of a chart using *unsupported* features (trendlines, rich gradients) does not lose them (PR 1 groundwork + PR 4).
+4. Existing chart tests green; ChartEx types unaffected.
+5. Examples: extend `XLibur.Examples` with a "formatted chart" sample — serves as living documentation.
+
+## Risks
+
+- DrawingML defaulting is subtle (automatic colors come from the theme); `null` must mean "omit element" (Excel default), never "emit black". Test against Excel-authored files, not assumptions.
+- If the writer regenerates chart XML from the model on save (rather than patching), preservation of unmodeled properties is the hard part — resolve this in PR 1 before building on top.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,54 @@
+# XLibur Improvement Roadmap — Top 10 Specs
+
+Ten prioritized, self-contained specs covering features, compatibility, architecture, and performance (memory + read/write times). Each spec is written to be handed to an independent agent/model: it states the problem with measured numbers, points at the exact files, prescribes a design, breaks the work into PR-sized tasks, and defines measurable acceptance criteria.
+
+Grounding: these were derived from a July 2026 survey of the codebase (architecture, feature inventory vs Excel, benchmark artifacts under `BenchmarkDotNet.Artifacts/results/`). Headline baselines: save 50K rows ≈ 1.0–1.1 s / **543 MB allocated**; load+read 250K×15 ≈ 5.6 s / 1.68 GB after PR #171; XLibur is already ~3× faster and ~6× leaner than upstream ClosedXML on save.
+
+## The list
+
+| # | Spec | Area | Effort | Parallelizable? |
+|---|------|------|--------|-----------------|
+| 01 | [Streaming write API](01-streaming-write-api.md) | Feature · Arch · Memory | L | Phase 1 refactor first, then independent |
+| 02 | [Load-path allocation elimination](02-load-path-allocations.md) | Perf (read) | M | 3 independent sub-tasks |
+| 03 | [Save-path allocation reduction](03-save-path-allocations.md) | Perf (write) | M | 7 small independent PRs |
+| 04 | [Demand-driven formula evaluation](04-demand-driven-formula-eval.md) | Perf · Arch | L | Single owner (correctness-critical) |
+| 05 | [Structural-edit & bulk-style scalability](05-structural-edit-scalability.md) | Arch · Perf | L | 3 independent workstreams |
+| 06 | [Workbook encryption (password files)](06-workbook-encryption.md) | Feature · Compat | L | Container/crypto layers in parallel |
+| 07 | [Formula function coverage (257→~420)](07-formula-function-coverage.md) | Feature | L | **6 fully independent waves** |
+| 08 | [LET / LAMBDA](08-let-lambda.md) | Feature | L | Single owner (engine core) |
+| 09 | [Threaded comments + round-trip fidelity](09-threaded-comments-roundtrip.md) | Feature · Compat | M | Comments vs fidelity-audit split |
+| 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | 4 PRs, 2–3 independent |
+
+## Why these ten
+
+**Performance (specs 02, 03, 04, 05).** The write cell-loop and the sheetData parse have both had a round of tuning; what remains, in measured order: per-cell string allocations on load (`<v>` + attributes + SST DOM), the ~543 MB formatted save (number formatting, inherited-style resolution, StyleKey hashing), the full-workbook-recalc cliff when reading one dirty formula cell (can build a 176 MB dependency tree to answer one read), and O(all-ranges·log) work per single row insert. Specs 02–05 attack each with concrete targets.
+
+**Features (specs 01, 07, 08, 10).** The fork already leads upstream on charts, dynamic arrays, in-cell images, sparklines, WebP/SVG. The gaps that matter: no bounded-memory export path for huge files (01), ~250 missing formula functions with a clean registry to extend (07), no LET/LAMBDA (08 — the one function family that needs engine work), and charts that can't be styled (10 — depth on the flagship differentiator).
+
+**Compatibility (specs 06, 09).** Password-encrypted files can't be opened or written at all (06 — hard blocker, zero code exists). Threaded comments are read lossily and silently downgraded on save; chartsheets, form controls, and slicers are dropped on round-trip (09).
+
+**Architecture (specs 01, 04, 05).** The three structural debts the surveys flagged: no streaming seam in the IO layer, calc-engine all-or-nothing recalculation, and materialize-everything patterns for range shift and style propagation (plus two redundant spatial indexes — QuadTree and RBush).
+
+## Suggested sequencing
+
+```
+Wave 1 (independent, start anytime):
+  02 load allocations · 03 save allocations · 07 function waves A–F · 09 threaded comments
+Wave 2 (after 03 lands, or coordinated):
+  01 streaming write (Phase 1 seam shared with 03's territory) · 06 encryption · 10 charts PR1
+Wave 3 (single-owner, correctness-critical — don't parallelize internally):
+  04 demand-driven eval · 05 structural edits · 08 LET/LAMBDA (08 after or alongside 04)
+```
+
+Conflict map: 01↔03 (`SheetDataWriter`), 04↔08 (evaluation stack / `CalcContext`), 07 waves B↔C (`Statistical.cs`). Everything else is disjoint.
+
+## Ground rules for implementing agents
+
+- **Branch per spec/task; never commit to main.** Commit style follows the repo convention (`perf:`, `feat:`, `fix:`, `refactor:`).
+- **Warnings are errors** (`TreatWarningsAsErrors=true`); nullable is enabled — new code must be null-annotated.
+- **Do not upgrade SixLabors.Fonts** (license conflict).
+- **No compound shell commands** (`&&`, `;`) in agent tool calls — repo convention (see `CLAUDE.md`).
+- Build check: `dotnet build XLibur/XLibur.csproj -c Release -v q` · Tests: `dotnet test XLibur.Tests` · Benchmarks: `dotnet run -c Release --project XLibur.Benchmarks/XLibur.Benchmarks.csproj -- --filter '*Name*'` · Memory snapshots: same project with `-- profile` (writes dotMemory `.dmw` to `C:\profiles\`).
+- **Perf PRs must include before/after numbers** (BenchmarkDotNet table + allocation delta) in the description, per the format of PR #171.
+- Line numbers in specs are from the July 2026 survey — **verify against current code before editing**.
+- File-format work (06, 09, 10) requires a recorded manual "opens clean in Excel" check plus automated reload-via-XLibur tests; Excel-authored test resources go in `XLibur.Tests/Resource/`.


### PR DESCRIPTION
## Summary

Adds ten prioritized, self-contained improvement specs under `docs/specs/`, covering features, compatibility, architecture, and performance (memory and read/write times). Each spec is written to be handed to an independent contributor: it states the problem with measured numbers, points at the exact files, prescribes a design, breaks the work into PR-sized tasks, and defines measurable acceptance criteria.

Documentation only — no code changes.

The specs were derived from a survey of the codebase and the checked-in benchmark artifacts rather than from assumptions, so they start from real baselines: save of 50K rows ~543 MB allocated; load+read of 250K x 15 ~5.6 s / 1.68 GB after #171; XLibur already ~3x faster and ~6x leaner than upstream ClosedXML on save.

## Changes

`docs/specs/README.md` is the ranked index, with suggested sequencing and a conflict map so several specs can be worked in parallel without collisions (01<->03 share `SheetDataWriter`, 04<->08 share the evaluation context, 07's waves B<->C share `Statistical.cs`).

| # | Spec | Area |
|---|------|------|
| 01 | Streaming (forward-only) write API | Feature / Architecture / Memory |
| 02 | Load-path allocation elimination | Performance (read) |
| 03 | Save-path allocation reduction | Performance (write) |
| 04 | Demand-driven formula evaluation | Performance / Architecture |
| 05 | Structural-edit and bulk-style scalability | Architecture / Performance |
| 06 | Password-protected workbook support (ECMA-376 encryption) | Feature / Compatibility |
| 07 | Formula function coverage, 257 -> ~420 | Feature |
| 08 | LET / LAMBDA and lambda-helper functions | Feature |
| 09 | Threaded comments round-trip and fidelity audit | Feature / Compatibility |
| 10 | Chart formatting depth | Feature |

Highlights of what the survey turned up, which shaped the priorities:

- Reading a single dirty formula cell can trigger a full-workbook recalculation, building a large dependency tree to answer one read (spec 04).
- A single row insert materializes and sorts *every* live range in the worksheet, and a range-wide style change allocates an `XLCell` per cell (spec 05).
- File-level encryption has no implementation at all — a hard blocker, not a gap (spec 06).
- Threaded comments are read lossily and silently downgraded to legacy notes on save (spec 09).
- Charts, dynamic arrays, in-cell images and sparklines already exist in this fork, unlike upstream, so the specs build on them rather than duplicating them.

## Related Issues

<!-- none -->

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually

Documentation-only change; no code paths affected.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch

---

Note: spec 02 has since been implemented and is up as a separate PR. Its status line and results section in `docs/specs/02-load-path-allocations.md` can be updated on this branch once the merge order is settled.
