### PR TITLE
chore: brace nested for loops in CreatePhaseProbe (S3973)

### DIFF
--- a/XLibur.Benchmarks/CreatePhaseProbe.cs
+++ b/XLibur.Benchmarks/CreatePhaseProbe.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using XLibur.Excel;
 using XLibur.Fonts.SixLabors.V1;
@@ -86,8 +86,10 @@ public static class CreatePhaseProbe
 
         // Identical to SetCellValueDouble, so subtracting that probe isolates the styling.
         for (var r = 1; r <= Rows; r++)
-        for (var c = 1; c <= Cols; c++)
-            ws.SetCellValue(r, c, r * 1.5);
+        {
+            for (var c = 1; c <= Cols; c++)
+                ws.SetCellValue(r, c, r * 1.5);
+        }
 
         ws.Range(1, 1, Rows, Cols).Style.Font.Bold = true;
     }
@@ -97,8 +99,10 @@ public static class CreatePhaseProbe
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("s");
         for (var r = 1; r <= Rows; r++)
-        for (var c = 1; c <= Cols; c++)
-            _ = ws.Cell(r, c);
+        {
+            for (var c = 1; c <= Cols; c++)
+                _ = ws.Cell(r, c);
+        }
     }
 
     private static void CellValueDouble()
@@ -106,8 +110,10 @@ public static class CreatePhaseProbe
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("s");
         for (var r = 1; r <= Rows; r++)
-        for (var c = 1; c <= Cols; c++)
-            ws.Cell(r, c).Value = r * 1.5;
+        {
+            for (var c = 1; c <= Cols; c++)
+                ws.Cell(r, c).Value = r * 1.5;
+        }
     }
 
     private static void SetCellValueDouble()
@@ -115,8 +121,10 @@ public static class CreatePhaseProbe
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("s");
         for (var r = 1; r <= Rows; r++)
-        for (var c = 1; c <= Cols; c++)
-            ws.SetCellValue(r, c, r * 1.5);
+        {
+            for (var c = 1; c <= Cols; c++)
+                ws.SetCellValue(r, c, r * 1.5);
+        }
     }
 
     private static void CellValueString()
@@ -127,8 +135,10 @@ public static class CreatePhaseProbe
         // allocating a fresh string per cell.
         string[] pool = ["Active", "Pending", "Closed", "Review", "Draft"];
         for (var r = 1; r <= Rows; r++)
-        for (var c = 1; c <= Cols; c++)
-            ws.Cell(r, c).Value = pool[(r + c) % pool.Length];
+        {
+            for (var c = 1; c <= Cols; c++)
+                ws.Cell(r, c).Value = pool[(r + c) % pool.Length];
+        }
     }
 
     private static void CellValueDateTime()
@@ -137,8 +147,10 @@ public static class CreatePhaseProbe
         var ws = wb.AddWorksheet("s");
         var baseDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
         for (var r = 1; r <= Rows; r++)
-        for (var c = 1; c <= Cols; c++)
-            ws.Cell(r, c).Value = baseDate.AddDays((r + c) % 1500);
+        {
+            for (var c = 1; c <= Cols; c++)
+                ws.Cell(r, c).Value = baseDate.AddDays((r + c) % 1500);
+        }
     }
 
     /// <summary>
@@ -153,8 +165,10 @@ public static class CreatePhaseProbe
         ws.Range(1, 1, 1, 4).Merge();
 
         for (var r = 2; r <= Rows + 1; r++)
-        for (var c = 1; c <= Cols; c++)
-            ws.Cell(r, c).Value = r * 1.5;
+        {
+            for (var c = 1; c <= Cols; c++)
+                ws.Cell(r, c).Value = r * 1.5;
+        }
     }
 
     private static void StyleWrapperOnly()
@@ -162,8 +176,10 @@ public static class CreatePhaseProbe
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("s");
         for (var r = 1; r <= Rows; r++)
-        for (var c = 1; c <= Cols; c++)
-            _ = ws.Cell(r, c).Style;
+        {
+            for (var c = 1; c <= Cols; c++)
+                _ = ws.Cell(r, c).Style;
+        }
     }
 
     private static void StyleOneMutation()
@@ -171,8 +187,10 @@ public static class CreatePhaseProbe
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("s");
         for (var r = 1; r <= Rows; r++)
-        for (var c = 1; c <= Cols; c++)
-            ws.Cell(r, c).Style.Font.Bold = true;
+        {
+            for (var c = 1; c <= Cols; c++)
+                ws.Cell(r, c).Style.Font.Bold = true;
+        }
     }
 
     private static void StyleFourMutations()
@@ -180,13 +198,15 @@ public static class CreatePhaseProbe
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("s");
         for (var r = 1; r <= Rows; r++)
-        for (var c = 1; c <= Cols; c++)
         {
-            var s = ws.Cell(r, c).Style;
-            s.Font.Bold = true;
-            s.Font.FontColor = XLColor.DarkRed;
-            s.Fill.BackgroundColor = XLColor.LightBlue;
-            s.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+            for (var c = 1; c <= Cols; c++)
+            {
+                var s = ws.Cell(r, c).Style;
+                s.Font.Bold = true;
+                s.Font.FontColor = XLColor.DarkRed;
+                s.Fill.BackgroundColor = XLColor.LightBlue;
+                s.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Continues our work clearing open SonarCloud findings. This PR resolves [S3973](https://sonarcloud.io/project/issues?impactSeverities=HIGH&impactSoftwareQualities=MAINTAINABILITY&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-ZsSPcnUgmSfWQRu7n) (HIGH maintainability): nested `for` loops in `CreatePhaseProbe` shared the same indentation, so the outer loop body was unclear.

## Changes

- Wrap each outer row `for` in braces in `XLibur.Benchmarks/CreatePhaseProbe.cs`
- Apply the same pattern across all probes (not only the flagged site) so the smell does not recur in this file

## Related Issues

- SonarCloud: [csharpsquid:S3973](https://sonarcloud.io/project/issues?impactSeverities=HIGH&impactSoftwareQualities=MAINTAINABILITY&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-ZsSPcnUgmSfWQRu7n) — “Use curly braces or indentation to denote the code conditionally executed by this `for”

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually (describe below if applicable)

Built `XLibur.Benchmarks` (`net10.0`, Release) successfully after the change. Behavior is unchanged; this is a formatting/clarity fix only.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Code Quality**
  * Improved code readability and consistency by adding explicit braces to nested loops across benchmark scenarios.
* **Behavior**
  * No functional changes; existing styling and value-setting operations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->