### PR TITLE
perf: cut save-path allocations by 50% (spec 03)

### DIFF
--- a/XLibur.Benchmarks/Program.cs
+++ b/XLibur.Benchmarks/Program.cs
@@ -10,7 +10,13 @@ SixLaborsV1FontBootstrap.Register();
 
 if (args.Length > 0 && args[0].Equals("profile", StringComparison.OrdinalIgnoreCase))
 {
-    MemoryProfile.Run(args);
+    // "profile alloc" is a fast, GC-exact allocation report for the save path, split into
+    // create/save phases. The other modes attach dotMemory and target the load path.
+    if (args.Length > 1 && args[1].Equals("alloc", StringComparison.OrdinalIgnoreCase))
+        SaveAllocationProfile.Run();
+    else
+        MemoryProfile.Run(args);
+
     return;
 }
 

--- a/XLibur.Benchmarks/SaveAllocationProfile.cs
+++ b/XLibur.Benchmarks/SaveAllocationProfile.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using XLibur.Excel;
+using XLibur.Fonts.SixLabors.V1;
+
+namespace XLibur.Benchmarks;
+
+/// <summary>
+/// Lightweight allocation accounting for the save path, split into a "create" phase and a
+/// "save" phase. BenchmarkDotNet reports a single total for
+/// <see cref="XLiburWorkbookBenchmarks.CreateFormattedAndSave"/>, which hides whether an
+/// optimisation landed on the cell-population side or the serialisation side.
+///
+/// Run with: dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile alloc
+/// </summary>
+public static class SaveAllocationProfile
+{
+    private const int RowCount = 50_000;
+
+    public static void Run()
+    {
+        SixLaborsV1FontBootstrap.Register();
+
+        var data = BenchmarkData.Create(RowCount);
+
+        // Warm up JIT / static caches so the measured run is not polluted by one-time costs.
+        RunPlain(data, out _, out _);
+        RunFormatted(data, out _, out _);
+
+        ForceGC();
+        var plainWatch = Stopwatch.StartNew();
+        RunPlain(data, out var plainCreate, out var plainSave);
+        plainWatch.Stop();
+
+        ForceGC();
+        var formattedWatch = Stopwatch.StartNew();
+        RunFormatted(data, out var formattedCreate, out var formattedSave);
+        formattedWatch.Stop();
+
+        Console.WriteLine();
+        Console.WriteLine("Allocated bytes (single iteration, 50,000 rows)");
+        Console.WriteLine("| Scenario               | Create      | Save        | Total       | Elapsed  |");
+        Console.WriteLine("|------------------------|-------------|-------------|-------------|----------|");
+        WriteRow("CreateAndSave", plainCreate, plainSave, plainWatch.ElapsedMilliseconds);
+        WriteRow("CreateFormattedAndSave", formattedCreate, formattedSave, formattedWatch.ElapsedMilliseconds);
+    }
+
+    private static void WriteRow(string name, long create, long save, long elapsedMs)
+    {
+        Console.WriteLine(
+            $"| {name,-22} | {Mb(create),11} | {Mb(save),11} | {Mb(create + save),11} | {elapsedMs + " ms",8} |");
+    }
+
+    private static string Mb(long bytes) => $"{bytes / 1024.0 / 1024.0:F1} MB";
+
+    private static void RunPlain(BenchmarkData data, out long createBytes, out long saveBytes)
+    {
+        var start = GC.GetTotalAllocatedBytes(precise: true);
+
+        using var workbook = new XLWorkbook();
+        var worksheet = workbook.AddWorksheet("Data");
+
+        worksheet.Cell(1, 1).Value = "Name";
+        worksheet.Cell(1, 2).Value = "Amount";
+        worksheet.Cell(1, 3).Value = "Date";
+
+        for (var i = 0; i < RowCount; i++)
+        {
+            var row = i + 2;
+            worksheet.Cell(row, 1).Value = data.Strings[i];
+            worksheet.Cell(row, 2).Value = data.Numbers[i];
+            worksheet.Cell(row, 3).Value = data.Dates[i];
+        }
+
+        var sumRow = RowCount + 2;
+        worksheet.Cell(sumRow, 1).Value = "Total";
+        worksheet.Cell(sumRow, 2).FormulaA1 = $"SUM(B2:B{RowCount + 1})";
+
+        var afterCreate = GC.GetTotalAllocatedBytes(precise: true);
+
+        using var stream = new MemoryStream();
+        workbook.SaveAs(stream);
+
+        var afterSave = GC.GetTotalAllocatedBytes(precise: true);
+
+        createBytes = afterCreate - start;
+        saveBytes = afterSave - afterCreate;
+    }
+
+    private static void RunFormatted(BenchmarkData data, out long createBytes, out long saveBytes)
+    {
+        var start = GC.GetTotalAllocatedBytes(precise: true);
+
+        using var workbook = new XLWorkbook();
+        var ws = workbook.AddWorksheet("Formatted");
+
+        FormattedSheetBuilder.WriteHeaders(ws);
+
+        for (var i = 0; i < RowCount; i++)
+        {
+            var row = i + 2;
+            FormattedSheetBuilder.WriteRowData(ws, data, row, i, i % RowCount);
+
+            if (i % 2 == 0)
+                FormattedSheetBuilder.ApplyRowFormatting(ws, row, i);
+        }
+
+        var afterCreate = GC.GetTotalAllocatedBytes(precise: true);
+
+        using var stream = new MemoryStream();
+        workbook.SaveAs(stream);
+
+        var afterSave = GC.GetTotalAllocatedBytes(precise: true);
+
+        createBytes = afterCreate - start;
+        saveBytes = afterSave - afterCreate;
+    }
+
+    // ReSharper disable once InconsistentNaming
+    private static void ForceGC()
+    {
+#pragma warning disable S1215 // Intentionally forcing GC to isolate phases
+        GC.Collect(2, GCCollectionMode.Forced, true, true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, true, true);
+#pragma warning restore S1215
+    }
+}
+
+/// <summary>
+/// Deterministic input data shared by the workbook benchmarks and the allocation profile,
+/// so both measure the same workload.
+/// </summary>
+public sealed class BenchmarkData
+{
+    public required string[] Strings { get; init; }
+
+    public required double[] Numbers { get; init; }
+
+    public required DateTime[] Dates { get; init; }
+
+    public static BenchmarkData Create(int rowCount)
+    {
+        var strings = new string[rowCount];
+        var numbers = new double[rowCount];
+        var dates = new DateTime[rowCount];
+
+#pragma warning disable S2245 // Deterministic seed for reproducible benchmarks
+        var random = new Random(42);
+#pragma warning restore S2245
+        var baseDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
+        for (var i = 0; i < rowCount; i++)
+        {
+            strings[i] = $"Item {i} - {random.Next(1000):D4}";
+            numbers[i] = Math.Round(random.NextDouble() * 10000, 2);
+            dates[i] = baseDate.AddDays(random.Next(0, 1500));
+        }
+
+        return new BenchmarkData { Strings = strings, Numbers = numbers, Dates = dates };
+    }
+}
+
+/// <summary>
+/// The formatted-sheet workload, shared by <see cref="XLiburWorkbookBenchmarks"/> and
+/// <see cref="SaveAllocationProfile"/> so the two never drift apart.
+/// </summary>
+public static class FormattedSheetBuilder
+{
+    private static readonly string[] Headers =
+        ["Name", "Amount", "Date", "Quantity", "Price", "Total", "Status", "Category", "Region", "Notes"];
+
+    public static void WriteHeaders(IXLWorksheet ws)
+    {
+        for (var c = 1; c <= 10; c++)
+        {
+            var hdr = ws.Cell(1, c);
+            hdr.Value = Headers[c - 1];
+            hdr.Style.Font.Bold = true;
+            hdr.Style.Font.FontColor = XLColor.White;
+            hdr.Style.Fill.BackgroundColor = XLColor.DarkBlue;
+            hdr.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+            hdr.Style.Border.BottomBorder = XLBorderStyleValues.Double;
+            hdr.Style.Border.BottomBorderColor = XLColor.Black;
+        }
+    }
+
+    public static void WriteRowData(IXLWorksheet ws, BenchmarkData data, int row, int i, int idx)
+    {
+        ws.Cell(row, 1).Value = data.Strings[idx];
+        ws.Cell(row, 2).Value = data.Numbers[idx];
+        ws.Cell(row, 3).Value = data.Dates[idx];
+        ws.Cell(row, 4).Value = (i % 500) + 1;
+        ws.Cell(row, 5).Value = data.Numbers[idx] * 0.1;
+        ws.Cell(row, 6).Value = data.Numbers[idx] * ((i % 500) + 1) * 0.1;
+        var status = (i % 3) switch { 0 => "Active", 1 => "Pending", _ => "Closed" };
+        ws.Cell(row, 7).Value = status;
+        ws.Cell(row, 8).Value = $"Cat-{(i % 12) + 1}";
+        var region = (i % 5) switch { 0 => "North", 1 => "South", 2 => "East", 3 => "West", _ => "Central" };
+        ws.Cell(row, 9).Value = region;
+        ws.Cell(row, 10).Value = $"Note for row {row}";
+    }
+
+    public static void ApplyRowFormatting(IXLWorksheet ws, int row, int i)
+    {
+        ApplyCellStyle(ws, row, 1, s =>
+        {
+            s.Font.Bold = true;
+            s.Fill.BackgroundColor = XLColor.LightBlue;
+        });
+
+        ApplyCellStyle(ws, row, 2, s =>
+        {
+            s.NumberFormat.Format = "#,##0.00";
+            s.Font.FontColor = XLColor.DarkRed;
+            s.Border.OutsideBorder = XLBorderStyleValues.Thin;
+            s.Border.OutsideBorderColor = XLColor.Gray;
+        });
+
+        ApplyCellStyle(ws, row, 3, s =>
+        {
+            s.NumberFormat.NumberFormatId = 15;
+            s.Font.Italic = true;
+            s.Fill.BackgroundColor = XLColor.LightGreen;
+        });
+
+        ApplyCellStyle(ws, row, 4, s =>
+        {
+            s.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+            s.Border.OutsideBorder = XLBorderStyleValues.Medium;
+            s.Border.OutsideBorderColor = XLColor.DarkGoldenrod;
+            s.Fill.BackgroundColor = XLColor.LightYellow;
+        });
+
+        ApplyCellStyle(ws, row, 5, s =>
+        {
+            s.NumberFormat.Format = "$ #,##0.00";
+            s.Font.FontName = "Consolas";
+            s.Font.FontSize = 10;
+            s.Fill.BackgroundColor = XLColor.LightCoral;
+        });
+
+        ApplyCellStyle(ws, row, 6, s =>
+        {
+            s.NumberFormat.Format = "_($* #,##0.00_)";
+            s.Font.Bold = true;
+            s.Border.BottomBorder = XLBorderStyleValues.Dashed;
+            s.Border.BottomBorderColor = XLColor.Navy;
+        });
+
+        ApplyCellStyle(ws, row, 7, s =>
+        {
+            s.Font.Strikethrough = i % 3 == 2;
+            s.Font.FontColor = (i % 3) switch { 0 => XLColor.Green, 1 => XLColor.Orange, _ => XLColor.Red };
+            s.Fill.BackgroundColor = XLColor.Lavender;
+        });
+
+        ApplyCellStyle(ws, row, 8, s =>
+        {
+            s.Font.Underline = XLFontUnderlineValues.Single;
+            s.Alignment.Horizontal = XLAlignmentHorizontalValues.Right;
+            s.Border.RightBorder = XLBorderStyleValues.Dotted;
+            s.Border.RightBorderColor = XLColor.Purple;
+            s.Fill.BackgroundColor = XLColor.LightGray;
+        });
+
+        ApplyCellStyle(ws, row, 9, s =>
+        {
+            s.Font.FontName = "Georgia";
+            s.Font.FontSize = 12;
+            s.Font.FontColor = XLColor.Teal;
+            s.Border.OutsideBorder = XLBorderStyleValues.Thick;
+            s.Border.OutsideBorderColor = XLColor.Teal;
+            s.Fill.BackgroundColor = XLColor.Wheat;
+        });
+
+        ApplyCellStyle(ws, row, 10, s =>
+        {
+            s.Alignment.WrapText = true;
+            s.Alignment.Vertical = XLAlignmentVerticalValues.Top;
+            s.Border.OutsideBorder = XLBorderStyleValues.Double;
+            s.Border.OutsideBorderColor = XLColor.Chocolate;
+            s.Fill.BackgroundColor = XLColor.LightSalmon;
+            s.Font.FontColor = XLColor.DarkSlateGray;
+        });
+    }
+
+    private static void ApplyCellStyle(IXLWorksheet ws, int row, int col, Action<IXLStyle> apply)
+    {
+        apply(ws.Cell(row, col).Style);
+    }
+}

--- a/XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs
@@ -15,6 +15,7 @@ public class XLiburWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
 
+    private BenchmarkData _data = null!;
     private string[] _strings = null!;
     private double[] _numbers = null!;
     private DateTime[] _dates = null!;
@@ -23,21 +24,10 @@ public class XLiburWorkbookBenchmarks
     public void Setup()
     {
         SixLaborsV1FontBootstrap.Register();
-        _strings = new string[RowCount];
-        _numbers = new double[RowCount];
-        _dates = new DateTime[RowCount];
-
-#pragma warning disable S2245 // Deterministic seed for reproducible benchmarks
-        var random = new Random(42);
-#pragma warning restore S2245
-        var baseDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
-
-        for (var i = 0; i < RowCount; i++)
-        {
-            _strings[i] = $"Item {i} - {random.Next(1000):D4}";
-            _numbers[i] = Math.Round(random.NextDouble() * 10000, 2);
-            _dates[i] = baseDate.AddDays(random.Next(0, 1500));
-        }
+        _data = BenchmarkData.Create(RowCount);
+        _strings = _data.Strings;
+        _numbers = _data.Numbers;
+        _dates = _data.Dates;
     }
 
     [Benchmark]
@@ -72,142 +62,20 @@ public class XLiburWorkbookBenchmarks
         using var workbook = new XLWorkbook();
         var ws = workbook.AddWorksheet("Formatted");
 
-        WriteHeaders(ws);
+        FormattedSheetBuilder.WriteHeaders(ws);
 
         for (var i = 0; i < RowCount; i++)
         {
             var row = i + 2;
             var idx = i % _strings.Length;
 
-            WriteRowData(ws, row, i, idx);
+            FormattedSheetBuilder.WriteRowData(ws, _data, row, i, idx);
 
             if (i % 2 == 0)
-                ApplyRowFormatting(ws, row, i);
+                FormattedSheetBuilder.ApplyRowFormatting(ws, row, i);
         }
 
         using var stream = new MemoryStream();
         workbook.SaveAs(stream);
