### PR TITLE
chore: clear S125 false positives from documentation comments

### DIFF
--- a/XLibur.Examples/Misc/SheetViews.cs
+++ b/XLibur.Examples/Misc/SheetViews.cs
@@ -36,8 +36,8 @@ public class SheetViews : IXLExample
         ws.SheetView.TopLeftCellAddress = ws.Cell("AZ2000").Address;
 
         // FocusCell sets the active cell AND scrolls the sheet so it is visible at the
-        // top-left of the scrollable region. On a frozen sheet it drives <pane topLeftCell>;
-        // on an unfrozen sheet it drives <sheetView topLeftCell>.
+        // top-left of the scrollable region. On a frozen sheet it drives <pane topLeftCell>.
+        // On an unfrozen sheet it drives <sheetView topLeftCell>.
         ws = wb.AddWorksheet("FocusCell");
         ws.SheetView.FreezeRows(2);
         ws.Cell("A1").SetValue("Frozen header");

--- a/XLibur/Excel/XLWorksheetRangeShifter.cs
+++ b/XLibur/Excel/XLWorksheetRangeShifter.cs
@@ -179,8 +179,8 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
         var first = range.RangeAddress.FirstAddress;
         var last = range.RangeAddress.LastAddress;
         // The area model handles every insert, including a first-column insert. (The old range-based
-        // path short-circuited here and let the blanket range shifter move the validation ranges;
-        // area-based coverage is no longer a repository range, so it must be shifted here.)
+        // path short-circuited here and let the blanket range shifter move the validation ranges.
+        // Area-based coverage is no longer a repository range, so it must be shifted here.)
         var affected = columnsShifted > 0
             ? new XLSheetRange(first.RowNumber, first.ColumnNumber, last.RowNumber, first.ColumnNumber + columnsShifted - 1)
             : new XLSheetRange(first.RowNumber, first.ColumnNumber, last.RowNumber, first.ColumnNumber - columnsShifted - 1);
@@ -195,8 +195,8 @@ internal sealed class XLWorksheetRangeShifter(XLWorksheet worksheet)
         var first = range.RangeAddress.FirstAddress;
         var last = range.RangeAddress.LastAddress;
         // The area model handles every insert, including a first-row insert. (The old range-based
-        // path short-circuited here and let the blanket range shifter move the validation ranges;
-        // area-based coverage is no longer a repository range, so it must be shifted here.)
+        // path short-circuited here and let the blanket range shifter move the validation ranges.
+        // Area-based coverage is no longer a repository range, so it must be shifted here.)
         var affected = rowsShifted > 0
             ? new XLSheetRange(first.RowNumber, first.ColumnNumber, first.RowNumber + rowsShifted - 1, last.ColumnNumber)
             : new XLSheetRange(first.RowNumber, first.ColumnNumber, first.RowNumber - rowsShifted - 1, last.ColumnNumber);

--- a/XLibur/Graphics/BmpInfoReader.cs
+++ b/XLibur/Graphics/BmpInfoReader.cs
@@ -45,8 +45,8 @@ internal sealed class BmpInfoReader : ImageInfoReader
 
     protected override XLPictureInfo ReadInfo(Stream stream)
     {
-        // OS/2 "BA" files prepend a BITMAPARRAYHEADER before the first BITMAPFILEHEADER;
-        // plain "BM" files start with the BITMAPFILEHEADER directly.
+        // OS/2 "BA" files prepend a BITMAPARRAYHEADER before the first BITMAPFILEHEADER.
+        // Plain "BM" files start with the BITMAPFILEHEADER directly.
         Span<byte> signature = stackalloc byte[2];
         stream.ReadExactly(signature);
         var fileHeaderStart = signature[1] == 'A' ? BitmapArrayHeaderSize : 0;


### PR DESCRIPTION
## Summary

Continues clearing open SonarCloud findings. This PR resolves several [S125](https://rules.sonarsource.com/csharp/RSPEC-125/) (MEDIUM) false positives where documentation comments were flagged as “commented out code” because a line ended with `;`.

These comments document real behavior — they are not dead code — so removing them would be the wrong fix. Converting to `/* */` alone would not help either; S125’s heuristic also scans block comments for code-like endings. Rephrased the prose so the flagged lines end with periods instead.

## Changes

- Rephrase `FocusCell` comment in `XLibur.Examples/Misc/SheetViews.cs`
- Rephrase data-validation shift comments in `XLibur/Excel/XLWorksheetRangeShifter.cs` (columns and rows)
- Rephrase OS/2 “BA” header comment in `XLibur/Graphics/BmpInfoReader.cs`

## Related Issues

- [AZ7yQVOVFSxzLqliAN65](https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ7yQVOVFSxzLqliAN65) — `SheetViews.cs`
- [AZ-O6AwsSZtFQqYTWbgN](https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-O6AwsSZtFQqYTWbgN) — `XLWorksheetRangeShifter.cs` (columns)
- [AZ-O6AwsSZtFQqYTWbgO](https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-O6AwsSZtFQqYTWbgO) — `XLWorksheetRangeShifter.cs` (rows)
- [AZ-NP4CY_yuSvoeMLY2Z](https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-NP4CY_yuSvoeMLY2Z) — `BmpInfoReader.cs`

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually (describe below if applicable)

Comment-only changes; no behavioral impact.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch