### PR TITLE
fix: migrate release-drafter config and workflows to the v7 API

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,47 +1,49 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 
+# Categories double as version resolvers: `semver-increment` on a category bumps
+# that part of the version when any PR lands in it. The highest matching
+# increment wins, and the trailing `type: version-resolver` entry with no `when`
+# is the fallback for anything uncategorised.
+#
+# While the project is pre-1.0, a breaking change is still a minor bump.
 categories:
   - title: 'Breaking Changes'
-    labels:
-      - 'breaking'
+    semver-increment: 'minor'
+    when:
+      labels:
+        - 'breaking'
   - title: 'New Features'
-    labels:
-      - 'enhancement'
+    semver-increment: 'minor'
+    when:
+      labels:
+        - 'enhancement'
   - title: 'Bug Fixes'
-    labels:
-      - 'bug'
+    when:
+      labels:
+        - 'bug'
   - title: 'Performance'
-    labels:
-      - 'performance'
+    when:
+      labels:
+        - 'performance'
   - title: 'Documentation'
-    labels:
-      - 'documentation'
+    when:
+      labels:
+        - 'documentation'
   - title: 'Dependencies'
-    labels:
-      - 'dependencies'
+    when:
+      labels:
+        - 'dependencies'
   - title: 'Other Changes'
-    labels:
-      - 'chore'
+    when:
+      labels:
+        - 'chore'
+  - type: 'version-resolver'
+    semver-increment: 'patch'
 
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 change-title-escapes: '\<*_&'
 no-changes-template: 'No changes.'
-
-# While the project is pre-1.0, a breaking change is still a minor bump.
-version-resolver:
-  minor:
-    labels:
-      - 'breaking'
-      - 'enhancement'
-  patch:
-    labels:
-      - 'bug'
-      - 'performance'
-      - 'documentation'
-      - 'dependencies'
-      - 'chore'
-  default: patch
 
 # Bots don't get a thank-you line.
 exclude-contributors:
@@ -53,6 +55,7 @@ no-contributors-template: ''
 
 # PR titles follow Conventional Commits, so the label — and therefore the release
 # note category and the version bump — is derived from the title automatically.
+# Applied by the PR Autolabel workflow, which runs the autolabeler sub-action.
 # Labels referenced here must already exist in the repository; the autolabeler
 # cannot create them.
 autolabeler:

--- a/.github/workflows/pr-autolabel.yml
+++ b/.github/workflows/pr-autolabel.yml
@@ -2,24 +2,29 @@ name: PR Autolabel
 
 # Labels pull requests from their Conventional Commits title. The label drives both
 # the release-note category and the version bump, so this has to run on every PR —
-# including PRs from forks, which is why the trigger is pull_request_target.
+# including PRs from forks, which is why the trigger is pull_request_target. A
+# plain pull_request trigger gets a read-only token on fork PRs and cannot label.
 #
 # Safety: this workflow never checks out or executes pull request code. It only reads
 # the PR title and applies labels.
+#
+# Note this uses the autolabeler sub-action, not the top-level action. In v7 the
+# autolabeler is a separate entry point; the main action has no disable-releaser
+# input, and running it here would try to draft a release with a read-only token.
 on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   autolabel:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - uses: release-drafter/release-drafter@v7
-        with:
-          disable-releaser: true
+      - uses: release-drafter/release-drafter/autolabeler@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,9 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Labelling happens in pr-autolabel.yml while the PR is open — in v7 the
+      # autolabeler is a separate sub-action, so this only drafts the release.
       - uses: release-drafter/release-drafter@v7
-        with:
-          # Labelling happens in pr-autolabel.yml while the PR is open.
-          disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -79,6 +79,18 @@ jobs:
             exit 1
           fi
 
