### PR TITLE
chore: make WriteFormattedHeaderRow static (S2325/CA1822)

### DIFF
--- a/XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs
@@ -286,7 +286,7 @@ public class OpenXmlWorkbookBenchmarks
 
     #region Formatted benchmark helpers
 
-    private void WriteFormattedHeaderRow(OpenXmlWriter writer, List<string> sstEntries, Dictionary<string, int> sstMap)
+    private static void WriteFormattedHeaderRow(OpenXmlWriter writer, List<string> sstEntries, Dictionary<string, int> sstMap)
     {
         var headers = new[] { "Name", "Amount", "Date", "Quantity", "Price", "Total", "Status", "Category", "Region", "Notes" };
         WriteRowStart(writer, 1);


### PR DESCRIPTION
## Summary

Continues clearing open SonarCloud findings. This resolves a duplicated report of the same unused-instance-data issue on `WriteFormattedHeaderRow` in `OpenXmlWorkbookBenchmarks.cs`:

- [S2325](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ0ECRxpoApNP_XKBs0C) — Make `WriteFormattedHeaderRow` a static method
- [CA1822](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ0ECRxpoApNP_XKBs0c) — Member does not access instance data and can be marked as static

The method only uses static helpers and its parameters, so marking it `static` clears both findings.

## Changes

- Mark `WriteFormattedHeaderRow` as `static` in `XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs`

## Related Issues

- SonarCloud: [csharpsquid:S2325](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ0ECRxpoApNP_XKBs0C)
- SonarCloud: [external_roslyn:CA1822](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ0ECRxpoApNP_XKBs0c)

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually (describe below if applicable)

Built `XLibur.Benchmarks` (`net10.0`, Release) successfully after the change.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch