### PR TITLE
chore: group CalcContext GetNonBlankValues overloads together (S4136)

### DIFF
--- a/XLibur/Excel/CalcEngine/CalcContext.cs
+++ b/XLibur/Excel/CalcEngine/CalcContext.cs
@@ -188,6 +188,26 @@ internal sealed class CalcContext
     }
 
     /// <summary>
+    /// This method should be used mostly for range arguments. If a value is scalar,
+    /// return a single value enumerable.
+    /// </summary>
+    internal IEnumerable<ScalarValue> GetNonBlankValues(AnyValue value)
+    {
+        if (value.TryPickScalar(out var scalar, out var collection))
+        {
+            if (scalar.IsBlank)
+                return [];
+
+            return new ScalarArray(scalar, 1, 1);
+        }
+
+        if (collection.TryPickT0(out var array, out var reference))
+            return array.Where(x => !x.IsBlank);
+
+        return GetNonBlankValues(reference);
+    }
+
+    /// <summary>
     /// Return all points in the <paramref name="areaReference" /> that satisfy the <paramref name="criteria" />.
     /// </summary>
     internal IEnumerable<XLSheetPoint> GetCriteriaPoints(XLRangeAddress areaReference, Criteria criteria)
@@ -290,26 +310,6 @@ internal sealed class CalcContext
 
             return _isHidden;
         }
-    }
-
-    /// <summary>
-    /// This method should be used mostly for range arguments. If a value is scalar,
-    /// return a single value enumerable.
-    /// </summary>
-    internal IEnumerable<ScalarValue> GetNonBlankValues(AnyValue value)
-    {
-        if (value.TryPickScalar(out var scalar, out var collection))
-        {
-            if (scalar.IsBlank)
-                return [];
-
-            return new ScalarArray(scalar, 1, 1);
-        }
-
-        if (collection.TryPickT0(out var array, out var reference))
-            return array.Where(x => !x.IsBlank);
-
-        return GetNonBlankValues(reference);
     }
 
     internal IEnumerable<ScalarValue> GetAllValues(AnyValue value)


### PR DESCRIPTION
## Summary
- Move `GetNonBlankValues(AnyValue)` next to `GetNonBlankValues(Reference)` in `CalcContext.cs` so the overloads are adjacent (SonarCloud [S4136](https://sonarcloud.io/project/issues?rules=csharpsquid%3AS4136&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZzs6w2CnvODKcpvTky6)).

## Test plan
- [x] `dotnet build XLibur/XLibur.csproj` succeeds
- [ ] SonarCloud S4136 issue closes after merge analysis


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal calculation logic without changing functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->