+          # Release Drafter resolves the previous version from published GitHub
+          # Releases, not from git tags. Until the first release is published it
+          # sees none and drafts v0.0.1, which would publish NuGet packages below
+          # the versions already out there — and NuGet versions cannot be reused.
+          # Refuse anything that is not an increase over the highest existing tag.
+          latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          if [ -n "$latest" ] && \
+             [ "$(printf '%s\n%s\n' "$version" "${latest#v}" | sort -V | head -n1)" = "$version" ]; then
+            echo "::error::$tag is not an increase over the latest tag $latest. If the release draft is wrong (it reads v0.0.1 until the first release is published), pass an explicit version input."
+            exit 1
+          fi
+
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "Releasing $tag"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,12 @@ Releases are one click, from the Actions tab:
 
 1. **Publish Release** workflow → *Run workflow*. Leave *version* empty to take the version
    Release Drafter resolved from the merged PRs, or set it explicitly.
+
+   > **The first release must set *version* explicitly.** Release Drafter resolves the previous
+   > version from published GitHub Releases, not from git tags. Until one exists it sees none
+   > and drafts `v0.0.1`. The workflow refuses any version that isn't an increase over the
+   > highest existing tag, so this fails safe — but you have to supply the real version once.
+   > After the first release is published, resolution is automatic.
 2. Run it once with **dry-run** ticked (the default). It resolves the version and prints the
    changelog roll without changing anything.
 3. Before the real run, open the release draft and edit the notes if you want — the draft is


### PR DESCRIPTION
Fixes the failing **PR Autolabel** workflow, clears the deprecation warnings, and closes a gap that would have published packages at the wrong version.

## Why PR Autolabel failed

```
Warning: Unexpected input(s) 'disable-releaser', valid inputs are [...]
...
Creating new release...
Error: Resource not accessible by integration
```

v7 has no `disable-releaser` input. The flag was silently ignored, so the main action ran its releaser inside a job scoped to `contents: read` and failed trying to create a release.

**In v7 the autolabeler is a separate entry point.** PR Autolabel now uses `release-drafter/release-drafter/autolabeler@v7`, and the drafter workflow drops the equally invalid `disable-autolabeler` input.

The trigger stays `pull_request_target`: the upstream example uses `pull_request`, but that yields a read-only token on fork PRs and can't label them — and community PRs here come from forks. The workflow still never checks out or executes PR code.

## Config migration

v7 deprecated `categories[*].labels` and `version-resolver.*.labels` (7 + 2 warnings per run). Migrated to the current schema:

```yaml
categories:
  - title: 'New Features'
    semver-increment: 'minor'     # was version-resolver.minor.labels
    when:
      labels: ['enhancement']     # was categories[*].labels
  # ...
  - type: 'version-resolver'      # was version-resolver.default: patch
    semver-increment: 'patch'
```

## The part that matters: a wrong version nearly reached NuGet

The draft on `main` right now reads **`v0.0.1`**.

Release Drafter resolves the previous version from published **GitHub Releases**, not from git tags. This repo has none — the `v0.105.0` tag is invisible to it — so it started from zero:

```
Found 0 releases
Version increment: patch
  name: v0.0.1
```

The publish workflow would have accepted that: the tag doesn't exist, and `0.0.1` parses as valid semver. It would have tagged `v0.0.1` and published five packages **below the `0.105.1-rc.*` versions already on NuGet**, at version numbers that can never be reused.

So the resolve step now refuses any version that isn't an increase over the highest existing `v*` tag:

```
version=0.0.1   latest=v0.105.0 -> BLOCKED     <- the actual hazard
version=0.106.0 latest=v0.105.0 -> allowed
version=0.105.1 latest=v0.105.0 -> allowed
version=0.105.0 latest=v0.105.0 -> BLOCKED
version=0.9.0   latest=v0.105.0 -> BLOCKED     <- version sort, not lexicographic
```

## Consequence for the first release

The first release must pass an explicit **version** input — the draft will keep saying `v0.0.1` until a real release exists. After that, resolution is automatic and the draft is correct. Documented in `CONTRIBUTING.md`.

The alternative is publishing a GitHub Release for the existing `v0.105.0` tag to give the drafter a baseline. I didn't do that unprompted — it creates a public release for the ClosedXML fork point that never shipped as an XLibur package, which seemed worse than typing the version once. Easy to add if you'd prefer it.

## Verification

- All four YAML files parse; the resolve step passes `bash -n`.
- The version guard was tested against all six cases above.
- Autolabeling itself can only be confirmed once this is on `main` — `pull_request_target` runs the workflow from the base branch, so this PR is still labelled by the broken version.

## Follow-up

The stale `v0.0.1` draft on the repo should be deleted once this merges, so the next drafter run recreates it cleanly. Say the word and I'll remove it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release drafts now categorize changes more clearly, including breaking changes, features, fixes, performance, documentation, and other updates.
  - Pull requests are automatically labeled to support consistent release note generation.

- **Bug Fixes**
  - Release publishing now prevents invalid or non-increasing version tags and provides guidance when an explicit version is required.

- **Documentation**
  - Added guidance for specifying the version during the first release workflow run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->