### PR TITLE
chore: mark AllocationBenchmarks methods static (CA1822)

### DIFF
--- a/XLibur.Benchmarks/AllocationBenchmarks.cs
+++ b/XLibur.Benchmarks/AllocationBenchmarks.cs
@@ -90,7 +90,7 @@ public class AllocationBenchmarks
 
     // #5 ColorExtensions.ToHex
     [Benchmark]
-    public int ToHex()
+    public static int ToHex()
     {
         var sum = 0;
         for (var i = 0; i < Iterations; i++)
@@ -100,7 +100,7 @@ public class AllocationBenchmarks
 
     // #6 XLAddress.ToString
     [Benchmark]
-    public int AddressToString()
+    public static int AddressToString()
     {
         var sum = 0;
         for (var i = 0; i < Iterations; i++)
@@ -110,7 +110,7 @@ public class AllocationBenchmarks
 
     // #7 XLAddress.Create
     [Benchmark]
-    public int AddressCreate()
+    public static int AddressCreate()
     {
         var sum = 0;
         for (var i = 0; i < Iterations; i++)
@@ -120,7 +120,7 @@ public class AllocationBenchmarks
 
     // #1 FormatExtensions.ToExcelFormat
     [Benchmark]
-    public int ToExcelFormat()
+    public static int ToExcelFormat()
     {
         var sum = 0;
         for (var i = 0; i < Iterations; i++)
@@ -130,7 +130,7 @@ public class AllocationBenchmarks
 
     // #10 StringExtensions.EscapeSheetName
     [Benchmark]
-    public int EscapeSheetName()
+    public static int EscapeSheetName()
     {
         var sum = 0;
         for (var i = 0; i < Iterations; i++)
@@ -140,7 +140,7 @@ public class AllocationBenchmarks
 
     // #9 StringExtensions.FixNewLines
     [Benchmark]
-    public int FixNewLines()
+    public static int FixNewLines()
     {
         var sum = 0;
         for (var i = 0; i < Iterations; i++)
@@ -150,7 +150,7 @@ public class AllocationBenchmarks
 
     // #8 StringExtensions.CharCount
     [Benchmark]
-    public int CharCount()
+    public static int CharCount()
     {
         var sum = 0;
         for (var i = 0; i < Iterations; i++)


### PR DESCRIPTION
## Summary

Continues clearing open SonarCloud findings. This resolves the [CA1822](https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-NRIq7Q38ITsHQN8tM) (“Member does not access instance data and can be marked as static”) hits in `AllocationBenchmarks.cs`.

Seven `[Benchmark]` methods only touch static fixture data, so they are now `static`. BenchmarkDotNet supports static benchmarks. Methods that use instance state (`ShiftFormulaRows`, `IsEmptyConditionalFormats`) are left unchanged.

## Changes

- Mark `ToHex`, `AddressToString`, `AddressCreate`, `ToExcelFormat`, `EscapeSheetName`, `FixNewLines`, and `CharCount` as `static`

## Related Issues

- SonarCloud: [external_roslyn:CA1822](https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-NRIq7Q38ITsHQN8tM) (and the six sibling CA1822 issues on the same file)

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually (describe below if applicable)

Built `XLibur.Benchmarks` (`net10.0`, Release) successfully after the change.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated allocation benchmark operations to run without instance state.
  * Preserved existing benchmark calculations and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->