### PR TITLE
chore: group IXLWorksheet overloads together (S4136)

### DIFF
--- a/XLibur/Excel/IXLWorksheet.cs
+++ b/XLibur/Excel/IXLWorksheet.cs
@@ -235,11 +235,6 @@ public interface IXLWorksheet : IXLRangeBase, IXLProtectable<IXLSheetProtection,
     /// <param name="lastCellAddress"> The last cell address in the worksheet.</param>
     IXLRange Range(IXLAddress firstCellAddress, IXLAddress lastCellAddress);
 
-    /// <summary>Returns a collection of ranges, separated by commas.</summary>
-    /// <para>e.g., Ranges("A1"), Ranges("A1:C2"), Ranges("A1:B2,D1:D4")</para>
-    /// <param name="ranges">The ranges to return.</param>
-    IXLRanges Ranges(string ranges);
-
     /// <summary>Returns the specified range.</summary>
     /// <param name="firstCellRow">   The first cell's row of the range to return.</param>
     /// <param name="firstCellColumn">The first cell's column of the range to return.</param>
@@ -247,6 +242,11 @@ public interface IXLWorksheet : IXLRangeBase, IXLProtectable<IXLSheetProtection,
     /// <param name="lastCellColumn"> The last cell's column of the range to return.</param>
     /// <returns>.</returns>
     IXLRange Range(int firstCellRow, int firstCellColumn, int lastCellRow, int lastCellColumn);
+
+    /// <summary>Returns a collection of ranges, separated by commas.</summary>
+    /// <para>e.g., Ranges("A1"), Ranges("A1:C2"), Ranges("A1:B2,D1:D4")</para>
+    /// <param name="ranges">The ranges to return.</param>
+    IXLRanges Ranges(string ranges);
 
     /// <summary>Gets the number of rows in this worksheet.</summary>
     int RowCount();
@@ -260,25 +260,15 @@ public interface IXLWorksheet : IXLRangeBase, IXLProtectable<IXLSheetProtection,
     IXLWorksheet CollapseRows();
 
     /// <summary>
-    /// Collapses all outlined columns.
-    /// </summary>
-    IXLWorksheet CollapseColumns();
-
-    /// <summary>
-    /// Expands all outlined rows.
-    /// </summary>
-    IXLWorksheet ExpandRows();
-
-    /// <summary>
-    /// Expands all outlined columns.
-    /// </summary>
-    IXLWorksheet ExpandColumns();
-
-    /// <summary>
     /// Collapses the outlined rows of the specified level.
     /// </summary>
     /// <param name="outlineLevel">The outline level.</param>
     IXLWorksheet CollapseRows(int outlineLevel);
+
+    /// <summary>
+    /// Collapses all outlined columns.
+    /// </summary>
+    IXLWorksheet CollapseColumns();
 
     /// <summary>
     /// Collapses the outlined columns of the specified level.
@@ -287,10 +277,20 @@ public interface IXLWorksheet : IXLRangeBase, IXLProtectable<IXLSheetProtection,
     IXLWorksheet CollapseColumns(int outlineLevel);
 
     /// <summary>
+    /// Expands all outlined rows.
+    /// </summary>
+    IXLWorksheet ExpandRows();
+
+    /// <summary>
     /// Expands the outlined rows of the specified level.
     /// </summary>
     /// <param name="outlineLevel">The outline level.</param>
     IXLWorksheet ExpandRows(int outlineLevel);
+
+    /// <summary>
+    /// Expands all outlined columns.
+    /// </summary>
+    IXLWorksheet ExpandColumns();
 
     /// <summary>
     /// Expands the outlined columns of the specified level.


### PR DESCRIPTION
Fixes SonarCloud S4136 by grouping Range, CollapseRows, CollapseColumns, ExpandRows, and ExpandColumns overloads in IXLWorksheet.cs so they are adjacent.