### PR TITLE
chore: group EnumConverter ToXLibur overloads together (S4136)

### DIFF
--- a/XLibur/Excel/EnumConverter.cs
+++ b/XLibur/Excel/EnumConverter.cs
@@ -1060,55 +1060,6 @@ internal static class EnumConverter
         return VerticalAlignmentMap[value];
     }
 
-    /// <summary>
-    /// Leniently converts a horizontal alignment attribute to its XLibur equivalent.
-    /// The OOXML spec requires lower-case values (e.g. <c>center</c>), but some third-party
-    /// tools emit invalid casing (e.g. <c>Center</c>). Such values are tolerated by retrying
-    /// the lookup with a lower-cased value. Values that remain unrecognized return
-    /// <c>null</c> so the offending alignment can be discarded and the file still loaded.
-    /// </summary>
-    public static XLAlignmentHorizontalValues? ToXLiburOrNull(this EnumValue<HorizontalAlignmentValues>? source)
-    {
-        if (source is null)
-            return null;
-
-        // HasValue parses without throwing; a valid (spec-compliant) value is always mapped.
-        if (source.HasValue)
-            return HorizontalAlignmentMap[source.Value];
-
-        return LenientAlignmentLookup(source.InnerText, HorizontalAlignmentMap, raw => new HorizontalAlignmentValues(raw));
-    }
-
-    /// <summary>
-    /// Leniently converts a vertical alignment attribute to its XLibur equivalent.
-    /// See <see cref="ToXLiburOrNull(EnumValue{HorizontalAlignmentValues})"/> for the casing
-    /// tolerance and discard-on-failure behavior.
-    /// </summary>
-    public static XLAlignmentVerticalValues? ToXLiburOrNull(this EnumValue<VerticalAlignmentValues>? source)
-    {
-        if (source is null)
-            return null;
-
-        if (source.HasValue)
-            return VerticalAlignmentMap[source.Value];
-
-        return LenientAlignmentLookup(source.InnerText, VerticalAlignmentMap, raw => new VerticalAlignmentValues(raw));
-    }
-
-    private static TValue? LenientAlignmentLookup<TKey, TValue>(
-        string? rawText,
-        Dictionary<TKey, TValue> map,
-        Func<string, TKey> factory)
-        where TKey : notnull
-        where TValue : struct
-    {
-        if (string.IsNullOrEmpty(rawText))
-            return null;
-
-        var lowered = factory(rawText!.ToLowerInvariant());
-        return map.TryGetValue(lowered, out var result) ? result : null;
-    }
-
     public static XLPageOrderValues ToXLibur(this PageOrderValues value)
     {
         return PageOrdersMap[value];
@@ -1293,6 +1244,55 @@ internal static class EnumConverter
         if (value == X14.DataBarAxisPositionValues.Middle) return XLDataBarAxisPosition.Middle;
         if (value == X14.DataBarAxisPositionValues.None) return XLDataBarAxisPosition.None;
         throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!");
+    }
+
+    /// <summary>
+    /// Leniently converts a horizontal alignment attribute to its XLibur equivalent.
+    /// The OOXML spec requires lower-case values (e.g. <c>center</c>), but some third-party
+    /// tools emit invalid casing (e.g. <c>Center</c>). Such values are tolerated by retrying
+    /// the lookup with a lower-cased value. Values that remain unrecognized return
+    /// <c>null</c> so the offending alignment can be discarded and the file still loaded.
+    /// </summary>
+    public static XLAlignmentHorizontalValues? ToXLiburOrNull(this EnumValue<HorizontalAlignmentValues>? source)
+    {
+        if (source is null)
+            return null;
+
+        // HasValue parses without throwing; a valid (spec-compliant) value is always mapped.
+        if (source.HasValue)
+            return HorizontalAlignmentMap[source.Value];
+
+        return LenientAlignmentLookup(source.InnerText, HorizontalAlignmentMap, raw => new HorizontalAlignmentValues(raw));
+    }
+
+    /// <summary>
+    /// Leniently converts a vertical alignment attribute to its XLibur equivalent.
+    /// See <see cref="ToXLiburOrNull(EnumValue{HorizontalAlignmentValues})"/> for the casing
+    /// tolerance and discard-on-failure behavior.
+    /// </summary>
+    public static XLAlignmentVerticalValues? ToXLiburOrNull(this EnumValue<VerticalAlignmentValues>? source)
+    {
+        if (source is null)
+            return null;
+
+        if (source.HasValue)
+            return VerticalAlignmentMap[source.Value];
+
+        return LenientAlignmentLookup(source.InnerText, VerticalAlignmentMap, raw => new VerticalAlignmentValues(raw));
+    }
+
+    private static TValue? LenientAlignmentLookup<TKey, TValue>(
+        string? rawText,
+        Dictionary<TKey, TValue> map,
+        Func<string, TKey> factory)
+        where TKey : notnull
+        where TValue : struct
+    {
+        if (string.IsNullOrEmpty(rawText))
+            return null;
+
+        var lowered = factory(rawText!.ToLowerInvariant());
+        return map.TryGetValue(lowered, out var result) ? result : null;
     }
 
 }


### PR DESCRIPTION
Fixes SonarCloud S4136 by grouping ToXLibur overloads in EnumConverter.cs so they are adjacent.