-    }
-
-    private static void WriteHeaders(IXLWorksheet ws)
-    {
-        var headers = new[]
-            { "Name", "Amount", "Date", "Quantity", "Price", "Total", "Status", "Category", "Region", "Notes" };
-        for (var c = 1; c <= 10; c++)
-        {
-            var hdr = ws.Cell(1, c);
-            hdr.Value = headers[c - 1];
-            hdr.Style.Font.Bold = true;
-            hdr.Style.Font.FontColor = XLColor.White;
-            hdr.Style.Fill.BackgroundColor = XLColor.DarkBlue;
-            hdr.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
-            hdr.Style.Border.BottomBorder = XLBorderStyleValues.Double;
-            hdr.Style.Border.BottomBorderColor = XLColor.Black;
-        }
-    }
-
-    private void WriteRowData(IXLWorksheet ws, int row, int i, int idx)
-    {
-        ws.Cell(row, 1).Value = _strings[idx];
-        ws.Cell(row, 2).Value = _numbers[idx];
-        ws.Cell(row, 3).Value = _dates[idx];
-        ws.Cell(row, 4).Value = (i % 500) + 1;
-        ws.Cell(row, 5).Value = _numbers[idx] * 0.1;
-        ws.Cell(row, 6).Value = _numbers[idx] * ((i % 500) + 1) * 0.1;
-        var status = (i % 3) switch { 0 => "Active", 1 => "Pending", _ => "Closed" };
-        ws.Cell(row, 7).Value = status;
-        ws.Cell(row, 8).Value = $"Cat-{(i % 12) + 1}";
-        var region = (i % 5) switch { 0 => "North", 1 => "South", 2 => "East", 3 => "West", _ => "Central" };
-        ws.Cell(row, 9).Value = region;
-        ws.Cell(row, 10).Value = $"Note for row {row}";
-    }
-
-    private static void ApplyRowFormatting(IXLWorksheet ws, int row, int i)
-    {
-        ApplyCellStyle(ws, row, 1, s =>
-        {
-            s.Font.Bold = true;
-            s.Fill.BackgroundColor = XLColor.LightBlue;
-        });
-
-        ApplyCellStyle(ws, row, 2, s =>
-        {
-            s.NumberFormat.Format = "#,##0.00";
-            s.Font.FontColor = XLColor.DarkRed;
-            s.Border.OutsideBorder = XLBorderStyleValues.Thin;
-            s.Border.OutsideBorderColor = XLColor.Gray;
-        });
-
-        ApplyCellStyle(ws, row, 3, s =>
-        {
-            s.NumberFormat.NumberFormatId = 15;
-            s.Font.Italic = true;
-            s.Fill.BackgroundColor = XLColor.LightGreen;
-        });
-
-        ApplyCellStyle(ws, row, 4, s =>
-        {
-            s.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
-            s.Border.OutsideBorder = XLBorderStyleValues.Medium;
-            s.Border.OutsideBorderColor = XLColor.DarkGoldenrod;
-            s.Fill.BackgroundColor = XLColor.LightYellow;
-        });
-
-        ApplyCellStyle(ws, row, 5, s =>
-        {
-            s.NumberFormat.Format = "$ #,##0.00";
-            s.Font.FontName = "Consolas";
-            s.Font.FontSize = 10;
-            s.Fill.BackgroundColor = XLColor.LightCoral;
-        });
-
-        ApplyCellStyle(ws, row, 6, s =>
-        {
-            s.NumberFormat.Format = "_($* #,##0.00_)";
-            s.Font.Bold = true;
-            s.Border.BottomBorder = XLBorderStyleValues.Dashed;
-            s.Border.BottomBorderColor = XLColor.Navy;
-        });
-
-        ApplyCellStyle(ws, row, 7, s =>
-        {
-            s.Font.Strikethrough = i % 3 == 2;
-            s.Font.FontColor = (i % 3) switch { 0 => XLColor.Green, 1 => XLColor.Orange, _ => XLColor.Red };
-            s.Fill.BackgroundColor = XLColor.Lavender;
-        });
-
-        ApplyCellStyle(ws, row, 8, s =>
-        {
-            s.Font.Underline = XLFontUnderlineValues.Single;
-            s.Alignment.Horizontal = XLAlignmentHorizontalValues.Right;
-            s.Border.RightBorder = XLBorderStyleValues.Dotted;
-            s.Border.RightBorderColor = XLColor.Purple;
-            s.Fill.BackgroundColor = XLColor.LightGray;
-        });
-
-        ApplyCellStyle(ws, row, 9, s =>
-        {
-            s.Font.FontName = "Georgia";
-            s.Font.FontSize = 12;
-            s.Font.FontColor = XLColor.Teal;
-            s.Border.OutsideBorder = XLBorderStyleValues.Thick;
-            s.Border.OutsideBorderColor = XLColor.Teal;
-            s.Fill.BackgroundColor = XLColor.Wheat;
-        });
-
-        ApplyCellStyle(ws, row, 10, s =>
-        {
-            s.Alignment.WrapText = true;
-            s.Alignment.Vertical = XLAlignmentVerticalValues.Top;
-            s.Border.OutsideBorder = XLBorderStyleValues.Double;
-            s.Border.OutsideBorderColor = XLColor.Chocolate;
-            s.Fill.BackgroundColor = XLColor.LightSalmon;
-            s.Font.FontColor = XLColor.DarkSlateGray;
-        });
-    }
-
-    private static void ApplyCellStyle(IXLWorksheet ws, int row, int col, Action<IXLStyle> apply)
-    {
-        apply(ws.Cell(row, col).Style);
     }
 }

--- a/XLibur.Tests/Extensions/XmlWriterExtensionsTests.cs
+++ b/XLibur.Tests/Extensions/XmlWriterExtensionsTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Xml;
+using NUnit.Framework;
+using XLibur.Excel;
+using XLibur.Extensions;
+
+namespace XLibur.Tests.Extensions;
+
+/// <summary>
+/// <see cref="XmlWriterExtensions"/> formats numbers into a reusable buffer instead of allocating
+/// a string per value. Those writes end up in the saved file verbatim, so the output has to stay
+/// byte-identical to <see cref="ObjectExtensions.ToInvariantString{T}"/>, which is what the writer
+/// used before and what round-trip stability depends on.
+/// </summary>
+[TestFixture]
+public class XmlWriterExtensionsTests
+{
+    [TestCase(0d)]
+    [TestCase(1d)]
+    [TestCase(-1d)]
+    [TestCase(0.1d)]
+    [TestCase(-0.5d)]
+    [TestCase(1234567890.123456d)]
+    [TestCase(1e-300)]
+    [TestCase(1e300)]
+    [TestCase(-1e-300)]
+    [TestCase(-1e300)]
+    [TestCase(double.Epsilon)]
+    [TestCase(double.MaxValue)]
+    [TestCase(double.MinValue)]
+    [TestCase(1d / 3d)]
+    [TestCase(2d / 3d)]
+    [TestCase(0.1d + 0.2d)]
+    public void WriteNumberValue_double_matches_ToInvariantString(double value)
+    {
+        Assert.AreEqual(value.ToInvariantString(), WriteDouble(value));
+    }
+
+    [Test]
+    public void WriteNumberValue_double_matches_ToInvariantString_for_random_values()
+    {
+#pragma warning disable S2245 // Deterministic seed keeps failures reproducible
+        var random = new Random(1234);
+#pragma warning restore S2245
+
+        for (var i = 0; i < 20_000; i++)
+        {
+            var value = NextDouble(random);
+            Assert.AreEqual(value.ToInvariantString(), WriteDouble(value), $"value #{i}");
+        }
+    }
+
+    [Test]
+    public void WriteNumberValue_serial_dates_match_ToInvariantString()
+    {
+#pragma warning disable S2245 // Deterministic seed keeps failures reproducible
+        var random = new Random(4321);
+#pragma warning restore S2245
+
+        var baseDate = new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+        for (var i = 0; i < 20_000; i++)
+        {
+            var date = baseDate
+                .AddDays(random.Next(0, 60_000))
+                .AddSeconds(random.Next(0, 86_400))
+                .AddMilliseconds(random.Next(0, 1000));
+
+            var serial = date.ToSerialDateTime();
+            Assert.AreEqual(serial.ToInvariantString(), WriteDouble(serial), $"date #{i}: {date:O}");
+        }
+    }
+
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(-1)]
+    [TestCase(12345)]
+    [TestCase(int.MaxValue)]
+    [TestCase(int.MinValue)]
+    public void WriteNumberValue_int_matches_ToInvariantString(int value)
+    {
+        Assert.AreEqual(value.ToInvariantString(), WriteInt(value));
+    }
+
+    [TestCase(0u)]
+    [TestCase(1u)]
+    [TestCase(12345u)]
+    [TestCase(uint.MaxValue)]
+    public void WriteNumberValue_uint_matches_ToInvariantString(uint value)
+    {
+        Assert.AreEqual(value.ToInvariantString(), WriteUInt(value));
+    }
+
+    [Test]
+    public void WriteNumberValue_int_matches_ToInvariantString_for_random_values()
+    {
+#pragma warning disable S2245 // Deterministic seed keeps failures reproducible
+        var random = new Random(99);
+#pragma warning restore S2245
+
+        for (var i = 0; i < 20_000; i++)
+        {
+            var value = random.Next(int.MinValue, int.MaxValue);
+            Assert.AreEqual(value.ToInvariantString(), WriteInt(value), $"value #{i}");
+        }
+    }
+
+    /// <summary>
+    /// The number buffer is thread-static and reused across calls, so a second value must not be
+    /// contaminated by the leftovers of a longer first one.
+    /// </summary>
+    [Test]
+    public void WriteNumberValue_reuses_the_buffer_without_leaking_previous_digits()
+    {
+        // "G15", not round-trip: 15 significant digits, matching ToInvariantString.
+        Assert.AreEqual("-1.79769313486232E+308", WriteDouble(double.MinValue));
+        Assert.AreEqual("1", WriteDouble(1d));
+        Assert.AreEqual("-2147483648", WriteInt(int.MinValue));
+        Assert.AreEqual("7", WriteInt(7));
+    }
+
+    private static string WriteDouble(double value) => Capture(w => w.WriteNumberValue(value));
+
+    private static string WriteInt(int value) => Capture(w => w.WriteNumberValue(value));
+
+    private static string WriteUInt(uint value) => Capture(w => w.WriteNumberValue(value));
+
+    /// <summary>
+    /// Capture what the extension writes as element content, which is exactly how the sheet writer
+    /// emits cell values.
+    /// </summary>
+    private static string Capture(Action<XmlWriter> write)
+    {
+        var sb = new StringBuilder();
+        var settings = new XmlWriterSettings
+        {
+            OmitXmlDeclaration = true,
+            ConformanceLevel = ConformanceLevel.Fragment,
+        };
+
+        using (var writer = XmlWriter.Create(sb, settings))
+        {
+            writer.WriteStartElement("v");
+            write(writer);
+            writer.WriteEndElement();
+        }
+
+        var xml = sb.ToString();
+        return xml["<v>".Length..^"</v>".Length];
+    }
+
+    private static double NextDouble(Random random)
+    {
+        return (random.Next(8)) switch
+        {
+            0 => random.NextDouble(),
+            1 => random.NextDouble() * 10_000,
+            2 => random.NextDouble() * 1e12,
+            3 => random.NextDouble() * 1e-12,
+            4 => -random.NextDouble() * 1e6,
+            5 => random.Next(-1_000_000, 1_000_000),
+            6 => Math.Round(random.NextDouble() * 10_000, 2),
+            _ => BitConverter.Int64BitsToDouble(NextFiniteBits(random)),
+        };
+    }
+
+    /// <summary>Random bit patterns, excluding NaN/Infinity which never reach the writer.</summary>
+    private static long NextFiniteBits(Random random)
+    {
+        while (true)
+        {
+            var bits = ((long)random.Next() << 32) | (uint)random.Next();
+            var candidate = BitConverter.Int64BitsToDouble(bits);
+            if (!double.IsNaN(candidate) && !double.IsInfinity(candidate))
+                return bits;
+        }
+    }
+}

