### PR TITLE
chore: remove redundant casts in AllocationBenchmarks (S1905)

### DIFF
--- a/XLibur.Benchmarks/AllocationBenchmarks.cs
+++ b/XLibur.Benchmarks/AllocationBenchmarks.cs
@@ -78,11 +78,11 @@ public class AllocationBenchmarks
         SixLaborsV1FontBootstrap.Register();
         _workbook = new XLWorkbook();
         _worksheet = (XLWorksheet)_workbook.AddWorksheet("Data");
-        _shiftRange = (XLRange)_worksheet.Range("A1:Z1000");
+        _shiftRange = _worksheet.Range("A1:Z1000");
 
         _emptyCells = new XLCell[Colors.Length];
         for (var i = 0; i < _emptyCells.Length; i++)
-            _emptyCells[i] = (XLCell)_worksheet.Cell(i + 1, 40); // untouched, still empty
+            _emptyCells[i] = _worksheet.Cell(i + 1, 40); // untouched, still empty
     }
 
     [GlobalCleanup]


### PR DESCRIPTION
## Summary

Continues clearing open SonarCloud findings. This resolves the [S1905](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-NRIq7Q38ITsHQN8tK) redundant-cast hits in `AllocationBenchmarks.cs`.

`XLWorksheet.Range(string)` and `Cell(int, int)` already return `XLRange` / `XLCell`, so the explicit casts were unnecessary.

## Changes

- Remove `(XLRange)` cast when assigning `_shiftRange`
- Remove `(XLCell)` cast when assigning `_emptyCells[i]`

Kept the `(XLWorksheet)` cast on `AddWorksheet` — that returns `IXLWorksheet` and still needs the concrete type.

## Related Issues

- SonarCloud: [csharpsquid:S1905](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-NRIq7Q38ITsHQN8tK) — unnecessary cast to `XLRange`
- SonarCloud: [csharpsquid:S1905](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-NRIq7Q38ITsHQN8tL) — unnecessary cast to `XLCell`

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually (describe below if applicable)

Built `XLibur.Benchmarks` (`net10.0`, Release) successfully after the change.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch