### PR TITLE
feat: automate release notes, changelog rolls and stable releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,10 @@
 # C# files: normalize + enable language-aware diffs.
 *.cs text diff=csharp eol=crlf
 
+# Shell scripts must keep LF even on Windows checkouts — CI runs them on Linux,
+# where CRLF line endings break the interpreter.
+*.sh text eol=lf
+
 # Binary files: never normalize or convert line endings.
 *.png binary
 *.jpg binary

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'Next Release'
-tag-template: ''
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 
 categories:
   - title: 'Breaking Changes'
@@ -8,33 +8,76 @@ categories:
   - title: 'New Features'
     labels:
       - 'enhancement'
-      - 'feature'
   - title: 'Bug Fixes'
     labels:
       - 'bug'
-      - 'fix'
   - title: 'Performance'
     labels:
       - 'performance'
-      - 'perf'
   - title: 'Documentation'
     labels:
       - 'documentation'
-      - 'docs'
   - title: 'Dependencies'
     labels:
       - 'dependencies'
   - title: 'Other Changes'
     labels:
-      - 'refactor'
       - 'chore'
-      - 'test'
 
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 change-title-escapes: '\<*_&'
 no-changes-template: 'No changes.'
 
+# While the project is pre-1.0, a breaking change is still a minor bump.
+version-resolver:
+  minor:
+    labels:
+      - 'breaking'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'bug'
+      - 'performance'
+      - 'documentation'
+      - 'dependencies'
+      - 'chore'
+  default: patch
+
+# Bots don't get a thank-you line.
+exclude-contributors:
+  - 'dependabot'
+  - 'dependabot[bot]'
+  - 'github-actions'
+  - 'github-actions[bot]'
+no-contributors-template: ''
+
+# PR titles follow Conventional Commits, so the label — and therefore the release
+# note category and the version bump — is derived from the title automatically.
+# Labels referenced here must already exist in the repository; the autolabeler
+# cannot create them.
+autolabeler:
+  - label: 'breaking'
+    title:
+      - '/^[a-z]+(\(.+\))?!:/'
+  - label: 'enhancement'
+    title:
+      - '/^feat(\(.+\))?!?:/'
+  - label: 'bug'
+    title:
+      - '/^fix(\(.+\))?!?:/'
+  - label: 'performance'
+    title:
+      - '/^perf(\(.+\))?!?:/'
+  - label: 'documentation'
+    title:
+      - '/^docs(\(.+\))?!?:/'
+  - label: 'chore'
+    title:
+      - '/^(chore|build|ci|style|refactor|test)(\(.+\))?!?:/'
+
 template: |
   ## What's Changed
 
   $CHANGES
+
+  Thanks to $CONTRIBUTORS for contributing to this release.

--- a/.github/scripts/roll-changelog.sh
+++ b/.github/scripts/roll-changelog.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Rolls the "Unreleased" section of CHANGELOG.md into a dated version heading and
+# leaves a fresh, empty "Unreleased" section at the top.
+#
+#   ## Unreleased          ->   ## Unreleased
+#
+#   ### Fixed                    ## v0.106.0 - 2026-07-25
+#   - ...
+#                                ### Fixed
+#                                - ...
+#
+# Usage: roll-changelog.sh <version> [date] [changelog-path]
+#
+#   version         Version being released, with or without a leading "v".
+#   date            Release date as YYYY-MM-DD. Defaults to today (UTC).
+#   changelog-path  Defaults to CHANGELOG.md in the repository root.
+#
+# Exits non-zero if the changelog has no "Unreleased" heading, or if that section
+# is empty — releasing with nothing written down is almost always a mistake.
+
+set -euo pipefail
+
+version=${1:?usage: roll-changelog.sh <version> [date] [changelog-path]}
+date=${2:-$(date -u +%Y-%m-%d)}
+changelog=${3:-"$(dirname "$0")/../../CHANGELOG.md"}
+
+# Normalise to a leading "v" so headings read "## v0.106.0".
+version=${version#v}
+heading="## v${version} - ${date}"
+
+if [[ ! -f $changelog ]]; then
+  echo "::error::Changelog not found: $changelog" >&2
+  exit 2
+fi
+
+if ! grep -qE '^## Unreleased[[:space:]]*$' "$changelog"; then
+  echo "::error::No '## Unreleased' heading found in $changelog" >&2
+  exit 3
+fi
+
+if grep -qE "^## v${version//./\\.} " "$changelog"; then
+  echo "::error::$changelog already contains a heading for v${version}" >&2
+  exit 4
+fi
+
+# Everything between "## Unreleased" and the next "## " heading (or EOF).
+unreleased_body=$(awk '
+  /^## Unreleased[[:space:]]*$/ { inside = 1; next }
+  inside && /^## / { exit }
+  inside { print }
+' "$changelog")
+
+if [[ -z ${unreleased_body//[[:space:]]/} ]]; then
+  echo "::error::The Unreleased section of $changelog is empty — nothing to release" >&2
+  exit 5
+fi
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+
+awk -v heading="$heading" '
+  { print }
+  !done && /^## Unreleased[[:space:]]*$/ {
+    print ""
+    print heading
+    done = 1
+  }
+' "$changelog" >"$tmp"
+
+mv "$tmp" "$changelog"
+trap - EXIT
+
+echo "Rolled Unreleased into '${heading}' in ${changelog}"

--- a/.github/workflows/pr-autolabel.yml
+++ b/.github/workflows/pr-autolabel.yml
@@ -1,0 +1,25 @@
+name: PR Autolabel
+
+# Labels pull requests from their Conventional Commits title. The label drives both
+# the release-note category and the version bump, so this has to run on every PR —
+# including PRs from forks, which is why the trigger is pull_request_target.
+#
+# Safety: this workflow never checks out or executes pull request code. It only reads
+# the PR title and applies labels.
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autolabel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v7
+        with:
+          disable-releaser: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,5 +16,8 @@ jobs:
 
     steps:
       - uses: release-drafter/release-drafter@v7
+        with:
+          # Labelling happens in pr-autolabel.yml while the PR is open.
+          disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,124 @@
+name: Publish Release
+
+# One-click stable release for the core packages:
+#
+#   1. resolves the version from the release draft (or the version input)
+#   2. rolls CHANGELOG.md's Unreleased section into a dated version heading
+#   3. commits that to main and tags it
+#   4. calls release.yml, which packs, publishes to NuGet, and publishes the
+#      draft release notes with contributor attribution
+#
+# Font packages version independently — release those by pushing their own tag
+# (fonts-skiasharp-v*, fonts-sixlabors-v*, fonts-sixlabors-1-v*).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 0.106.0. Leave empty to use the drafted version.'
+        required: false
+        type: string
+      dry-run:
+        description: 'Dry run — resolve the version and show the changelog roll without tagging or publishing'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check branch
+        run: |
+          if [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "::error::Releases must be published from main (got $GITHUB_REF_NAME)"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve version
+        id: resolve
+        run: |
+          version='${{ inputs.version }}'
+
+          if [ -z "$version" ]; then
+            version=$(gh api "repos/$GITHUB_REPOSITORY/releases" \
+              --jq '[.[] | select(.draft)] | .[0].tag_name // ""')
+            if [ -z "$version" ]; then
+              echo "::error::No release draft found — pass an explicit version input"
+              exit 1
+            fi
+            echo "Resolved from release draft: $version"
+          fi
+
+          version=${version#v}
+
+          if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::'$version' is not a stable MAJOR.MINOR.PATCH version. Pre-releases go through the Pre-release workflow."
+            exit 1
+          fi
+
+          tag="v$version"
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "::error::Tag $tag already exists"
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Releasing $tag"
+
+      - name: Roll changelog
+        run: bash .github/scripts/roll-changelog.sh "${{ steps.resolve.outputs.version }}"
+
+      - name: Show changelog diff
+        run: git --no-pager diff -- CHANGELOG.md
+
+      - name: Dry run summary
+        if: ${{ inputs.dry-run }}
+        run: |
+          {
+            echo "### Dry run — nothing was published"
+            echo
+            echo "Would release **${{ steps.resolve.outputs.tag }}** with the changelog roll shown in the job log."
+            echo
+            echo "Re-run with **dry-run** unchecked to tag and publish."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit and tag
+        if: ${{ !inputs.dry-run }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add CHANGELOG.md
+          git commit -m "chore: roll changelog for ${{ steps.resolve.outputs.tag }}"
+          git tag -a "${{ steps.resolve.outputs.tag }}" -m "Release ${{ steps.resolve.outputs.tag }}"
+          git push origin HEAD:main
+          git push origin "${{ steps.resolve.outputs.tag }}"
+
+  release:
+    name: Release
+    needs: prepare
+    if: ${{ !inputs.dry-run }}
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.prepare.outputs.tag }}
+    permissions:
+      contents: write
+      id-token: write
+    secrets: inherit

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,8 +8,8 @@ name: Publish Release
 #   4. calls release.yml, which packs, publishes to NuGet, and publishes the
 #      draft release notes with contributor attribution
 #
-# Font packages version independently — release those by pushing their own tag
-# (fonts-skiasharp-v*, fonts-sixlabors-v*, fonts-sixlabors-1-v*).
+# All five packages version in lockstep from the tag, so this releases the whole
+# set: XLibur, XLibur.Bundle, and the three font engine packages.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
 
+# All packages version in lockstep from the `v*` tag, so one tag releases the
+# whole set: XLibur, XLibur.Bundle, and the three font engine packages.
 on:
   push:
-    tags: ['v*', 'fonts-sixlabors-1-v*', 'fonts-sixlabors-v*', 'fonts-skiasharp-v*']
+    tags: ['v*']
   # Called by release-publish.yml, which creates the tag and then invokes this
   # workflow directly. A tag pushed with GITHUB_TOKEN does not trigger the
   # `push: tags` trigger above, so the call has to be explicit.
@@ -32,38 +34,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      # A font tag releases only that font package. A core `v*` tag releases the
-      # core packages together, because XLibur.Bundle references the font engine
-      # by project and must be published alongside it.
-      - name: Resolve release scope
-        id: scope
-        run: |
-          case "$TAG" in
-            fonts-sixlabors-1-v*)
-              projects='XLibur.Fonts.SixLabors.V1'
-              core=false ;;
-            fonts-sixlabors-v*)
-              projects='XLibur.Fonts.SixLabors'
-              core=false ;;
-            fonts-skiasharp-v*)
-              projects='XLibur.Fonts.SkiaSharp'
-              core=false ;;
-            v*)
-              projects='XLibur XLibur.Fonts.SixLabors.V1 XLibur.Bundle XLibur.Fonts.SixLabors XLibur.Fonts.SkiaSharp'
-              core=true ;;
-            *)
-              echo "::error::Unrecognised release tag: $TAG"
-              exit 1 ;;
-          esac
-          echo "projects=$projects" >> "$GITHUB_OUTPUT"
-          echo "core=$core" >> "$GITHUB_OUTPUT"
-          echo "Releasing from tag $TAG: $projects"
-
       # Captured before publishing, because once this release is published it
       # becomes "latest" and can no longer serve as the previous tag.
       - name: Resolve previous release tag
         id: previous
-        if: steps.scope.outputs.core == 'true'
         run: |
           prev=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts --exclude-pre-releases \
                    --limit 1 --json tagName --jq '.[0].tagName // ""')
@@ -85,12 +59,32 @@ jobs:
 
       - name: Pack
         run: |
-          for project in ${{ steps.scope.outputs.projects }}; do
+          for project in XLibur XLibur.Fonts.SixLabors.V1 XLibur.Bundle XLibur.Fonts.SixLabors XLibur.Fonts.SkiaSharp; do
             echo "::group::Pack $project"
             dotnet pack "$project/$project.csproj" --configuration Release --no-build --output ./artifacts
             echo "::endgroup::"
           done
           ls -la ./artifacts/
+
+      # Every package must carry the tag's version. A mismatch means MinVer did
+      # not see the tag, which would publish a prerelease-versioned package and
+      # leave XLibur.Bundle depending on a version that was never released.
+      - name: Verify package versions match the tag
+        run: |
+          expected=${TAG#v}
+          status=0
+          for package in ./artifacts/*.nupkg; do
+            name=$(basename "$package" .nupkg)
+            if [ "${name%.$expected}" = "$name" ]; then
+              echo "::error::$name is not version $expected"
+              status=1
+            fi
+          done
+          if [ "$status" -ne 0 ]; then
+            echo "::error::Package versions do not match tag $TAG — refusing to publish"
+            exit 1
+          fi
+          echo "All packages are version $expected"
 
       - name: NuGet login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
@@ -104,10 +98,9 @@ jobs:
       - name: Push symbols to NuGet
         run: dotnet nuget push ./artifacts/*.snupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
 
-      # Core releases publish the rolling draft that Release Drafter has been
-      # accumulating from merged PRs, so any manual edits made to it are kept.
-      - name: Publish GitHub Release (core)
-        if: steps.scope.outputs.core == 'true'
+      # Publishes the rolling draft that Release Drafter has been accumulating
+      # from merged PRs, so any manual edits made to it are kept.
+      - name: Publish GitHub Release
         uses: release-drafter/release-drafter@v7
         with:
           publish: true
@@ -119,7 +112,6 @@ jobs:
       # Release Drafter has no first-time-contributor detection, so borrow
       # GitHub's own and append its "New Contributors" section to the notes.
       - name: Append new contributors
-        if: steps.scope.outputs.core == 'true'
         run: |
           prev='${{ steps.previous.outputs.tag }}'
           if [ -n "$prev" ]; then
@@ -143,12 +135,6 @@ jobs:
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file notes.md
           echo "Appended:"
           cat new-contributors.md
-
-      # Font packages version independently and have no rolling draft, so their
-      # notes come from GitHub's generated comparison against the previous tag.
-      - name: Publish GitHub Release (font package)
-        if: steps.scope.outputs.core == 'false'
-        run: gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,15 @@ name: Release
 on:
   push:
     tags: ['v*', 'fonts-sixlabors-1-v*', 'fonts-sixlabors-v*', 'fonts-skiasharp-v*']
+  # Called by release-publish.yml, which creates the tag and then invokes this
+  # workflow directly. A tag pushed with GITHUB_TOKEN does not trigger the
+  # `push: tags` trigger above, so the call has to be explicit.
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,11 +21,54 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
           fetch-tags: true
+
+      # A font tag releases only that font package. A core `v*` tag releases the
+      # core packages together, because XLibur.Bundle references the font engine
+      # by project and must be published alongside it.
+      - name: Resolve release scope
+        id: scope
+        run: |
+          case "$TAG" in
+            fonts-sixlabors-1-v*)
+              projects='XLibur.Fonts.SixLabors.V1'
+              core=false ;;
+            fonts-sixlabors-v*)
+              projects='XLibur.Fonts.SixLabors'
+              core=false ;;
+            fonts-skiasharp-v*)
+              projects='XLibur.Fonts.SkiaSharp'
+              core=false ;;
+            v*)
+              projects='XLibur XLibur.Fonts.SixLabors.V1 XLibur.Bundle XLibur.Fonts.SixLabors XLibur.Fonts.SkiaSharp'
+              core=true ;;
+            *)
+              echo "::error::Unrecognised release tag: $TAG"
+              exit 1 ;;
+          esac
+          echo "projects=$projects" >> "$GITHUB_OUTPUT"
+          echo "core=$core" >> "$GITHUB_OUTPUT"
+          echo "Releasing from tag $TAG: $projects"
+
+      # Captured before publishing, because once this release is published it
+      # becomes "latest" and can no longer serve as the previous tag.
+      - name: Resolve previous release tag
+        id: previous
+        if: steps.scope.outputs.core == 'true'
+        run: |
+          prev=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts --exclude-pre-releases \
+                   --limit 1 --json tagName --jq '.[0].tagName // ""')
+          echo "tag=$prev" >> "$GITHUB_OUTPUT"
+          echo "Previous release tag: ${prev:-<none>}"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -31,20 +83,14 @@ jobs:
       - name: Build
         run: dotnet build XLibur.slnx --configuration Release --no-restore
 
-      - name: Pack XLibur
-        run: dotnet pack XLibur/XLibur.csproj --configuration Release --no-build --output ./artifacts
-
-      - name: Pack XLibur.Fonts.SixLabors.V1
-        run: dotnet pack XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj --configuration Release --no-build --output ./artifacts
-
-      - name: Pack XLibur.Bundle
-        run: dotnet pack XLibur.Bundle/XLibur.Bundle.csproj --configuration Release --no-build --output ./artifacts
-
-      - name: Pack XLibur.Fonts.SixLabors
-        run: dotnet pack XLibur.Fonts.SixLabors/XLibur.Fonts.SixLabors.csproj --configuration Release --no-build --output ./artifacts
-
-      - name: Pack XLibur.Fonts.SkiaSharp
-        run: dotnet pack XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj --configuration Release --no-build --output ./artifacts
+      - name: Pack
+        run: |
+          for project in ${{ steps.scope.outputs.projects }}; do
+            echo "::group::Pack $project"
+            dotnet pack "$project/$project.csproj" --configuration Release --no-build --output ./artifacts
+            echo "::endgroup::"
+          done
+          ls -la ./artifacts/
 
       - name: NuGet login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
@@ -58,17 +104,56 @@ jobs:
       - name: Push symbols to NuGet
         run: dotnet nuget push ./artifacts/*.snupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
 
-      - name: Publish GitHub Release
+      # Core releases publish the rolling draft that Release Drafter has been
+      # accumulating from merged PRs, so any manual edits made to it are kept.
+      - name: Publish GitHub Release (core)
+        if: steps.scope.outputs.core == 'true'
         uses: release-drafter/release-drafter@v7
         with:
           publish: true
-          tag: ${{ github.ref_name }}
+          tag: ${{ env.TAG }}
+          name: ${{ env.TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Release Drafter has no first-time-contributor detection, so borrow
+      # GitHub's own and append its "New Contributors" section to the notes.
+      - name: Append new contributors
+        if: steps.scope.outputs.core == 'true'
+        run: |
+          prev='${{ steps.previous.outputs.tag }}'
+          if [ -n "$prev" ]; then
+            generated=$(gh api --method POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="$TAG" -f previous_tag_name="$prev" --jq .body)
+          else
+            generated=$(gh api --method POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="$TAG" --jq .body)
+          fi
+
+          printf '%s\n' "$generated" | awk '/^## New Contributors/ { found = 1 } found { print }' > new-contributors.md
+
+          if [ ! -s new-contributors.md ]; then
+            echo "No new contributors in this release."
+            exit 0
+          fi
+
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body > notes.md
+          printf '\n' >> notes.md
+          cat new-contributors.md >> notes.md
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file notes.md
+          echo "Appended:"
+          cat new-contributors.md
+
+      # Font packages version independently and have no rolling draft, so their
+      # notes come from GitHub's generated comparison against the previous tag.
+      - name: Publish GitHub Release (font package)
+        if: steps.scope.outputs.core == 'false'
+        run: gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ env.TAG }}
           files: |
             ./artifacts/*.nupkg
             ./artifacts/*.snupkg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,67 @@ Here are some tips.
 * Please submit pull requests that are based on the `main` branch.
 * Where possible, pull requests should include unit tests that cover as many uses cases as possible.
 
+## Pull request titles
+
+**The PR title becomes the release note**, so write it as a short imperative summary of the
+change. Titles follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add SMALL, RANK, PERCENTILE, QUARTILE and MODE functions
+fix: shift conditional-format ranges once on row/column insert
+perf: read sheetData with a raw XmlReader
+```
+
+The prefix is what labels the PR, and the label decides both which section of the release
+notes the change lands in and how the version is bumped:
+
+| Prefix | Label | Release notes section | Version bump |
+|---|---|---|---|
+| `feat:` | `enhancement` | New Features | minor |
+| `fix:` | `bug` | Bug Fixes | patch |
+| `perf:` | `performance` | Performance | patch |
+| `docs:` | `documentation` | Documentation | patch |
+| `chore:` `build:` `ci:` `style:` `refactor:` `test:` | `chore` | Other Changes | patch |
+| any prefix with `!`, e.g. `feat!:` | `breaking` | Breaking Changes | minor (pre-1.0) |
+
+Labelling is automatic — the **PR Autolabel** workflow applies the label from the title when
+the PR is opened or edited. You can override it by changing the label by hand; the label
+always wins over the title.
+
+Contributors are credited automatically: every entry is attributed to its author, and
+first-time contributors get a "New Contributors" section in the release.
+
+## Changelog
+
+User-visible changes belong in `CHANGELOG.md` under `## Unreleased`, in the appropriate
+`###` section (`Added`, `Fixed`, `Performance`, `Upgrade Guide`, …). This is written by
+hand — it is the place for the detail that a one-line release note can't carry: why the
+change matters, migration steps, before/after examples.
+
+Don't add a version heading yourself. The release workflow rolls `## Unreleased` into a
+dated version heading when the release is published.
+
+## Releasing
+
+Releases are one click, from the Actions tab:
+
+1. **Publish Release** workflow → *Run workflow*. Leave *version* empty to take the version
+   Release Drafter resolved from the merged PRs, or set it explicitly.
+2. Run it once with **dry-run** ticked (the default). It resolves the version and prints the
+   changelog roll without changing anything.
+3. Before the real run, open the release draft and edit the notes if you want — the draft is
+   published as-is, so manual edits survive.
+4. Re-run with **dry-run** unticked. The workflow rolls the changelog, commits and tags it on
+   `main`, packs the packages, pushes them to NuGet, publishes the release notes, and attaches
+   the `.nupkg`/`.snupkg` files.
+
+Pre-release builds go through the **Pre-release** workflow instead (alpha/beta/rc, also with a
+dry-run option).
+
+The font engine packages version independently of the core packages. Release one by pushing
+its own tag — `fonts-skiasharp-v*`, `fonts-sixlabors-v*`, or `fonts-sixlabors-1-v*` — which
+runs the same **Release** workflow for just that package.
+
 ## Test Conventions
 
 * Tests use [NUnit](https://nunit.org/) 4.x.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,11 @@ Releases are one click, from the Actions tab:
 Pre-release builds go through the **Pre-release** workflow instead (alpha/beta/rc, also with a
 dry-run option).
 
-The font engine packages version independently of the core packages. Release one by pushing
-its own tag — `fonts-skiasharp-v*`, `fonts-sixlabors-v*`, or `fonts-sixlabors-1-v*` — which
-runs the same **Release** workflow for just that package.
+All five packages — `XLibur`, `XLibur.Bundle`, and the three font engines — version in lockstep
+from the `v*` tag and are published together. `XLibur.Bundle` references the font engine by
+project, so its published dependency is whatever version the font package was packed at; keeping
+one version across the set is what guarantees that dependency is a version that actually exists
+on NuGet.
 
 ## Test Conventions
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,8 +20,7 @@
     <PackageProjectUrl>https://github.com/XLibur/XLibur</PackageProjectUrl>
     <PackageIcon>nuget-logo.png</PackageIcon>
     <PackageTags>Excel OpenXml xlsx</PackageTags>
-    <Description>See release notes https://github.com/XLibur/XLibur/releases/tag/$(Version) XLibur is a .NET library for reading, manipulating and writing Excel 2007+ (.xlsx, .xlsm) files. It aims to provide an intuitive and user-friendly interface to dealing with the underlying OpenXML API.</Description>
-    <PackageReleaseNotes>See https://github.com/XLibur/XLibur/releases/tag/$(Version)</PackageReleaseNotes>
+    <Description>XLibur is a .NET library for reading, manipulating and writing Excel 2007+ (.xlsx, .xlsm) files. It aims to provide an intuitive and user-friendly interface to dealing with the underlying OpenXML API.</Description>
     <RepositoryUrl>https://github.com/XLibur/XLibur</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 
@@ -41,5 +40,18 @@
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' != ''">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
+
+  <!--
+    MinVer computes the version inside a target, so the release-notes link has to be
+    built after that target runs. Setting these as ordinary properties above would
+    interpolate an empty version (which shipped a broken "releases/tag/" link).
+  -->
+  <Target Name="SetPackageReleaseNotesFromVersion" DependsOnTargets="MinVer" BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+      <_XLiburReleaseUrl>https://github.com/XLibur/XLibur/releases/tag/$(MinVerTagPrefix)$(MinVerVersion)</_XLiburReleaseUrl>
+      <PackageReleaseNotes>See $(_XLiburReleaseUrl)</PackageReleaseNotes>
+      <PackageDescription>See release notes $(_XLiburReleaseUrl) $(Description)</PackageDescription>
+    </PropertyGroup>
+  </Target>
 
 </Project>

--- a/XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj
+++ b/XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
-        <MinVerTagPrefix>fonts-sixlabors-1-v</MinVerTagPrefix>
         <Description>Default IXLFontEngine implementation for XLibur using SixLabors.Fonts 1.x (Apache 2.0).</Description>
         <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
         <PackageTags>Excel OpenXml xlsx Font SixLabors</PackageTags>

--- a/XLibur.Fonts.SixLabors/XLibur.Fonts.SixLabors.csproj
+++ b/XLibur.Fonts.SixLabors/XLibur.Fonts.SixLabors.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <RootNamespace>XLibur.Fonts.SixLabors</RootNamespace>
-        <MinVerTagPrefix>fonts-sixlabors-v</MinVerTagPrefix>
         <Description>SixLabors.Fonts 2.x implementation of IXLFontEngine for XLibur.</Description>
         <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
         <PackageTags>Excel OpenXml xlsx Font SixLabors</PackageTags>

--- a/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
+++ b/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <RootNamespace>XLibur.Fonts.SkiaSharp</RootNamespace>
-        <MinVerTagPrefix>fonts-skiasharp-v</MinVerTagPrefix>
         <Description>SkiaSharp implementation of IXLFontEngine for XLibur.</Description>
         <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
         <PackageTags>Excel OpenXml xlsx Font SkiaSharp</PackageTags>

--- a/docs/font-architecture.md
+++ b/docs/font-architecture.md
@@ -126,16 +126,18 @@ When a `FontEngine` is explicitly provided but no `GraphicEngine` is set, the wo
 
 ### Versioning
 
-Each package has independent MinVer versioning with distinct tag prefixes:
+All packages version in lockstep from the `v` MinVer tag prefix, so a single `v0.106.0` tag
+releases `XLibur`, `XLibur.Bundle`, and all three font engine packages at `0.106.0`.
 
-| Package | Tag prefix | Example |
-|---------|-----------|---------|
-| XLibur | `v` | `v0.106.0` |
-| XLibur.Fonts.SixLabors.V1 | `fonts-sixlabors-1-v` | `fonts-sixlabors-1-v1.0.0` |
-| XLibur.Fonts.SixLabors | `fonts-sixlabors-v` | `fonts-sixlabors-v0.1.0` |
-| XLibur.Fonts.SkiaSharp | `fonts-skiasharp-v` | `fonts-skiasharp-v0.1.0` |
+The font packages originally had their own tag prefixes (`fonts-skiasharp-v`,
+`fonts-sixlabors-v`, `fonts-sixlabors-1-v`) for independent versioning. Those tags were never
+created, so MinVer fell back to `0.0.0` and the font packages published as `0.0.0-rc.*` — and
+because `XLibur.Bundle` references the font engine by project, the published bundle depended on
+`XLibur.Fonts.SkiaSharp 0.0.0-rc.2250`. Lockstep versioning removes that class of mismatch:
+whatever version the bundle is packed at, its font dependency is the same version, packed and
+published in the same run. The release workflow verifies this before pushing to NuGet.
 
-The release workflow triggers on any of these tag patterns. `--skip-duplicate` on NuGet push means unchanged packages are not re-published.
+`--skip-duplicate` on NuGet push means unchanged packages are not re-published.
 
 ### Bold/Italic Font Style
 


### PR DESCRIPTION
Automates release notes, the changelog and stable releases, per the agreed design: breaking = minor while pre-1.0, hand-written changelog with automated version-heading rolls, and a one-click `workflow_dispatch` release.

## The problem

Release notes were entirely label-driven, but **18 of the last 20 merged PRs had no labels**, so Release Drafter couldn't categorise anything — the rolling draft was an ungrouped dump. Meanwhile PR titles already follow Conventional Commits rigorously. The signal existed; nothing read it.

## How it works now

**PR opened → labelled automatically.** New `pr-autolabel.yml` derives the label from the PR title (`feat:` → `enhancement`, `fix:` → `bug`, `perf:` → `performance`, `docs:` → `documentation`, `chore|build|ci|style|refactor|test:` → `chore`, any `!:` → `breaking`). Runs on `pull_request_target` so fork PRs get labelled too; it never checks out or executes PR code. A hand-applied label still wins.

**PR merged → draft updated.** Unchanged, except the draft now names and tags itself from a `version-resolver`: `breaking`/`enhancement` → minor, everything else → patch.

**Release → one click.** New `release-publish.yml` (`workflow_dispatch`, **dry-run defaults to on**):

1. resolves the version from the draft, or takes an explicit input
2. validates it's stable `MAJOR.MINOR.PATCH` and the tag doesn't exist
3. rolls `## Unreleased` in `CHANGELOG.md` into `## v0.106.0 - <date>`, leaving a fresh empty `Unreleased`
4. commits and tags `main`, then calls the Release workflow

Dry run stops after step 3 and prints the diff, so you can see exactly what a real run would do.

## Attribution

- Per-entry `@author` (already present).
- New `Thanks to $CONTRIBUTORS` line, with `dependabot`/`github-actions` excluded.
- Release Drafter has no first-time-contributor detection, so the release job calls GitHub's own `releases/generate-notes` and appends its `## New Contributors` section to the published notes. The previous tag is captured *before* publishing, since publishing makes this release "latest".

Manual edits to the draft survive — the draft is published as-is.

## Fixes folded in

- **Published packages shipped a broken release-notes link.** `Directory.Build.props` interpolated `$(Version)`, which is empty at property-evaluation time (MinVer sets it in a target). Confirmed against the live nuspec for `0.105.1-rc.151`: `.../releases/tag/` with no version. The link is now built in a target after MinVer runs; verified by packing locally — `.../releases/tag/v0.105.1-alpha.0.156`.
- **Font packages published as `0.0.0-rc.*`** and the bundle depended on one of them — see below.
- **`*.sh` forced to LF.** `.gitattributes` sets `eol=crlf` for every platform, which would have delivered the changelog script to the Linux runner with CRLF endings and broken it.

## Reusable-workflow refactor

`release.yml` gains a `workflow_call` trigger alongside `push: tags`. This is necessary, not cosmetic: **a tag pushed with `GITHUB_TOKEN` does not trigger `on: push: tags`**, so the publish workflow calls it directly rather than relying on the tag event. Pushing a tag by hand still works exactly as before.

## Verification

- All five YAML files parse.
- `roll-changelog.sh` tested against the real `CHANGELOG.md`: correct roll, plus all three guards fire — missing `Unreleased` heading, duplicate version heading, and empty `Unreleased` section (releasing with nothing written down is almost always a mistake).
- `dotnet pack` run locally to confirm the nuspec fix.
- The `breaking` and `chore` labels have been created in the repo — the autolabeler cannot create labels, and would silently no-op without them.


## Package versioning: lockstep (second commit)

The font packages had their own MinVer tag prefixes for independent versioning, but **those tags were never created**. MinVer fell back to `0.0.0`, so all three font packages published as `0.0.0-rc.*` — and since `XLibur.Bundle` references the font engine by `ProjectReference`, the published bundle depended on `XLibur.Fonts.SkiaSharp 0.0.0-rc.2250`.

Tagging the font packages would not have fixed this durably. MinVer only yields a stable version *on the tagged commit itself*; at any later commit it produces `1.0.1-alpha.0.N`, so the next core release would pack a bundle depending on a prerelease again.

So all packages now version in lockstep from the `v*` tag:

- the three `MinVerTagPrefix` overrides are removed
- `release.yml` loses the per-tag scope resolution and the separate font-release path
- a new guard fails the release **before** pushing to NuGet if any packed package doesn't carry the tag's version

Verified by packing `XLibur.Bundle` locally — both dependencies now resolve to the bundle's own version:

```
<dependency id="XLibur"                 version="0.105.1-alpha.0.157" />
<dependency id="XLibur.Fonts.SkiaSharp" version="0.105.1-alpha.0.157" />   <!-- was 0.0.0-rc.2250 -->
```

The guard's logic was tested against all three cases: matching versions pass, a font package stuck at `0.0.0-rc.*` fails, and a prerelease build against a stable tag fails.

Trade-off accepted: font packages now bump even when unchanged, and they jump from `0.0.0-rc.*` to the core version rather than starting at `1.0.0`. The existing `0.0.0-*` versions on NuGet are left alone — they're prereleases, which NuGet hides from default search and resolution.

`docs/font-architecture.md` is updated to describe lockstep versioning and why the independent scheme was dropped.