--- a/XLibur/Excel/Caching/XLRepositoryBase.cs
+++ b/XLibur/Excel/Caching/XLRepositoryBase.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Collections;
+using System.Threading;
 
 namespace XLibur.Excel.Caching;
 
@@ -18,8 +18,17 @@ internal class XLRepositoryBase<Tkey, Tvalue> : XLRepositoryBase, IXLRepository<
     const int CONCURRENCY_LEVEL = 4;
     const int INITIAL_CAPACITY = 1000;
 
-    private readonly ConcurrentDictionary<Tkey, WeakReference> _storage;
+    /// <summary>
+    /// Number of lookups that found a collected entry before an opportunistic prune is triggered.
+    /// The repositories are process-wide and hold one entry per distinct key ever seen, so without
+    /// pruning a long-lived process that builds many workbooks accumulates dead shells forever.
+    /// Sweeping is O(n), hence the counter rather than sweeping on every miss.
+    /// </summary>
+    private const int DeadEntriesBeforePrune = 512;
+
+    private readonly ConcurrentDictionary<Tkey, WeakReference<Tvalue>> _storage;
     private readonly Func<Tkey, Tvalue> _createNew;
+    private int _deadEntriesSeen;
 
     internal XLRepositoryBase(Func<Tkey, Tvalue> createNew)
         : this(createNew, EqualityComparer<Tkey>.Default)
@@ -28,7 +37,7 @@ internal class XLRepositoryBase<Tkey, Tvalue> : XLRepositoryBase, IXLRepository<
 
     internal XLRepositoryBase(Func<Tkey, Tvalue> createNew, IEqualityComparer<Tkey> comparer)
     {
-        _storage = new ConcurrentDictionary<Tkey, WeakReference>(CONCURRENCY_LEVEL, INITIAL_CAPACITY, comparer);
+        _storage = new ConcurrentDictionary<Tkey, WeakReference<Tvalue>>(CONCURRENCY_LEVEL, INITIAL_CAPACITY, comparer);
         _createNew = createNew;
     }
 
@@ -41,11 +50,17 @@ internal class XLRepositoryBase<Tkey, Tvalue> : XLRepositoryBase, IXLRepository<
     /// <returns>True if entry exists and alive, false otherwise.</returns>
     public bool ContainsKey(ref Tkey key, out Tvalue? value)
     {
-        if (_storage.TryGetValue(key, out WeakReference? cachedReference))
+        if (_storage.TryGetValue(key, out var cachedReference))
         {
-            value = cachedReference.Target as Tvalue;
-            return value != null;
+            if (cachedReference.TryGetTarget(out var target))
+            {
+                value = target;
+                return true;
+            }
+
+            NoteDeadEntry();
         }
+
         value = null;
         return false;
     }
@@ -64,27 +79,37 @@ internal class XLRepositoryBase<Tkey, Tvalue> : XLRepositoryBase, IXLRepository<
         if (value is null)
             return null;
 
-        do
+        while (true)
         {
-            if (_storage.TryGetValue(key, out WeakReference? cachedReference) &&
-                cachedReference.Target is Tvalue storedValue)
+            if (_storage.TryGetValue(key, out var cachedReference))
             {
-                return storedValue;
-            }
-        } while (!_storage.TryAdd(key, new WeakReference(value)));
+                if (cachedReference.TryGetTarget(out var storedValue))
+                    return storedValue;
 
-        return value;
+                // The entry is a collected shell. Swap it atomically so that a racing reviver or
+                // a concurrent prune cannot make two callers walk away with different instances
+                // for the same key: whoever loses the swap loops and picks up the winner's value.
+                if (_storage.TryUpdate(key, new WeakReference<Tvalue>(value), cachedReference))
+                    return value;
+
+                continue;
+            }
+
+            if (_storage.TryAdd(key, new WeakReference<Tvalue>(value)))
+                return value;
+        }
     }
 
     public Tvalue GetOrCreate(ref Tkey key)
     {
-        if (_storage.TryGetValue(key, out WeakReference? cachedReference) &&
-            cachedReference.Target is Tvalue storedValue)
+        if (_storage.TryGetValue(key, out var cachedReference))
         {
-            return storedValue;
+            if (cachedReference.TryGetTarget(out var storedValue))
+                return storedValue;
+
+            NoteDeadEntry();
         }
 
-        _storage.TryRemove(key, out WeakReference? _);
         var value = _createNew(key);
         return Store(ref key, value)!;
     }
@@ -108,6 +133,7 @@ internal class XLRepositoryBase<Tkey, Tvalue> : XLRepositoryBase, IXLRepository<
     public override void Clear()
     {
         _storage.Clear();
+        _deadEntriesSeen = 0;
     }
 
     /// <summary>
@@ -115,22 +141,52 @@ internal class XLRepositoryBase<Tkey, Tvalue> : XLRepositoryBase, IXLRepository<
     /// </summary>
     public IEnumerator<Tvalue> GetEnumerator()
     {
-        return _storage
-            .Select(pair =>
-            {
-                var val = pair.Value.Target as Tvalue;
-                if (val == null)
-                {
-                    _storage.TryRemove(pair.Key, out _);
-                }
-                return val;
-            })
-            .Where(val => val != null)
-            .GetEnumerator()!;
+        foreach (var pair in _storage)
+        {
+            if (pair.Value.TryGetTarget(out var value))
+                yield return value;
+            else
+                RemoveIfDead(pair.Key, pair.Value);
+        }
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
         return GetEnumerator();
+    }
+
+    /// <summary>
+    /// Count a lookup that hit a collected entry and sweep the whole repository once enough of
+    /// them have accumulated.
+    /// </summary>
+    private void NoteDeadEntry()
+    {
+        if (Interlocked.Increment(ref _deadEntriesSeen) < DeadEntriesBeforePrune)
+            return;
+
+        Interlocked.Exchange(ref _deadEntriesSeen, 0);
+        Prune();
+    }
+
+    private void Prune()
+    {
+        foreach (var pair in _storage)
+        {
+            if (!pair.Value.TryGetTarget(out _))
+                RemoveIfDead(pair.Key, pair.Value);
+        }
+    }
+
+    /// <summary>
+    /// Remove an entry only if it is still the same collected shell we observed, so a value
+    /// stored concurrently under that key is never dropped.
+    /// </summary>
+    private void RemoveIfDead(Tkey key, WeakReference<Tvalue> observed)
+    {
+        if (observed.TryGetTarget(out _))
+            return;
+
+        ((ICollection<KeyValuePair<Tkey, WeakReference<Tvalue>>>)_storage)
+            .Remove(new KeyValuePair<Tkey, WeakReference<Tvalue>>(key, observed));
     }
 }

--- a/XLibur/Excel/Cells/XLCellsCollection.cs
+++ b/XLibur/Excel/Cells/XLCellsCollection.cs
@@ -190,6 +190,45 @@ internal sealed class XLCellsCollection : IWorkbookListener
         }
     }
 
+    /// <summary>
+    /// Whether any cell in the sheet has a comment. Scans the misc slice directly, so it costs
+    /// nothing on sheets that never touched comments, phonetics or metadata.
+    /// </summary>
+    internal bool HasAnyComment()
+    {
+        if (MiscSlice.IsEmpty)
+            return false;
+
+        var enumerator = new Slice<XLMiscSliceContent>.Enumerator(MiscSlice, XLSheetRange.Full);
+        while (enumerator.MoveNext())
+        {
+            if (enumerator.Current.Comment is not null)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Points of all cells that carry an in-cell image, in row-major order. Scans the misc slice
+    /// directly rather than materialising an <see cref="XLCell"/> per used cell.
+    /// </summary>
+    internal List<XLSheetPoint> GetCellImagePoints()
+    {
+        var points = new List<XLSheetPoint>();
+        if (MiscSlice.IsEmpty)
+            return points;
+
+        var enumerator = new Slice<XLMiscSliceContent>.Enumerator(MiscSlice, XLSheetRange.Full);
+        while (enumerator.MoveNext())
+        {
+            if (enumerator.Current.CellImage is not null)
+                points.Add(enumerator.Point);
+        }
+
+        return points;
+    }
+
     internal IEnumerable<XLCell> GetCellsInColumn(int column)
     {
         return GetCells(1, column, XLHelper.MaxRowNumber, column);

--- a/XLibur/Excel/IO/CalculationChainPartWriter.cs
+++ b/XLibur/Excel/IO/CalculationChainPartWriter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using XLibur.Excel.Coordinates;
 using static XLibur.Excel.XLWorkbook;
 
 namespace XLibur.Excel.IO;
@@ -19,9 +20,17 @@ internal static class CalculationChainPartWriter
 
         foreach (var worksheet in workbook.WorksheetsInternal)
         {
-            foreach (var c in worksheet.Internals.CellsCollection.GetCells().Where(c => c.HasFormula))
+            // Enumerate the formula slice instead of every used cell: only formula cells need an
+            // XLCell wrapper here, and on a large sheet they are a tiny fraction of the total.
+            var cellsCollection = worksheet.Internals.CellsCollection;
+            var formulas = cellsCollection.FormulaSlice;
+            if (formulas.IsEmpty)
+                continue;
+
+            using var formulaEnumerator = formulas.GetForwardEnumerator(XLSheetRange.Full);
+            while (formulaEnumerator.MoveNext())
             {
-                AppendFormulaCell(calculationChain, c, worksheet);
+                AppendFormulaCell(calculationChain, cellsCollection.GetCell(formulaEnumerator.Point), worksheet);
             }
         }
 

--- a/XLibur/Excel/IO/SheetDataWriter.cs
+++ b/XLibur/Excel/IO/SheetDataWriter.cs
@@ -504,14 +504,14 @@ internal static class SheetDataWriter
         w.WriteStartElement("row", Main2006SsNs);
 
         w.WriteStartAttribute("r");
-        w.WriteValue(rowNumber);
+        w.WriteNumberValue(rowNumber);
         w.WriteEndAttribute();
 
         if (maxColumn > 0)
         {
             w.WriteStartAttribute("spans");
             w.WriteString("1:");
-            w.WriteValue(maxColumn);
+            w.WriteNumberValue(maxColumn);
             w.WriteEndAttribute();
         }
 
@@ -597,7 +597,7 @@ internal static class SheetDataWriter
     private static void WriteValue(XmlWriter xml, int sharedStringId)
     {
         xml.WriteStartElement("v", Main2006SsNs);
-        xml.WriteValue(sharedStringId);
+        xml.WriteNumberValue(sharedStringId);
         xml.WriteEndElement();
     }
 

--- a/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
@@ -5,6 +5,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel.AutoFilters;
+using XLibur.Excel.Coordinates;
 using XLibur.Excel.Tables;
 using XLibur.Utils;
 using static XLibur.Excel.XLWorkbook;
@@ -128,8 +129,13 @@ internal static class WorkbookStylesPartWriter
             foreach (var s in worksheet.Internals.RowsCollection.Select(r => r.Value.StyleValue))
                 styles.Add(s);
 
-            foreach (var c in worksheet.Internals.CellsCollection.GetCells())
-                styles.Add(c.StyleValue);
+            // Read the effective style straight from the slices. Going through GetCells() would
+            // materialise an XLCell wrapper for every used cell just to read one property, which
+            // on a large sheet is the single biggest allocation of the whole save.
+            var cellsCollection = worksheet.Internals.CellsCollection;
+            var cells = new XLCellsCollection.SlicesEnumerator(XLSheetRange.Full, cellsCollection);
+            while (cells.MoveNext())
+                styles.Add(worksheet.GetStyleValue(cells.Current));
 
             var xlPivotTableDataFieldFormats = worksheet.PivotTables
                 .SelectMany<XLPivotTable, XLPivotDataField>(pt => pt.DataFields)

--- a/XLibur/Excel/Style/XLStyleKey.cs
+++ b/XLibur/Excel/Style/XLStyleKey.cs
@@ -1,22 +1,98 @@
-﻿namespace XLibur.Excel;
+namespace XLibur.Excel;
 
+/// <summary>
+/// The composite key of a style. Instances are only ever produced through object initialisers
+/// (every member is <c>required</c>) or <c>with</c> expressions, so each component's hash code is
+/// computed once in the corresponding <c>init</c> accessor and reused afterwards.
+/// </summary>
+/// <remarks>
+/// The style repository hashes and compares this key on every style mutation, and the components
+/// are large structs whose hashes are expensive (the border alone carries five colours, and the
+/// number format hashes a string). Re-deriving all of that on every dictionary probe dominated
+/// the cost of styling a sheet, so the per-component hashes are memoised in the key itself and
+/// <see cref="GetHashCode"/> just folds seven ints together. The memoised hashes also give
+/// <see cref="Equals(XLStyleKey)"/> a cheap way to reject non-matching keys before touching the
+/// components.
+/// </remarks>
 internal readonly record struct XLStyleKey
 {
     private const string DefaultLabel = "Default";
 
-    public required XLAlignmentKey Alignment { get; init; }
+    private readonly XLAlignmentKey _alignment;
+    private readonly XLBorderKey _border;
+    private readonly XLFillKey _fill;
+    private readonly XLFontKey _font;
+    private readonly XLNumberFormatKey _numberFormat;
+    private readonly XLProtectionKey _protection;
 
-    public required XLBorderKey Border { get; init; }
+    private readonly int _alignmentHash;
+    private readonly int _borderHash;
+    private readonly int _fillHash;
+    private readonly int _fontHash;
+    private readonly int _numberFormatHash;
+    private readonly int _protectionHash;
 
-    public required XLFillKey Fill { get; init; }
+    public required XLAlignmentKey Alignment
+    {
+        get => _alignment;
+        init
+        {
+            _alignment = value;
+            _alignmentHash = value.GetHashCode();
+        }
+    }
 
-    public required XLFontKey Font { get; init; }
+    public required XLBorderKey Border
+    {
+        get => _border;
+        init
+        {
+            _border = value;
+            _borderHash = value.GetHashCode();
+        }
+    }
+
+    public required XLFillKey Fill
+    {
+        get => _fill;
+        init
+        {
+            _fill = value;
+            _fillHash = value.GetHashCode();
+        }
+    }
+
+    public required XLFontKey Font
+    {
+        get => _font;
+        init
+        {
+            _font = value;
+            _fontHash = value.GetHashCode();
+        }
+    }
 
     public required bool IncludeQuotePrefix { get; init; }
 
-    public required XLNumberFormatKey NumberFormat { get; init; }
+    public required XLNumberFormatKey NumberFormat
+    {
+        get => _numberFormat;
+        init
+        {
+            _numberFormat = value;
+            _numberFormatHash = value.GetHashCode();
+        }
+    }
 
-    public required XLProtectionKey Protection { get; init; }
+    public required XLProtectionKey Protection
+    {
+        get => _protection;
+        init
+        {
+            _protection = value;
+            _protectionHash = value.GetHashCode();
+        }
+    }
 
     public override string ToString()
     {
@@ -40,27 +116,39 @@ internal readonly record struct XLStyleKey
     {
         unchecked
         {
-            var hash = Alignment.GetHashCode();
-            hash = (hash * 397) ^ Border.GetHashCode();
-            hash = (hash * 397) ^ Fill.GetHashCode();
-            hash = (hash * 397) ^ Font.GetHashCode();
-            hash = (hash * 397) ^ IncludeQuotePrefix.GetHashCode();
-            hash = (hash * 397) ^ NumberFormat.GetHashCode();
-            hash = (hash * 397) ^ Protection.GetHashCode();
+            var hash = _alignmentHash;
+            hash = (hash * 397) ^ _borderHash;
+            hash = (hash * 397) ^ _fillHash;
+            hash = (hash * 397) ^ _fontHash;
+            hash = (hash * 397) ^ (IncludeQuotePrefix ? 1 : 0);
+            hash = (hash * 397) ^ _numberFormatHash;
+            hash = (hash * 397) ^ _protectionHash;
             return hash;
         }
     }
 
     public bool Equals(XLStyleKey other)
     {
+        // Reject on the memoised component hashes first: a mismatch there is proof of inequality
+        // (each component's hash is consistent with its Equals) and costs a single int compare.
+        if (_fontHash != other._fontHash
+            || _fillHash != other._fillHash
+            || _borderHash != other._borderHash
+            || _numberFormatHash != other._numberFormatHash
+            || _alignmentHash != other._alignmentHash
+            || _protectionHash != other._protectionHash
+            || IncludeQuotePrefix != other.IncludeQuotePrefix)
+        {
+            return false;
+        }
+
         // Order by discrimination power: font/fill/border vary most, protection/alignment least.
-        return Font.Equals(other.Font)
-               && Fill.Equals(other.Fill)
-               && Border.Equals(other.Border)
-               && NumberFormat.Equals(other.NumberFormat)
-               && Alignment.Equals(other.Alignment)
-               && IncludeQuotePrefix == other.IncludeQuotePrefix
-               && Protection.Equals(other.Protection);
+        return _font.Equals(other._font)
+               && _fill.Equals(other._fill)
+               && _border.Equals(other._border)
+               && _numberFormat.Equals(other._numberFormat)
+               && _alignment.Equals(other._alignment)
+               && _protection.Equals(other._protection);
     }
 
     public void Deconstruct(
@@ -72,12 +160,12 @@ internal readonly record struct XLStyleKey
         out XLNumberFormatKey numberFormat,
         out XLProtectionKey protection)
     {
-        alignment = Alignment;
-        border = Border;
-        fill = Fill;
-        font = Font;
+        alignment = _alignment;
+        border = _border;
+        fill = _fill;
+        font = _font;
         includeQuotePrefix = IncludeQuotePrefix;
-        numberFormat = NumberFormat;
-        protection = Protection;
+        numberFormat = _numberFormat;
+        protection = _protection;
     }
 }

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -12,6 +12,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml.Validation;
+using XLibur.Excel.Coordinates;
 using XLibur.Excel.IO;
 using XLibur.Extensions;
 using Path = System.IO.Path;
@@ -290,15 +291,32 @@ public partial class XLWorkbook
     /// <c>@</c> operator. Sets <see cref="SaveContext.DynamicArrayMetaIndex"/> so
     /// the sheet writer can emit the <c>cm</c> attribute on those cells.
     /// </summary>
+    /// <summary>
+    /// Walk the formula slices directly rather than <c>GetCells()</c>, which would materialise an
+    /// <c>XLCell</c> for every used cell in the workbook just to test a formula flag.
+    /// </summary>
+    private bool AnyDynamicArrayFormula()
+    {
+        foreach (var worksheet in WorksheetsInternal)
+        {
+            var formulas = worksheet.Internals.CellsCollection.FormulaSlice;
+            if (formulas.IsEmpty)
+                continue;
+
+            using var formulaEnumerator = formulas.GetForwardEnumerator(XLSheetRange.Full);
+            while (formulaEnumerator.MoveNext())
+            {
+                if (formulaEnumerator.Current.IsDynamicArray)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
     private void EnsureDynamicArrayMetadata(WorkbookPart workbookPart, SaveContext context)
     {
-        var hasDynamicArray = WorksheetsInternal
-            .Cast<XLWorksheet>()
-            .Any(ws => ws.Internals.CellsCollection
-                .GetCells(c => c.HasFormula && c.Formula!.IsDynamicArray)
-                .Any());
-
-        if (!hasDynamicArray)
+        if (!AnyDynamicArrayFormula())
             return;
 
         // The XLDAPR metadata structure in metadata.xml consists of three parts:
@@ -472,8 +490,10 @@ public partial class XLWorkbook
         var cellsWithImages = new List<(XLCell Cell, XLCellImage Image)>();
         foreach (var ws in WorksheetsInternal.Cast<XLWorksheet>())
         {
-            foreach (var cell in ws.Internals.CellsCollection.GetCells(c => c.CellImage is not null))
+            var cellsCollection = ws.Internals.CellsCollection;
+            foreach (var point in cellsCollection.GetCellImagePoints())
             {
+                var cell = cellsCollection.GetCell(point);
                 cellsWithImages.Add((cell, cell.CellImage!));
             }
         }
@@ -658,7 +678,7 @@ public partial class XLWorkbook
     private static void GenerateCommentsAndVmlParts(WorksheetPart worksheetPart, XLWorksheet worksheet,
         SaveContext context)
     {
-        var worksheetHasComments = worksheet.Internals.CellsCollection.GetCells(c => c.HasComment).Any();
+        var worksheetHasComments = worksheet.Internals.CellsCollection.HasAnyComment();
 
         // VML part is the source of truth for shapes of comments, form controls and likely others.
         // Excel won't display any shape without VML. The drawing part is always present but is likely

--- a/XLibur/Extensions/XmlWriterExtensions.cs
+++ b/XLibur/Extensions/XmlWriterExtensions.cs
@@ -10,6 +10,12 @@ namespace XLibur.Extensions;
 
 internal static class XmlWriterExtensions
 {
+    /// <summary>
+    /// Enough for any <c>double</c> in "G15" form (longest is 22 chars, e.g.
+    /// <c>-1.23456789012345E-308</c>) and for any <c>int</c>/<c>uint</c>.
+    /// </summary>
+    private const int NumberBufferLength = 32;
+
     [ThreadStatic] private static char[]? _tNumberBuffer;
 
     extension(XmlWriter w)
@@ -30,16 +36,14 @@ internal static class XmlWriterExtensions
         public void WriteAttribute(string attrName, int value)
         {
             w.WriteStartAttribute(attrName);
-            w.WriteValue(value);
+            w.WriteNumberValue(value);
             w.WriteEndAttribute();
         }
 
         public void WriteAttribute(string attrName, uint value)
         {
-            // Cast to long to avoid boxing via XmlWriter.WriteValue(object).
-            // XmlWriter has a WriteValue(long) overload but not WriteValue(uint).
             w.WriteStartAttribute(attrName);
-            w.WriteValue(value);
+            w.WriteNumberValue(value);
             w.WriteEndAttribute();
         }
 
@@ -110,10 +114,54 @@ internal static class XmlWriterExtensions
             w.WriteEndAttribute();
         }
 
+        /// <summary>
+        /// Write a double using the same "G15" invariant representation as
+        /// <see cref="ObjectExtensions.ToInvariantString{T}"/>, but formatted into a reusable
+        /// buffer instead of allocating a string per value.
+        /// </summary>
         public void WriteNumberValue(double value)
         {
-            var buffer = _tNumberBuffer ??= new char[32];
-            value.TryFormat(buffer, out var charsWritten, "G15", CultureInfo.InvariantCulture);
+            var buffer = _tNumberBuffer ??= new char[NumberBufferLength];
+            if (!value.TryFormat(buffer, out var charsWritten, "G15", CultureInfo.InvariantCulture))
+            {
+                // Unreachable for double with "G15" (longest output is ~22 chars), but a silent
+                // empty attribute would corrupt the file, so fall back rather than trust it.
+                w.WriteString(value.ToString("G15", CultureInfo.InvariantCulture));
+                return;
+            }
+
+            w.WriteRaw(buffer, 0, charsWritten);
+        }
+
+        /// <summary>
+        /// Write an <see cref="int"/> without going through <see cref="XmlWriter.WriteValue(int)"/>,
+        /// which allocates a string for every value.
+        /// </summary>
+        public void WriteNumberValue(int value)
+        {
+            var buffer = _tNumberBuffer ??= new char[NumberBufferLength];
+            if (!value.TryFormat(buffer, out var charsWritten, default, CultureInfo.InvariantCulture))
+            {
+                w.WriteString(value.ToString(CultureInfo.InvariantCulture));
+                return;
+            }
+
+            w.WriteRaw(buffer, 0, charsWritten);
+        }
+
+        /// <summary>
+        /// Write a <see cref="uint"/> without going through <c>XmlWriter.WriteValue</c>,
+        /// which allocates a string for every value.
+        /// </summary>
+        public void WriteNumberValue(uint value)
+        {
+            var buffer = _tNumberBuffer ??= new char[NumberBufferLength];
+            if (!value.TryFormat(buffer, out var charsWritten, default, CultureInfo.InvariantCulture))
+            {
+                w.WriteString(value.ToString(CultureInfo.InvariantCulture));
+                return;
+            }
+
             w.WriteRaw(buffer, 0, charsWritten);
         }
 

--- a/docs/specs/03-save-path-allocations.md
+++ b/docs/specs/03-save-path-allocations.md
@@ -3,7 +3,7 @@
 **Area:** Performance (write time + memory)
 **Effort:** M (1–2 weeks, mostly independent small tasks)
 **Dependencies:** Coordinate with Spec 01 (both touch `SheetDataWriter`); land this first or rebase.
-**Status:** Proposed
+**Status:** In progress — see [Results](#results-2026-07-25) below.
 
 ## Summary
 
@@ -57,3 +57,64 @@ Same as Spec 02: BenchmarkDotNet filter `'*XLiburWorkbookBenchmarks*'` + dotMemo
 
 - Memory notes: prior allocation plan identified items 1, 4, 5 plus the (already-landed) cell-loop optimizations.
 - Perf survey: 543 MB headline, StyleKey hash numbers, repository WeakReference accumulation.
+
+## Results (2026-07-25)
+
+Measured with `dotnet run -c Release --project XLibur.Benchmarks --framework net10.0 -- profile alloc`,
+which reports GC-exact allocated bytes for the same two workloads as
+`XLiburWorkbookBenchmarks`, split into a create phase and a save phase. Three runs per side;
+allocation figures are stable to ±0.5 MB, elapsed is the min–max of three runs.
+
+| Scenario | Create | Save | Total | Elapsed |
+|---|---|---|---|---|
+| `CreateAndSave` — before | 58.3 MB | 72.2 MB | 130.5 MB | 322–368 ms |
+| `CreateAndSave` — after | 58.3 MB | **34.9 MB** | **93.2 MB** (−28.6%) | 276–329 ms |
+| `CreateFormattedAndSave` — before | 305.6 MB | 237.1 MB | 542.7 MB | 1187–1290 ms |
+| `CreateFormattedAndSave` — after | 305.5 MB | **117.9 MB** (−50.3%) | **423.3 MB** (−22.0%) | 1051–1167 ms |
+
+`StyleKey_GetHashCode`: **6,952 µs → 320 µs per 100K** (−95%). The absolute numbers differ from the
+40.7 ms in the spec body because that figure came from different hardware; the ratio is what
+carries over, and it clears the ≤15/40.7 (−63%) bar by a wide margin.
+
+Saved output is byte-identical to `main`: unzipping both packages and diffing shows every part
+under `xl/` and `docProps/` matches exactly. Only the package-level `_rels/.rels` and the
+`core-properties` part name differ, and those carry GUIDs that `System.IO.Packaging` regenerates
+on every save regardless of this change.
+
+### What landed
+
+| # | Task | Outcome |
+|---|------|---------|
+| 1 | Span-based number write | Already landed for `double`; hardened (the `TryFormat` result was ignored) and extended to `int`/`uint`, which were still going through `XmlWriter.WriteValue` and allocating a string per cell. Parity test added: `XmlWriterExtensionsTests` compares the writer against `ToInvariantString` over 60K random doubles, serial dates and ints. |
+| 2 | Inherited-style memo | **Not implemented — profile disconfirmed the premise.** Redirecting the sheet-data writer at `Stream.Null` drops its allocation from 96.0 MB to 0.0 MB, i.e. the cell loop (including `GetStyleValue` → `GetInheritedStyleValue`) allocates nothing at all; every byte is the package stream. A memo here would add state for no allocation win. |
+| 3 | StyleKey hash caching | Implemented. Component hashes are memoised in the `init` accessors of `XLStyleKey` and folded together in `GetHashCode`; `Equals` now rejects on those ints before touching the components. The combining formula is unchanged, so hash *values* are identical to before and style ordering in the output is untouched. |
+| 4 | Table-totals guard | Already landed — `CollectTableTotalCells` returns `null` when there are no tables and allocates only when some table has a totals row; the per-cell probe is behind that null check. |
+| 5 | SST `EnsureCapacity` | Already landed on the load path (`XLWorkbook_Load`). No save-side bulk-populate path exists: the SST is filled incrementally by `IncreaseRef` as cells are assigned, and `SharedStringTableWriter` streams straight out of it. |
+| 6 | Repository dead-entry sweep | Implemented. `XLRepositoryBase` uses `WeakReference<T>`, revives collected entries with an atomic `TryUpdate` instead of remove-then-add, and prunes the whole map once 512 lookups have hit collected entries. |
+| — | Full-sheet `GetCells()` scans (not in the original plan) | Four save-path helpers materialised an `XLCell` wrapper for **every used cell** just to read one property. This was the bulk of the save-phase allocation. `CollectWorkbookStyles` now reads `GetStyleValue` off the slices; `EnsureDynamicArrayMetadata` and `CalculationChainPartWriter` walk the formula slice; comment/cell-image detection walks the misc slice. |
+
+### Remaining hotspots (Task 7)
+
+Save phase, `CreateFormattedAndSave`, 117.9 MB total:
+
+- **~96 MB (81%) — `System.IO.Packaging` part buffering.** `worksheetPart.GetStream(FileMode.Create)`
+  is backed by a `ZipArchive` in update mode, so the whole ~25 MB `sheet1.xml` is buffered in a
+  `MemoryStream` that doubles as it grows. Writing the identical XML to `Stream.Null` allocates
+  0.0 MB. As the spec anticipated: noted, not chased — it needs a different packaging strategy
+  (Spec 01 Phase 3).
+- **~13 MB — workbook-level parts** (styles + SST serialisation).
+- **~9 MB — package dispose** (compression).
+
+Create phase, 305.5 MB, is untouched by this spec and is where the next 30% lives:
+
+- **~186 MB — cell population.** `ws.Cell(r, c).Value = x` costs ~372 bytes/cell, dominated by the
+  `XLAddress`/`XLCell` wrappers minted per access. `XLWorksheet.SetCellValue(row, column, value)`
+  already bypasses them internally.
+- **~120 MB — styling.** Each `ws.Cell(r, c).Style` mints an `XLCell`, an `XLStyle` and its
+  sub-wrappers; the sub-wrapper cache on `XLStyle` cannot help because the `XLStyle` itself is new
+  every time. Fixing this means reworking how `IXLStyle` handles are vended, which conflicts with
+  the "no public API changes" constraint here.
+
+Consequence for acceptance criterion 1: the ≥30% target (≤380 MB) is **not reachable from the
+save path alone** — the save path is now 117.9 MB in total, of which 96 MB is packaging. The
+remaining 43 MB gap has to come from the create-phase items above, which belong in their own spec.


### PR DESCRIPTION
## Summary

Implements [Spec 03 — Save-Path Allocation Reduction](docs/specs/03-save-path-allocations.md).

`CreateFormattedAndSave` (50K rows × 10 cols) allocated 542.7 MB, of which 237.1 MB was the save itself. **The save phase is now 117.9 MB (−50.3%)** and the benchmark total 423.3 MB (−22.0%). Wall time improves on both scenarios.

| Scenario | Create | Save | Total | Elapsed |
|---|---|---|---|---|
| `CreateAndSave` — before | 58.3 MB | 72.2 MB | 130.5 MB | 322–368 ms |
| `CreateAndSave` — after | 58.3 MB | **34.9 MB** | **93.2 MB** (−28.6%) | 276–329 ms |
| `CreateFormattedAndSave` — before | 305.6 MB | 237.1 MB | 542.7 MB | 1187–1290 ms |
| `CreateFormattedAndSave` — after | 305.5 MB | **117.9 MB** (−50.3%) | **423.3 MB** (−22.0%) | 1051–1167 ms |

`StyleKey_GetHashCode`: **6,952 µs → 320 µs per 100K (−95%)**. The absolute numbers differ from the 40.7 ms in the spec because that figure came from different hardware; the ratio clears the ≤15/40.7 (−63%) bar by a wide margin.

<details>
<summary>Benchmark environment</summary>

net10.0, Release, `dotnet run --project XLibur.Benchmarks -- profile alloc` (GC-exact, 3 runs per side; allocation stable to ±0.5 MB, elapsed reported min–max). `StyleKeyHashCodeBenchmarks` via BenchmarkDotNet, `--warmupCount 3 --iterationCount 5`.
</details>

### The dominant cost was not the cell loop

Four save helpers materialised an `XLCell` wrapper for **every used cell** just to read one property. That, not number formatting, was the bulk of the save-phase allocation. They now read the slices directly:

- `CollectWorkbookStyles` reads `GetStyleValue` off the slices
- `EnsureDynamicArrayMetadata` and `CalculationChainPartWriter` walk the formula slice
- comment / cell-image detection walks the misc slice

## Changes

Spec task outcomes:

- **1 — Span-based number write.** Already landed for `double`; hardened (the `TryFormat` result was being ignored, so a failure would have silently written an empty value) and extended to `int`/`uint`, which still went through `XmlWriter.WriteValue` and allocated a string per cell. `G15` parity confirmed independently, matching the note added in #177.
- **2 — Inherited-style memo: not implemented.** The spec said profile first; the profile disconfirmed it. Pointing the sheet-data writer at `Stream.Null` drops its allocation from 96.0 MB to **0.0 MB** — the cell loop (including `GetStyleValue` → `GetInheritedStyleValue`) allocates nothing at all, so a memo would add state for no win.
- **3 — StyleKey hash caching.** Component hashes are memoised in the `init` accessors of `XLStyleKey` and folded in `GetHashCode`; `Equals` rejects on those ints before touching the components. The combining formula is unchanged, so hash *values* are identical and style ordering in the output is untouched.
- **4 — Table-totals guard.** Already present; confirmed.
- **5 — SST `EnsureCapacity`.** Already present on the load path. There is no save-side bulk-populate path to add it to — the SST fills incrementally via `IncreaseRef`, and `SharedStringTableWriter` streams straight out of it.
- **6 — Repository dead-entry sweep.** `WeakReference<T>`, atomic `TryUpdate` to revive collected entries (instead of remove-then-add, which could hand two callers different instances for the same key), and a prune once 512 lookups have hit collected entries.
- **7 — Profile-verify.** Remaining hotspots recorded in the spec's new Results section.

Tooling:

- New `profile alloc` mode in `XLibur.Benchmarks`: GC-exact allocated bytes split into create/save phases. This split is what made the attribution above possible — BenchmarkDotNet reports a single total that hides which side an optimisation landed on.
- `XLiburWorkbookBenchmarks` now shares its workload with the profile via `FormattedSheetBuilder`, so the two can't drift.

## Testing

- [x] Added or updated unit tests — `XmlWriterExtensionsTests` compares the writer against `ToInvariantString` over 60K random doubles, serial dates and ints, plus edge cases and buffer-reuse checks.
- [x] All existing tests pass — 6320 passed / 0 failed on **net8.0 and net10.0**.
- [x] Tested manually — **saved output is byte-identical to `main`**: unzipping both packages and diffing shows every part under `xl/` and `docProps/` matches exactly. Only `_rels/.rels` and the `core-properties` part name differ, and those carry GUIDs `System.IO.Packaging` regenerates on every save regardless of this change.

## What this PR does *not* achieve

Acceptance criterion 1 (≥30%, ≤380 MB) is **not reachable from the save path alone**, and I'd rather flag that than quietly claim it. The save phase is now 117.9 MB in total, of which **~96 MB is `System.IO.Packaging` buffering the 25 MB `sheet1.xml` in a doubling `MemoryStream`** — which the spec explicitly says to note and not chase (Spec 01 Phase 3).

The remaining 43 MB gap sits in the untouched 305 MB create phase:

- **~186 MB** — per-cell `XLCell`/`XLAddress` wrappers from `ws.Cell(r, c)` (~372 bytes/cell)
- **~120 MB** — `XLStyle` and sub-wrappers from `.Style`; the sub-wrapper cache can't help because the `XLStyle` itself is new on every access

Fixing the second means reworking how `IXLStyle` handles are vended, which collides with this spec's "no public API changes" constraint. Both are written up in the spec's Results section and want their own spec.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced (`TreatWarningsAsErrors` clean on all TFMs)
- [x] PR targets the `main` branch
