### PR TITLE
chore: remove unused anchor parameter from LoadGroupedPictures (S1172)

### DIFF
--- a/XLibur/Excel/IO/DrawingPartReader.cs
+++ b/XLibur/Excel/IO/DrawingPartReader.cs
@@ -67,7 +67,7 @@ internal static class DrawingPartReader
                 var group = anchor.Elements<Xdr.GroupShape>().FirstOrDefault();
                 if (group != null)
                 {
-                    LoadGroupedPictures(anchor, group, drawingsPart, ws);
+                    LoadGroupedPictures(group, drawingsPart, ws);
                     continue;
                 }
 
@@ -98,8 +98,7 @@ internal static class DrawingPartReader
     /// transform) and tagged with its <see cref="XLPictureGroup"/> so the writer can update it in
     /// place. Non-picture children (connectors, shapes) are left untouched and preserved verbatim.
     /// </summary>
-    private static void LoadGroupedPictures(OpenXmlElement anchor, Xdr.GroupShape group,
-        DrawingsPart drawingsPart, XLWorksheet ws)
+    private static void LoadGroupedPictures(Xdr.GroupShape group, DrawingsPart drawingsPart, XLWorksheet ws)
     {
         // The parent coordinate space of the top-level group is the sheet itself: identity transform.
         LoadGroupRecursive(group, drawingsPart, ws, parentScaleX: 1.0, parentScaleY: 1.0,


### PR DESCRIPTION
## Summary

Continues clearing open SonarCloud findings. This resolves [S1172](https://sonarcloud.io/project/issues?severities=MAJOR&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ7aPVYS5NXmL4P0hn9j): unused method parameter `anchor` on `LoadGroupedPictures`.

The parameter was never read — only `group` is forwarded into `LoadGroupRecursive` — so it is safe to remove.

## Changes

- Drop the unused `OpenXmlElement anchor` parameter from `LoadGroupedPictures`
- Update the call site in `LoadDrawings` accordingly

## Related Issues

- SonarCloud: [csharpsquid:S1172](https://sonarcloud.io/project/issues?severities=MAJOR&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ7aPVYS5NXmL4P0hn9j) — “Remove this unused method parameter 'anchor'.”

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually (describe below if applicable)

Signature cleanup only; grouped-picture loading behavior is unchanged.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch