### PR TITLE
feat: chart series formatting, secondary axis and edit-in-place charts (spec 10 PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Added
+
+- **Chart series formatting**: `IXLChartSeries` gained `FillColor`, `LineColor`, `LineWidthPt`, `MarkerStyle` (new `XLMarkerStyle` enum), `MarkerSize`, `MarkerFillColor` and `Smooth`, so a generated chart can be styled instead of relying on Excel's automatic theme colours. Leaving a property `null` omits its element, which keeps the automatic colour — nothing is ever written as an explicit black.
+
+- **Secondary value axis per series**: `IXLChartSeries.UseSecondaryAxis` plots a series against a value axis on the right, so a percentage can share a chart with values in the thousands. It applies to series of the primary chart type as well as to a combo chart's `SecondarySeries`.
+
+- **Charts loaded from a file can be restyled**: setting the series formatting on a loaded chart now writes back on save. Only the properties actually assigned are patched into the existing chart part, so trendlines, error bars, gradient fills, per-point colours, data labels and the chart's style/colour parts are all preserved — and a chart nobody edited is left byte for byte as it was.
+
+### Fixed
+
+- **Chart XML now passes OpenXML schema validation.** Three long-standing violations in the chart writer are fixed: series names were written as a `c:strRef` with no required `c:f` (a literal name now uses `<c:tx><c:v>`, and both forms are read back), `c:doughnutChart` omitted the required `c:holeSize`, and `c:marker` was written after `c:cat`/`c:val` instead of before. Excel tolerated all three, but stricter readers and `SaveOptions.ValidatePackage` did not.
+
+- **A `Line` chart whose markers are switched off no longer reads back as `LineWithMarkers`.** The reader treated the presence of a `c:marker` element as "has markers", even when it held `<c:symbol val="none"/>`.
+
+- **Charts with more than one plot group of the same type now read all of their series.** The reader took only the first `c:barChart` (or `c:lineChart`, …) of a plot area, so the series of a second group — which is how Excel stores a secondary axis — were dropped.
+
 ## v0.106.0 - 2026-07-25
 
 First XLibur release since forking [ClosedXML v0.105.0](https://github.com/ClosedXML/ClosedXML/)

--- a/XLibur.Examples/Charts/FormattedChartExamples.cs
+++ b/XLibur.Examples/Charts/FormattedChartExamples.cs
@@ -1,0 +1,173 @@
+using XLibur.Excel;
+
+namespace XLibur.Examples.Charts;
+
+/// <summary>
+/// Creates a workbook showing what the series formatting API can do: explicit fills and outlines,
+/// markers, smoothing, and a series plotted against a secondary value axis.
+/// </summary>
+public class FormattedChartExamples : IXLExample
+{
+    public void Create(string filePath)
+    {
+        using var wb = new XLWorkbook();
+
+        BrandedColumns(wb);
+        LineStyles(wb);
+        TwoScales(wb);
+        HighlightOneSeries(wb);
+
+        wb.SaveAs(filePath);
+    }
+
+    /// <summary>
+    /// The everyday case: give each series a colour from the corporate palette instead of accepting
+    /// Excel's automatic theme colours.
+    /// </summary>
+    private static void BrandedColumns(XLWorkbook wb)
+    {
+        var ws = wb.Worksheets.Add("Branded columns");
+        WriteQuarterlyData(ws);
+
+        var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+        chart.SetTitle("Revenue vs cost");
+
+        var revenue = chart.Series.Add("Revenue", "'Branded columns'!$B$2:$B$5", "'Branded columns'!$A$2:$A$5");
+        revenue.FillColor = XLColor.FromHtml("#4472C4");
+        revenue.LineColor = XLColor.FromHtml("#203864");
+        revenue.LineWidthPt = 1;
+
+        // A muted grey keeps the comparison series in the background.
+        var cost = chart.Series.Add("Cost", "'Branded columns'!$C$2:$C$5", "'Branded columns'!$A$2:$A$5");
+        cost.FillColor = XLColor.FromHtml("#A5A5A5");
+
+        chart.Position.SetColumn(6).SetRow(1);
+        chart.SecondPosition.SetColumn(14).SetRow(17);
+    }
+
+    /// <summary>
+    /// Markers and smoothing on line series.
+    /// </summary>
+    private static void LineStyles(XLWorkbook wb)
+    {
+        var ws = wb.Worksheets.Add("Line styles");
+        WriteQuarterlyData(ws);
+
+        var chart = ws.Charts.Add(XLChartType.Line);
+        chart.SetTitle("Marker styles and smoothing");
+
+        var straight = chart.Series.Add("Revenue", "'Line styles'!$B$2:$B$5", "'Line styles'!$A$2:$A$5");
+        straight.LineColor = XLColor.FromHtml("#4472C4");
+        straight.LineWidthPt = 2.25;
+        straight.MarkerStyle = XLMarkerStyle.Circle;
+        straight.MarkerSize = 8;
+        straight.MarkerFillColor = XLColor.FromHtml("#FFFFFF");
+
+        var smooth = chart.Series.Add("Cost", "'Line styles'!$C$2:$C$5", "'Line styles'!$A$2:$A$5");
+        smooth.LineColor = XLColor.FromTheme(XLThemeColor.Accent6);
+        smooth.LineWidthPt = 2.25;
+        smooth.MarkerStyle = XLMarkerStyle.Diamond;
+        smooth.MarkerSize = 8;
+        smooth.Smooth = true;
+
+        chart.Position.SetColumn(6).SetRow(1);
+        chart.SecondPosition.SetColumn(14).SetRow(17);
+    }
+
+    /// <summary>
+    /// A percentage next to values in the thousands only reads if it gets its own axis.
+    /// </summary>
+    private static void TwoScales(XLWorkbook wb)
+    {
+        var ws = wb.Worksheets.Add("Two scales");
+        WriteQuarterlyData(ws);
+        ws.Cell("D1").Value = "Margin %";
+        for (var row = 2; row <= 5; row++)
+            ws.Cell(row, 4).FormulaA1 = $"=(B{row}-C{row})/B{row}";
+        ws.Range("D2:D5").Style.NumberFormat.Format = "0.0%";
+
+        var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+        chart.SetTitle("Revenue and margin");
+        chart.Series.Add("Revenue", "'Two scales'!$B$2:$B$5", "'Two scales'!$A$2:$A$5");
+
+        chart.SecondaryChartType = XLChartType.LineWithMarkers;
+        var margin = chart.SecondarySeries.Add("Margin %", "'Two scales'!$D$2:$D$5", "'Two scales'!$A$2:$A$5");
+        margin.UseSecondaryAxis = true;
+        margin.LineColor = XLColor.FromHtml("#ED7D31");
+        margin.LineWidthPt = 2.25;
+        margin.MarkerStyle = XLMarkerStyle.Circle;
+        margin.MarkerSize = 7;
+
+        chart.Position.SetColumn(6).SetRow(1);
+        chart.SecondPosition.SetColumn(15).SetRow(19);
+    }
+
+    /// <summary>
+    /// Series on the primary chart type can go on the secondary axis too — here one quarter is
+    /// picked out in a strong colour while the rest stay automatic.
+    /// </summary>
+    private static void HighlightOneSeries(XLWorkbook wb)
+    {
+        var ws = wb.Worksheets.Add("Highlight");
+        ws.Cell("A1").Value = "Region";
+        ws.Cell("B1").Value = "This year";
+        ws.Cell("C1").Value = "Last year";
+        ws.Cell("D1").Value = "Growth %";
+
+        string[] regions = ["North", "South", "East", "West"];
+        double[] thisYear = [42_000, 38_500, 51_000, 29_750];
+        double[] lastYear = [39_000, 40_100, 44_500, 31_000];
+
+        for (var i = 0; i < regions.Length; i++)
+        {
+            ws.Cell(i + 2, 1).Value = regions[i];
+            ws.Cell(i + 2, 2).Value = thisYear[i];
+            ws.Cell(i + 2, 3).Value = lastYear[i];
+            ws.Cell(i + 2, 4).FormulaA1 = $"=(B{i + 2}-C{i + 2})/C{i + 2}";
+        }
+
+        ws.Range("B2:C5").Style.NumberFormat.Format = "$ #,##0";
+        ws.Range("D2:D5").Style.NumberFormat.Format = "0.0%";
+        ws.Columns("A", "D").AdjustToContents();
+
+        var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+        chart.SetTitle("Year on year by region");
+
+        chart.Series.Add("This year", "Highlight!$B$2:$B$5", "Highlight!$A$2:$A$5").FillColor =
+            XLColor.FromHtml("#4472C4");
+
+        // No colour at all: Excel picks the next theme colour, which is the right default for a
+        // series nobody is meant to look at first.
+        chart.Series.Add("Last year", "Highlight!$C$2:$C$5", "Highlight!$A$2:$A$5");
+
+        // Growth is a percentage, so it needs the secondary axis even though it is the same
+        // (column) chart type as the other two series.
+        var growth = chart.Series.Add("Growth %", "Highlight!$D$2:$D$5", "Highlight!$A$2:$A$5");
+        growth.UseSecondaryAxis = true;
+        growth.FillColor = XLColor.FromHtml("#70AD47");
+
+        chart.Position.SetColumn(6).SetRow(1);
+        chart.SecondPosition.SetColumn(15).SetRow(19);
+    }
+
+    private static void WriteQuarterlyData(IXLWorksheet ws)
+    {
+        ws.Cell("A1").Value = "Quarter";
+        ws.Cell("B1").Value = "Revenue";
+        ws.Cell("C1").Value = "Cost";
+
+        string[] quarters = ["Q1", "Q2", "Q3", "Q4"];
+        double[] revenue = [30_000, 45_000, 28_000, 50_000];
+        double[] cost = [21_000, 29_000, 20_500, 31_000];
+
+        for (var i = 0; i < quarters.Length; i++)
+        {
+            ws.Cell(i + 2, 1).Value = quarters[i];
+            ws.Cell(i + 2, 2).Value = revenue[i];
+            ws.Cell(i + 2, 3).Value = cost[i];
+        }
+
+        ws.Range("B2:C5").Style.NumberFormat.Format = "$ #,##0";
+        ws.Columns("A", "C").AdjustToContents();
+    }
+}

--- a/XLibur.Examples/Charts/FormattedChartExamples.cs
+++ b/XLibur.Examples/Charts/FormattedChartExamples.cs
@@ -103,8 +103,9 @@ public class FormattedChartExamples : IXLExample
     }
 
     /// <summary>
-    /// Series on the primary chart type can go on the secondary axis too — here one quarter is
-    /// picked out in a strong colour while the rest stay automatic.
+    /// Series on the primary chart type can go on the secondary axis too: the two currency series
+    /// share the left axis while the growth percentage gets the right one, without the chart needing
+    /// a secondary chart type. Only the series worth looking at first is given an explicit colour.
     /// </summary>
     private static void HighlightOneSeries(XLWorkbook wb)
     {

--- a/XLibur.Examples/Creating/CreateFiles.cs
+++ b/XLibur.Examples/Creating/CreateFiles.cs
@@ -96,6 +96,7 @@ public static class CreateFiles
         new PivotTables.PivotTables().Create(Path.Combine(path, "PivotTables.xlsx"));
         new SheetViews().Create(Path.Combine(path, "SheetViews.xlsx"));
         new ChartExamples().Create(Path.Combine(path, "ChartExamples.xlsx"));
+        new FormattedChartExamples().Create(Path.Combine(path, "FormattedChartExamples.xlsx"));
         new CFDataBarModify().Create(Path.Combine(path, "CFDataBarModify.xlsx"));
     }
 }

--- a/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
@@ -1,0 +1,333 @@
+using DocumentFormat.OpenXml.Packaging;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// Reading Excel-shaped chart XML, and keeping the parts of it that XLibur does not model when a
+/// chart is edited and saved again.
+/// </summary>
+/// <remarks>
+/// The fixture below is hand-written to match the XML Excel emits — the extra <c>a:effectLst</c>,
+/// <c>a:round</c> and <c>cap</c> attributes, a scheme colour, a series name held in a
+/// <c>c:strRef</c> cache, a trendline, and a secondary axis pair — because no Excel is available to
+/// author a resource file in CI.
+/// </remarks>
+[TestFixture]
+public class ChartRoundTripPreservationTests
+{
+    private const string ExcelShapedChartXml = """
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+          <c:chart>
+            <c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr lang="en-US"/><a:t>Units and price</a:t></a:r></a:p></c:rich></c:tx><c:overlay val="0"/></c:title>
+            <c:autoTitleDeleted val="0"/>
+            <c:plotArea>
+              <c:layout/>
+              <c:barChart>
+                <c:barDir val="col"/>
+                <c:grouping val="clustered"/>
+                <c:varyColors val="0"/>
+                <c:ser>
+                  <c:idx val="0"/>
+                  <c:order val="0"/>
+                  <c:tx><c:strRef><c:f>Data!$B$1</c:f><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Units</c:v></c:pt></c:strCache></c:strRef></c:tx>
+                  <c:spPr>
+                    <a:solidFill><a:srgbClr val="ED7D31"/></a:solidFill>
+                    <a:ln w="19050" cap="rnd"><a:solidFill><a:srgbClr val="203864"/></a:solidFill><a:round/></a:ln>
+                    <a:effectLst/>
+                  </c:spPr>
+                  <c:invertIfNegative val="0"/>
+                  <c:trendline><c:trendlineType val="linear"/></c:trendline>
+                  <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+                  <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+                </c:ser>
+                <c:gapWidth val="219"/>
+                <c:overlap val="-27"/>
+                <c:axId val="111111111"/>
+                <c:axId val="222222222"/>
+              </c:barChart>
+              <c:lineChart>
+                <c:grouping val="standard"/>
+                <c:varyColors val="0"/>
+                <c:ser>
+                  <c:idx val="1"/>
+                  <c:order val="1"/>
+                  <c:tx><c:v>Price</c:v></c:tx>
+                  <c:spPr>
+                    <a:ln w="28575" cap="rnd"><a:solidFill><a:schemeClr val="accent2"/></a:solidFill><a:round/></a:ln>
+                    <a:effectLst/>
+                  </c:spPr>
+                  <c:marker>
+                    <c:symbol val="circle"/>
+                    <c:size val="7"/>
+                    <c:spPr><a:solidFill><a:srgbClr val="70AD47"/></a:solidFill><a:ln w="9525"><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill></a:ln></c:spPr>
+                  </c:marker>
+                  <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+                  <c:val><c:numRef><c:f>Data!$C$1:$C$2</c:f></c:numRef></c:val>
+                  <c:smooth val="1"/>
+                </c:ser>
+                <c:marker val="1"/>
+                <c:axId val="333333333"/>
+                <c:axId val="444444444"/>
+              </c:lineChart>
+              <c:catAx><c:axId val="111111111"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="222222222"/></c:catAx>
+              <c:valAx><c:axId val="222222222"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="111111111"/></c:valAx>
+              <c:valAx><c:axId val="444444444"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="r"/><c:crossAx val="333333333"/><c:crosses val="max"/></c:valAx>
+              <c:catAx><c:axId val="333333333"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="1"/><c:axPos val="b"/><c:crossAx val="444444444"/></c:catAx>
+            </c:plotArea>
+            <c:legend><c:legendPos val="b"/><c:overlay val="0"/></c:legend>
+            <c:plotVisOnly val="1"/>
+          </c:chart>
+        </c:chartSpace>
+        """;
+
+    /// <summary>
+    /// Produces a workbook whose single chart part holds <see cref="ExcelShapedChartXml"/>.
+    /// </summary>
+    private static MemoryStream CreateWorkbookWithExcelShapedChart()
+    {
+        var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Data");
+            ws.Cell("A1").Value = "Q1";
+            ws.Cell("A2").Value = "Q2";
+            ws.Cell("B1").Value = 100;
+            ws.Cell("B2").Value = 200;
+            ws.Cell("C1").Value = 5;
+            ws.Cell("C2").Value = 8;
+
+            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+            chart.Series.Add("Units", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Position.SetColumn(5).SetRow(1);
+            chart.SecondPosition.SetColumn(12).SetRow(15);
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        using (var doc = SpreadsheetDocument.Open(ms, true))
+        {
+            var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
+            using var source = new MemoryStream(Encoding.UTF8.GetBytes(ExcelShapedChartXml));
+            chartPart.FeedData(source);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static string ReadChartXml(Stream stream)
+    {
+        stream.Position = 0;
+        using var doc = SpreadsheetDocument.Open(stream, false);
+        var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
+        using var reader = new StreamReader(chartPart.GetStream(FileMode.Open, FileAccess.Read));
+        return reader.ReadToEnd();
+    }
+
+    // ── Reading Excel-shaped XML ────────────────────────────────────────
+
+    [Test]
+    public void ExcelShapedSeriesFormattingIsRead()
+    {
+        using var ms = CreateWorkbookWithExcelShapedChart();
+        using var wb = new XLWorkbook(ms);
+        var chart = wb.Worksheet("Data").Charts.First();
+
+        Assert.That(chart.Title, Is.EqualTo("Units and price"));
+        Assert.That(chart.ChartType, Is.EqualTo(XLChartType.ColumnClustered));
+        Assert.That(chart.SecondaryChartType, Is.EqualTo(XLChartType.LineWithMarkers));
+
+        var bar = chart.Series.Single();
+        Assert.That(bar.Name, Is.EqualTo("Units"), "The name lives in the c:strRef cache.");
+        Assert.That(bar.FillColor, Is.EqualTo(XLColor.FromHtml("#ED7D31")));
+        Assert.That(bar.LineColor, Is.EqualTo(XLColor.FromHtml("#203864")));
+        Assert.That(bar.LineWidthPt, Is.EqualTo(1.5));
+        Assert.That(bar.UseSecondaryAxis, Is.False);
+
+        var line = chart.SecondarySeries.Single();
+        Assert.That(line.Name, Is.EqualTo("Price"), "The name is a literal c:v.");
+        Assert.That(line.LineColor!.ColorType, Is.EqualTo(XLColorType.Theme));
+        Assert.That(line.LineColor.ThemeColor, Is.EqualTo(XLThemeColor.Accent2));
+        Assert.That(line.LineWidthPt, Is.EqualTo(2.25));
+        Assert.That(line.MarkerStyle, Is.EqualTo(XLMarkerStyle.Circle));
+        Assert.That(line.MarkerSize, Is.EqualTo(7));
+        Assert.That(line.MarkerFillColor, Is.EqualTo(XLColor.FromHtml("#70AD47")));
+        Assert.That(line.Smooth, Is.True);
+        Assert.That(line.UseSecondaryAxis, Is.True,
+            "The line group is plotted against the value axis on the right.");
+    }
+
+    // ── Preservation ────────────────────────────────────────────────────
+
+    [Test]
+    public void LoadAndSaveWithoutEditsLeavesTheChartPartUntouched()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        var before = ReadChartXml(original);
+
+        using var saved = new MemoryStream();
+        original.Position = 0;
+        using (var wb = new XLWorkbook(original))
+        {
+            wb.SaveAs(saved);
+        }
+
+        Assert.That(ReadChartXml(saved), Is.EqualTo(before));
+    }
+
+    [Test]
+    public void EditingOneSeriesKeepsEverythingElseInTheChartPart()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            var series = wb.Worksheet("Data").Charts.First().Series.Single();
+            series.FillColor = XLColor.FromHtml("#00B050");
+            series.LineWidthPt = 3;
+            wb.SaveAs(saved);
+        }
+
+        var xml = ReadChartXml(saved);
+
+        // The edits landed.
+        Assert.That(xml, Does.Contain("00B050"));
+        Assert.That(xml, Does.Not.Contain("ED7D31"), "The old fill colour must be replaced, not doubled up.");
+        Assert.That(xml, Does.Contain("w=\"38100\""), "3 pt is 38100 EMU.");
+
+        // Everything XLibur does not model survived.
+        Assert.That(xml, Does.Contain("<c:trendline>"));
+        Assert.That(xml, Does.Contain("cap=\"rnd\""));
+        Assert.That(xml, Does.Contain("<a:round"));
+        Assert.That(xml, Does.Contain("<a:effectLst"));
+        Assert.That(xml, Does.Contain("<c:gapWidth val=\"219\""));
+        Assert.That(xml, Does.Contain("<c:legend>"));
+
+        // The untouched line series kept its own formatting.
+        Assert.That(xml, Does.Contain("accent2"));
+        Assert.That(xml, Does.Contain("<c:size val=\"7\""));
+        Assert.That(xml, Does.Contain("70AD47"));
+    }
+
+    [Test]
+    public void EditedSeriesFormattingReloadsWithTheNewValues()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            chart.Series.Single().FillColor = XLColor.FromHtml("#00B050");
+
+            var line = chart.SecondarySeries.Single();
+            line.MarkerStyle = XLMarkerStyle.Square;
+            line.MarkerSize = 10;
+            line.Smooth = false;
+            wb.SaveAs(saved);
+        }
+
+        saved.Position = 0;
+        using (var wb = new XLWorkbook(saved))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.Series.Single().FillColor, Is.EqualTo(XLColor.FromHtml("#00B050")));
+
+            var line = chart.SecondarySeries.Single();
+            Assert.That(line.MarkerStyle, Is.EqualTo(XLMarkerStyle.Square));
+            Assert.That(line.MarkerSize, Is.EqualTo(10));
+            Assert.That(line.Smooth, Is.False);
+            Assert.That(line.MarkerFillColor, Is.EqualTo(XLColor.FromHtml("#70AD47")),
+                "A property that was not assigned keeps the value from the file.");
+        }
+    }
+
+    [Test]
+    public void ClearingAColorRemovesTheFillRatherThanWritingBlack()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            wb.Worksheet("Data").Charts.First().Series.Single().FillColor = null;
+            wb.SaveAs(saved);
+        }
+
+        var xml = ReadChartXml(saved);
+        Assert.That(xml, Does.Not.Contain("ED7D31"));
+        Assert.That(xml, Does.Not.Contain("<a:solidFill><a:srgbClr val=\"000000\"/></a:solidFill>"));
+
+        saved.Position = 0;
+        using (var wb = new XLWorkbook(saved))
+        {
+            Assert.That(wb.Worksheet("Data").Charts.First().Series.Single().FillColor, Is.Null);
+        }
+    }
+
+    [Test]
+    public void MarkerAndSmoothAreNotPatchedIntoASeriesTypeThatCannotHoldThem()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            // A bar series has neither c:marker nor c:smooth in its schema.
+            var bar = wb.Worksheet("Data").Charts.First().Series.Single();
+            bar.MarkerStyle = XLMarkerStyle.Circle;
+            bar.MarkerSize = 10;
+            bar.Smooth = true;
+            bar.FillColor = XLColor.FromHtml("#00B050");
+
+            wb.SaveAs(saved, validate: true);
+        }
+
+        var xml = ReadChartXml(saved);
+        var barSeries = xml[xml.IndexOf("<c:barChart>", StringComparison.Ordinal)..
+                            xml.IndexOf("<c:lineChart>", StringComparison.Ordinal)];
+        Assert.That(barSeries, Does.Not.Contain("<c:marker"));
+        Assert.That(barSeries, Does.Not.Contain("<c:smooth"));
+        Assert.That(barSeries, Does.Contain("00B050"), "The fill still applies.");
+    }
+
+    [Test]
+    public void SavingANewChartTwiceDoesNotDuplicateIt()
+    {
+        using var first = new MemoryStream();
+        using var second = new MemoryStream();
+
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Data");
+            ws.Cell("A1").Value = "Q1";
+            ws.Cell("B1").Value = 100;
+
+            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+            var series = chart.Series.Add("Units", "Data!$B$1:$B$1", "Data!$A$1:$A$1");
+            chart.Position.SetColumn(5).SetRow(1);
+            chart.SecondPosition.SetColumn(12).SetRow(15);
+            wb.SaveAs(first);
+
+            // The second save has to patch the part written by the first one.
+            series.FillColor = XLColor.FromHtml("#00B050");
+            wb.SaveAs(second);
+        }
+
+        second.Position = 0;
+        using (var wb = new XLWorkbook(second))
+        {
+            var ws = wb.Worksheet("Data");
+            Assert.That(ws.Charts.Count, Is.EqualTo(1));
+            Assert.That(ws.Charts.First().Series.Single().FillColor, Is.EqualTo(XLColor.FromHtml("#00B050")));
+        }
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
@@ -90,7 +90,13 @@ public class ChartRoundTripPreservationTests
     /// <summary>
     /// Produces a workbook whose single chart part holds <see cref="ExcelShapedChartXml"/>.
     /// </summary>
-    private static MemoryStream CreateWorkbookWithExcelShapedChart()
+    private static MemoryStream CreateWorkbookWithExcelShapedChart() =>
+        CreateWorkbookWithExcelShapedChart(ExcelShapedChartXml);
+
+    /// <summary>
+    /// Produces a workbook whose single chart part holds the given XML.
+    /// </summary>
+    private static MemoryStream CreateWorkbookWithExcelShapedChart(string chartXml)
     {
         var ms = new MemoryStream();
         using (var wb = new XLWorkbook())
@@ -114,7 +120,7 @@ public class ChartRoundTripPreservationTests
         using (var doc = SpreadsheetDocument.Open(ms, true))
         {
             var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
-            using var source = new MemoryStream(Encoding.UTF8.GetBytes(ExcelShapedChartXml));
+            using var source = new MemoryStream(Encoding.UTF8.GetBytes(chartXml));
             chartPart.FeedData(source);
         }
 
@@ -297,6 +303,196 @@ public class ChartRoundTripPreservationTests
         Assert.That(barSeries, Does.Not.Contain("<c:marker"));
         Assert.That(barSeries, Does.Not.Contain("<c:smooth"));
         Assert.That(barSeries, Does.Contain("00B050"), "The fill still applies.");
+    }
+
+    /// <summary>
+    /// The fixture's line series without its <c>c:marker</c> and <c>c:smooth</c>, so the patcher has
+    /// to add them rather than update them.
+    /// </summary>
+    private static string ChartXmlWithPlainLineSeries()
+    {
+        var marker = ExcelShapedChartXml.IndexOf("<c:marker>", StringComparison.Ordinal);
+        var afterMarker = ExcelShapedChartXml.IndexOf("</c:marker>", StringComparison.Ordinal)
+                          + "</c:marker>".Length;
+        var withoutMarker = ExcelShapedChartXml[..marker] + ExcelShapedChartXml[afterMarker..];
+        return withoutMarker.Replace("<c:smooth val=\"1\"/>", string.Empty);
+    }
+
+    [Test]
+    public void MarkerAndSmoothCanBeAddedToASeriesThatHadNeither()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart(ChartXmlWithPlainLineSeries());
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            var line = wb.Worksheet("Data").Charts.First().SecondarySeries.Single();
+            Assert.That(line.MarkerStyle, Is.EqualTo(XLMarkerStyle.Auto));
+            Assert.That(line.Smooth, Is.False);
+
+            line.MarkerStyle = XLMarkerStyle.Triangle;
+            line.MarkerSize = 9;
+            line.MarkerFillColor = XLColor.FromHtml("#FFC000");
+            line.Smooth = true;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        saved.Position = 0;
+        using (var wb = new XLWorkbook(saved))
+        {
+            var line = wb.Worksheet("Data").Charts.First().SecondarySeries.Single();
+            Assert.That(line.MarkerStyle, Is.EqualTo(XLMarkerStyle.Triangle));
+            Assert.That(line.MarkerSize, Is.EqualTo(9));
+            Assert.That(line.MarkerFillColor, Is.EqualTo(XLColor.FromHtml("#FFC000")));
+            Assert.That(line.Smooth, Is.True);
+            Assert.That(line.LineColor!.ThemeColor, Is.EqualTo(XLThemeColor.Accent2),
+                "The outline the series came with is untouched.");
+        }
+    }
+
+    [Test]
+    public void ClearingEveryMarkerPropertyLeavesNoEmptyMarkerBehind()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart(ChartXmlWithPlainLineSeries());
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            var line = wb.Worksheet("Data").Charts.First().SecondarySeries.Single();
+            line.MarkerSize = null;
+            line.MarkerFillColor = null;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        // An empty c:marker on the series would read back as "this series has markers", which would
+        // turn the chart type into LineWithMarkers. The group-level c:marker flag is a different
+        // element and is left alone.
+        var xml = ReadChartXml(saved);
+        var lineSeries = xml[xml.IndexOf("<c:lineChart>", StringComparison.Ordinal)..
+                             xml.IndexOf("</c:ser>", xml.IndexOf("<c:lineChart>", StringComparison.Ordinal),
+                                 StringComparison.Ordinal)];
+        Assert.That(lineSeries, Does.Not.Contain("<c:marker"));
+
+        saved.Position = 0;
+        using (var wb = new XLWorkbook(saved))
+        {
+            Assert.That(wb.Worksheet("Data").Charts.First().SecondaryChartType,
+                Is.EqualTo(XLChartType.Line));
+        }
+    }
+
+    [Test]
+    public void SmoothingCanBeTurnedOffOnASeriesThatHadIt()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            var line = wb.Worksheet("Data").Charts.First().SecondarySeries.Single();
+            Assert.That(line.Smooth, Is.True);
+            line.Smooth = false;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        saved.Position = 0;
+        using (var wb = new XLWorkbook(saved))
+        {
+            Assert.That(wb.Worksheet("Data").Charts.First().SecondarySeries.Single().Smooth, Is.False);
+        }
+    }
+
+    [Test]
+    public void AnOutlineCanBeAddedToASeriesThatOnlyHadAFill()
+    {
+        // The bar series' spPr carries a solidFill and an a:ln; strip the a:ln so the patcher has to
+        // insert one, in the right place, next to the fill and the effect list.
+        var chartXml = ExcelShapedChartXml.Replace(
+            "<a:ln w=\"19050\" cap=\"rnd\"><a:solidFill><a:srgbClr val=\"203864\"/></a:solidFill><a:round/></a:ln>",
+            string.Empty);
+
+        using var original = CreateWorkbookWithExcelShapedChart(chartXml);
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            var bar = wb.Worksheet("Data").Charts.First().Series.Single();
+            Assert.That(bar.LineColor, Is.Null);
+            bar.LineColor = XLColor.FromHtml("#203864");
+            bar.LineWidthPt = 2;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        var xml = ReadChartXml(saved);
+        Assert.That(xml, Does.Contain("w=\"25400\""));
+        Assert.That(xml, Does.Contain("<a:effectLst"), "The effect list is still after the outline.");
+
+        saved.Position = 0;
+        using (var wb = new XLWorkbook(saved))
+        {
+            var bar = wb.Worksheet("Data").Charts.First().Series.Single();
+            Assert.That(bar.LineColor, Is.EqualTo(XLColor.FromHtml("#203864")));
+            Assert.That(bar.LineWidthPt, Is.EqualTo(2));
+            Assert.That(bar.FillColor, Is.EqualTo(XLColor.FromHtml("#ED7D31")),
+                "The fill it came with is untouched.");
+        }
+    }
+
+    [Test]
+    public void ClearingTheOutlineWidthLeavesTheColourAlone()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            var bar = wb.Worksheet("Data").Charts.First().Series.Single();
+            bar.LineWidthPt = null;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        saved.Position = 0;
+        using (var wb = new XLWorkbook(saved))
+        {
+            var bar = wb.Worksheet("Data").Charts.First().Series.Single();
+            Assert.That(bar.LineWidthPt, Is.Null);
+            Assert.That(bar.LineColor, Is.EqualTo(XLColor.FromHtml("#203864")));
+        }
+    }
+
+    [Test]
+    public void EveryMarkerStyleRoundTrips()
+    {
+        XLMarkerStyle[] styles =
+        [
+            XLMarkerStyle.None, XLMarkerStyle.Circle, XLMarkerStyle.Dash, XLMarkerStyle.Diamond,
+            XLMarkerStyle.Dot, XLMarkerStyle.Plus, XLMarkerStyle.Square, XLMarkerStyle.Star,
+            XLMarkerStyle.Triangle, XLMarkerStyle.X
+        ];
+
+        foreach (var style in styles)
+        {
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Data");
+                ws.Cell("A1").Value = "Q1";
+                ws.Cell("B1").Value = 100;
+
+                var chart = ws.Charts.Add(XLChartType.LineWithMarkers);
+                chart.Series.Add("Sales", "Data!$B$1:$B$1", "Data!$A$1:$A$1").MarkerStyle = style;
+                chart.Position.SetColumn(5).SetRow(1);
+                chart.SecondPosition.SetColumn(12).SetRow(15);
+                wb.SaveAs(ms, validate: true);
+            }
+
+            ms.Position = 0;
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.That(wb.Worksheet("Data").Charts.First().Series.Single().MarkerStyle,
+                    Is.EqualTo(style), $"{style} did not round-trip.");
+            }
+        }
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
@@ -1,0 +1,495 @@
+using DocumentFormat.OpenXml.Packaging;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using XLibur.Excel;
+using A = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// Series formatting: fill, outline, markers, smoothing and secondary axis binding.
+/// </summary>
+[TestFixture]
+public class ChartSeriesFormattingTests
+{
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private static IXLWorksheet AddDataSheet(XLWorkbook wb, string name = "Data")
+    {
+        var ws = wb.AddWorksheet(name);
+        ws.Cell("A1").Value = "Q1";
+        ws.Cell("A2").Value = "Q2";
+        ws.Cell("B1").Value = 100;
+        ws.Cell("B2").Value = 200;
+        ws.Cell("C1").Value = 5;
+        ws.Cell("C2").Value = 8;
+        return ws;
+    }
+
+    private static IXLChart AddChart(IXLWorksheet ws, XLChartType type)
+    {
+        var chart = ws.Charts.Add(type);
+        chart.Position.SetColumn(5).SetRow(1);
+        chart.SecondPosition.SetColumn(12).SetRow(15);
+        return chart;
+    }
+
+    /// <summary>
+    /// Saves with the OpenXML validator switched on, so a schema-invalid child order fails the test
+    /// rather than only showing up as a repair prompt in Excel.
+    /// </summary>
+    private static MemoryStream SaveValidated(XLWorkbook wb)
+    {
+        var ms = new MemoryStream();
+        wb.SaveAs(ms, validate: true);
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static C.ChartSpace ChartSpaceOf(Stream stream)
+    {
+        stream.Position = 0;
+        using var doc = SpreadsheetDocument.Open(stream, false);
+        var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
+        // Detach from the package so the caller can keep using it after the document is closed.
+        return (C.ChartSpace)chartPart.ChartSpace!.CloneNode(true);
+    }
+
+    // ── Writing and reading back ────────────────────────────────────────
+
+    [Test]
+    public void SeriesFillAndLineRoundTrip()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            var series = chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            series.FillColor = XLColor.FromArgb(0xFF, 0x00, 0x00);
+            series.LineColor = XLColor.FromArgb(0x00, 0x33, 0x66);
+            series.LineWidthPt = 2.25;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var series = wb.Worksheet("Data").Charts.First().Series.First();
+            Assert.That(series.FillColor, Is.EqualTo(XLColor.FromArgb(0xFF, 0x00, 0x00)));
+            Assert.That(series.LineColor, Is.EqualTo(XLColor.FromArgb(0x00, 0x33, 0x66)));
+            Assert.That(series.LineWidthPt, Is.EqualTo(2.25));
+        }
+    }
+
+    [Test]
+    public void SeriesFillIsWrittenAsSolidFillInShapeProperties()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2").FillColor = XLColor.FromArgb(0x12, 0x34, 0x56);
+
+        using var ms = SaveValidated(wb);
+        var chartSpace = ChartSpaceOf(ms);
+
+        var seriesElement = chartSpace.Descendants<C.BarChartSeries>().Single();
+        var shapeProperties = seriesElement.Elements<C.ChartShapeProperties>().Single();
+        var rgb = shapeProperties.Elements<A.SolidFill>().Single().Elements<A.RgbColorModelHex>().Single();
+        Assert.That(rgb.Val!.Value, Is.EqualTo("123456"));
+
+        // c:spPr has to come before c:cat and c:val.
+        var children = seriesElement.ChildElements.Select(e => e.LocalName).ToList();
+        Assert.That(children.IndexOf("spPr"), Is.LessThan(children.IndexOf("cat")));
+    }
+
+    [Test]
+    public void NoFormattingWritesNoShapeProperties()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+
+        using var ms = SaveValidated(wb);
+        var chartSpace = ChartSpaceOf(ms);
+
+        var seriesElement = chartSpace.Descendants<C.BarChartSeries>().Single();
+        Assert.That(seriesElement.Elements<C.ChartShapeProperties>(), Is.Empty,
+            "An unformatted series must not pin down a colour; Excel picks the theme colour.");
+    }
+
+    [Test]
+    public void ThemeFillColorRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2").FillColor =
+                XLColor.FromTheme(XLThemeColor.Accent3);
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var series = wb.Worksheet("Data").Charts.First().Series.First();
+            Assert.That(series.FillColor!.ColorType, Is.EqualTo(XLColorType.Theme));
+            Assert.That(series.FillColor.ThemeColor, Is.EqualTo(XLThemeColor.Accent3));
+        }
+    }
+
+    [Test]
+    public void MarkerRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.Line);
+            var series = chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            series.MarkerStyle = XLMarkerStyle.Diamond;
+            series.MarkerSize = 9;
+            series.MarkerFillColor = XLColor.FromArgb(0x00, 0xB0, 0x50);
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var series = wb.Worksheet("Data").Charts.First().Series.First();
+            Assert.That(series.MarkerStyle, Is.EqualTo(XLMarkerStyle.Diamond));
+            Assert.That(series.MarkerSize, Is.EqualTo(9));
+            Assert.That(series.MarkerFillColor, Is.EqualTo(XLColor.FromArgb(0x00, 0xB0, 0x50)));
+        }
+    }
+
+    [Test]
+    public void MarkerStyleNoneKeepsChartTypeLine()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.Line);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2").MarkerStyle = XLMarkerStyle.None;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.ChartType, Is.EqualTo(XLChartType.Line));
+            Assert.That(chart.Series.First().MarkerStyle, Is.EqualTo(XLMarkerStyle.None));
+        }
+    }
+
+    [Test]
+    public void LineWithMarkersStillWritesAutoMarker()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.LineWithMarkers);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+
+        using var ms = SaveValidated(wb);
+        var chartSpace = ChartSpaceOf(ms);
+
+        var seriesElement = chartSpace.Descendants<C.LineChartSeries>().Single();
+        var marker = seriesElement.Elements<C.Marker>().Single();
+        Assert.That(marker.Elements<C.Symbol>().Single().Val!.Value, Is.EqualTo(C.MarkerStyleValues.Auto));
+
+        // c:marker has to sit between c:tx and c:cat.
+        var children = seriesElement.ChildElements.Select(e => e.LocalName).ToList();
+        Assert.That(children.IndexOf("marker"), Is.LessThan(children.IndexOf("cat")));
+    }
+
+    [Test]
+    public void SmoothRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.Line);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2").Smooth = true;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            Assert.That(wb.Worksheet("Data").Charts.First().Series.First().Smooth, Is.True);
+        }
+    }
+
+    [Test]
+    public void SmoothIsNotWrittenWhenLeftAlone()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.Line);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+
+        using var ms = SaveValidated(wb);
+        var chartSpace = ChartSpaceOf(ms);
+
+        Assert.That(chartSpace.Descendants<C.Smooth>(), Is.Empty);
+    }
+
+    [Test]
+    public void SmoothScatterTypeIsWrittenAsSmoothed()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.XYScatterSmoothLinesNoMarkers);
+        chart.Series.Add("Points", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+
+        using var ms = SaveValidated(wb);
+        var chartSpace = ChartSpaceOf(ms);
+
+        Assert.That(chartSpace.Descendants<C.Smooth>().Single().Val!.Value, Is.True);
+    }
+
+    [Test]
+    public void ExplicitFalseOverridesTheSmoothChartTypeDefault()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.XYScatterSmoothLinesNoMarkers);
+        chart.Series.Add("Points", "Data!$B$1:$B$2", "Data!$A$1:$A$2").Smooth = false;
+
+        using var ms = SaveValidated(wb);
+        var chartSpace = ChartSpaceOf(ms);
+
+        Assert.That(chartSpace.Descendants<C.Smooth>().Single().Val!.Value, Is.False);
+    }
+
+    [Test]
+    public void FormattingSurvivesEveryStandardChartFamily()
+    {
+        // The formatting is appended by each chart family's own builder, so every family gets a
+        // schema check.
+        XLChartType[] types =
+        [
+            XLChartType.ColumnClustered, XLChartType.BarStacked, XLChartType.ColumnClustered3D,
+            XLChartType.Line, XLChartType.LineWithMarkers, XLChartType.Area, XLChartType.Radar,
+            XLChartType.Pie, XLChartType.Doughnut, XLChartType.XYScatterMarkers, XLChartType.Bubble,
+            XLChartType.StockHighLowClose, XLChartType.Surface, XLChartType.ConeClustered
+        ];
+
+        foreach (var type in types)
+        {
+            using var wb = new XLWorkbook();
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, type);
+
+            // A stock chart is only valid with three or four series (high/low/close).
+            var seriesCount = type == XLChartType.StockHighLowClose ? 3 : 1;
+            for (var i = 0; i < seriesCount; i++)
+            {
+                var series = chart.Series.Add($"S{i}", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+                series.FillColor = XLColor.Red;
+                series.LineColor = XLColor.Blue;
+                series.LineWidthPt = 1.5;
+                series.MarkerStyle = XLMarkerStyle.Square;
+                series.MarkerSize = 7;
+                series.Smooth = true;
+            }
+
+            Assert.DoesNotThrow(() =>
+            {
+                using var ms = SaveValidated(wb);
+            }, $"{type} produced invalid chart XML.");
+        }
+    }
+
+    // ── Secondary axis ──────────────────────────────────────────────────
+
+    [Test]
+    public void SecondaryAxisSeriesGetsItsOwnPlotGroupAndAxes()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Units", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+        chart.Series.Add("Price", "Data!$C$1:$C$2", "Data!$A$1:$A$2").UseSecondaryAxis = true;
+
+        using var ms = SaveValidated(wb);
+        var chartSpace = ChartSpaceOf(ms);
+        var plotArea = chartSpace.Descendants<C.PlotArea>().Single();
+
+        var barCharts = plotArea.Elements<C.BarChart>().ToList();
+        Assert.That(barCharts, Has.Count.EqualTo(2), "The secondary series needs its own bar chart group.");
+
+        var primaryAxisIds = barCharts[0].Elements<C.AxisId>().Select(a => a.Val!.Value).ToList();
+        var secondaryAxisIds = barCharts[1].Elements<C.AxisId>().Select(a => a.Val!.Value).ToList();
+        Assert.That(secondaryAxisIds, Is.Not.EquivalentTo(primaryAxisIds));
+
+        Assert.That(plotArea.Elements<C.ValueAxis>().Count(), Is.EqualTo(2));
+        Assert.That(plotArea.Elements<C.CategoryAxis>().Count(), Is.EqualTo(2));
+
+        // The extra category axis is hidden and the extra value axis sits on the right.
+        var hiddenCategoryAxis = plotArea.Elements<C.CategoryAxis>()
+            .Single(a => a.Elements<C.Delete>().Single().Val!.Value);
+        Assert.That(hiddenCategoryAxis.Elements<C.AxisId>().Single().Val!.Value,
+            Is.EqualTo(secondaryAxisIds[0]));
+
+        var rightValueAxis = plotArea.Elements<C.ValueAxis>()
+            .Single(a => a.Elements<C.AxisPosition>().Single().Val!.Value == C.AxisPositionValues.Right);
+        Assert.That(rightValueAxis.Elements<C.Crosses>().Single().Val!.Value,
+            Is.EqualTo(C.CrossesValues.Maximum));
+    }
+
+    [Test]
+    public void SecondaryAxisRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Units", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Series.Add("Price", "Data!$C$1:$C$2", "Data!$A$1:$A$2").UseSecondaryAxis = true;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var series = wb.Worksheet("Data").Charts.First().Series.ToList();
+            Assert.That(series, Has.Count.EqualTo(2));
+            Assert.That(series[0].Name, Is.EqualTo("Units"));
+            Assert.That(series[0].UseSecondaryAxis, Is.False);
+            Assert.That(series[1].Name, Is.EqualTo("Price"));
+            Assert.That(series[1].UseSecondaryAxis, Is.True);
+        }
+    }
+
+    [Test]
+    public void ComboChartCanPutItsSecondaryTypeOnTheSecondaryAxis()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Units", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.SecondaryChartType = XLChartType.Line;
+            chart.SecondarySeries.Add("Price", "Data!$C$1:$C$2", "Data!$A$1:$A$2").UseSecondaryAxis = true;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.ChartType, Is.EqualTo(XLChartType.ColumnClustered));
+            Assert.That(chart.SecondaryChartType, Is.EqualTo(XLChartType.Line));
+            Assert.That(chart.Series.Single().UseSecondaryAxis, Is.False);
+            Assert.That(chart.SecondarySeries.Single().UseSecondaryAxis, Is.True);
+        }
+    }
+
+    [Test]
+    public void SecondaryAxisIsIgnoredForChartTypesWithoutOne()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.Pie);
+        chart.Series.Add("Share", "Data!$B$1:$B$2", "Data!$A$1:$A$2").UseSecondaryAxis = true;
+
+        using var ms = SaveValidated(wb);
+        var chartSpace = ChartSpaceOf(ms);
+
+        Assert.That(chartSpace.Descendants<C.PieChart>().Count(), Is.EqualTo(1));
+        Assert.That(chartSpace.Descendants<C.ValueAxis>(), Is.Empty);
+    }
+
+    // ── Validation of the property setters ──────────────────────────────
+
+    [Test]
+    public void MarkerSizeOutsideExcelsRangeIsRejected()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var series = AddChart(ws, XLChartType.Line).Series.Add("S", "Data!$B$1:$B$2");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => series.MarkerSize = 1);
+        Assert.Throws<ArgumentOutOfRangeException>(() => series.MarkerSize = 73);
+        Assert.DoesNotThrow(() => series.MarkerSize = null);
+    }
+
+    [Test]
+    public void LineWidthOutsideExcelsRangeIsRejected()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var series = AddChart(ws, XLChartType.Line).Series.Add("S", "Data!$B$1:$B$2");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => series.LineWidthPt = -1);
+        Assert.Throws<ArgumentOutOfRangeException>(() => series.LineWidthPt = 1585);
+        Assert.DoesNotThrow(() => series.LineWidthPt = null);
+    }
+
+    [Test]
+    public void TheFormattedChartExampleProducesAValidWorkbook()
+    {
+        // Left on disk on purpose: this is the file to open in Excel when checking that the
+        // formatting renders the way it is meant to.
+        var path = Path.Combine(TestContext.CurrentContext.WorkDirectory, "FormattedChartExamples.xlsx");
+        new XLibur.Examples.Charts.FormattedChartExamples().Create(path);
+        TestContext.Out.WriteLine($"Formatted chart example: {path}");
+
+        // Reloading through XLibur and saving with validation on checks both that the example reads
+        // back and that what it wrote is schema-valid.
+        using var wb = new XLWorkbook(path);
+        using var ms = SaveValidated(wb);
+        Assert.That(wb.Worksheets.Count, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void SecondaryAxisCannotBeChangedOnALoadedChart()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Units", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var series = wb.Worksheet("Data").Charts.First().Series.First();
+            var ex = Assert.Throws<NotSupportedException>(() => series.UseSecondaryAxis = true);
+            Assert.That(ex!.Message, Does.Contain("loaded from a file"));
+
+            // Assigning the value it already has is not a change, so it is allowed.
+            Assert.DoesNotThrow(() => series.UseSecondaryAxis = false);
+        }
+    }
+}

