### PR TITLE
docs: record spec 02 results and correct spec 03's number format

### DIFF
--- a/docs/specs/02-load-path-allocations.md
+++ b/docs/specs/02-load-path-allocations.md
@@ -3,7 +3,64 @@
 **Area:** Performance (read time + memory)
 **Effort:** M (1–2 weeks, three independent sub-tasks)
 **Dependencies:** None. Builds on PR #171 (raw `XmlReader` sheetData pass).
-**Status:** Proposed
+**Status:** ✅ Implemented in PR #175 — Tasks A, C1, C2 landed; Task B deferred (see Results)
+
+## Results
+
+`XLiburReadBenchmarks.LoadWorkbook`, 250K×15, net8.0, `InProcessEmitToolchain`, Ryzen 9 5950X:
+
+| Stage | Mean | Allocated |
+|---|---:|---:|
+| Baseline | 4.750 s | 1020.92 MB |
+| + Task A (SST raw reader) + C1 (dense style cache) | 3.897 s | 775.78 MB |
+| + Task C2 (chunked attribute/value reads) | **3.968 s** | **392.88 MB** |
+
+**−16.5% wall time, −61.5% allocations**, against acceptance targets of ≥15% and ≥35%. The
+allocation target was beaten comfortably; the time target was met but only just. The final time is
+within noise of the intermediate reading (Error ±0.03 s) — Task C2 buys allocation, not CPU. The
+"≤ 3.2 s" aspiration in the Summary was **not** reached: after these three tasks, load time is no
+longer dominated by garbage, so further gains need a different lever (see Follow-ups).
+
+### What shipped
+
+- **Task A** — `SharedStringReader` streams `<si>` entries with a raw `XmlReader`. Rich/phonetic
+  entries still need the DOM, and richness is only knowable after the first child is consumed (a
+  leading `<t>` may be followed by `<rPh>`), so their subtree is re-serialized rather than read via
+  a plain `ReadOuterXml`.
+- **Task C1** — `StyleValueCache`: flat array indexed by `cellXfs` index, scoped to the *workbook*
+  rather than per-worksheet, since `styles.xml` is workbook-global and resolution is a pure
+  function of the index.
+- **Task C2** — `XmlReader.ReadValueChunk` into a reusable 64-char buffer for cell *and row*
+  attributes and `<v>` content, parsing from the span, with a `StringBuilder` fallback for content
+  wider than the buffer. `String`, `Error` and `Date` values still materialize a string, either
+  because the text *is* the value or because the type is too rare to justify a span parser.
+
+### Task B was deferred, deliberately
+
+The remap targets the `Dictionary<Text,int>` probe in `SharedStringTable.IncreaseRef`: ~750K probes
+at ~25–30 ns on the benchmark sheet, i.e. **under 1% of load time and zero allocations**. That does
+not justify the risk to shared-string reference counting, which drives `DecreaseRef`, free-list
+reuse, and what gets written back to the SST on save. Revisit only if a string-dominated workload
+profiles as probe-bound.
+
+### Findings for other specs
+
+1. **`ReadValueChunk` works on attribute nodes**, not just text, and removed 99.8% of the
+   allocation for that work (103.8 → 0.2 bytes/cell) when measured in isolation. This was verified
+   with a throwaway probe before being built on. The technique generalizes to any `XmlReader` hot
+   path in the IO layer.
+2. **Doubles are saved with `"G15"`** by deliberate policy in `ObjectExtensions.ToInvariantString`,
+   so values wider than 15 significant digits already lose precision on save today. **Spec 03's
+   span-based `TryFormat` rewrite must target `G15`, not `"R"`/shortest-round-trip**, or it will
+   silently change output for every workbook. Spec 03 task 1 currently says "R"/G17 — treat this
+   as the correction.
+
+### Follow-ups this opened
+
+- Formula cells still allocate: `<f>` content is retained (unavoidable) but the `f` element's
+  attributes (`t`, `ref`, `si`, `aca`, …) still go through `reader.Value`. Same technique applies.
+- Load remains single-threaded; with garbage no longer dominant, per-sheet parallelism is the
+  next structural lever rather than further allocation trimming.
 
 ## Summary
 

--- a/docs/specs/03-save-path-allocations.md
+++ b/docs/specs/03-save-path-allocations.md
@@ -22,7 +22,7 @@ The 50K-row formatted save (`CreateFormattedAndSave`) allocates ~543 MB and has 
 
 | # | Task | Detail | Size |
 |---|------|--------|------|
