### PR TITLE
chore: group XLColumns Group and Ungroup overloads together (S4136)

### DIFF
--- a/XLibur/Excel/Columns/XLColumns.cs
+++ b/XLibur/Excel/Columns/XLColumns.cs
@@ -143,11 +143,6 @@ internal sealed class XLColumns : XLStylizedBase, IXLColumns, IXLStylized
         Group(outlineLevel, false);
     }
 
-    public void Ungroup()
-    {
-        Ungroup(false);
-    }
-
     public void Group(bool collapse)
     {
         Columns.ForEach(c => c.Group(collapse));
@@ -156,6 +151,11 @@ internal sealed class XLColumns : XLStylizedBase, IXLColumns, IXLStylized
     public void Group(int outlineLevel, bool collapse)
     {
         Columns.ForEach(c => c.Group(outlineLevel, collapse));
+    }
+
+    public void Ungroup()
+    {
+        Ungroup(false);
     }
 
     public void Ungroup(bool fromAll)


### PR DESCRIPTION
## Summary
- Reorder `Group` and `Ungroup` overloads in `XLColumns.cs` so each name’s overloads are adjacent (SonarCloud [S4136 Group](https://sonarcloud.io/project/issues?rules=csharpsquid%3AS4136&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZzs6xJ_nvODKcpvTk-n), [S4136 Ungroup](https://sonarcloud.io/project/issues?rules=csharpsquid%3AS4136&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZzs6xJ_nvODKcpvTk-o)).

## Test plan
- [x] `dotnet build XLibur/XLibur.csproj` succeeds
- [ ] SonarCloud S4136 issues close after merge analysis