--- a/XLibur/Excel/Charts/IXLChartSeries.cs
+++ b/XLibur/Excel/Charts/IXLChartSeries.cs
@@ -39,9 +39,10 @@ public interface IXLChartSeries
     uint Order { get; }
 
     /// <summary>
-    /// Gets or sets the solid fill colour of the series (bar/column/area/pie interior, marker
-    /// interior for scatter). <c>null</c> — the default — omits the fill, so Excel applies the
-    /// automatic colour from the workbook theme.
+    /// Gets or sets the solid fill colour of the series interior — the bar, column, area or pie
+    /// body. Line and scatter series have no interior; use <see cref="MarkerFillColor"/> for their
+    /// markers. <c>null</c> — the default — omits the fill, so Excel applies the automatic colour
+    /// from the workbook theme.
     /// </summary>
     /// <remarks>
     /// A theme colour (<see cref="XLColor.FromTheme(XLThemeColor)"/>) is written as a DrawingML
@@ -99,9 +100,9 @@ public interface IXLChartSeries
     /// right-hand side of the plot area.
     /// </summary>
     /// <remarks>
-    /// Honoured for chart types that have a category and a value axis (bar, column, line, area,
-    /// radar, stock and surface). Chart types without a value axis (pie, doughnut) and the
-    /// two-value-axis types (scatter, bubble) ignore it.
+    /// Honoured for chart types with one category and one value axis (bar, column, line, area,
+    /// radar and stock). Chart types without a value axis (pie, doughnut), the two-value-axis types
+    /// (scatter, bubble) and surface — which adds a series axis — ignore it.
     /// </remarks>
     /// <exception cref="System.NotSupportedException">
     /// The chart was loaded from a file. Moving a series of an existing chart onto a secondary

--- a/XLibur/Excel/Charts/IXLChartSeries.cs
+++ b/XLibur/Excel/Charts/IXLChartSeries.cs
@@ -1,8 +1,15 @@
-﻿namespace XLibur.Excel;
+namespace XLibur.Excel;
 
 /// <summary>
 /// Represents a single data series within a chart.
 /// </summary>