-| 1 | Span-based number write | In `WriteNumberValue`: `Span<char> buf = stackalloc char[24]; value.TryFormat(buf, out int len, "R"/G17-equivalent, CultureInfo.InvariantCulture)` then `WriteRaw(char[], ...)` via a reusable `char[]` (XmlWriter.WriteRaw has no span overload — reuse a cached buffer). **Must produce byte-identical output** to `ToInvariantString` for round-trip stability — add a property-based test comparing both formatters over random doubles, ints, dates. | S |
+| 1 | Span-based number write | In `WriteNumberValue`: `Span<char> buf = stackalloc char[32]; value.TryFormat(buf, out int len, "G15", CultureInfo.InvariantCulture)` then `WriteRaw(char[], ...)` via a reusable `char[]` (XmlWriter.WriteRaw has no span overload — reuse a cached buffer). **The format specifier is `G15`, not `"R"`/G17** — see the note below. **Must produce byte-identical output** to `ToInvariantString` for round-trip stability — add a property-based test comparing both formatters over random doubles, ints, dates. | S |
 | 2 | Inherited-style memo | In the save loop, memoize `GetStyleValue` results per (row-style, column-style) pair — for a typical sheet most cells inherit the same worksheet/column style. Cache last row's resolved inherited value; invalidate on row change. Profile first to confirm this is the hot allocation (dotMemory `profile` harness). | M |
 | 3 | StyleKey hash caching | `XLStyleValue` is immutable — compute the full hash once in the constructor and store it (`_cachedHashCode`), or fix `XLStyleKey.GetHashCode` to combine pre-computed component hashes instead of re-hashing all fields. Verify with `StyleKeyHashCodeBenchmarks`. | S |
 | 4 | Table-totals guard | Skip `CollectTableTotalCells` + per-cell `Contains` entirely when `worksheet.Tables.All(t => !t.ShowTotalsRow)` (or count == 0). | XS |
@@ -43,7 +43,14 @@ Same as Spec 02: BenchmarkDotNet filter `'*XLiburWorkbookBenchmarks*'` + dotMemo
 
 ## Risks
 
