### PR TITLE
docs: drop the ClosedXML comparison note from the Charts page

### DIFF
--- a/docs-website/docs/charts.md
+++ b/docs-website/docs/charts.md
@@ -10,12 +10,6 @@ description: Add column, line, pie, scatter, stock, surface, combo, and modern E
 XLibur can embed charts in a worksheet. You choose a chart type, add one or more series that
 point at ranges of data, and anchor the chart to a rectangle of cells.
 
-:::note
-Chart support here is substantially wider than in ClosedXML 0.105, which could not create
-charts at all. Over 70 chart types are available, including combo charts and the Office 2016+
-"extended" types (Waterfall, Funnel, Treemap, Sunburst, Box &amp; Whisker).
-:::
-
 ## A first chart
 
 ```csharp


### PR DESCRIPTION
Removes the introductory note from `docs-website/docs/charts.md`:

> Chart support here is substantially wider than in ClosedXML 0.105, which could not create charts at all. Over 70 chart types are available, including combo charts and the Office 2016+ "extended" types (Waterfall, Funnel, Treemap, Sunburst, Box & Whisker).

The page already lists every chart type by family a little further down, including the extended ones, so the note was redundant on the facts and framed the feature as a comparison rather than describing it.

Follow-up to #186. `pnpm build` passes.