+/// <remarks>
+/// The formatting properties (<see cref="FillColor"/>, <see cref="LineColor"/>,
+/// <see cref="LineWidthPt"/>, <see cref="MarkerStyle"/>, <see cref="MarkerSize"/>,
+/// <see cref="MarkerFillColor"/> and <see cref="Smooth"/>) apply to standard chart types only.
+/// The extended (Office 2016+) types — Sunburst, Treemap, Waterfall, Funnel and Box &amp; Whisker —
+/// ignore them.
+/// </remarks>
 public interface IXLChartSeries
 {
     /// <summary>
@@ -30,4 +37,76 @@ public interface IXLChartSeries
     /// Gets the zero-based plot order of this series within the chart.
     /// </summary>
     uint Order { get; }
+
+    /// <summary>
+    /// Gets or sets the solid fill colour of the series (bar/column/area/pie interior, marker
+    /// interior for scatter). <c>null</c> — the default — omits the fill, so Excel applies the
+    /// automatic colour from the workbook theme.
+    /// </summary>
+    /// <remarks>
+    /// A theme colour (<see cref="XLColor.FromTheme(XLThemeColor)"/>) is written as a DrawingML
+    /// scheme colour; its <see cref="XLColor.ThemeTint"/> is not applied.
+    /// </remarks>
+    XLColor? FillColor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the colour of the series outline — the line itself for line, scatter and radar
+    /// series, the border for bar, column, area and pie series. <c>null</c> — the default — omits
+    /// the outline colour, so Excel applies the automatic colour.
+    /// </summary>
+    XLColor? LineColor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the series outline in points. <c>null</c> — the default — omits
+    /// the width, so Excel applies its own.
+    /// </summary>
+    /// <exception cref="System.ArgumentOutOfRangeException">
+    /// The value is negative or greater than 1584 (the maximum line width Excel accepts).
+    /// </exception>
+    double? LineWidthPt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the marker symbol drawn at each data point.
+    /// Defaults to <see cref="XLMarkerStyle.Auto"/>, which leaves the choice to Excel.
+    /// Only line, scatter and radar series draw markers.
+    /// </summary>
+    XLMarkerStyle MarkerStyle { get; set; }
+
+    /// <summary>
+    /// Gets or sets the marker size in points. <c>null</c> — the default — lets Excel choose.
+    /// </summary>
+    /// <exception cref="System.ArgumentOutOfRangeException">
+    /// The value is outside the range Excel accepts (2 to 72 points).
+    /// </exception>
+    double? MarkerSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fill colour of the marker interior.
+    /// <c>null</c> — the default — lets Excel choose.
+    /// </summary>
+    XLColor? MarkerFillColor { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the line connecting the data points is smoothed.
+    /// Applies to line and scatter series. When <c>false</c> — the default — no smoothing element
+    /// is written and the chart type's own default applies (the <c>XYScatterSmoothLines*</c> types
+    /// are smoothed, everything else is not).
+    /// </summary>
+    bool Smooth { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the series is plotted against a secondary value axis, drawn on the
+    /// right-hand side of the plot area.
+    /// </summary>
+    /// <remarks>
+    /// Honoured for chart types that have a category and a value axis (bar, column, line, area,
+    /// radar, stock and surface). Chart types without a value axis (pie, doughnut) and the
+    /// two-value-axis types (scatter, bubble) ignore it.
+    /// </remarks>
+    /// <exception cref="System.NotSupportedException">
+    /// The chart was loaded from a file. Moving a series of an existing chart onto a secondary
+    /// axis would require regrouping the chart, which XLibur does not do; recreate the chart with
+    /// <see cref="IXLCharts.Add(XLChartType)"/> instead.
+    /// </exception>
+    bool UseSecondaryAxis { get; set; }
 }

--- a/XLibur/Excel/Charts/XLChart.cs
+++ b/XLibur/Excel/Charts/XLChart.cs
@@ -39,8 +39,8 @@ internal sealed class XLChart : XLDrawing<IXLChart>, IXLChart
         ZOrder = zOrder;
         ShapeId = worksheet.Workbook.ShapeIdManager.GetNext();
         RightAngleAxes = true;
-        Series = new XLChartSeriesCollection();
-        SecondarySeries = new XLChartSeriesCollection();
+        Series = new XLChartSeriesCollection(this);
+        SecondarySeries = new XLChartSeriesCollection(this);
         SecondPosition = new XLDrawingPosition();
     }
 
@@ -73,6 +73,23 @@ internal sealed class XLChart : XLDrawing<IXLChart>, IXLChart
     /// ChartWriter only writes charts where this is <c>true</c>.
     /// </summary>
     internal bool IsNew { get; set; } = true;
+
+    /// <summary>
+    /// Whether this chart came out of an existing file. Unlike <see cref="IsNew"/> — which the writer
+    /// clears once a new chart has been emitted — this stays <c>true</c> for the lifetime of the chart
+    /// and gates the operations that would require regenerating the chart XML from scratch.
+    /// </summary>
+    internal bool LoadedFromFile { get; set; }
+
+    /// <summary>
+    /// The primary series collection, typed for internal use.
+    /// </summary>
+    internal XLChartSeriesCollection SeriesInternal => (XLChartSeriesCollection)Series;
+
+    /// <summary>
+    /// The secondary (combo) series collection, typed for internal use.
+    /// </summary>
+    internal XLChartSeriesCollection SecondarySeriesInternal => (XLChartSeriesCollection)SecondarySeries;
 
     public bool RightAngleAxes { get; set; }
 

--- a/XLibur/Excel/Charts/XLChartSeries.cs
+++ b/XLibur/Excel/Charts/XLChartSeries.cs
@@ -1,10 +1,160 @@
-﻿namespace XLibur.Excel;
+using System;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// Identifies the formatting properties a caller has explicitly assigned. The writer ignores this
+/// (a <c>null</c> property simply omits its element), but the patcher that updates charts loaded
+/// from a file needs to tell "never assigned" from "assigned to <c>null</c>" so that it only
+/// rewrites the parts of the chart XML the caller actually asked to change.
+/// </summary>
+[Flags]
+internal enum XLChartSeriesFormat
+{
+    None = 0,
+    Fill = 1 << 0,
+    Line = 1 << 1,
+    LineWidth = 1 << 2,
+    Marker = 1 << 3,
+    MarkerSize = 1 << 4,
+    MarkerFill = 1 << 5,
+    Smooth = 1 << 6
+}
 
 internal sealed class XLChartSeries : IXLChartSeries
 {
+    /// <summary>The largest line width, in points, that Excel accepts (1584 pt = 20116800 EMU).</summary>
+    private const double MaxLineWidthPt = 1584;
+
+    private const double MinMarkerSize = 2;
+    private const double MaxMarkerSize = 72;
+
+    private readonly XLChart _chart;
+
+    private XLColor? _fillColor;
+    private XLColor? _lineColor;
+    private double? _lineWidthPt;
+    private XLMarkerStyle _markerStyle;
+    private double? _markerSize;
+    private XLColor? _markerFillColor;
+    private bool _smooth;
+    private bool _useSecondaryAxis;
+
+    internal XLChartSeries(XLChart chart)
+    {
+        _chart = chart;
+    }
+
     public string Name { get; set; } = string.Empty;
     public string? CategoryReferences { get; set; }
     public string ValueReferences { get; set; } = string.Empty;
     public uint Index { get; internal set; }
     public uint Order { get; internal set; }
+
+    public XLColor? FillColor
+    {
+        get => _fillColor;
+        set => Assign(ref _fillColor, value, XLChartSeriesFormat.Fill);
+    }
+
+    public XLColor? LineColor
+    {
+        get => _lineColor;
+        set => Assign(ref _lineColor, value, XLChartSeriesFormat.Line);
+    }
+
+    public double? LineWidthPt
+    {
+        get => _lineWidthPt;
+        set
+        {
+            if (value is < 0 or > MaxLineWidthPt)
+                throw new ArgumentOutOfRangeException(nameof(LineWidthPt), value,
+                    $"Line width must be between 0 and {MaxLineWidthPt} points.");
+
+            Assign(ref _lineWidthPt, value, XLChartSeriesFormat.LineWidth);
+        }
+    }
+
+    public XLMarkerStyle MarkerStyle
+    {
+        get => _markerStyle;
+        set => Assign(ref _markerStyle, value, XLChartSeriesFormat.Marker);
+    }
+
+    public double? MarkerSize
+    {
+        get => _markerSize;
+        set
+        {
+            if (value is < MinMarkerSize or > MaxMarkerSize)
+                throw new ArgumentOutOfRangeException(nameof(MarkerSize), value,
+                    $"Marker size must be between {MinMarkerSize} and {MaxMarkerSize} points.");
+
+            Assign(ref _markerSize, value, XLChartSeriesFormat.MarkerSize);
+        }
+    }
+
+    public XLColor? MarkerFillColor
+    {
+        get => _markerFillColor;
+        set => Assign(ref _markerFillColor, value, XLChartSeriesFormat.MarkerFill);
+    }
+
+    public bool Smooth
+    {
+        get => _smooth;
+        set => Assign(ref _smooth, value, XLChartSeriesFormat.Smooth);
+    }
+
+    public bool UseSecondaryAxis
+    {
+        get => _useSecondaryAxis;
+        set
+        {
+            if (value != _useSecondaryAxis && _chart.LoadedFromFile)
+                throw new NotSupportedException(
+                    "UseSecondaryAxis cannot be changed on a chart loaded from a file, because the " +
+                    "series would have to be moved into a different plot group. Recreate the chart " +
+                    "with IXLCharts.Add instead.");
+
+            _useSecondaryAxis = value;
+        }
+    }
+
+    /// <summary>
+    /// The formatting properties that have been explicitly assigned through the public API.
+    /// </summary>
+    internal XLChartSeriesFormat AssignedFormat { get; private set; }
+
+    /// <summary>
+    /// Seeds the formatting properties from the values read out of an existing chart part, without
+    /// marking them as assigned by the caller. Values seeded this way are never written back, so a
+    /// chart nobody edited keeps its original XML byte for byte.
+    /// </summary>
+    internal void SeedLoadedFormat(
+        XLColor? fillColor,
+        XLColor? lineColor,
+        double? lineWidthPt,
+        XLMarkerStyle markerStyle,
+        double? markerSize,
+        XLColor? markerFillColor,
+        bool smooth,
+        bool useSecondaryAxis)
+    {
+        _fillColor = fillColor;
+        _lineColor = lineColor;
+        _lineWidthPt = lineWidthPt;
+        _markerStyle = markerStyle;
+        _markerSize = markerSize;
+        _markerFillColor = markerFillColor;
+        _smooth = smooth;
+        _useSecondaryAxis = useSecondaryAxis;
+    }
+
+    private void Assign<T>(ref T field, T value, XLChartSeriesFormat flag)
+    {
+        field = value;
+        AssignedFormat |= flag;
+    }
 }

--- a/XLibur/Excel/Charts/XLChartSeriesCollection.cs
+++ b/XLibur/Excel/Charts/XLChartSeriesCollection.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace XLibur.Excel;
@@ -6,12 +6,23 @@ namespace XLibur.Excel;
 internal sealed class XLChartSeriesCollection : IXLChartSeriesCollection
 {
     private readonly List<XLChartSeries> _series = [];
+    private readonly XLChart _chart;
+
+    internal XLChartSeriesCollection(XLChart chart)
+    {
+        _chart = chart;
+    }
 
     public int Count => _series.Count;
 
+    /// <summary>
+    /// The series of this collection, in plot order.
+    /// </summary>
+    internal IReadOnlyList<XLChartSeries> Items => _series;
+
     public IXLChartSeries Add(string name, string valueReferences, string? categoryReferences = null)
     {
-        var series = new XLChartSeries
+        var series = new XLChartSeries(_chart)
         {
             Name = name,
             ValueReferences = valueReferences,

--- a/XLibur/Excel/Charts/XLMarkerStyle.cs
+++ b/XLibur/Excel/Charts/XLMarkerStyle.cs
@@ -1,0 +1,44 @@
+namespace XLibur.Excel;
+
+/// <summary>
+/// The marker symbol drawn at each data point of a line, scatter or radar series.
+/// </summary>
+public enum XLMarkerStyle
+{
+    /// <summary>
+    /// No explicit symbol: the marker element is omitted and Excel picks the default for the
+    /// chart type (markers for <c>LineWithMarkers*</c> and scatter types, none otherwise).
+    /// This is the default.
+    /// </summary>
+    Auto,
+
+    /// <summary>No marker is drawn.</summary>
+    None,
+
+    /// <summary>A filled circle.</summary>
+    Circle,
+
+    /// <summary>A short horizontal dash.</summary>
+    Dash,
+
+    /// <summary>A filled diamond.</summary>
+    Diamond,
+
+    /// <summary>A small filled dot.</summary>
+    Dot,
+
+    /// <summary>A plus sign.</summary>
+    Plus,
+
+    /// <summary>A filled square.</summary>
+    Square,
+
+    /// <summary>A filled star.</summary>
+    Star,
+
+    /// <summary>A filled triangle.</summary>
+    Triangle,
+
+    /// <summary>An X (cross) symbol.</summary>
+    X
+}

--- a/XLibur/Excel/IO/ChartFormatting.cs
+++ b/XLibur/Excel/IO/ChartFormatting.cs
@@ -1,0 +1,510 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using XLibur.Extensions;
+using A = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Translates the series formatting exposed by <see cref="IXLChartSeries"/> to and from the
+/// DrawingML elements Excel understands (<c>c:spPr</c>, <c>c:marker</c>, <c>c:smooth</c>).
+/// </summary>
+/// <remarks>
+/// A <c>null</c> property always means "omit the element" so that Excel falls back to its own
+/// automatic formatting. Nothing here ever writes an explicit black or white.
+/// </remarks>
+internal static class ChartFormatting
+{
+    /// <summary>EMU per point, the unit DrawingML uses for line widths.</summary>
+    private const double EmuPerPoint = 12700;
+
+    // ── Writing ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds the <c>c:spPr</c> element for a series, or returns <c>null</c> when the series has no
+    /// explicit fill or outline.
+    /// </summary>
+    internal static C.ChartShapeProperties? BuildSeriesShapeProperties(XLChartSeries series)
+    {
+        var fill = BuildSolidFill(series.FillColor);
+        var outline = BuildOutline(series.LineColor, series.LineWidthPt);
+        if (fill == null && outline == null)
+            return null;
+
+        var shapeProperties = new C.ChartShapeProperties();
+        if (fill != null)
+            shapeProperties.Append(fill);
+        if (outline != null)
+            shapeProperties.Append(outline);
+        return shapeProperties;
+    }
+
+    /// <summary>
+    /// Builds the <c>c:marker</c> element for a series, or returns <c>null</c> when the series
+    /// leaves every marker property automatic.
+    /// </summary>
+    /// <param name="series">The series whose marker is built.</param>
+    /// <param name="autoSymbol">
+    /// <c>true</c> for the chart types that draw markers by default (<c>LineWithMarkers*</c>), which
+    /// need an explicit <c>&lt;c:symbol val="auto"/&gt;</c> even when the caller set nothing.
+    /// </param>
+    internal static C.Marker? BuildMarker(XLChartSeries series, bool autoSymbol)
+    {
+        var symbol = MapMarkerSymbol(series.MarkerStyle);
+        var fill = BuildSolidFill(series.MarkerFillColor);
+
+        if (symbol == null && series.MarkerSize == null && fill == null)
+        {
+            if (!autoSymbol)
+                return null;
+
+            return new C.Marker(new C.Symbol { Val = C.MarkerStyleValues.Auto });
+        }
+
+        var marker = new C.Marker();
+        marker.Append(new C.Symbol { Val = symbol ?? C.MarkerStyleValues.Auto });
+        if (series.MarkerSize != null)
+            marker.Append(new C.Size { Val = (byte)Math.Round(series.MarkerSize.Value) });
+        if (fill != null)
+            marker.Append(new C.ChartShapeProperties(fill));
+        return marker;
+    }
+
+    /// <summary>
+    /// Builds the <c>c:smooth</c> element, or returns <c>null</c> to leave the chart type's own
+    /// default in place.
+    /// </summary>
+    /// <param name="series">The series whose smoothing is built.</param>
+    /// <param name="smoothByChartType">
+    /// <c>true</c> for the chart types Excel smooths by default (the <c>XYScatterSmoothLines*</c>
+    /// types), which are written as smoothed unless the caller asked otherwise.
+    /// </param>
+    internal static C.Smooth? BuildSmooth(XLChartSeries series, bool smoothByChartType)
+    {
+        if ((series.AssignedFormat & XLChartSeriesFormat.Smooth) != 0)
+            return new C.Smooth { Val = series.Smooth };
+
+        return smoothByChartType ? new C.Smooth { Val = true } : null;
+    }
+
+    private static A.SolidFill? BuildSolidFill(XLColor? color) =>
+        color == null || !color.HasValue ? null : new A.SolidFill(BuildColor(color));
+
+    private static A.Outline? BuildOutline(XLColor? color, double? widthPt)
+    {
+        var fill = BuildSolidFill(color);
+        if (fill == null && widthPt == null)
+            return null;
+
+        var outline = new A.Outline();
+        if (widthPt != null)
+            outline.Width = (int)Math.Round(widthPt.Value * EmuPerPoint);
+        if (fill != null)
+            outline.Append(fill);
+        return outline;
+    }
+
+    private static OpenXmlElement BuildColor(XLColor color)
+    {
+        if (color.ColorType == XLColorType.Theme)
+            return new A.SchemeColor { Val = MapSchemeColor(color.ThemeColor) };
+
+        return new A.RgbColorModelHex { Val = color.Color.ToHex().Substring(2) };
+    }
+
+    // ── Reading ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Reads the formatting of one <c>c:ser</c> element into the model.
+    /// </summary>
+    internal static void ReadSeriesFormat(
+        OpenXmlCompositeElement seriesElement, XLChartSeries series, bool useSecondaryAxis)
+    {
+        var shapeProperties = seriesElement.Elements<C.ChartShapeProperties>().FirstOrDefault();
+        var outline = shapeProperties?.Elements<A.Outline>().FirstOrDefault();
+        var marker = seriesElement.Elements<C.Marker>().FirstOrDefault();
+        var markerFill = marker?.Elements<C.ChartShapeProperties>().FirstOrDefault();
+        var smooth = seriesElement.Elements<C.Smooth>().FirstOrDefault();
+
+        series.SeedLoadedFormat(
+            fillColor: ReadSolidFillColor(shapeProperties),
+            lineColor: ReadSolidFillColor(outline),
+            lineWidthPt: outline?.Width?.Value is { } width ? width / EmuPerPoint : null,
+            markerStyle: ReadMarkerStyle(marker),
+            markerSize: marker?.Elements<C.Size>().FirstOrDefault()?.Val?.Value,
+            markerFillColor: ReadSolidFillColor(markerFill),
+            // c:smooth defaults to true when the element is present without a val attribute.
+            smooth: smooth != null && (smooth.Val?.Value ?? true),
+            useSecondaryAxis: useSecondaryAxis);
+    }
+
+    private static XLColor? ReadSolidFillColor(OpenXmlCompositeElement? parent)
+    {
+        var solidFill = parent?.Elements<A.SolidFill>().FirstOrDefault();
+        if (solidFill == null)
+            return null;
+
+        var rgb = solidFill.Elements<A.RgbColorModelHex>().FirstOrDefault()?.Val?.Value;
+        if (IsHexRgb(rgb))
+            return XLColor.FromHexRgb(rgb!);
+
+        var scheme = solidFill.Elements<A.SchemeColor>().FirstOrDefault()?.Val;
+        if (scheme != null && TryMapThemeColor(scheme.Value, out var themeColor))
+            return XLColor.FromTheme(themeColor);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether the value is a six digit hexadecimal RGB colour. Malformed chart XML must be read
+    /// as "no explicit colour" rather than throwing.
+    /// </summary>
+    private static bool IsHexRgb(string? value)
+    {
+        if (value is not { Length: 6 })
+            return false;
+
+        foreach (var c in value)
+        {
+            var isHexDigit = c is >= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F';
+            if (!isHexDigit)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static XLMarkerStyle ReadMarkerStyle(C.Marker? marker)
+    {
+        var symbol = marker?.Elements<C.Symbol>().FirstOrDefault()?.Val;
+        if (symbol == null)
+            return XLMarkerStyle.Auto;
+
+        var value = symbol.Value;
+        if (value == C.MarkerStyleValues.None) return XLMarkerStyle.None;
+        if (value == C.MarkerStyleValues.Circle) return XLMarkerStyle.Circle;
+        if (value == C.MarkerStyleValues.Dash) return XLMarkerStyle.Dash;
+        if (value == C.MarkerStyleValues.Diamond) return XLMarkerStyle.Diamond;
+        if (value == C.MarkerStyleValues.Dot) return XLMarkerStyle.Dot;
+        if (value == C.MarkerStyleValues.Plus) return XLMarkerStyle.Plus;
+        if (value == C.MarkerStyleValues.Square) return XLMarkerStyle.Square;
+        if (value == C.MarkerStyleValues.Star) return XLMarkerStyle.Star;
+        if (value == C.MarkerStyleValues.Triangle) return XLMarkerStyle.Triangle;
+        if (value == C.MarkerStyleValues.X) return XLMarkerStyle.X;
+        return XLMarkerStyle.Auto;
+    }
+
+    // ── Patching an existing series element ─────────────────────────────
+
+    /// <summary>
+    /// Applies the formatting properties the caller assigned onto an existing <c>c:ser</c> element,
+    /// leaving every other child — trendlines, error bars, data point overrides, gradients on
+    /// properties XLibur does not model — exactly as it was.
+    /// </summary>
+    /// <param name="seriesElement">The <c>c:ser</c> element to update.</param>
+    /// <param name="series">The model series holding the values and what was assigned.</param>
+    /// <param name="kind">
+    /// The kind of chart group the series belongs to. Only some series types accept a marker or a
+    /// smoothing flag, so the kind decides which properties can be written at all.
+    /// </param>
+    internal static void PatchSeriesFormat(
+        OpenXmlCompositeElement seriesElement, XLChartSeries series, XLChartGroupKind kind)
+    {
+        var assigned = series.AssignedFormat;
+        if (assigned == XLChartSeriesFormat.None)
+            return;
+
+        if ((assigned & (XLChartSeriesFormat.Fill | XLChartSeriesFormat.Line | XLChartSeriesFormat.LineWidth)) != 0)
+            PatchShapeProperties(seriesElement, series, assigned);
+
+        var markerAssigned = assigned &
+            (XLChartSeriesFormat.Marker | XLChartSeriesFormat.MarkerSize | XLChartSeriesFormat.MarkerFill);
+        if (markerAssigned != 0 && SupportsMarker(kind))
+            PatchMarker(seriesElement, series, assigned);
+
+        if ((assigned & XLChartSeriesFormat.Smooth) != 0 && SupportsSmooth(kind))
+            PatchSmooth(seriesElement, series);
+    }
+
+    /// <summary>Whether the series type of a chart group accepts a <c>c:marker</c> child.</summary>
+    private static bool SupportsMarker(XLChartGroupKind kind) => kind is XLChartGroupKind.Line
+        or XLChartGroupKind.Scatter or XLChartGroupKind.Radar or XLChartGroupKind.Stock;
+
+    /// <summary>Whether the series type of a chart group accepts a <c>c:smooth</c> child.</summary>
+    private static bool SupportsSmooth(XLChartGroupKind kind) => kind is XLChartGroupKind.Line
+        or XLChartGroupKind.Scatter or XLChartGroupKind.Stock;
+
+    private static void PatchShapeProperties(
+        OpenXmlCompositeElement seriesElement, XLChartSeries series, XLChartSeriesFormat assigned)
+    {
+        var shapeProperties = EnsureShapeProperties(seriesElement);
+
+        if ((assigned & XLChartSeriesFormat.Fill) != 0)
+            SetFill(shapeProperties, series.FillColor);
+
+        if ((assigned & (XLChartSeriesFormat.Line | XLChartSeriesFormat.LineWidth)) != 0)
+            SetOutline(shapeProperties, series, assigned);
+    }
+
+    private static void PatchMarker(
+        OpenXmlCompositeElement seriesElement, XLChartSeries series, XLChartSeriesFormat assigned)
+    {
+        var marker = seriesElement.Elements<C.Marker>().FirstOrDefault();
+        var markerIsNew = marker == null;
+        if (marker == null)
+        {
+            marker = new C.Marker();
+            InsertAfterLastOf(seriesElement, marker,
+                typeof(C.ChartShapeProperties), typeof(C.SeriesText), typeof(C.Order), typeof(C.Index));
+        }
+
+        if ((assigned & XLChartSeriesFormat.Marker) != 0)
+        {
+            var symbol = MapMarkerSymbol(series.MarkerStyle);
+            marker.Elements<C.Symbol>().ToList().ForEach(e => e.Remove());
+            if (symbol != null)
+                marker.InsertAt(new C.Symbol { Val = symbol }, 0);
+        }
+
+        if ((assigned & XLChartSeriesFormat.MarkerSize) != 0)
+        {
+            marker.Elements<C.Size>().ToList().ForEach(e => e.Remove());
+            if (series.MarkerSize != null)
+            {
+                var size = new C.Size { Val = (byte)Math.Round(series.MarkerSize.Value) };
+                InsertAfterLastOf(marker, size, typeof(C.Symbol));
+            }
+        }
+
+        if ((assigned & XLChartSeriesFormat.MarkerFill) != 0)
+            PatchMarkerFill(marker, series);
+
+        // A marker element that ended up empty would read back as "this series has markers", so an
+        // element created here for nothing is taken away again.
+        if (markerIsNew && !marker.HasChildren)
+            marker.Remove();
+    }
+
+    private static void PatchMarkerFill(C.Marker marker, XLChartSeries series)
+    {
+        var markerShapeProperties = marker.Elements<C.ChartShapeProperties>().FirstOrDefault();
+        if (markerShapeProperties == null)
+        {
+            if (series.MarkerFillColor == null)
+                return;
+
+            markerShapeProperties = new C.ChartShapeProperties();
+            InsertAfterLastOf(marker, markerShapeProperties, typeof(C.Size), typeof(C.Symbol));
+        }
+
+        SetFill(markerShapeProperties, series.MarkerFillColor);
+    }
+
+    private static void PatchSmooth(OpenXmlCompositeElement seriesElement, XLChartSeries series)
+    {
+        var existing = seriesElement.Elements<C.Smooth>().ToList();
+
+        if (!series.Smooth)
+        {
+            // An explicit false is written, rather than dropped, so that a chart whose type smooths
+            // by default (the XYScatterSmoothLines* types) can be turned back into straight lines.
+            if (existing.Count == 0)
+                AppendBeforeExtensionList(seriesElement, new C.Smooth { Val = false });
+            else
+                existing[0].Val = false;
+        }
+        else if (existing.Count == 0)
+        {
+            AppendBeforeExtensionList(seriesElement, new C.Smooth { Val = true });
+        }
+        else
+        {
+            existing[0].Val = true;
+        }
+
+        for (var i = 1; i < existing.Count; i++)
+            existing[i].Remove();
+    }
+
+    private static C.ChartShapeProperties EnsureShapeProperties(OpenXmlCompositeElement seriesElement)
+    {
+        var shapeProperties = seriesElement.Elements<C.ChartShapeProperties>().FirstOrDefault();
+        if (shapeProperties != null)
+            return shapeProperties;
+
+        shapeProperties = new C.ChartShapeProperties();
+        InsertAfterLastOf(seriesElement, shapeProperties,
+            typeof(C.SeriesText), typeof(C.Order), typeof(C.Index));
+        return shapeProperties;
+    }
+
+    private static void SetFill(C.ChartShapeProperties shapeProperties, XLColor? color)
+    {
+        foreach (var existing in shapeProperties.ChildElements
+                     .Where(IsFillElement).ToList())
+            existing.Remove();
+
+        if (color == null || !color.HasValue)
+            return;
+
+        // The fill precedes the outline and every effect in CT_ShapeProperties.
+        var anchor = shapeProperties.ChildElements.FirstOrDefault(IsAfterFill);
+        var fill = new A.SolidFill(BuildColor(color));
+        if (anchor != null)
+            shapeProperties.InsertBefore(fill, anchor);
+        else
+            shapeProperties.Append(fill);
+    }
+
+    private static void SetOutline(
+        C.ChartShapeProperties shapeProperties, XLChartSeries series, XLChartSeriesFormat assigned)
+    {
+        var outline = shapeProperties.Elements<A.Outline>().FirstOrDefault();
+        if (outline == null)
+        {
+            // Nothing to clear and nothing to set: leave the element out entirely.
+            if (series.LineColor == null && series.LineWidthPt == null)
+                return;
+
+            outline = new A.Outline();
+            var anchor = shapeProperties.ChildElements.FirstOrDefault(IsAfterOutline);
+            if (anchor != null)
+                shapeProperties.InsertBefore(outline, anchor);
+            else
+                shapeProperties.Append(outline);
+        }
+
+        if ((assigned & XLChartSeriesFormat.LineWidth) != 0)
+        {
+            if (series.LineWidthPt == null)
+                outline.Width = null;
+            else
+                outline.Width = (int)Math.Round(series.LineWidthPt.Value * EmuPerPoint);
+        }
+
+        if ((assigned & XLChartSeriesFormat.Line) != 0)
+        {
+            foreach (var existing in outline.ChildElements.Where(IsFillElement).ToList())
+                existing.Remove();
+
+            if (series.LineColor is { HasValue: true })
+                outline.InsertAt(new A.SolidFill(BuildColor(series.LineColor)), 0);
+        }
+    }
+
+    private static bool IsFillElement(OpenXmlElement element) =>
+        element is A.NoFill or A.SolidFill or A.GradientFill or A.BlipFill or A.PatternFill or A.GroupFill;
+
+    private static bool IsAfterFill(OpenXmlElement element) =>
+        element is A.Outline || IsEffectOrLater(element);
+
+    private static bool IsAfterOutline(OpenXmlElement element) => IsEffectOrLater(element);
+
+    private static bool IsEffectOrLater(OpenXmlElement element) =>
+        element is A.EffectList or A.EffectDag or A.Scene3DType or A.Shape3DType or A.ExtensionList;
+
+    /// <summary>
+    /// Inserts <paramref name="element"/> directly after the last present element of the given types,
+    /// which must be listed most- to least-preferred. Falls back to inserting first.
+    /// </summary>
+    private static void InsertAfterLastOf(
+        OpenXmlCompositeElement parent, OpenXmlElement element, params Type[] precedingTypes)
+    {
+        foreach (var type in precedingTypes)
+        {
+            var anchor = parent.ChildElements.LastOrDefault(e => e.GetType() == type);
+            if (anchor != null)
+            {
+                parent.InsertAfter(element, anchor);
+                return;
+            }
+        }
+
+        parent.InsertAt(element, 0);
+    }
+
+    private static void AppendBeforeExtensionList(OpenXmlCompositeElement parent, OpenXmlElement element)
+    {
+        var extensionList = parent.Elements<C.ExtensionList>().FirstOrDefault();
+        if (extensionList != null)
+            parent.InsertBefore(element, extensionList);
+        else
+            parent.Append(element);
+    }
+
+    // ── Enum mapping ────────────────────────────────────────────────────
+
+    private static C.MarkerStyleValues? MapMarkerSymbol(XLMarkerStyle style) => style switch
+    {
+        XLMarkerStyle.Auto => null,
+        XLMarkerStyle.None => C.MarkerStyleValues.None,
+        XLMarkerStyle.Circle => C.MarkerStyleValues.Circle,
+        XLMarkerStyle.Dash => C.MarkerStyleValues.Dash,
+        XLMarkerStyle.Diamond => C.MarkerStyleValues.Diamond,
+        XLMarkerStyle.Dot => C.MarkerStyleValues.Dot,
+        XLMarkerStyle.Plus => C.MarkerStyleValues.Plus,
+        XLMarkerStyle.Square => C.MarkerStyleValues.Square,
+        XLMarkerStyle.Star => C.MarkerStyleValues.Star,
+        XLMarkerStyle.Triangle => C.MarkerStyleValues.Triangle,
+        XLMarkerStyle.X => C.MarkerStyleValues.X,
+        _ => throw new ArgumentOutOfRangeException(nameof(style), style, "Unknown marker style.")
+    };
+
+    private static A.SchemeColorValues MapSchemeColor(XLThemeColor themeColor) => themeColor switch
+    {
+        XLThemeColor.Background1 => A.SchemeColorValues.Background1,
+        XLThemeColor.Text1 => A.SchemeColorValues.Text1,
+        XLThemeColor.Background2 => A.SchemeColorValues.Background2,
+        XLThemeColor.Text2 => A.SchemeColorValues.Text2,
+        XLThemeColor.Accent1 => A.SchemeColorValues.Accent1,
+        XLThemeColor.Accent2 => A.SchemeColorValues.Accent2,
+        XLThemeColor.Accent3 => A.SchemeColorValues.Accent3,
+        XLThemeColor.Accent4 => A.SchemeColorValues.Accent4,
+        XLThemeColor.Accent5 => A.SchemeColorValues.Accent5,
+        XLThemeColor.Accent6 => A.SchemeColorValues.Accent6,
+        XLThemeColor.Hyperlink => A.SchemeColorValues.Hyperlink,
+        XLThemeColor.FollowedHyperlink => A.SchemeColorValues.FollowedHyperlink,
+        _ => throw new ArgumentOutOfRangeException(nameof(themeColor), themeColor, "Unknown theme colour.")
+    };
+
+    private static bool TryMapThemeColor(A.SchemeColorValues value, out XLThemeColor themeColor)
+    {
+        if (value == A.SchemeColorValues.Background1 || value == A.SchemeColorValues.Light1)
+        {
+            themeColor = XLThemeColor.Background1;
+            return true;
+        }
+        if (value == A.SchemeColorValues.Text1 || value == A.SchemeColorValues.Dark1)
+        {
+            themeColor = XLThemeColor.Text1;
+            return true;
+        }
+        if (value == A.SchemeColorValues.Background2 || value == A.SchemeColorValues.Light2)
+        {
+            themeColor = XLThemeColor.Background2;
+            return true;
+        }
+        if (value == A.SchemeColorValues.Text2 || value == A.SchemeColorValues.Dark2)
+        {
+            themeColor = XLThemeColor.Text2;
+            return true;
+        }
+        if (value == A.SchemeColorValues.Accent1) { themeColor = XLThemeColor.Accent1; return true; }
+        if (value == A.SchemeColorValues.Accent2) { themeColor = XLThemeColor.Accent2; return true; }
+        if (value == A.SchemeColorValues.Accent3) { themeColor = XLThemeColor.Accent3; return true; }
+        if (value == A.SchemeColorValues.Accent4) { themeColor = XLThemeColor.Accent4; return true; }
+        if (value == A.SchemeColorValues.Accent5) { themeColor = XLThemeColor.Accent5; return true; }
+        if (value == A.SchemeColorValues.Accent6) { themeColor = XLThemeColor.Accent6; return true; }
+        if (value == A.SchemeColorValues.Hyperlink) { themeColor = XLThemeColor.Hyperlink; return true; }
+        if (value == A.SchemeColorValues.FollowedHyperlink)
+        {
+            themeColor = XLThemeColor.FollowedHyperlink;
+            return true;
+        }
+
+        themeColor = default;
+        return false;
+    }
+}

--- a/XLibur/Excel/IO/ChartPatcher.cs
+++ b/XLibur/Excel/IO/ChartPatcher.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Applies model changes to a chart that already exists in the package.
+/// </summary>
+/// <remarks>
+/// <para>
+/// XLibur never regenerates the XML of a chart it read from a file: <see cref="ChartWriter"/> only
+/// emits charts created through <see cref="IXLCharts.Add(XLChartType)"/>, so everything an existing
+/// chart part contains — trendlines, error bars, gradient fills, per-point formatting, the chart
+/// style and colour parts next to it — survives a load/save round trip untouched.
+/// </para>
+/// <para>
+/// The price of that guarantee is that edits to an existing chart have to be patched into the DOM
+/// the reader loaded. This class does exactly that, and only for the properties the caller actually
+/// assigned (see <see cref="XLChartSeries.AssignedFormat"/>): a chart nobody edited is not modified
+/// at all.
+/// </para>
+/// </remarks>
+internal static class ChartPatcher
+{
+    /// <summary>
+    /// Writes the pending series formatting of a loaded chart back into its chart part.
+    /// </summary>
+    internal static void PatchChart(WorksheetPart worksheetPart, XLChart xlChart)
+    {
+        if (!HasPendingChanges(xlChart))
+            return;
+
+        // Extended (ChartEx) charts model their series in the cx namespace and do not support the
+        // series formatting properties, so there is nothing to patch.
+        var chartPart = ResolveChartPart(worksheetPart, xlChart);
+        var plotArea = chartPart?.ChartSpace?.Elements<C.Chart>().FirstOrDefault()?.PlotArea;
+        if (plotArea == null)
+            return;
+
+        var groups = ChartPlotAreaScanner.Scan(plotArea);
+        var primaryKind = ChartPlotAreaScanner.ChoosePrimaryKind(groups);
+        if (primaryKind == null)
+            return;
+
+        // The reader walked the same groups in the same order, so the n-th series element of the
+        // primary kind is the n-th series of the model collection.
+        var primaryElements = new List<(OpenXmlCompositeElement Element, XLChartGroupKind Kind)>();
+        var secondaryElements = new List<(OpenXmlCompositeElement Element, XLChartGroupKind Kind)>();
+        foreach (var group in groups)
+        {
+            var target = group.Kind == primaryKind.Value ? primaryElements : secondaryElements;
+            foreach (var seriesElement in group.SeriesElements)
+                target.Add((seriesElement, group.Kind));
+        }
+
+        PatchSeries(xlChart.SeriesInternal, primaryElements);
+        PatchSeries(xlChart.SecondarySeriesInternal, secondaryElements);
+    }
+
+    private static bool HasPendingChanges(XLChart xlChart) =>
+        HasPendingChanges(xlChart.SeriesInternal) || HasPendingChanges(xlChart.SecondarySeriesInternal);
+
+    private static bool HasPendingChanges(XLChartSeriesCollection series)
+    {
+        foreach (var s in series.Items)
+        {
+            if (s.AssignedFormat != XLChartSeriesFormat.None)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static void PatchSeries(
+        XLChartSeriesCollection series,
+        List<(OpenXmlCompositeElement Element, XLChartGroupKind Kind)> seriesElements)
+    {
+        var count = Math.Min(series.Count, seriesElements.Count);
+        for (var i = 0; i < count; i++)
+        {
+            var (element, kind) = seriesElements[i];
+            ChartFormatting.PatchSeriesFormat(element, series.Items[i], kind);
+        }
+    }
+
+    private static ChartPart? ResolveChartPart(WorksheetPart worksheetPart, XLChart xlChart)
+    {
+        if (xlChart.RelId == null)
+            return null;
+
+        var drawingsPart = worksheetPart.DrawingsPart;
+        if (drawingsPart == null)
+            return null;
+
+        // GetPartById throws for an unknown id, and the relationship can be missing when the chart
+        // was created in a workbook that has not been saved through this package yet.
+        if (!drawingsPart.Parts.Any(p => p.RelationshipId == xlChart.RelId))
+            return null;
+
+        return drawingsPart.GetPartById(xlChart.RelId) as ChartPart;
+    }
+}

--- a/XLibur/Excel/IO/ChartPlotAreaScanner.cs
+++ b/XLibur/Excel/IO/ChartPlotAreaScanner.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// The kind of chart group element (<c>c:barChart</c>, <c>c:lineChart</c>, …) found in a plot area.
+/// Several <see cref="XLChartType"/> values map onto one kind.
+/// </summary>
+internal enum XLChartGroupKind
+{
+    Bar,
+    Bar3D,
+    Pie,
+    Doughnut,
+    Area,
+    Line,
+    Radar,
+    Bubble,
+    Scatter,
+    Stock,
+    Surface
+}
+
+/// <summary>
+/// One chart group of a plot area: the group element itself, its <c>c:ser</c> children in document
+/// order, and the value axis it is plotted against.
+/// </summary>
+internal sealed class XLChartGroup
+{
+    internal XLChartGroup(
+        XLChartGroupKind kind,
+        OpenXmlCompositeElement element,
+        List<OpenXmlCompositeElement> seriesElements,
+        uint? valueAxisId)
+    {
+        Kind = kind;
+        Element = element;
+        SeriesElements = seriesElements;
+        ValueAxisId = valueAxisId;
+    }
+
+    internal XLChartGroupKind Kind { get; }
+
+    internal OpenXmlCompositeElement Element { get; }
+
+    internal List<OpenXmlCompositeElement> SeriesElements { get; }
+
+    /// <summary>
+    /// The identifier of the value axis this group is plotted against — the second <c>c:axId</c> of
+    /// the group — or <c>null</c> for the axis-less pie and doughnut groups.
+    /// </summary>
+    internal uint? ValueAxisId { get; }
+
+    /// <summary>
+    /// Whether the group carries X/Y values (<c>c:xVal</c>/<c>c:yVal</c>) instead of categories and
+    /// values (<c>c:cat</c>/<c>c:val</c>).
+    /// </summary>
+    internal bool IsXyBased => Kind is XLChartGroupKind.Scatter or XLChartGroupKind.Bubble;
+}
+
+/// <summary>
+/// Walks a plot area and reports its chart groups. Shared by <see cref="ChartReader"/> — which turns
+/// the groups into the model — and <see cref="ChartPatcher"/> — which walks them again on save to
+/// find the <c>c:ser</c> element belonging to a given model series. Because both use the same scan,
+/// series positions line up on load and on save.
+/// </summary>
+internal static class ChartPlotAreaScanner
+{
+    /// <summary>
+    /// The order in which a plot area's groups are considered for the role of primary chart type.
+    /// The first kind present wins, which keeps a bar-plus-line combo reading as a bar chart with a
+    /// line secondary regardless of the order the two groups appear in the file.
+    /// </summary>
+    private static readonly XLChartGroupKind[] PrimaryPrecedence =
+    [
+        XLChartGroupKind.Bar,
+        XLChartGroupKind.Bar3D,
+        XLChartGroupKind.Pie,
+        XLChartGroupKind.Doughnut,
+        XLChartGroupKind.Area,
+        XLChartGroupKind.Line,
+        XLChartGroupKind.Radar,
+        XLChartGroupKind.Bubble,
+        XLChartGroupKind.Scatter,
+        XLChartGroupKind.Stock,
+        XLChartGroupKind.Surface
+    ];
+
+    /// <summary>
+    /// Collects the chart groups of a plot area in document order.
+    /// </summary>
+    internal static List<XLChartGroup> Scan(C.PlotArea plotArea)
+    {
+        var groups = new List<XLChartGroup>();
+
+        foreach (var child in plotArea.ChildElements)
+        {
+            switch (child)
+            {
+                case C.BarChart bar:
+                    groups.Add(Build(XLChartGroupKind.Bar, bar, bar.Elements<C.BarChartSeries>()));
+                    break;
+                case C.Bar3DChart bar3D:
+                    groups.Add(Build(XLChartGroupKind.Bar3D, bar3D, bar3D.Elements<C.BarChartSeries>()));
+                    break;
+                case C.PieChart pie:
+                    groups.Add(Build(XLChartGroupKind.Pie, pie, pie.Elements<C.PieChartSeries>()));
+                    break;
+                case C.DoughnutChart doughnut:
+                    groups.Add(Build(XLChartGroupKind.Doughnut, doughnut, doughnut.Elements<C.PieChartSeries>()));
+                    break;
+                case C.AreaChart area:
+                    groups.Add(Build(XLChartGroupKind.Area, area, area.Elements<C.AreaChartSeries>()));
+                    break;
+                case C.LineChart line:
+                    groups.Add(Build(XLChartGroupKind.Line, line, line.Elements<C.LineChartSeries>()));
+                    break;
+                case C.RadarChart radar:
+                    groups.Add(Build(XLChartGroupKind.Radar, radar, radar.Elements<C.RadarChartSeries>()));
+                    break;
+                case C.BubbleChart bubble:
+                    groups.Add(Build(XLChartGroupKind.Bubble, bubble, bubble.Elements<C.BubbleChartSeries>()));
+                    break;
+                case C.ScatterChart scatter:
+                    groups.Add(Build(XLChartGroupKind.Scatter, scatter, scatter.Elements<C.ScatterChartSeries>()));
+                    break;
+                case C.StockChart stock:
+                    groups.Add(Build(XLChartGroupKind.Stock, stock, stock.Elements<C.LineChartSeries>()));
+                    break;
+                case C.SurfaceChart surface:
+                    groups.Add(Build(XLChartGroupKind.Surface, surface, surface.Elements<C.SurfaceChartSeries>()));
+                    break;
+            }
+        }
+
+        return groups;
+    }
+
+    /// <summary>
+    /// Picks the group kind that represents the chart as a whole. Returns <c>null</c> for a plot area
+    /// with no recognised group.
+    /// </summary>
+    internal static XLChartGroupKind? ChoosePrimaryKind(List<XLChartGroup> groups)
+    {
+        foreach (var kind in PrimaryPrecedence)
+        {
+            if (groups.Any(g => g.Kind == kind))
+                return kind;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The value axis of the first group of the primary kind. Groups plotted against a different
+    /// value axis are on a secondary axis.
+    /// </summary>
+    internal static uint? PrimaryValueAxisId(List<XLChartGroup> groups, XLChartGroupKind primaryKind) =>
+        groups.First(g => g.Kind == primaryKind).ValueAxisId;
+
+    private static XLChartGroup Build<TSeries>(
+        XLChartGroupKind kind, OpenXmlCompositeElement element, IEnumerable<TSeries> seriesElements)
+        where TSeries : OpenXmlCompositeElement
+    {
+        var axisIds = element.Elements<C.AxisId>().ToList();
+        var valueAxisId = axisIds.Count >= 2 ? axisIds[1].Val?.Value : null;
+        return new XLChartGroup(kind, element, seriesElements.Cast<OpenXmlCompositeElement>().ToList(), valueAxisId);
+    }
+}

--- a/XLibur/Excel/IO/ChartReader.cs
+++ b/XLibur/Excel/IO/ChartReader.cs
@@ -96,6 +96,8 @@ internal static class ChartReader
         if (plotArea != null)
             ReadPlotArea(plotArea, xlChart);
 
+        // Set last: the series readers above assign properties that are refused on a loaded chart.
+        xlChart.LoadedFromFile = true;
         return xlChart;
     }
 
@@ -116,158 +118,71 @@ internal static class ChartReader
 
     private static void ReadPlotArea(C.PlotArea plotArea, XLChart xlChart)
     {
+        var groups = ChartPlotAreaScanner.Scan(plotArea);
+        var primaryKind = ChartPlotAreaScanner.ChoosePrimaryKind(groups);
+        if (primaryKind == null)
+            return;
+
+        var primaryValueAxisId = ChartPlotAreaScanner.PrimaryValueAxisId(groups, primaryKind.Value);
         var primarySet = false;
 
-        // Primary-only chart types (cannot be secondary in a combo chart)
-        primarySet |= TryReadPrimaryChart<C.BarChart, C.BarChartSeries>(plotArea, xlChart, ref primarySet, DetermineBarChartType);
-        primarySet |= TryReadPrimaryChart<C.Bar3DChart, C.BarChartSeries>(plotArea, xlChart, ref primarySet, DetermineBar3DChartType);
-        primarySet |= TryReadPrimaryChart<C.PieChart, C.PieChartSeries>(plotArea, xlChart, ref primarySet, _ => XLChartType.Pie);
-        primarySet |= TryReadPrimaryChart<C.DoughnutChart, C.PieChartSeries>(plotArea, xlChart, ref primarySet, _ => XLChartType.Doughnut);
+        foreach (var group in groups)
+        {
+            var chartType = DetermineChartType(group);
+            var isPrimary = group.Kind == primaryKind.Value;
+            var useSecondaryAxis = group.ValueAxisId != null
+                                   && primaryValueAxisId != null
+                                   && group.ValueAxisId != primaryValueAxisId;
 
-        // Chart types that can appear as primary or secondary (combo charts)
-        TryReadComboChart<C.AreaChart, C.AreaChartSeries>(plotArea, xlChart, ref primarySet, DetermineAreaChartType);
-        TryReadComboChart<C.LineChart, C.LineChartSeries>(plotArea, xlChart, ref primarySet, DetermineLineChartType);
-        TryReadComboChart<C.RadarChart, C.RadarChartSeries>(plotArea, xlChart, ref primarySet, DetermineRadarChartType);
+            if (isPrimary)
+            {
+                if (!primarySet)
+                {
+                    xlChart.ChartType = chartType;
+                    primarySet = true;
+                }
 
-        // Primary-only chart types with custom series readers
-        TryReadPrimaryChartCustom(plotArea, xlChart, ref primarySet);
+                ReadGroupSeries(group, xlChart.SeriesInternal, useSecondaryAxis);
+            }
+            else
+            {
+                xlChart.SecondaryChartType ??= chartType;
+                ReadGroupSeries(group, xlChart.SecondarySeriesInternal, useSecondaryAxis);
+            }
+        }
     }
 
-    private static bool TryReadPrimaryChart<TChart, TSeries>(
-        C.PlotArea plotArea, XLChart xlChart, ref bool primarySet,
-        Func<TChart, XLChartType> determineType)
-        where TChart : OpenXmlCompositeElement
-        where TSeries : OpenXmlCompositeElement
+    private static XLChartType DetermineChartType(XLChartGroup group) => group.Kind switch
     {
-        if (primarySet) return false;
-        var chart = plotArea.Elements<TChart>().FirstOrDefault();
-        if (chart == null) return false;
-
-        xlChart.ChartType = determineType(chart);
-        ReadSeriesFromElements<TSeries>(chart, xlChart.Series);
-        return true;
-    }
-
-    private static void TryReadComboChart<TChart, TSeries>(
-        C.PlotArea plotArea, XLChart xlChart, ref bool primarySet,
-        Func<TChart, XLChartType> determineType)
-        where TChart : OpenXmlCompositeElement
-        where TSeries : OpenXmlCompositeElement
-    {
-        var chart = plotArea.Elements<TChart>().FirstOrDefault();
-        if (chart == null) return;
-
-        var chartType = determineType(chart);
-        if (!primarySet)
-        {
-            xlChart.ChartType = chartType;
-            ReadSeriesFromElements<TSeries>(chart, xlChart.Series);
-            primarySet = true;
-        }
-        else
-        {
-            xlChart.SecondaryChartType = chartType;
-            ReadSeriesFromElements<TSeries>(chart, xlChart.SecondarySeries);
-        }
-    }
-
-    private static void TryReadPrimaryChartCustom(
-        C.PlotArea plotArea, XLChart xlChart, ref bool primarySet)
-    {
-        // Bubble
-        if (!primarySet)
-        {
-            var bubbleChart = plotArea.Elements<C.BubbleChart>().FirstOrDefault();
-            if (bubbleChart != null)
-            {
-                xlChart.ChartType = XLChartType.Bubble;
-                ReadBubbleSeries(bubbleChart, xlChart.Series);
-                primarySet = true;
-            }
-        }
-
-        // Scatter
-        if (!primarySet)
-        {
-            var scatterChart = plotArea.Elements<C.ScatterChart>().FirstOrDefault();
-            if (scatterChart != null)
-            {
-                xlChart.ChartType = DetermineScatterChartType(scatterChart);
-                ReadScatterSeries(scatterChart, xlChart.Series);
-                primarySet = true;
-            }
-        }
-
-        // Stock
-        if (!primarySet)
-        {
-            var stockChart = plotArea.Elements<C.StockChart>().FirstOrDefault();
-            if (stockChart != null)
-            {
-                xlChart.ChartType = XLChartType.StockHighLowClose;
-                ReadSeriesFromElements<C.LineChartSeries>(stockChart, xlChart.Series);
-                primarySet = true;
-            }
-        }
-
-        // Surface
-        if (!primarySet)
-        {
-            var surfaceChart = plotArea.Elements<C.SurfaceChart>().FirstOrDefault();
-            if (surfaceChart != null)
-            {
-                var wireframe = surfaceChart.Elements<C.Wireframe>().FirstOrDefault()?.Val?.Value ?? false;
-                xlChart.ChartType = wireframe ? XLChartType.SurfaceWireframe : XLChartType.Surface;
-                ReadSeriesFromElements<C.SurfaceChartSeries>(surfaceChart, xlChart.Series);
-            }
-        }
-    }
+        XLChartGroupKind.Bar => DetermineBarChartType((C.BarChart)group.Element),
+        XLChartGroupKind.Bar3D => DetermineBar3DChartType((C.Bar3DChart)group.Element),
+        XLChartGroupKind.Pie => XLChartType.Pie,
+        XLChartGroupKind.Doughnut => XLChartType.Doughnut,
+        XLChartGroupKind.Area => DetermineAreaChartType((C.AreaChart)group.Element),
+        XLChartGroupKind.Line => DetermineLineChartType((C.LineChart)group.Element),
+        XLChartGroupKind.Radar => DetermineRadarChartType((C.RadarChart)group.Element),
+        XLChartGroupKind.Bubble => XLChartType.Bubble,
+        XLChartGroupKind.Scatter => DetermineScatterChartType((C.ScatterChart)group.Element),
+        XLChartGroupKind.Stock => XLChartType.StockHighLowClose,
+        XLChartGroupKind.Surface => DetermineSurfaceChartType((C.SurfaceChart)group.Element),
+        _ => XLChartType.ColumnClustered
+    };
 
     /// <summary>
-    /// Generic reader for standard series types that use SeriesText + CategoryAxisData + Values.
+    /// Reads every series of one chart group — references, name and formatting — into the model.
     /// </summary>
-    private static void ReadSeriesFromElements<TSeries>(
-        OpenXmlCompositeElement parent, IXLChartSeriesCollection target)
-        where TSeries : OpenXmlCompositeElement
+    private static void ReadGroupSeries(
+        XLChartGroup group, XLChartSeriesCollection target, bool useSecondaryAxis)
     {
-        foreach (var series in parent.Elements<TSeries>())
+        foreach (var seriesElement in group.SeriesElements)
         {
-            var (name, catRef, valRef) = ExtractSeriesData(
-                series.Elements<C.SeriesText>().FirstOrDefault(),
-                series.Elements<C.CategoryAxisData>().FirstOrDefault(),
-                series.Elements<C.Values>().FirstOrDefault());
-            target.Add(name, valRef, catRef);
-        }
-    }
+            var name = ExtractSeriesName(seriesElement.Elements<C.SeriesText>().FirstOrDefault());
+            var (catRef, valRef) = group.IsXyBased
+                ? ExtractXyReferences(seriesElement)
+                : ExtractCategoryAndValueReferences(seriesElement);
 
-    private static void ReadScatterSeries(C.ScatterChart scatterChart, IXLChartSeriesCollection target)
-    {
-        foreach (var series in scatterChart.Elements<C.ScatterChartSeries>())
-        {
-            var name = ExtractSeriesName(series.Elements<C.SeriesText>().FirstOrDefault());
-
-            string? xRef = null;
-            var xValues = series.Elements<C.XValues>().FirstOrDefault();
-            if (xValues != null)
-            {
-                var numRef = xValues.Elements<C.NumberReference>().FirstOrDefault();
-                xRef = numRef?.Formula?.Text;
-                if (xRef == null)
-                {
-                    var strRef = xValues.Elements<C.StringReference>().FirstOrDefault();
-                    xRef = strRef?.Formula?.Text;
-                }
-            }
-
-            var yRef = string.Empty;
-            var yValues = series.Elements<C.YValues>().FirstOrDefault();
-            if (yValues != null)
-            {
-                var numRef = yValues.Elements<C.NumberReference>().FirstOrDefault();
-                yRef = numRef?.Formula?.Text ?? string.Empty;
-            }
-
-            target.Add(name, yRef, xRef);
+            var series = (XLChartSeries)target.Add(name, valRef, catRef);
+            ChartFormatting.ReadSeriesFormat(seriesElement, series, useSecondaryAxis);
         }
     }
 
@@ -287,6 +202,7 @@ internal static class ChartReader
         ReadExtendedTitle(chartSpace, xlChart);
         ReadExtendedSeries(chartSpace, xlChart);
 
+        xlChart.LoadedFromFile = true;
         return xlChart;
     }
 
@@ -380,7 +296,7 @@ internal static class ChartReader
     private static XLChartType DetermineLineChartType(C.LineChart lineChart)
     {
         var grouping = lineChart.Grouping?.Val?.Value;
-        var hasMarkers = lineChart.Elements<C.LineChartSeries>().Any(s => s.Elements<C.Marker>().Any());
+        var hasMarkers = lineChart.Elements<C.LineChartSeries>().Any(HasVisibleMarker);
 
         if (grouping == C.GroupingValues.Stacked)
             return hasMarkers ? XLChartType.LineWithMarkersStacked : XLChartType.LineStacked;
@@ -388,6 +304,21 @@ internal static class ChartReader
             return hasMarkers ? XLChartType.LineWithMarkersStacked100Percent : XLChartType.LineStacked100Percent;
 
         return hasMarkers ? XLChartType.LineWithMarkers : XLChartType.Line;
+    }
+
+    /// <summary>
+    /// Whether a series carries a marker that actually draws something. A <c>c:marker</c> holding
+    /// <c>&lt;c:symbol val="none"/&gt;</c> switches markers off, so it must not turn a Line chart
+    /// into a LineWithMarkers chart.
+    /// </summary>
+    private static bool HasVisibleMarker(C.LineChartSeries series)
+    {
+        var marker = series.Elements<C.Marker>().FirstOrDefault();
+        if (marker == null)
+            return false;
+
+        var symbol = marker.Elements<C.Symbol>().FirstOrDefault()?.Val;
+        return symbol == null || symbol.Value != C.MarkerStyleValues.None;
     }
 
     private static XLChartType DetermineRadarChartType(C.RadarChart radarChart) =>
@@ -465,27 +396,10 @@ internal static class ChartReader
         return XLChartType.Area;
     }
 
-    private static void ReadBubbleSeries(C.BubbleChart bubbleChart, IXLChartSeriesCollection target)
+    private static XLChartType DetermineSurfaceChartType(C.SurfaceChart surfaceChart)
     {
-        foreach (var series in bubbleChart.Elements<C.BubbleChartSeries>())
-        {
-            var name = ExtractSeriesName(series.Elements<C.SeriesText>().FirstOrDefault());
-
-            string? xRef = null;
-            var xValues = series.Elements<C.XValues>().FirstOrDefault();
-            if (xValues != null)
-            {
-                xRef = xValues.Elements<C.NumberReference>().FirstOrDefault()?.Formula?.Text;
-                xRef ??= xValues.Elements<C.StringReference>().FirstOrDefault()?.Formula?.Text;
-            }
-
-            var yRef = string.Empty;
-            var yValues = series.Elements<C.YValues>().FirstOrDefault();
-            if (yValues != null)
-                yRef = yValues.Elements<C.NumberReference>().FirstOrDefault()?.Formula?.Text ?? string.Empty;
-
-            target.Add(name, yRef, xRef);
-        }
+        var wireframe = surfaceChart.Elements<C.Wireframe>().FirstOrDefault()?.Val?.Value ?? false;
+        return wireframe ? XLChartType.SurfaceWireframe : XLChartType.Surface;
     }
 
     private static XLChartType DetermineScatterChartType(C.ScatterChart scatterChart)
@@ -498,10 +412,14 @@ internal static class ChartReader
 
     // ── Shared extraction helpers ───────────────────────────────────────
 
-    private static (string name, string? catRef, string valRef) ExtractSeriesData(
-        C.SeriesText? seriesText, C.CategoryAxisData? catData, C.Values? valData)
+    /// <summary>
+    /// Extracts the category and value references of a series that uses <c>c:cat</c>/<c>c:val</c>.
+    /// </summary>
+    private static (string? catRef, string valRef) ExtractCategoryAndValueReferences(
+        OpenXmlCompositeElement seriesElement)
     {
-        var name = ExtractSeriesName(seriesText);
+        var catData = seriesElement.Elements<C.CategoryAxisData>().FirstOrDefault();
+        var valData = seriesElement.Elements<C.Values>().FirstOrDefault();
 
         string? catRef = null;
         if (catData != null)
@@ -510,18 +428,41 @@ internal static class ChartReader
             catRef ??= catData.Elements<C.NumberReference>().FirstOrDefault()?.Formula?.Text;
         }
 
-        var valRef = string.Empty;
-        if (valData != null)
-        {
-            valRef = valData.Elements<C.NumberReference>().FirstOrDefault()?.Formula?.Text ?? string.Empty;
-        }
-
-        return (name, catRef, valRef);
+        var valRef = valData?.Elements<C.NumberReference>().FirstOrDefault()?.Formula?.Text ?? string.Empty;
+        return (catRef, valRef);
     }
 
+    /// <summary>
+    /// Extracts the X and Y references of a scatter or bubble series, which uses
+    /// <c>c:xVal</c>/<c>c:yVal</c> instead of categories and values.
+    /// </summary>
+    private static (string? catRef, string valRef) ExtractXyReferences(OpenXmlCompositeElement seriesElement)
+    {
+        string? xRef = null;
+        var xValues = seriesElement.Elements<C.XValues>().FirstOrDefault();
+        if (xValues != null)
+        {
+            xRef = xValues.Elements<C.NumberReference>().FirstOrDefault()?.Formula?.Text;
+            xRef ??= xValues.Elements<C.StringReference>().FirstOrDefault()?.Formula?.Text;
+        }
+
+        var yValues = seriesElement.Elements<C.YValues>().FirstOrDefault();
+        var yRef = yValues?.Elements<C.NumberReference>().FirstOrDefault()?.Formula?.Text ?? string.Empty;
+        return (xRef, yRef);
+    }
+
+    /// <summary>
+    /// Reads the series name from either form of <c>c:tx</c>: the literal <c>c:v</c> XLibur writes,
+    /// or the <c>c:strRef</c> Excel writes when the name comes from a cell — in which case the
+    /// cached value is the name the user sees.
+    /// </summary>
     private static string ExtractSeriesName(C.SeriesText? seriesText)
     {
         if (seriesText == null) return string.Empty;
+
+        var literal = seriesText.Elements<C.NumericValue>().FirstOrDefault()?.Text;
+        if (literal != null) return literal;
+
         var strRef = seriesText.Elements<C.StringReference>().FirstOrDefault();
         var strCache = strRef?.Elements<C.StringCache>().FirstOrDefault();
         var pt = strCache?.Elements<C.StringPoint>().FirstOrDefault();

--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Packaging;
 using System.Linq;
@@ -38,7 +39,13 @@ internal static class ChartWriter
         {
             var xlChart = (XLChart)chart;
             if (!xlChart.IsNew)
+            {
+                // Charts that already exist in the package are not regenerated — that is what keeps
+                // the parts of their XML that XLibur does not model intact. Only the properties the
+                // caller actually changed are patched into the existing part.
+                ChartPatcher.PatchChart(worksheetPart, xlChart);
                 continue;
+            }
 
             if (IsExtendedType(xlChart.ChartType))
                 WriteExtendedChart(worksheet, cm, worksheetPart, xlChart, context);
@@ -65,6 +72,8 @@ internal static class ChartWriter
         var chartRelId = context.RelIdGenerator.GetNext(RelType.Workbook);
         var chartPart = drawingsPart.AddNewPart<ChartPart>(chartRelId);
         chartPart.ChartSpace = BuildChartSpace(xlChart);
+        // Remembered so that a later save can patch this part instead of regenerating it.
+        xlChart.RelId = chartRelId;
 
         AppendAnchor(worksheetDrawing, xlChart,
             new A.GraphicData(new C.ChartReference { Id = chartRelId })
@@ -419,6 +428,30 @@ internal static class ChartWriter
         return new C.ChartSpace(chart);
     }
 
+    private const uint CatAxisId = 1u;
+    private const uint ValAxisId = 2u;
+    private const uint SerAxisId = 3u;
+    private const uint SecondaryCatAxisId = 4u;
+    private const uint SecondaryValAxisId = 5u;
+
+    /// <summary>
+    /// One chart group to emit into the plot area: a chart type, the series plotted with it, and
+    /// whether those series hang off the secondary value axis.
+    /// </summary>
+    private readonly struct PlotGroup(
+        XLChartType chartType, List<XLChartSeries> series, bool secondaryAxis, uint indexOffset)
+    {
+        internal XLChartType ChartType { get; } = chartType;
+        internal List<XLChartSeries> Series { get; } = series;
+        internal bool SecondaryAxis { get; } = secondaryAxis;
+
+        /// <summary>Added to each series index so that combo charts do not reuse an index.</summary>
+        internal uint IndexOffset { get; } = indexOffset;
+
+        internal uint CatAxisIdOfGroup => SecondaryAxis ? SecondaryCatAxisId : CatAxisId;
+        internal uint ValAxisIdOfGroup => SecondaryAxis ? SecondaryValAxisId : ValAxisId;
+    }
+
     private static C.PlotArea BuildPlotArea(XLChart xlChart)
     {
         if (IsPieType(xlChart.ChartType) || IsDoughnutType(xlChart.ChartType))
@@ -427,173 +460,204 @@ internal static class ChartWriter
         if (IsBubbleType(xlChart.ChartType))
             return BuildBubblePlotArea(xlChart);
 
-        const uint catAxisId = 1u;
-        const uint valAxisId = 2u;
-        const uint serAxisId = 3u;
-
         var plotArea = new C.PlotArea();
         plotArea.Append(new C.Layout());
 
-        AppendChartElement(plotArea, xlChart.ChartType, xlChart.Series, catAxisId, valAxisId, 0);
+        var groups = BuildPlotGroups(xlChart);
+        foreach (var group in groups)
+            AppendChartElement(plotArea, group);
 
-        if (xlChart.SecondaryChartType.HasValue && xlChart.SecondarySeries.Count > 0)
-        {
-            // Secondary series indices must continue from primary to avoid conflicts
-            AppendChartElement(plotArea, xlChart.SecondaryChartType.Value, xlChart.SecondarySeries,
-                catAxisId, valAxisId, (uint)xlChart.Series.Count);
-        }
-
-        // Axes depend on primary chart type
-        if (IsScatterType(xlChart.ChartType))
-        {
-            // Scatter uses two ValueAxis (X and Y)
-            plotArea.Append(new C.ValueAxis(
-                new C.AxisId { Val = catAxisId },
-                new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-                new C.Delete { Val = false },
-                new C.AxisPosition { Val = C.AxisPositionValues.Bottom },
-                new C.CrossingAxis { Val = valAxisId }
-            ));
-            plotArea.Append(new C.ValueAxis(
-                new C.AxisId { Val = valAxisId },
-                new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-                new C.Delete { Val = false },
-                new C.AxisPosition { Val = C.AxisPositionValues.Left },
-                new C.CrossingAxis { Val = catAxisId }
-            ));
-        }
-        else if (IsSurfaceType(xlChart.ChartType))
-        {
-            plotArea.Append(new C.CategoryAxis(
-                new C.AxisId { Val = catAxisId },
-                new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-                new C.Delete { Val = false },
-                new C.AxisPosition { Val = C.AxisPositionValues.Bottom },
-                new C.CrossingAxis { Val = valAxisId }
-            ));
-            plotArea.Append(new C.ValueAxis(
-                new C.AxisId { Val = valAxisId },
-                new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-                new C.Delete { Val = false },
-                new C.AxisPosition { Val = C.AxisPositionValues.Left },
-                new C.CrossingAxis { Val = catAxisId }
-            ));
-            plotArea.Append(new C.SeriesAxis(
-                new C.AxisId { Val = serAxisId },
-                new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-                new C.Delete { Val = false },
-                new C.AxisPosition { Val = C.AxisPositionValues.Bottom },
-                new C.CrossingAxis { Val = valAxisId }
-            ));
-        }
-        else
-        {
-            plotArea.Append(new C.CategoryAxis(
-                new C.AxisId { Val = catAxisId },
-                new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-                new C.Delete { Val = false },
-                new C.AxisPosition { Val = C.AxisPositionValues.Bottom },
-                new C.CrossingAxis { Val = valAxisId }
-            ));
-            plotArea.Append(new C.ValueAxis(
-                new C.AxisId { Val = valAxisId },
-                new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-                new C.Delete { Val = false },
-                new C.AxisPosition { Val = C.AxisPositionValues.Left },
-                new C.CrossingAxis { Val = catAxisId }
-            ));
-        }
+        // Every chart group has to precede every axis in CT_PlotArea.
+        AppendAxes(plotArea, xlChart.ChartType, groups.Exists(g => g.SecondaryAxis));
 
         return plotArea;
     }
 
-    private static void AppendChartElement(
-        C.PlotArea plotArea, XLChartType chartType,
-        IXLChartSeriesCollection seriesCollection, uint catAxisId, uint valAxisId, uint indexOffset)
+    /// <summary>
+    /// Splits the chart's series into the groups the plot area needs: one per chart type, and one
+    /// more for each chart type that has series bound to the secondary value axis.
+    /// </summary>
+    private static List<PlotGroup> BuildPlotGroups(XLChart xlChart)
     {
-        if (IsAreaType(chartType))
-            AppendAreaChart(plotArea, chartType, seriesCollection, catAxisId, valAxisId, indexOffset);
-        else if (IsLineType(chartType))
-            AppendLineChart(plotArea, chartType, seriesCollection, catAxisId, valAxisId, indexOffset);
-        else if (IsRadarType(chartType))
-            AppendRadarChart(plotArea, chartType, seriesCollection, catAxisId, valAxisId, indexOffset);
-        else if (IsScatterType(chartType))
-            AppendScatterChart(plotArea, chartType, seriesCollection, catAxisId, valAxisId, indexOffset);
-        else if (IsStockType(chartType))
-            AppendStockChart(plotArea, seriesCollection, catAxisId, valAxisId, indexOffset);
-        else if (IsSurfaceType(chartType))
-            AppendSurfaceChart(plotArea, chartType, seriesCollection, catAxisId, valAxisId, indexOffset);
-        else if (IsBar3DType(chartType))
-            AppendBar3DChart(plotArea, chartType, seriesCollection, catAxisId, valAxisId, indexOffset);
+        var groups = new List<PlotGroup>(4);
+        AddPlotGroups(groups, xlChart.ChartType, xlChart.SeriesInternal.Items, 0);
+
+        if (xlChart.SecondaryChartType.HasValue && xlChart.SecondarySeries.Count > 0)
+        {
+            AddPlotGroups(groups, xlChart.SecondaryChartType.Value,
+                xlChart.SecondarySeriesInternal.Items, (uint)xlChart.Series.Count);
+        }
+
+        return groups;
+    }
+
+    private static void AddPlotGroups(
+        List<PlotGroup> groups, XLChartType chartType, IReadOnlyList<XLChartSeries> series, uint indexOffset)
+    {
+        if (series.Count == 0)
+            return;
+
+        if (!SupportsSecondaryAxis(chartType))
+        {
+            groups.Add(new PlotGroup(chartType, [.. series], secondaryAxis: false, indexOffset));
+            return;
+        }
+
+        var primary = new List<XLChartSeries>(series.Count);
+        var secondary = new List<XLChartSeries>();
+        foreach (var s in series)
+            (s.UseSecondaryAxis ? secondary : primary).Add(s);
+
+        if (primary.Count > 0)
+            groups.Add(new PlotGroup(chartType, primary, secondaryAxis: false, indexOffset));
+        if (secondary.Count > 0)
+            groups.Add(new PlotGroup(chartType, secondary, secondaryAxis: true, indexOffset));
+    }
+
+    /// <summary>
+    /// Whether <see cref="IXLChartSeries.UseSecondaryAxis"/> means anything for a chart type. The
+    /// types with two value axes (scatter, bubble), no value axis (pie, doughnut) or a series axis
+    /// (surface) have no secondary value axis to bind to.
+    /// </summary>
+    private static bool SupportsSecondaryAxis(XLChartType ct) =>
+        !IsScatterType(ct) && !IsBubbleType(ct) && !IsSurfaceType(ct)
+        && !IsPieType(ct) && !IsDoughnutType(ct);
+
+    private static void AppendAxes(C.PlotArea plotArea, XLChartType primaryChartType, bool hasSecondaryAxis)
+    {
+        if (IsScatterType(primaryChartType))
+        {
+            // Scatter uses two ValueAxis (X and Y)
+            plotArea.Append(BuildValueAxis(CatAxisId, ValAxisId, C.AxisPositionValues.Bottom));
+            plotArea.Append(BuildValueAxis(ValAxisId, CatAxisId, C.AxisPositionValues.Left));
+        }
+        else if (IsSurfaceType(primaryChartType))
+        {
+            plotArea.Append(BuildCategoryAxis(CatAxisId, ValAxisId));
+            plotArea.Append(BuildValueAxis(ValAxisId, CatAxisId, C.AxisPositionValues.Left));
+            plotArea.Append(new C.SeriesAxis(
+                new C.AxisId { Val = SerAxisId },
+                new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
+                new C.Delete { Val = false },
+                new C.AxisPosition { Val = C.AxisPositionValues.Bottom },
+                new C.CrossingAxis { Val = ValAxisId }
+            ));
+        }
         else
-            AppendBarChart(plotArea, chartType, seriesCollection, catAxisId, valAxisId, indexOffset);
+        {
+            plotArea.Append(BuildCategoryAxis(CatAxisId, ValAxisId));
+            plotArea.Append(BuildValueAxis(ValAxisId, CatAxisId, C.AxisPositionValues.Left));
+        }
+
+        if (!hasSecondaryAxis)
+            return;
+
+        // The secondary group needs its own axis pair. Excel hides the extra category axis and puts
+        // the extra value axis on the right, crossing the category axis at its maximum.
+        plotArea.Append(BuildCategoryAxis(SecondaryCatAxisId, SecondaryValAxisId, deleted: true));
+        plotArea.Append(BuildValueAxis(SecondaryValAxisId, SecondaryCatAxisId,
+            C.AxisPositionValues.Right, crossesMaximum: true));
+    }
+
+    private static C.CategoryAxis BuildCategoryAxis(uint axisId, uint crossingAxisId, bool deleted = false)
+    {
+        var axis = new C.CategoryAxis(
+            new C.AxisId { Val = axisId },
+            new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
+            new C.Delete { Val = deleted },
+            new C.AxisPosition { Val = C.AxisPositionValues.Bottom },
+            new C.CrossingAxis { Val = crossingAxisId }
+        );
+        return axis;
+    }
+
+    private static C.ValueAxis BuildValueAxis(
+        uint axisId, uint crossingAxisId, C.AxisPositionValues position, bool crossesMaximum = false)
+    {
+        var axis = new C.ValueAxis(
+            new C.AxisId { Val = axisId },
+            new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
+            new C.Delete { Val = false },
+            new C.AxisPosition { Val = position },
+            new C.CrossingAxis { Val = crossingAxisId }
+        );
+        if (crossesMaximum)
+            axis.Append(new C.Crosses { Val = C.CrossesValues.Maximum });
+        return axis;
+    }
+
+    private static void AppendChartElement(C.PlotArea plotArea, PlotGroup group)
+    {
+        var chartType = group.ChartType;
+
+        if (IsAreaType(chartType))
+            AppendAreaChart(plotArea, group);
+        else if (IsLineType(chartType))
+            AppendLineChart(plotArea, group);
+        else if (IsRadarType(chartType))
+            AppendRadarChart(plotArea, group);
+        else if (IsScatterType(chartType))
+            AppendScatterChart(plotArea, group);
+        else if (IsStockType(chartType))
+            AppendStockChart(plotArea, group);
+        else if (IsSurfaceType(chartType))
+            AppendSurfaceChart(plotArea, group);
+        else if (IsBar3DType(chartType))
+            AppendBar3DChart(plotArea, group);
+        else
+            AppendBarChart(plotArea, group);
     }
 
     // ── Pie / Doughnut (no axes) ──
 
     private static C.PlotArea BuildNoAxesPlotArea(XLChart xlChart)
     {
-        OpenXmlCompositeElement chartElement;
+        var isDoughnut = IsDoughnutType(xlChart.ChartType);
+        OpenXmlCompositeElement chartElement = isDoughnut
+            ? new C.DoughnutChart()
+            : new C.PieChart();
 
-        if (IsDoughnutType(xlChart.ChartType))
+        foreach (var s in xlChart.SeriesInternal.Items)
         {
-            var doughnut = new C.DoughnutChart();
-            foreach (var s in xlChart.Series)
+            var series = new C.PieChartSeries
             {
-                var series = new C.PieChartSeries
-                {
-                    Index = new C.Index { Val = s.Index },
-                    Order = new C.Order { Val = s.Order },
-                    SeriesText = BuildSeriesText(s)
-                };
-                AppendCatAndVal(series, s);
-                doughnut.Append(series);
-            }
-            chartElement = doughnut;
+                Index = new C.Index { Val = s.Index },
+                Order = new C.Order { Val = s.Order },
+                SeriesText = BuildSeriesText(s)
+            };
+            AppendShapeProperties(series, s);
+            AppendCatAndVal(series, s);
+            chartElement.Append(series);
         }
-        else
-        {
-            var pie = new C.PieChart();
-            foreach (var s in xlChart.Series)
-            {
-                var series = new C.PieChartSeries
-                {
-                    Index = new C.Index { Val = s.Index },
-                    Order = new C.Order { Val = s.Order },
-                    SeriesText = BuildSeriesText(s)
-                };
-                AppendCatAndVal(series, s);
-                pie.Append(series);
-            }
-            chartElement = pie;
-        }
+
+        // c:holeSize is required by CT_DoughnutChart; 75% is the size Excel gives a new doughnut.
+        if (isDoughnut)
+            chartElement.Append(new C.HoleSize { Val = 75 });
 
         return new C.PlotArea(new C.Layout(), chartElement);
     }
 
     // ── Area ──
 
-    private static void AppendAreaChart(
-        C.PlotArea plotArea, XLChartType chartType,
-        IXLChartSeriesCollection seriesCollection, uint catAxisId, uint valAxisId, uint indexOffset)
+    private static void AppendAreaChart(C.PlotArea plotArea, PlotGroup group)
     {
         var areaChart = new C.AreaChart
         {
-            Grouping = new C.Grouping { Val = GetAreaGrouping(chartType) }
+            Grouping = new C.Grouping { Val = GetAreaGrouping(group.ChartType) }
         };
-        foreach (var s in seriesCollection)
+        foreach (var s in group.Series)
         {
             var series = new C.AreaChartSeries
             {
-                Index = new C.Index { Val = s.Index + indexOffset },
-                Order = new C.Order { Val = s.Order + indexOffset },
+                Index = new C.Index { Val = s.Index + group.IndexOffset },
+                Order = new C.Order { Val = s.Order + group.IndexOffset },
                 SeriesText = BuildSeriesText(s)
             };
+            AppendShapeProperties(series, s);
             AppendCatAndVal(series, s);
             areaChart.Append(series);
         }
-        areaChart.Append(new C.AxisId { Val = catAxisId });
-        areaChart.Append(new C.AxisId { Val = valAxisId });
+        AppendAxisIds(areaChart, group);
         plotArea.Append(areaChart);
     }
 
@@ -608,7 +672,7 @@ internal static class ChartWriter
         const uint yAxisId = 2u;
 
         var bubbleChart = new C.BubbleChart();
-        foreach (var s in xlChart.Series)
+        foreach (var s in xlChart.SeriesInternal.Items)
         {
             var series = new C.BubbleChartSeries
             {
@@ -616,15 +680,8 @@ internal static class ChartWriter
                 Order = new C.Order { Val = s.Order },
                 SeriesText = BuildSeriesText(s)
             };
-            if (!string.IsNullOrWhiteSpace(s.CategoryReferences))
-            {
-                series.Append(new C.XValues(
-                    new C.NumberReference { Formula = new C.Formula(s.CategoryReferences) }
-                ));
-            }
-            series.Append(new C.YValues(
-                new C.NumberReference { Formula = new C.Formula(s.ValueReferences) }
-            ));
+            AppendShapeProperties(series, s);
+            AppendXAndY(series, s);
             series.Append(new C.BubbleSize(
                 new C.NumberReference { Formula = new C.Formula(s.ValueReferences) }
             ));
@@ -656,211 +713,204 @@ internal static class ChartWriter
 
     // ── Bar/Column ──
 
-    private static void AppendBarChart(
-        C.PlotArea plotArea, XLChartType chartType,
-        IXLChartSeriesCollection seriesCollection, uint catAxisId, uint valAxisId, uint indexOffset)
+    private static void AppendBarChart(C.PlotArea plotArea, PlotGroup group)
     {
-        var bp = new BarParams(chartType);
+        var bp = new BarParams(group.ChartType);
         var barChart = new C.BarChart
         {
             BarDirection = new C.BarDirection { Val = bp.Direction },
             BarGrouping = new C.BarGrouping { Val = bp.Grouping }
         };
-        foreach (var s in seriesCollection)
+        foreach (var s in group.Series)
         {
             var series = new C.BarChartSeries
             {
-                Index = new C.Index { Val = s.Index + indexOffset },
-                Order = new C.Order { Val = s.Order + indexOffset },
+                Index = new C.Index { Val = s.Index + group.IndexOffset },
+                Order = new C.Order { Val = s.Order + group.IndexOffset },
                 SeriesText = BuildSeriesText(s)
             };
+            AppendShapeProperties(series, s);
             AppendCatAndVal(series, s);
             barChart.Append(series);
         }
-        barChart.Append(new C.AxisId { Val = catAxisId });
-        barChart.Append(new C.AxisId { Val = valAxisId });
+        AppendAxisIds(barChart, group);
         plotArea.Append(barChart);
     }
 
     // ── Bar3D (Cone, Cylinder, Pyramid, Column3D, 3D Bar variants) ──
 
-    private static void AppendBar3DChart(
-        C.PlotArea plotArea, XLChartType chartType,
-        IXLChartSeriesCollection seriesCollection, uint catAxisId, uint valAxisId, uint indexOffset)
+    private static void AppendBar3DChart(C.PlotArea plotArea, PlotGroup group)
     {
-        var bp = new BarParams(chartType);
+        var bp = new BarParams(group.ChartType);
         var bar3DChart = new C.Bar3DChart
         {
             BarDirection = new C.BarDirection { Val = bp.Direction },
             BarGrouping = new C.BarGrouping { Val = bp.Grouping }
         };
-        foreach (var s in seriesCollection)
+        foreach (var s in group.Series)
         {
             var series = new C.BarChartSeries
             {
-                Index = new C.Index { Val = s.Index + indexOffset },
-                Order = new C.Order { Val = s.Order + indexOffset },
+                Index = new C.Index { Val = s.Index + group.IndexOffset },
+                Order = new C.Order { Val = s.Order + group.IndexOffset },
                 SeriesText = BuildSeriesText(s)
             };
+            AppendShapeProperties(series, s);
             AppendCatAndVal(series, s);
             bar3DChart.Append(series);
         }
-        bar3DChart.Append(new C.Shape { Val = GetBar3DShape(chartType) });
-        bar3DChart.Append(new C.AxisId { Val = catAxisId });
-        bar3DChart.Append(new C.AxisId { Val = valAxisId });
+        bar3DChart.Append(new C.Shape { Val = GetBar3DShape(group.ChartType) });
+        AppendAxisIds(bar3DChart, group);
         plotArea.Append(bar3DChart);
     }
 
     // ── Line ──
 
-    private static void AppendLineChart(
-        C.PlotArea plotArea, XLChartType chartType,
-        IXLChartSeriesCollection seriesCollection, uint catAxisId, uint valAxisId, uint indexOffset)
+    private static void AppendLineChart(C.PlotArea plotArea, PlotGroup group)
     {
         var lineChart = new C.LineChart
         {
-            Grouping = new C.Grouping { Val = GetLineGrouping(chartType) }
+            Grouping = new C.Grouping { Val = GetLineGrouping(group.ChartType) }
         };
-        foreach (var s in seriesCollection)
+        var markersByChartType = group.ChartType is XLChartType.LineWithMarkers
+            or XLChartType.LineWithMarkersStacked
+            or XLChartType.LineWithMarkersStacked100Percent;
+
+        foreach (var s in group.Series)
         {
             var series = new C.LineChartSeries
             {
-                Index = new C.Index { Val = s.Index + indexOffset },
-                Order = new C.Order { Val = s.Order + indexOffset },
+                Index = new C.Index { Val = s.Index + group.IndexOffset },
+                Order = new C.Order { Val = s.Order + group.IndexOffset },
                 SeriesText = BuildSeriesText(s)
             };
+            AppendShapeProperties(series, s);
+            AppendMarker(series, s, markersByChartType);
             AppendCatAndVal(series, s);
-            if (chartType is XLChartType.LineWithMarkers
-                or XLChartType.LineWithMarkersStacked
-                or XLChartType.LineWithMarkersStacked100Percent)
-            {
-                series.Append(new C.Marker { Symbol = new C.Symbol { Val = C.MarkerStyleValues.Auto } });
-            }
+            AppendSmooth(series, s, smoothByChartType: false);
             lineChart.Append(series);
         }
-        lineChart.Append(new C.AxisId { Val = catAxisId });
-        lineChart.Append(new C.AxisId { Val = valAxisId });
+        AppendAxisIds(lineChart, group);
         plotArea.Append(lineChart);
     }
 
     // ── Radar ──
 
-    private static void AppendRadarChart(
-        C.PlotArea plotArea, XLChartType chartType,
-        IXLChartSeriesCollection seriesCollection, uint catAxisId, uint valAxisId, uint indexOffset)
+    private static void AppendRadarChart(C.PlotArea plotArea, PlotGroup group)
     {
         var radarChart = new C.RadarChart
         {
             RadarStyle = new C.RadarStyle
             {
-                Val = chartType == XLChartType.RadarFilled ? C.RadarStyleValues.Filled : C.RadarStyleValues.Marker
+                Val = group.ChartType == XLChartType.RadarFilled
+                    ? C.RadarStyleValues.Filled
+                    : C.RadarStyleValues.Marker
             }
         };
-        foreach (var s in seriesCollection)
+        foreach (var s in group.Series)
         {
             var series = new C.RadarChartSeries
             {
-                Index = new C.Index { Val = s.Index + indexOffset },
-                Order = new C.Order { Val = s.Order + indexOffset },
+                Index = new C.Index { Val = s.Index + group.IndexOffset },
+                Order = new C.Order { Val = s.Order + group.IndexOffset },
                 SeriesText = BuildSeriesText(s)
             };
+            AppendShapeProperties(series, s);
+            AppendMarker(series, s, autoSymbol: false);
             AppendCatAndVal(series, s);
             radarChart.Append(series);
         }
-        radarChart.Append(new C.AxisId { Val = catAxisId });
-        radarChart.Append(new C.AxisId { Val = valAxisId });
+        AppendAxisIds(radarChart, group);
         plotArea.Append(radarChart);
     }
 
     // ── Scatter ──
 
-    private static void AppendScatterChart(
-        C.PlotArea plotArea, XLChartType chartType,
-        IXLChartSeriesCollection seriesCollection, uint xAxisId, uint yAxisId, uint indexOffset)
+    private static void AppendScatterChart(C.PlotArea plotArea, PlotGroup group)
     {
         var scatterChart = new C.ScatterChart
         {
-            ScatterStyle = new C.ScatterStyle { Val = GetScatterStyle(chartType) }
+            ScatterStyle = new C.ScatterStyle { Val = GetScatterStyle(group.ChartType) }
         };
-        foreach (var s in seriesCollection)
+        var smoothByChartType = group.ChartType is XLChartType.XYScatterSmoothLinesNoMarkers
+            or XLChartType.XYScatterSmoothLinesWithMarkers;
+
+        foreach (var s in group.Series)
         {
             var series = new C.ScatterChartSeries
             {
-                Index = new C.Index { Val = s.Index + indexOffset },
-                Order = new C.Order { Val = s.Order + indexOffset },
+                Index = new C.Index { Val = s.Index + group.IndexOffset },
+                Order = new C.Order { Val = s.Order + group.IndexOffset },
                 SeriesText = BuildSeriesText(s)
             };
+            AppendShapeProperties(series, s);
+            AppendMarker(series, s, autoSymbol: false);
             // Scatter uses XValues + YValues, not CategoryAxisData + Values
-            if (!string.IsNullOrWhiteSpace(s.CategoryReferences))
-            {
-                series.Append(new C.XValues(
-                    new C.NumberReference { Formula = new C.Formula(s.CategoryReferences) }
-                ));
-            }
-            series.Append(new C.YValues(
-                new C.NumberReference { Formula = new C.Formula(s.ValueReferences) }
-            ));
+            AppendXAndY(series, s);
+            AppendSmooth(series, s, smoothByChartType);
             scatterChart.Append(series);
         }
-        scatterChart.Append(new C.AxisId { Val = xAxisId });
-        scatterChart.Append(new C.AxisId { Val = yAxisId });
+        AppendAxisIds(scatterChart, group);
         plotArea.Append(scatterChart);
     }
 
     // ── Stock ──
 
-    private static void AppendStockChart(
-        C.PlotArea plotArea, IXLChartSeriesCollection seriesCollection,
-        uint catAxisId, uint valAxisId, uint indexOffset)
+    private static void AppendStockChart(C.PlotArea plotArea, PlotGroup group)
     {
         var stockChart = new C.StockChart();
-        foreach (var s in seriesCollection)
+        foreach (var s in group.Series)
         {
             var series = new C.LineChartSeries
             {
-                Index = new C.Index { Val = s.Index + indexOffset },
-                Order = new C.Order { Val = s.Order + indexOffset },
+                Index = new C.Index { Val = s.Index + group.IndexOffset },
+                Order = new C.Order { Val = s.Order + group.IndexOffset },
                 SeriesText = BuildSeriesText(s)
             };
+            AppendShapeProperties(series, s);
+            AppendMarker(series, s, autoSymbol: false);
             AppendCatAndVal(series, s);
             stockChart.Append(series);
         }
-        stockChart.Append(new C.AxisId { Val = catAxisId });
-        stockChart.Append(new C.AxisId { Val = valAxisId });
+        AppendAxisIds(stockChart, group);
         plotArea.Append(stockChart);
     }
 
     // ── Surface ──
 
-    private static void AppendSurfaceChart(
-        C.PlotArea plotArea, XLChartType chartType,
-        IXLChartSeriesCollection seriesCollection, uint catAxisId, uint valAxisId, uint indexOffset)
+    private static void AppendSurfaceChart(C.PlotArea plotArea, PlotGroup group)
     {
-        const uint serAxisId = 3u;
-        var wireframe = chartType is XLChartType.SurfaceWireframe or XLChartType.SurfaceContourWireframe;
+        var wireframe = group.ChartType is XLChartType.SurfaceWireframe
+            or XLChartType.SurfaceContourWireframe;
 
         var surfaceChart = new C.SurfaceChart();
         if (wireframe)
             surfaceChart.Append(new C.Wireframe { Val = true });
 
-        foreach (var s in seriesCollection)
+        foreach (var s in group.Series)
         {
             var series = new C.SurfaceChartSeries
             {
-                Index = new C.Index { Val = s.Index + indexOffset },
-                Order = new C.Order { Val = s.Order + indexOffset },
+                Index = new C.Index { Val = s.Index + group.IndexOffset },
+                Order = new C.Order { Val = s.Order + group.IndexOffset },
                 SeriesText = BuildSeriesText(s)
             };
+            AppendShapeProperties(series, s);
             AppendCatAndVal(series, s);
             surfaceChart.Append(series);
         }
-        surfaceChart.Append(new C.AxisId { Val = catAxisId });
-        surfaceChart.Append(new C.AxisId { Val = valAxisId });
-        surfaceChart.Append(new C.AxisId { Val = serAxisId });
+        AppendAxisIds(surfaceChart, group);
+        surfaceChart.Append(new C.AxisId { Val = SerAxisId });
         plotArea.Append(surfaceChart);
     }
 
     // ── Shared helpers ──────────────────────────────────────────────────
+
+    private static void AppendAxisIds(OpenXmlCompositeElement chartElement, PlotGroup group)
+    {
+        chartElement.Append(new C.AxisId { Val = group.CatAxisIdOfGroup });
+        chartElement.Append(new C.AxisId { Val = group.ValAxisIdOfGroup });
+    }
 
     private static void AppendCatAndVal(OpenXmlCompositeElement series, IXLChartSeries s)
     {
@@ -875,13 +925,47 @@ internal static class ChartWriter
         ));
     }
 
-    private static C.SeriesText BuildSeriesText(IXLChartSeries s) =>
-        new(new C.StringReference(
-            new C.StringCache(
-                new C.PointCount { Val = 1 },
-                new C.StringPoint(new C.NumericValue(s.Name)) { Index = 0 }
-            )
+    private static void AppendXAndY(OpenXmlCompositeElement series, IXLChartSeries s)
+    {
+        if (!string.IsNullOrWhiteSpace(s.CategoryReferences))
+        {
+            series.Append(new C.XValues(
+                new C.NumberReference { Formula = new C.Formula(s.CategoryReferences) }
+            ));
+        }
+        series.Append(new C.YValues(
+            new C.NumberReference { Formula = new C.Formula(s.ValueReferences) }
         ));
+    }
+
+    private static void AppendShapeProperties(OpenXmlCompositeElement series, XLChartSeries s)
+    {
+        var shapeProperties = ChartFormatting.BuildSeriesShapeProperties(s);
+        if (shapeProperties != null)
+            series.Append(shapeProperties);
+    }
+
+    private static void AppendMarker(OpenXmlCompositeElement series, XLChartSeries s, bool autoSymbol)
+    {
+        var marker = ChartFormatting.BuildMarker(s, autoSymbol);
+        if (marker != null)
+            series.Append(marker);
+    }
+
+    private static void AppendSmooth(OpenXmlCompositeElement series, XLChartSeries s, bool smoothByChartType)
+    {
+        var smooth = ChartFormatting.BuildSmooth(s, smoothByChartType);
+        if (smooth != null)
+            series.Append(smooth);
+    }
+
+    /// <summary>
+    /// Writes the series name as the literal <c>&lt;c:tx&gt;&lt;c:v&gt;</c> form. The alternative,
+    /// <c>c:strRef</c>, is for names that come from a cell and requires a <c>c:f</c> formula, which
+    /// a literal name does not have.
+    /// </summary>
+    private static C.SeriesText BuildSeriesText(IXLChartSeries s) =>
+        new(new C.NumericValue(s.Name));
 
     private static void AppendAnchor(Xdr.WorksheetDrawing worksheetDrawing, XLChart xlChart, A.GraphicData graphicData)
     {

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -104,3 +104,31 @@ static XLibur.Excel.XLAlignmentKey.operator !=(XLibur.Excel.XLAlignmentKey left,
 static XLibur.AttributeExtensions.GetMethod<T>(this T instance, System.Linq.Expressions.Expression<System.Func<T, object!>!>! methodSelector) -> System.Reflection.MethodInfo!
 static XLibur.AttributeExtensions.GetMethod<T>(this T instance, System.Linq.Expressions.Expression<System.Action<T>!>! methodSelector) -> System.Reflection.MethodInfo!
 XLibur.Excel.XLError.SpillRange = 7 -> XLibur.Excel.XLError
+XLibur.Excel.IXLChartSeries.FillColor.get -> XLibur.Excel.XLColor?
+XLibur.Excel.IXLChartSeries.FillColor.set -> void
+XLibur.Excel.IXLChartSeries.LineColor.get -> XLibur.Excel.XLColor?
+XLibur.Excel.IXLChartSeries.LineColor.set -> void
+XLibur.Excel.IXLChartSeries.LineWidthPt.get -> double?
+XLibur.Excel.IXLChartSeries.LineWidthPt.set -> void
+XLibur.Excel.IXLChartSeries.MarkerFillColor.get -> XLibur.Excel.XLColor?
+XLibur.Excel.IXLChartSeries.MarkerFillColor.set -> void
+XLibur.Excel.IXLChartSeries.MarkerSize.get -> double?
+XLibur.Excel.IXLChartSeries.MarkerSize.set -> void
+XLibur.Excel.IXLChartSeries.MarkerStyle.get -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.IXLChartSeries.MarkerStyle.set -> void
+XLibur.Excel.IXLChartSeries.Smooth.get -> bool
+XLibur.Excel.IXLChartSeries.Smooth.set -> void
+XLibur.Excel.IXLChartSeries.UseSecondaryAxis.get -> bool
+XLibur.Excel.IXLChartSeries.UseSecondaryAxis.set -> void
+XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Auto = 0 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.None = 1 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Circle = 2 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Dash = 3 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Diamond = 4 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Dot = 5 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Plus = 6 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Square = 7 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Star = 8 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Triangle = 9 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.X = 10 -> XLibur.Excel.XLMarkerStyle

--- a/docs-website/docs/charts.md
+++ b/docs-website/docs/charts.md
@@ -179,6 +179,100 @@ combo.SecondPosition.SetColumn(10).SetRow(24);
 
 Set `SecondaryChartType` back to `null` to turn a combo chart into a single-type chart.
 
+## Series formatting
+
+Each series carries its own fill, outline and marker. Every property is optional: leave it alone
+and Excel picks the automatic colour from the workbook theme, which is usually what you want for
+all but one or two highlighted series.
+
+```csharp
+var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+var revenue = chart.Series.Add("Revenue", "Sales!$B$2:$B$5", "Sales!$A$2:$A$5");
+
+revenue.FillColor = XLColor.FromHtml("#4472C4");     // bar interior
+revenue.LineColor = XLColor.FromHtml("#203864");     // bar border
+revenue.LineWidthPt = 1.5;
+```
+
+For a line or scatter series the same two colours mean the line and — with `MarkerStyle` — the
+symbol drawn at each point:
+
+```csharp
+var trend = chart.SecondarySeries.Add("Margin %", "Sales!$D$2:$D$5", "Sales!$A$2:$A$5");
+
+trend.LineColor = XLColor.FromTheme(XLThemeColor.Accent2);
+trend.LineWidthPt = 2.25;
+trend.MarkerStyle = XLMarkerStyle.Circle;
+trend.MarkerSize = 7;                                 // 2 to 72 points
+trend.MarkerFillColor = XLColor.FromHtml("#70AD47");
+trend.Smooth = true;                                  // curve rather than straight segments
+```
+
+| Property | Applies to | Default |
+|---|---|---|
+| `FillColor` | bar, column, area, pie interiors; scatter markers | automatic (theme) |
+| `LineColor` | line and scatter lines; borders elsewhere | automatic (theme) |
+| `LineWidthPt` | any outline, 0 to 1584 points | Excel's own |
+| `MarkerStyle` | line, scatter, radar | `Auto` |
+| `MarkerSize` | line, scatter, radar, 2 to 72 points | Excel's own |
+| `MarkerFillColor` | line, scatter, radar | automatic (theme) |
+| `Smooth` | line, scatter | the chart type's default |
+
+`XLMarkerStyle` offers `Auto`, `None`, `Circle`, `Dash`, `Diamond`, `Dot`, `Plus`, `Square`,
+`Star`, `Triangle` and `X`. `Auto` — the default — writes nothing, so the chart type decides:
+the `LineWithMarkers*` types draw markers, plain `Line` does not.
+
+:::note
+Setting a colour to `null` clears it back to automatic; it never writes an explicit black. A
+theme colour is written as a DrawingML scheme colour, but its `ThemeTint` is not applied — pass an
+RGB colour if you need a specific tint.
+
+The extended (Office 2016+) types — Waterfall, Funnel, Treemap, Sunburst, Box &amp; Whisker —
+ignore series formatting.
+:::
+
+### Secondary value axis
+
+`UseSecondaryAxis` moves a series onto a second value axis drawn on the right, which is what
+makes a two-scale chart readable — units in the thousands next to a percentage, say:
+
+```csharp
+var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+chart.Series.Add("Units", "Sales!$B$2:$B$5", "Sales!$A$2:$A$5");
+
+chart.SecondaryChartType = XLChartType.LineWithMarkers;
+var margin = chart.SecondarySeries.Add("Margin %", "Sales!$D$2:$D$5", "Sales!$A$2:$A$5");
+margin.UseSecondaryAxis = true;
+```
+
+It works on any series of a chart type that has a category and a value axis — bar, column, line,
+area, radar, stock and surface — including series of the primary chart type. Pie and doughnut
+charts have no value axis and scatter and bubble charts already have two, so they ignore it.
+
+:::caution
+`UseSecondaryAxis` can only be set on charts you create. Moving a series of a chart **loaded from
+a file** onto a secondary axis would mean regrouping the chart's XML, which XLibur does not do, so
+the setter throws `NotSupportedException`. The colour and marker properties have no such limit.
+:::
+
+### Editing charts loaded from a file
+
+XLibur never regenerates the XML of a chart it read from a file — it patches in just the
+properties you assign. Everything it does not model stays exactly as Excel wrote it: trendlines,
+error bars, gradient and picture fills, per-point colours, data labels, the chart's style and
+colour parts.
+
+```csharp
+using var workbook = new XLWorkbook("Report.xlsx");
+var chart = workbook.Worksheet("Data").Charts.First();
+
+chart.Series.First().FillColor = XLColor.FromHtml("#C00000");
+workbook.Save();   // only the fill changes; the trendline stays
+```
+
+Chart type, title and series references are settable on charts you create, but on a loaded chart
+only the series formatting is written back.
+
 ## Chart types
 
 `XLChartType` covers the full Excel catalogue. Pick by data shape:
@@ -278,9 +372,9 @@ chart.Title = null;               // remove the title
 
 ## What is not covered
 
-The chart API is deliberately narrow: type, title, series, and placement. Axis titles, legend
-placement, gridlines, data labels, per-series colours, and trend lines are not exposed. If you
-need that level of control, the usual approach is to build a template workbook in Excel with
+The chart API is deliberately narrow: type, title, series, series formatting, and placement. Axis
+titles and scaling, legend placement, gridlines, data labels, and trend lines are not exposed. If
+you need that level of control, the usual approach is to build a template workbook in Excel with
 the chart formatted exactly as you want it, then use XLibur to write the source data the chart
 already points at:
 
@@ -340,20 +434,29 @@ ws.Columns().AdjustToContents();
 const string sheet = "Quarterly";
 var categories = $"{sheet}!$A$2:$A${last}";
 
-// Chart 1: revenue vs cost
+// Chart 1: revenue vs cost, with cost played down
 var bars = ws.Charts.Add(XLChartType.ColumnClustered);
 bars.SetTitle("Revenue vs cost");
-bars.Series.Add("Revenue", $"{sheet}!$B$2:$B${last}", categories);
-bars.Series.Add("Cost", $"{sheet}!$C$2:$C${last}", categories);
+bars.Series.Add("Revenue", $"{sheet}!$B$2:$B${last}", categories).FillColor =
+    XLColor.FromHtml("#4472C4");
+bars.Series.Add("Cost", $"{sheet}!$C$2:$C${last}", categories).FillColor =
+    XLColor.FromHtml("#A5A5A5");
 bars.Position.SetColumn(5).SetRow(1);
 bars.SecondPosition.SetColumn(13).SetRow(16);
 
-// Chart 2: combo — revenue bars with the margin line over them
+// Chart 2: combo — revenue bars with the margin line on its own axis
 var combo = ws.Charts.Add(XLChartType.ColumnClustered);
 combo.SetTitle("Revenue and margin");
 combo.Series.Add("Revenue", $"{sheet}!$B$2:$B${last}", categories);
 combo.SecondaryChartType = XLChartType.LineWithMarkers;
-combo.SecondarySeries.Add("Margin %", $"{sheet}!$D$2:$D${last}", categories);
+
+var margin = combo.SecondarySeries.Add("Margin %", $"{sheet}!$D$2:$D${last}", categories);
+margin.UseSecondaryAxis = true;
+margin.LineColor = XLColor.FromHtml("#ED7D31");
+margin.LineWidthPt = 2.25;
+margin.MarkerStyle = XLMarkerStyle.Circle;
+margin.MarkerSize = 7;
+
 combo.Position.SetColumn(5).SetRow(18);
 combo.SecondPosition.SetColumn(13).SetRow(33);
 

--- a/docs-website/docs/charts.md
+++ b/docs-website/docs/charts.md
@@ -194,10 +194,11 @@ revenue.LineColor = XLColor.FromHtml("#203864");     // bar border
 revenue.LineWidthPt = 1.5;
 ```
 
-For a line or scatter series the same two colours mean the line and — with `MarkerStyle` — the
-symbol drawn at each point:
+On a line or scatter series `LineColor` and `LineWidthPt` draw the line itself. The marker is a
+separate thing: `MarkerStyle` picks the symbol and `MarkerFillColor` fills it.
 
 ```csharp
+chart.SecondaryChartType = XLChartType.LineWithMarkers;
 var trend = chart.SecondarySeries.Add("Margin %", "Sales!$D$2:$D$5", "Sales!$A$2:$A$5");
 
 trend.LineColor = XLColor.FromTheme(XLThemeColor.Accent2);
@@ -210,7 +211,7 @@ trend.Smooth = true;                                  // curve rather than strai
 
 | Property | Applies to | Default |
 |---|---|---|
-| `FillColor` | bar, column, area, pie interiors; scatter markers | automatic (theme) |
+| `FillColor` | bar, column, area and pie interiors | automatic (theme) |
 | `LineColor` | line and scatter lines; borders elsewhere | automatic (theme) |
 | `LineWidthPt` | any outline, 0 to 1584 points | Excel's own |
 | `MarkerStyle` | line, scatter, radar | `Auto` |
@@ -245,9 +246,10 @@ var margin = chart.SecondarySeries.Add("Margin %", "Sales!$D$2:$D$5", "Sales!$A$
 margin.UseSecondaryAxis = true;
 ```
 
-It works on any series of a chart type that has a category and a value axis — bar, column, line,
-area, radar, stock and surface — including series of the primary chart type. Pie and doughnut
-charts have no value axis and scatter and bubble charts already have two, so they ignore it.
+It works on any series of a chart type that has one category and one value axis — bar, column, line,
+area, radar and stock — including series of the primary chart type. Pie and doughnut charts have no
+value axis, scatter and bubble charts already have two, and surface charts add a series axis, so all
+of those ignore it.
 
 :::caution
 `UseSecondaryAxis` can only be set on charts you create. Moving a series of a chart **loaded from

--- a/docs/specs/10-chart-formatting-depth.md
+++ b/docs/specs/10-chart-formatting-depth.md
@@ -3,7 +3,7 @@
 **Area:** Feature (flagship differentiator — upstream ClosedXML has no charts at all)
 **Effort:** L total, but splits into 4 independent PRs
 **Dependencies:** None.
-**Status:** Proposed
+**Status:** In progress — PR 1 implemented; see [Results](#results-pr-1). PRs 2–4 open.
 
 ## Summary
 
@@ -99,3 +99,98 @@ PRs 2 and 3 are independent of each other once PR 1's groundwork lands.
 
 - DrawingML defaulting is subtle (automatic colors come from the theme); `null` must mean "omit element" (Excel default), never "emit black". Test against Excel-authored files, not assumptions.
 - If the writer regenerates chart XML from the model on save (rather than patching), preservation of unmodeled properties is the hard part — resolve this in PR 1 before building on top.
+
+## Results (PR 1)
+
+Series formatting, secondary-axis binding and the round-trip-preservation groundwork landed.
+`IXLChartSeries` gained `FillColor`, `LineColor`, `LineWidthPt`, `MarkerStyle` (new `XLMarkerStyle`
+enum), `MarkerSize`, `MarkerFillColor`, `Smooth` and `UseSecondaryAxis`. `DataLabels` is left to
+PR 2. 6360 tests pass on net8.0 and net10.0.
+
+### The preservation question is answered: the writer does not regenerate
+
+`ChartWriter.WriteCharts` only ever emitted charts with `IsNew == true`, i.e. charts created through
+`Charts.Add`. A chart read from a file was skipped entirely, and because `SaveAs` copies the original
+package bytes to the target and then patches it, its chart part passed through **byte for byte** —
+trendlines, error bars, gradient fills, per-point formatting and the sibling chart style/colour parts
+included. Acceptance criterion 3 was therefore already met before this PR, and there is no need to
+stash raw XML for unmodeled properties.
+
+The flip side is that edits to a loaded chart were silently dropped. PR 1 keeps the
+never-regenerate rule and adds `ChartPatcher`, which writes back **only** the properties the caller
+actually assigned:
+
+- `XLChartSeries` tracks assignments in an `XLChartSeriesFormat` flag set. The reader seeds values
+  through `SeedLoadedFormat`, which does not set the flags, so a chart nobody edited is not touched
+  at all (`LoadAndSaveWithoutEditsLeavesTheChartPartUntouched` asserts byte equality).
+- A patched `c:spPr` / `c:marker` / `c:smooth` replaces just its own child; `cap="rnd"`, `a:round`,
+  `a:effectLst`, `c:gapWidth`, `c:trendline` and the neighbouring untouched series all survive.
+- `ChartPlotAreaScanner` is shared by the reader and the patcher, so the n-th model series still maps
+  to the n-th `c:ser` element on save.
+
+### Secondary axis
+
+`UseSecondaryAxis` splits a chart's series into plot groups: series bound to the secondary axis get
+their own chart group referencing a second axis pair (hidden `c:catAx`, right-hand `c:valAx` with
+`c:crosses val="max"`). It works for the primary chart type as well as the combo `SecondarySeries`,
+which is more than the spec asked for — the spec assumed generalising the existing combo plumbing,
+but the combo path plotted both types against the *same* axis pair, so the grouping had to be built
+from scratch either way.
+
+Two deliberate limits, both documented on the interface:
+
+- Chart types without a single value axis ignore it — pie and doughnut have none, scatter and bubble
+  have two, surface has a series axis.
+- Setting it on a chart **loaded from a file** throws `NotSupportedException`. Honouring it would mean
+  moving a `c:ser` into a newly created chart group, i.e. regenerating the structure the patch
+  approach exists to avoid. Colour and marker properties have no such limit.
+
+### Three pre-existing writer bugs found by switching validation on
+
+The new tests save with `SaveAs(stream, validate: true)`, which runs `OpenXmlValidator`. No chart
+test had done that before, and it failed immediately on output the writer had always produced:
+
+1. **Series names were schema-invalid.** `c:tx` held a `c:strRef` with a `c:strCache` but no `c:f`,
+   which `CT_StrRef` requires. A literal name belongs in `<c:tx><c:v>` instead, which is what the
+   writer now emits; the reader accepts both forms, so files written by earlier versions and by Excel
+   (where the name does come from a cell) still read correctly.
+2. **`c:doughnutChart` was missing the required `c:holeSize`.** Now written as 75%, Excel's own
+   default for a new doughnut chart.
+3. **Markers were emitted after `c:cat`/`c:val`.** `CT_LineSer` puts `c:marker` before them. The
+   `LineWithMarkers*` types had been writing an out-of-order child all along.
+
+Excel tolerated all three, which is why they went unnoticed. Every chart family is now round-tripped
+through the validator by `FormattingSurvivesEveryStandardChartFamily`.
+
+### Reader restructure
+
+`ReadPlotArea` no longer takes the first element of each chart-group type. It scans every group in
+the plot area, picks the primary kind by the same precedence the old code implied (bar, bar3D, pie,
+doughnut, area, line, radar, bubble, scatter, stock, surface), and merges every group of that kind
+into `Series` — which is what makes a two-group secondary-axis chart read back correctly. Groups of
+another kind become `SecondaryChartType` / `SecondarySeries` as before. Also fixed:
+`DetermineLineChartType` treated `<c:marker><c:symbol val="none"/></c:marker>` as "has markers" and
+reported a plain `Line` chart as `LineWithMarkers`.
+
+### Acceptance criteria
+
+| # | Criterion | Status |
+|---|---|---|
+| 1 | Set via API → save → reload reads the same value | ✅ automated per property |
+| 1 | Set via API → save → **renders in Excel** | ⚠️ not executed — no Excel in this environment. The test suite leaves `FormattedChartExamples.xlsx` in the test output directory for a manual pass |
+| 2 | Excel-authored charts load with correct values | ⚠️ approximated — `ChartRoundTripPreservationTests` reads a hand-written fixture shaped like Excel's own output (scheme colour, `c:strRef` name cache, `cap`/`a:round`/`a:effectLst`, marker `c:spPr`, secondary axis pair, trendline). No file could be authored in Excel in CI; `XLibur.Tests/Resource/Charts/` is still empty |
+| 3 | Round-trip of unsupported features loses nothing | ✅ guaranteed by construction, asserted both ways |
+| 4 | Existing chart tests green; ChartEx unaffected | ✅ extended charts ignore series formatting and are not patched |
+| 5 | `XLibur.Examples` gains a formatted-chart sample | ✅ `FormattedChartExamples` — four sheets, validated by a test |
+
+### Notes for PRs 2–4
+
+- Build data labels, legend and axes on `ChartPatcher`/`ChartFormatting`, not on a second mechanism:
+  add flags to the assignment set and a patch step per element. The "only write what was assigned"
+  rule is what keeps preservation free.
+- `ChartPlotAreaScanner` is the place to add group kinds the reader still ignores: `c:pie3DChart`,
+  `c:line3DChart`, `c:area3DChart`, `c:surface3DChart`, `c:ofPieChart`. Today a chart built from
+  those reads as zero series with a default chart type — worth folding into PR 3 or 4.
+- Title, chart type and series references are still write-only for new charts; editing them on a
+  loaded chart does nothing. If PR 3 wants `chart.Title` to work on loaded charts, that is another
+  patch step.

--- a/docs/specs/10-chart-formatting-depth.md
+++ b/docs/specs/10-chart-formatting-depth.md
@@ -105,7 +105,7 @@ PRs 2 and 3 are independent of each other once PR 1's groundwork lands.
 Series formatting, secondary-axis binding and the round-trip-preservation groundwork landed.
 `IXLChartSeries` gained `FillColor`, `LineColor`, `LineWidthPt`, `MarkerStyle` (new `XLMarkerStyle`
 enum), `MarkerSize`, `MarkerFillColor`, `Smooth` and `UseSecondaryAxis`. `DataLabels` is left to
-PR 2. 6360 tests pass on net8.0 and net10.0.
+PR 2. 6366 tests pass on net8.0 and net10.0.
 
 ### The preservation question is answered: the writer does not regenerate
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -19,7 +19,7 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 07 | [Formula function coverage (257→~420)](07-formula-function-coverage.md) | Feature | L | Proposed | **6 fully independent waves** |
 | 08 | [LET / LAMBDA](08-let-lambda.md) | Feature | L | Proposed | Single owner (engine core) |
 | 09 | [Threaded comments + round-trip fidelity](09-threaded-comments-roundtrip.md) | Feature · Compat | M | Proposed | Comments vs fidelity-audit split |
-| 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | Proposed | 4 PRs, 2–3 independent |
+| 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | 🚧 **PR 1 done** | 4 PRs, 2–3 independent |
 | 11 | [Create-path allocation reduction](11-create-path-allocations.md) | Perf (write) | M | ✅ **Tasks 1–4 done** | Task 4 lands in 11; 05 rebases |
 
 Spec 11 was added after spec 03 landed: 03 halved the *save* phase and showed the rest of it is
@@ -30,6 +30,12 @@ Spec 02 delivered **−16.5% load time and −61.5% allocations** (4.750 s / 102
 392.88 MB on the 250K×15 benchmark). It also produced two findings that change other specs: a
 correction to spec 03's number-formatting task, and a reusable `XmlReader.ReadValueChunk` technique
 for the IO layer. Both are recorded in spec 02's Results section.
+
+Spec 10's PR 1 settled the question the spec flagged as its own hard part: the chart writer never
+regenerates a chart it loaded, so unmodeled chart XML round-trips byte for byte, and edits are
+patched into the existing part instead. **PRs 2–4 should extend that patcher rather than add a second
+write path** — see spec 10's Results section. Turning the OpenXML validator on for the new chart
+tests also surfaced three long-standing schema violations in the chart writer, now fixed.
 
 ## Why these ten (01–10)
 
@@ -48,7 +54,8 @@ Wave 1 (independent, start anytime):
   02 load allocations ✅ done · 03 save allocations · 07 function waves A–F · 09 threaded comments
   11 Tasks 1–4 ✅ done (−28.8% on the write benchmark; bulk styling −86% per cell)
 Wave 2 (after 03 lands, or coordinated):
-  01 streaming write (Phase 1 seam shared with 03's territory) · 06 encryption · 10 charts PR1
+  01 streaming write (Phase 1 seam shared with 03's territory) · 06 encryption
+  10 charts PR1 ✅ done (series formatting, secondary axis, preservation groundwork) · PRs 2–4 open
 Wave 3 (single-owner, correctness-critical — don't parallelize internally):
   04 demand-driven eval · 05 structural edits · 08 LET/LAMBDA (08 after or alongside 04)
 ```


### PR DESCRIPTION
## Summary

PR 1 of 4 for [spec 10 — Chart formatting depth](https://github.com/XLibur/XLibur/blob/main/docs/specs/10-chart-formatting-depth.md). Adds the series formatting layer that makes a generated chart presentation-ready, the per-series secondary-axis binding, and the round-trip-preservation groundwork the rest of the spec builds on.

**Stack** — review in order, each PR targets the one before it:

1. **this PR** — series formatting + secondary axis + preservation groundwork
2. #221 — data labels
3. #222 — legend + axes
4. #223 — anchor reader gaps

### The question the spec flagged as its own hard part

The spec asked whether the writer regenerates chart XML on save, because unmodeled properties would then have to be stashed and replayed. **It does not.** `ChartWriter.WriteCharts` only ever emitted charts with `IsNew == true`, and `SaveAs` copies the original package bytes to the target before patching it, so a chart read from a file passed through byte for byte — trendlines, error bars, gradient fills, per-point formatting and the sibling chart style/colour parts included. Acceptance criterion 3 was already met.

The gap was the other direction: **edits to a loaded chart were silently dropped.** This PR keeps the never-regenerate rule and adds `ChartPatcher`, which writes back only the properties a caller actually assigned — tracked per series in an `XLChartSeriesFormat` flag set that the reader seeds without setting. A chart nobody edited is still not modified at all (`LoadAndSaveWithoutEditsLeavesTheChartPartUntouched` asserts byte equality).

## Changes

- `IXLChartSeries` gains `FillColor`, `LineColor`, `LineWidthPt`, `MarkerStyle` (new `XLMarkerStyle` enum), `MarkerSize`, `MarkerFillColor`, `Smooth` and `UseSecondaryAxis`. A `null` colour omits its element so Excel keeps the automatic theme colour — nothing is ever written as an explicit black.
- `UseSecondaryAxis` splits a chart into plot groups: secondary series get their own chart group plus a hidden `c:catAx` and a right-hand `c:valAx` with `c:crosses val="max"`. Works for the primary chart type as well as a combo chart's `SecondarySeries` — the existing combo path plotted both types against the *same* axis pair, so the grouping had to be built from scratch.
- `ChartPatcher` + `ChartPlotAreaScanner`: the reader and the patcher share one plot-area scan, so the n-th model series still maps to the n-th `c:ser` on save.
- Reader: scans **every** chart group of a plot area instead of the first of each type, which is what makes a two-group secondary-axis chart read back.

### Three pre-existing writer bugs, found by turning validation on

The new tests save with `SaveAs(stream, validate: true)`. No chart test had ever run `OpenXmlValidator`, and it failed immediately on output the writer had always produced:

1. **Series names were schema-invalid** — `c:tx` held a `c:strRef` with a `c:strCache` but no `c:f`, which `CT_StrRef` requires. A literal name now uses `<c:tx><c:v>`; the reader accepts both forms, so files written by earlier versions and by Excel still read correctly.
2. **`c:doughnutChart` omitted the required `c:holeSize`** — now 75%, Excel's own default for a new doughnut.
3. **`c:marker` was written after `c:cat`/`c:val`** — `CT_LineSer` puts it before them. The `LineWithMarkers*` types had been emitting an out-of-order child all along.

Excel tolerated all three, which is why they went unnoticed.

Also fixed: `DetermineLineChartType` treated `<c:marker><c:symbol val="none"/></c:marker>` as "has markers", so a plain `Line` chart with markers switched off read back as `LineWithMarkers`.

### Deliberate limits, documented on the interface

- Chart types without a single value axis ignore `UseSecondaryAxis` — pie and doughnut have none, scatter and bubble have two, surface has a series axis.
- Setting `UseSecondaryAxis` on a chart **loaded from a file** throws `NotSupportedException`: honouring it means moving a `c:ser` into a newly created chart group, i.e. regenerating the structure the patch approach exists to avoid. The colour and marker properties have no such limit.
- Extended (ChartEx) types ignore series formatting.

## Related Issues

Implements PR 1 of `docs/specs/10-chart-formatting-depth.md`. Findings recorded in that spec's "Results (PR 1)" section.

## Testing

- [x] Added or updated unit tests — `ChartSeriesFormattingTests` (19) and `ChartRoundTripPreservationTests` (12)
- [x] All existing tests pass — 6366 on net8.0 and net10.0
- [ ] Tested manually

A second commit adds the patch-path coverage the first one was missing — adding a marker or a smoothing flag to a series that had neither, clearing every marker property so the element is removed again, inserting an `a:ln` into an `spPr` that only had a fill — which is what took SonarCloud's new-code coverage over its 80% gate.

Every new property is round-tripped, and every chart family is saved through `OpenXmlValidator`. `ChartRoundTripPreservationTests` reads a hand-written fixture shaped like Excel's own output — scheme colour, `c:strRef` name cache, `cap`/`a:round`/`a:effectLst`, marker `c:spPr`, a secondary axis pair, a trendline — then edits one series and asserts nothing else moved.

**Two acceptance criteria not fully met, both recorded in the spec:**

- *"Opens clean in Excel"* could not be executed — no Excel in this environment. The suite leaves `FormattedChartExamples.xlsx` in the test output directory for a manual pass.
- *"Test resources authored in Excel"* is approximated by the in-test Excel-shaped fixtures above; `XLibur.Tests/Resource/Charts/` is still empty.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