-- Task 1 formatting parity: `double.ToInvariantString` may use shortest-round-trip ("R"-like) semantics — match exactly; Excel files store shortest-round-trip doubles. The property test is mandatory, not optional.
+- Task 1 formatting parity — **resolved while implementing Spec 02, do not re-derive**:
+  `ObjectExtensions.ToInvariantString` formats `double` with **`"G15"`** and `float` with `"G7"`,
+  annotated "Specify precision explicitly for backward compatibility". So the current output is
+  *not* shortest-round-trip: values wider than 15 significant digits already lose precision on
+  save (e.g. `1234567890.123456` is written as `1234567890.12346` and reads back as
+  `1234567890.1234601`). Matching `"R"`/G17 would change the bytes of essentially every workbook
+  and look like a regression in diffs. Use `G15`. The property test is still mandatory — it is
+  what pins this behaviour down.
 - Task 2 can add complexity for marginal gain if the profile doesn't confirm — profile first, implement second.
 
 ## References

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,18 +6,23 @@ Grounding: these were derived from a July 2026 survey of the codebase (architect
 
 ## The list
 
-| # | Spec | Area | Effort | Parallelizable? |
-|---|------|------|--------|-----------------|
-| 01 | [Streaming write API](01-streaming-write-api.md) | Feature · Arch · Memory | L | Phase 1 refactor first, then independent |
-| 02 | [Load-path allocation elimination](02-load-path-allocations.md) | Perf (read) | M | 3 independent sub-tasks |
-| 03 | [Save-path allocation reduction](03-save-path-allocations.md) | Perf (write) | M | 7 small independent PRs |
-| 04 | [Demand-driven formula evaluation](04-demand-driven-formula-eval.md) | Perf · Arch | L | Single owner (correctness-critical) |
-| 05 | [Structural-edit & bulk-style scalability](05-structural-edit-scalability.md) | Arch · Perf | L | 3 independent workstreams |
-| 06 | [Workbook encryption (password files)](06-workbook-encryption.md) | Feature · Compat | L | Container/crypto layers in parallel |
-| 07 | [Formula function coverage (257→~420)](07-formula-function-coverage.md) | Feature | L | **6 fully independent waves** |
-| 08 | [LET / LAMBDA](08-let-lambda.md) | Feature | L | Single owner (engine core) |
-| 09 | [Threaded comments + round-trip fidelity](09-threaded-comments-roundtrip.md) | Feature · Compat | M | Comments vs fidelity-audit split |
-| 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | 4 PRs, 2–3 independent |
+| # | Spec | Area | Effort | Status | Parallelizable? |
+|---|------|------|--------|--------|-----------------|
+| 01 | [Streaming write API](01-streaming-write-api.md) | Feature · Arch · Memory | L | Proposed | Phase 1 refactor first, then independent |
+| 02 | [Load-path allocation elimination](02-load-path-allocations.md) | Perf (read) | M | ✅ **Done** (#175) | 3 independent sub-tasks |
+| 03 | [Save-path allocation reduction](03-save-path-allocations.md) | Perf (write) | M | Proposed | 7 small independent PRs |
+| 04 | [Demand-driven formula evaluation](04-demand-driven-formula-eval.md) | Perf · Arch | L | Proposed | Single owner (correctness-critical) |
+| 05 | [Structural-edit & bulk-style scalability](05-structural-edit-scalability.md) | Arch · Perf | L | Proposed | 3 independent workstreams |
+| 06 | [Workbook encryption (password files)](06-workbook-encryption.md) | Feature · Compat | L | Proposed | Container/crypto layers in parallel |
+| 07 | [Formula function coverage (257→~420)](07-formula-function-coverage.md) | Feature | L | Proposed | **6 fully independent waves** |
+| 08 | [LET / LAMBDA](08-let-lambda.md) | Feature | L | Proposed | Single owner (engine core) |
+| 09 | [Threaded comments + round-trip fidelity](09-threaded-comments-roundtrip.md) | Feature · Compat | M | Proposed | Comments vs fidelity-audit split |
+| 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | Proposed | 4 PRs, 2–3 independent |
+
+Spec 02 delivered **−16.5% load time and −61.5% allocations** (4.750 s / 1020.92 MB → 3.968 s /
+392.88 MB on the 250K×15 benchmark). It also produced two findings that change other specs: a
+correction to spec 03's number-formatting task, and a reusable `XmlReader.ReadValueChunk` technique
+for the IO layer. Both are recorded in spec 02's Results section.
 
 ## Why these ten
 
@@ -33,12 +38,15 @@ Grounding: these were derived from a July 2026 survey of the codebase (architect
 
 ```
 Wave 1 (independent, start anytime):
-  02 load allocations · 03 save allocations · 07 function waves A–F · 09 threaded comments
+  02 load allocations ✅ done · 03 save allocations · 07 function waves A–F · 09 threaded comments
 Wave 2 (after 03 lands, or coordinated):
   01 streaming write (Phase 1 seam shared with 03's territory) · 06 encryption · 10 charts PR1
 Wave 3 (single-owner, correctness-critical — don't parallelize internally):
   04 demand-driven eval · 05 structural edits · 08 LET/LAMBDA (08 after or alongside 04)
 ```
+
+**Read spec 02's Results section before starting 03** — it corrects 03's number-formatting task
+and describes an allocation technique that applies to the rest of the IO layer.
 
 Conflict map: 01↔03 (`SheetDataWriter`), 04↔08 (evaluation stack / `CalcContext`), 07 waves B↔C (`Statistical.cs`). Everything else is disjoint.
 


### PR DESCRIPTION
## Summary

Closes the loop on #175 by recording what spec 02 actually measured, and fixes an instruction in spec 03 that #175 proved wrong.

## Changes

**`02-load-path-allocations.md`** — marked implemented, with a results section covering:

| Stage | Mean | Allocated |
|---|---:|---:|
| Baseline | 4.750 s | 1020.92 MB |
| + Task A + C1 | 3.897 s | 775.78 MB |
| + Task C2 | **3.968 s** | **392.88 MB** |

−16.5% wall time, −61.5% allocations, against targets of ≥15% / ≥35%. It also records the parts that did *not* go to plan: the "≤ 3.2 s" aspiration in the spec's own Summary was not reached, because after these tasks load time is no longer garbage-dominated and further gains need a different lever; and Task B (the SST id remap) was deliberately skipped after measuring it at under 1% of load time with zero allocation benefit, which does not justify the risk to shared-string reference counting.

**`03-save-path-allocations.md`** — corrected. Task 1 told the implementer to format doubles with `"R"`/G17, and the risks section hedged that the current behaviour "may use shortest-round-trip semantics". It does not: `ObjectExtensions.ToInvariantString` uses **`"G15"`** for `double` and `"G7"` for `float`, annotated "Specify precision explicitly for backward compatibility". Following the spec as written would have changed the bytes of essentially every saved workbook and surfaced as a large, confusing diff. Now states `G15` with the evidence, including the worked example (`1234567890.123456` is saved as `1234567890.12346`), so the next implementer doesn't re-derive it.

**`README.md`** — adds a status column, marks 02 done in both the table and the sequencing plan, and directs anyone starting 03 to read 02's results first.

## Related Issues

Follows #175. Documents #176.

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually

Documentation-only; no code paths affected.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
