### PR TITLE
chore: group XLCell CopyFrom overloads together (S4136)

### DIFF
--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -833,6 +833,15 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         return CopyFrom(XLCellCopyHelper.GetTargetCell(otherCell, Worksheet));
     }
 
+    public IXLCell CopyFrom(IXLRangeBase rangeBase)
+        => XLCellCopyHelper.CopyFromRange(this, rangeBase);
+
+    public IXLCell CopyFrom(IXLCell otherCell, XLCellCopyOptions options)
+    {
+        CopyFromInternal((XLCell)otherCell, options);
+        return this;
+    }
+
     public IXLCell SetFormulaA1(string formula)
     {
         FormulaA1 = formula;
@@ -1058,9 +1067,6 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         return formatCodes.TryGetValue(style.NumberFormat.NumberFormatId, out var format) ? format : string.Empty;
     }
 
-    public IXLCell CopyFrom(IXLRangeBase rangeBase)
-        => XLCellCopyHelper.CopyFromRange(this, rangeBase);
-
     private void ClearMerged()
         => XLCellCopyHelper.ClearMerged(this);
 
@@ -1081,12 +1087,6 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
 
     internal IXLCell CopyFromInternal(XLCell otherCell, XLCellCopyOptions options)
         => XLCellCopyHelper.CopyFromInternal(this, otherCell, options);
-
-    public IXLCell CopyFrom(IXLCell otherCell, XLCellCopyOptions options)
-    {
-        CopyFromInternal((XLCell)otherCell, options);
-        return this;
-    }
 
     internal void CopyDataValidation(XLCell otherCell, IXLDataValidation otherDv)
         => XLCellCopyHelper.CopyDataValidation(this, otherCell, otherDv);


### PR DESCRIPTION
## Summary
- Move `CopyFrom(IXLRangeBase)` and `CopyFrom(IXLCell, XLCellCopyOptions)` next to the other `CopyFrom` overloads in `XLCell.cs` (SonarCloud [S4136](https://sonarcloud.io/project/issues?rules=csharpsquid%3AS4136&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZzs6wvGnvODKcpvTkuW)).

## Test plan
- [x] `dotnet build XLibur/XLibur.csproj` succeeds
- [ ] SonarCloud S4136 issue closes after merge analysis
