### PR TITLE
chore: group XLDataValidation List overloads together (S4136)

### DIFF
--- a/XLibur/Excel/DataValidation/XLDataValidation.cs
+++ b/XLibur/Excel/DataValidation/XLDataValidation.cs
@@ -312,6 +312,16 @@ internal sealed class XLDataValidation : IXLDataValidation
         Value = QuoteListValueIfNeeded(list);
     }
 
+    public void List(IXLRange range)
+    {
+        List(range, true);
+    }
+
+    public void List(IXLRange range, bool inCellDropdown)
+    {
+        List(range.RangeAddress.ToStringFixed(XLReferenceStyle.A1, true));
+    }
+
     private string QuoteListValueIfNeeded(string list)
     {
         if (list.Length == 0 || list[0] == '=' || list[0] == '"')
@@ -325,16 +335,6 @@ internal sealed class XLDataValidation : IXLDataValidation
             return list;
 
         return "\"" + list + "\"";
-    }
-
-    public void List(IXLRange range)
-    {
-        List(range, true);
-    }
-
-    public void List(IXLRange range, bool inCellDropdown)
-    {
-        List(range.RangeAddress.ToStringFixed(XLReferenceStyle.A1, true));
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes SonarCloud S4136 by grouping List overloads in XLDataValidation.cs so they are adjacent.