### PR TITLE
style: add missing UTF-8 BOM to 23 source files

### DIFF
--- a/XLibur.Benchmarks/AllocationBenchmarks.cs
+++ b/XLibur.Benchmarks/AllocationBenchmarks.cs
@@ -1,4 +1,4 @@
-using System.Drawing;
+﻿using System.Drawing;
 using System.Globalization;
 using BenchmarkDotNet.Attributes;
 using XLibur.Excel;

--- a/XLibur.Fonts.SkiaSharp.Tests/SkiaSharpFontBootstrapTests.cs
+++ b/XLibur.Fonts.SkiaSharp.Tests/SkiaSharpFontBootstrapTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using XLibur.Excel;

--- a/XLibur.Fonts.SkiaSharp/SkiaSharpFontBootstrap.cs
+++ b/XLibur.Fonts.SkiaSharp/SkiaSharpFontBootstrap.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using XLibur.Excel;
 using XLibur.Graphics;
 

--- a/XLibur.Tests/Excel/CalcEngine/CriteriaAggregateFunctionTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/CriteriaAggregateFunctionTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.CalcEngine;

--- a/XLibur.Tests/Excel/CalcEngine/DynamicArrayFunctionTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DynamicArrayFunctionTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.CalcEngine;

--- a/XLibur.Tests/Excel/CalcEngine/FinancialTvmTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FinancialTvmTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.CalcEngine;

--- a/XLibur.Tests/Excel/CalcEngine/IfsSwitchTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/IfsSwitchTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.CalcEngine;

--- a/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.CalcEngine;

--- a/XLibur.Tests/Excel/CalcEngine/StatisticalRankPercentileTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/StatisticalRankPercentileTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.CalcEngine;

--- a/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
+++ b/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
@@ -1,4 +1,4 @@
-using XLibur.Excel;
+﻿using XLibur.Excel;
 using XLibur.Excel.ConditionalFormats;
 using XLibur.Excel.Coordinates;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/Coordinates/XLAreaConsolidatorTests.cs
+++ b/XLibur.Tests/Excel/Coordinates/XLAreaConsolidatorTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using XLibur.Excel.Coordinates;
 using NUnit.Framework;
 

--- a/XLibur.Tests/Excel/Coordinates/XLAreaListTests.cs
+++ b/XLibur.Tests/Excel/Coordinates/XLAreaListTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel.Coordinates;
 using NUnit.Framework;

--- a/XLibur.Tests/Excel/DataValidations/DataValidationDropOnInsertTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationDropOnInsertTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using NUnit.Framework;
 using XLibur.Excel;
 

--- a/XLibur.Tests/Excel/Loading/SheetDataValueReadingTests.cs
+++ b/XLibur.Tests/Excel/Loading/SheetDataValueReadingTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;

--- a/XLibur/Excel/CalcEngine/Functions/DynamicArray.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DynamicArray.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel.CalcEngine.Functions;

--- a/XLibur/Excel/Coordinates/XLAreaConsolidator.cs
+++ b/XLibur/Excel/Coordinates/XLAreaConsolidator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/XLibur/Excel/Coordinates/XLAreaList.cs
+++ b/XLibur/Excel/Coordinates/XLAreaList.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/XLibur/Excel/IO/SharedStringReader.cs
+++ b/XLibur/Excel/IO/SharedStringReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/XLibur/Excel/IO/StyleValueCache.cs
+++ b/XLibur/Excel/IO/StyleValueCache.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel.IO;
 

--- a/XLibur/Excel/Ranges/XLRangeConditionalFormatHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeConditionalFormatHelper.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel.ConditionalFormats;
 using XLibur.Excel.Coordinates;

--- a/XLibur/Extensions/ColorExtensions.cs
+++ b/XLibur/Extensions/ColorExtensions.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Drawing;
 

--- a/XLibur/Extensions/FormatExtensions.cs
+++ b/XLibur/Extensions/FormatExtensions.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Globalization;
 using ExcelNumberFormat;
 

--- a/XLibur/Graphics/DefaultFontEngineProbe.cs
+++ b/XLibur/Graphics/DefaultFontEngineProbe.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Reflection;
 


### PR DESCRIPTION
Clears the "Fix file encoding" warnings from the build-and-test formatting check.

## Cause

`.editorconfig` sets `charset = utf-8-bom` under `[*]`, but 23 source files were written without a BOM. `dotnet format --verify-no-changes` flags each one. CI treats the formatting check as a warning rather than a failure, so these accumulated over time instead of blocking a build.

The 10 files named in the latest CI annotations were a subset — a full scan found 23 across `XLibur`, `XLibur.Tests`, `XLibur.Benchmarks`, and `XLibur.Fonts.SkiaSharp`.

## Fix

Ran `dotnet format XLibur.slnx`, which rewrites files to the configured charset.

The diff is BOM-only. Every file shows exactly `1 insertion, 1 deletion`, and that one line differs solely by the three BOM bytes:

```
HEAD:     \n   u   s   i   n   g       S   y   s   t   e   m   ;
working: 357 273 277  \r  \n   u   s   i   n   g       S   y   s   t   e   m   ;
```

(The leading blank line in that example is pre-existing, not introduced here.)

## Verification

- `dotnet format XLibur.slnx --verify-no-changes` — exit 0, the same check CI runs
- `dotnet build XLibur.slnx -c Release` — 0 warnings, 0 errors
- `dotnet test XLibur.Tests` on net10.0 — **6290 passed, 0 failed**, 41 skipped

## Worth considering separately

CI currently downgrades formatting failures to a `::warning::`, which is why 23 files drifted. Now that the tree is clean, that check could be made blocking — happy to do it in a follow-up if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized file headers and text encoding across source, benchmark, and test files.
  - No user-facing functionality, public APIs, calculations, formatting, or test behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->