### PR TITLE
chore: group DateAndTime TryGetDate overloads together (S4136)

### DIFF
--- a/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -724,6 +724,18 @@ internal static class DateAndTime
         return true;
     }
 
+    private static bool TryGetDate(CalcContext ctx, double serialDateTime, out int serialDate)
+    {
+        if (serialDateTime < 0 || serialDateTime >= ctx.DateSystemUpperLimit)
+        {
+            serialDate = default;
+            return false;
+        }
+
+        serialDate = checked((int)Math.Truncate(serialDateTime));
+        return true;
+    }
+
     private static bool TryGetMonthsOffset(double monthsOffset, out int months)
     {
         // Limit enough so integer math won't overflow when added to a date
@@ -734,18 +746,6 @@ internal static class DateAndTime
         }
 
         months = checked((int)monthsOffset);
-        return true;
-    }
-
-    private static bool TryGetDate(CalcContext ctx, double serialDateTime, out int serialDate)
-    {
-        if (serialDateTime < 0 || serialDateTime >= ctx.DateSystemUpperLimit)
-        {
-            serialDate = default;
-            return false;
-        }
-
-        serialDate = checked((int)Math.Truncate(serialDateTime));
         return true;
     }
 


### PR DESCRIPTION
## Summary
- Move `TryGetDate(CalcContext, double, out int)` next to the `ScalarValue` overload in `DateAndTime.cs` (SonarCloud [S4136](https://sonarcloud.io/project/issues?rules=csharpsquid%3AS4136&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZzs6w0bnvODKcpvTkxd)).

## Test plan
- [x] `dotnet build XLibur/XLibur.csproj` succeeds
- [ ] SonarCloud S4136 issue closes after merge analysis
