### PR TITLE
feat: chart data labels (spec 10 PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 - **Secondary value axis per series**: `IXLChartSeries.UseSecondaryAxis` plots a series against a value axis on the right, so a percentage can share a chart with values in the thousands. It applies to series of the primary chart type as well as to a combo chart's `SecondarySeries`.
 
-- **Charts loaded from a file can be restyled**: setting the series formatting on a loaded chart now writes back on save. Only the properties actually assigned are patched into the existing chart part, so trendlines, error bars, gradient fills, per-point colours, data labels and the chart's style/colour parts are all preserved — and a chart nobody edited is left byte for byte as it was.
+- **Chart data labels**: `IXLDataLabels` on both `IXLChart.DataLabels` (chart-wide) and `IXLChartSeries.DataLabels` (per series, overriding the chart's), with `ShowValue`, `ShowCategoryName`, `ShowSeriesName`, `ShowPercentage`, `NumberFormat` and `Position`. `Position` is validated against the chart type — Excel refuses to open a file that uses a position it does not offer for that type, so the setter throws with the allowed values listed rather than producing a workbook Excel has to repair.
+
+- **Charts loaded from a file can be restyled**: setting the series formatting or data labels on a loaded chart now writes back on save. Only the properties actually assigned are patched into the existing chart part, so trendlines, error bars, gradient fills, per-point colours and label overrides, label fonts and the chart's style/colour parts are all preserved — and a chart nobody edited is left byte for byte as it was.
 
 ### Fixed
 

--- a/XLibur.Examples/Charts/FormattedChartExamples.cs
+++ b/XLibur.Examples/Charts/FormattedChartExamples.cs
@@ -16,6 +16,7 @@ public class FormattedChartExamples : IXLExample
         LineStyles(wb);
         TwoScales(wb);
         HighlightOneSeries(wb);
+        Labels(wb);
 
         wb.SaveAs(filePath);
     }
@@ -149,6 +150,45 @@ public class FormattedChartExamples : IXLExample
 
         chart.Position.SetColumn(6).SetRow(1);
         chart.SecondPosition.SetColumn(15).SetRow(19);
+    }
+
+    /// <summary>
+    /// Data labels: chart-wide defaults, a per-series override, and the percentage labels a pie chart
+    /// usually wants.
+    /// </summary>
+    private static void Labels(XLWorkbook wb)
+    {
+        var ws = wb.Worksheets.Add("Labels");
+        WriteQuarterlyData(ws);
+
+        var columns = ws.Charts.Add(XLChartType.ColumnClustered);
+        columns.SetTitle("Labelled columns");
+        columns.Series.Add("Revenue", "Labels!$B$2:$B$5", "Labels!$A$2:$A$5");
+        var cost = columns.Series.Add("Cost", "Labels!$C$2:$C$5", "Labels!$A$2:$A$5");
+
+        // Every series gets a value above its column...
+        columns.DataLabels.ShowValue = true;
+        columns.DataLabels.NumberFormat = "$ #,##0";
+        columns.DataLabels.Position = XLDataLabelPosition.OutsideEnd;
+
+        // ...except this one, which puts its label inside and names the series as well.
+        cost.DataLabels.ShowValue = true;
+        cost.DataLabels.ShowSeriesName = true;
+        cost.DataLabels.NumberFormat = "$ #,##0";
+        cost.DataLabels.Position = XLDataLabelPosition.InsideEnd;
+
+        columns.Position.SetColumn(6).SetRow(1);
+        columns.SecondPosition.SetColumn(15).SetRow(19);
+
+        var pie = ws.Charts.Add(XLChartType.Pie);
+        pie.SetTitle("Revenue share");
+        var share = pie.Series.Add("Revenue", "Labels!$B$2:$B$5", "Labels!$A$2:$A$5");
+        share.DataLabels.ShowCategoryName = true;
+        share.DataLabels.ShowPercentage = true;
+        share.DataLabels.Position = XLDataLabelPosition.BestFit;
+
+        pie.Position.SetColumn(6).SetRow(21);
+        pie.SecondPosition.SetColumn(15).SetRow(39);
     }
 
     private static void WriteQuarterlyData(IXLWorksheet ws)

--- a/XLibur.Tests/Excel/Charts/ChartDataLabelTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartDataLabelTests.cs
@@ -1,0 +1,348 @@
+using DocumentFormat.OpenXml.Packaging;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using XLibur.Excel;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// Data labels, per series and chart-wide.
+/// </summary>
+[TestFixture]
+public class ChartDataLabelTests
+{
+    private static IXLWorksheet AddDataSheet(XLWorkbook wb)
+    {
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = "Q1";
+        ws.Cell("A2").Value = "Q2";
+        ws.Cell("B1").Value = 100;
+        ws.Cell("B2").Value = 200;
+        ws.Cell("C1").Value = 5;
+        ws.Cell("C2").Value = 8;
+        return ws;
+    }
+
+    private static IXLChart AddChart(IXLWorksheet ws, XLChartType type)
+    {
+        var chart = ws.Charts.Add(type);
+        chart.Position.SetColumn(5).SetRow(1);
+        chart.SecondPosition.SetColumn(12).SetRow(15);
+        return chart;
+    }
+
+    private static MemoryStream SaveValidated(XLWorkbook wb)
+    {
+        var ms = new MemoryStream();
+        wb.SaveAs(ms, validate: true);
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static C.ChartSpace ChartSpaceOf(Stream stream)
+    {
+        stream.Position = 0;
+        using var doc = SpreadsheetDocument.Open(stream, false);
+        var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
+        return (C.ChartSpace)chartPart.ChartSpace!.CloneNode(true);
+    }
+
+    // ── Writing and reading back ────────────────────────────────────────
+
+    [Test]
+    public void SeriesDataLabelsRoundTrip()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            var series = chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            series.DataLabels.ShowValue = true;
+            series.DataLabels.ShowCategoryName = true;
+            series.DataLabels.NumberFormat = "#,##0";
+            series.DataLabels.Position = XLDataLabelPosition.OutsideEnd;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var labels = wb.Worksheet("Data").Charts.First().Series.First().DataLabels;
+            Assert.That(labels.ShowValue, Is.True);
+            Assert.That(labels.ShowCategoryName, Is.True);
+            Assert.That(labels.ShowSeriesName, Is.False);
+            Assert.That(labels.ShowPercentage, Is.False);
+            Assert.That(labels.NumberFormat, Is.EqualTo("#,##0"));
+            Assert.That(labels.Position, Is.EqualTo(XLDataLabelPosition.OutsideEnd));
+        }
+    }
+
+    [Test]
+    public void ChartWideDataLabelsRoundTrip()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Series.Add("Cost", "Data!$C$1:$C$2", "Data!$A$1:$A$2");
+            chart.DataLabels.ShowValue = true;
+            chart.DataLabels.Position = XLDataLabelPosition.InsideEnd;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.DataLabels.ShowValue, Is.True);
+            Assert.That(chart.DataLabels.Position, Is.EqualTo(XLDataLabelPosition.InsideEnd));
+
+            // Nothing was set per series, so the series labels stay at their defaults.
+            Assert.That(chart.Series.First().DataLabels.ShowValue, Is.False);
+        }
+    }
+
+    [Test]
+    public void ChartWideLabelsAreWrittenOnTheChartGroupAndSeriesLabelsOnTheSeries()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+        chart.Series.Add("Cost", "Data!$C$1:$C$2", "Data!$A$1:$A$2").DataLabels.ShowSeriesName = true;
+        chart.DataLabels.ShowValue = true;
+
+        using var ms = SaveValidated(wb);
+        var chartSpace = ChartSpaceOf(ms);
+        var barChart = chartSpace.Descendants<C.BarChart>().Single();
+
+        var groupLabels = barChart.Elements<C.DataLabels>().Single();
+        Assert.That(groupLabels.Elements<C.ShowValue>().Single().Val!.Value, Is.True);
+
+        var seriesElements = barChart.Elements<C.BarChartSeries>().ToList();
+        Assert.That(seriesElements[0].Elements<C.DataLabels>(), Is.Empty);
+        Assert.That(seriesElements[1].Elements<C.DataLabels>().Single()
+            .Elements<C.ShowSeriesName>().Single().Val!.Value, Is.True);
+
+        // c:dLbls sits after the last c:ser and before the axis ids.
+        var children = barChart.ChildElements.Select(e => e.LocalName).ToList();
+        Assert.That(children.LastIndexOf("ser"), Is.LessThan(children.IndexOf("dLbls")));
+        Assert.That(children.IndexOf("dLbls"), Is.LessThan(children.IndexOf("axId")));
+    }
+
+    [Test]
+    public void NoDataLabelsAreWrittenWhenNothingIsAsked()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+
+        using var ms = SaveValidated(wb);
+        Assert.That(ChartSpaceOf(ms).Descendants<C.DataLabels>(), Is.Empty);
+    }
+
+    [Test]
+    public void EveryShowFlagIsWrittenSoTheResultDoesNotDependOnTheChartStyle()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2").DataLabels.ShowValue = true;
+
+        using var ms = SaveValidated(wb);
+        var labels = ChartSpaceOf(ms).Descendants<C.DataLabels>().Single();
+
+        Assert.That(labels.Elements<C.ShowLegendKey>().Single().Val!.Value, Is.False);
+        Assert.That(labels.Elements<C.ShowValue>().Single().Val!.Value, Is.True);
+        Assert.That(labels.Elements<C.ShowCategoryName>().Single().Val!.Value, Is.False);
+        Assert.That(labels.Elements<C.ShowSeriesName>().Single().Val!.Value, Is.False);
+        Assert.That(labels.Elements<C.ShowPercent>().Single().Val!.Value, Is.False);
+        Assert.That(labels.Elements<C.ShowBubbleSize>().Single().Val!.Value, Is.False);
+    }
+
+    [Test]
+    public void PercentageLabelsOnAPieChartRoundTrip()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.Pie);
+            var series = chart.Series.Add("Share", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            series.DataLabels.ShowPercentage = true;
+            series.DataLabels.Position = XLDataLabelPosition.BestFit;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var labels = wb.Worksheet("Data").Charts.First().Series.First().DataLabels;
+            Assert.That(labels.ShowPercentage, Is.True);
+            Assert.That(labels.Position, Is.EqualTo(XLDataLabelPosition.BestFit));
+        }
+    }
+
+    [Test]
+    public void LabelsSurviveEveryChartFamilyThatSupportsThem()
+    {
+        XLChartType[] types =
+        [
+            XLChartType.ColumnClustered, XLChartType.BarStacked, XLChartType.ColumnClustered3D,
+            XLChartType.Line, XLChartType.LineWithMarkers, XLChartType.Area, XLChartType.Radar,
+            XLChartType.Pie, XLChartType.Doughnut, XLChartType.XYScatterMarkers, XLChartType.Bubble,
+            XLChartType.StockHighLowClose, XLChartType.Surface, XLChartType.ConeClustered
+        ];
+
+        foreach (var type in types)
+        {
+            using var wb = new XLWorkbook();
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, type);
+
+            var seriesCount = type == XLChartType.StockHighLowClose ? 3 : 1;
+            for (var i = 0; i < seriesCount; i++)
+            {
+                var series = chart.Series.Add($"S{i}", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+                series.DataLabels.ShowValue = true;
+                series.DataLabels.NumberFormat = "0.00";
+            }
+
+            chart.DataLabels.ShowCategoryName = true;
+
+            Assert.DoesNotThrow(() =>
+            {
+                using var ms = SaveValidated(wb);
+            }, $"{type} produced invalid chart XML.");
+        }
+    }
+
+    [Test]
+    public void SurfaceChartsDoNotGetDataLabels()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.Surface);
+        chart.Series.Add("S1", "Data!$B$1:$B$2", "Data!$A$1:$A$2").DataLabels.ShowValue = true;
+        chart.DataLabels.ShowValue = true;
+
+        using var ms = SaveValidated(wb);
+        Assert.That(ChartSpaceOf(ms).Descendants<C.DataLabels>(), Is.Empty,
+            "Neither CT_SurfaceChart nor CT_SurfaceSer has a dLbls child.");
+    }
+
+    // ── Position validation ─────────────────────────────────────────────
+
+    [Test]
+    public void OutsideEndIsRejectedOnAStackedColumnChart()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnStacked);
+        var labels = chart.Series.Add("S", "Data!$B$1:$B$2").DataLabels;
+
+        var ex = Assert.Throws<ArgumentException>(() => labels.Position = XLDataLabelPosition.OutsideEnd);
+        Assert.That(ex!.Message, Does.Contain("ColumnStacked"));
+        Assert.That(ex.Message, Does.Contain("InsideBase"), "The message lists what Excel does offer.");
+
+        Assert.DoesNotThrow(() => labels.Position = XLDataLabelPosition.InsideEnd);
+    }
+
+    [Test]
+    public void MarkerPositionsAreRejectedOnAColumnChart()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var labels = AddChart(ws, XLChartType.ColumnClustered)
+            .Series.Add("S", "Data!$B$1:$B$2").DataLabels;
+
+        Assert.Throws<ArgumentException>(() => labels.Position = XLDataLabelPosition.Above);
+        Assert.Throws<ArgumentException>(() => labels.Position = XLDataLabelPosition.BestFit);
+    }
+
+    [Test]
+    public void BarPositionsAreRejectedOnALineChart()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var labels = AddChart(ws, XLChartType.Line).Series.Add("S", "Data!$B$1:$B$2").DataLabels;
+
+        Assert.Throws<ArgumentException>(() => labels.Position = XLDataLabelPosition.OutsideEnd);
+        Assert.DoesNotThrow(() => labels.Position = XLDataLabelPosition.Above);
+    }
+
+    [Test]
+    public void ChartTypesWithoutPositionsAcceptOnlyAuto()
+    {
+        XLChartType[] types =
+        [
+            XLChartType.Area, XLChartType.Doughnut, XLChartType.Bubble,
+            XLChartType.StockHighLowClose, XLChartType.ColumnClustered3D, XLChartType.Surface
+        ];
+
+        foreach (var type in types)
+        {
+            using var wb = new XLWorkbook();
+            var ws = AddDataSheet(wb);
+            var labels = AddChart(ws, type).Series.Add("S", "Data!$B$1:$B$2").DataLabels;
+
+            var ex = Assert.Throws<ArgumentException>(
+                () => labels.Position = XLDataLabelPosition.Center, $"{type} should refuse a position.");
+            Assert.That(ex!.Message, Does.Contain("only Auto"));
+        }
+    }
+
+    [Test]
+    public void AComboChartsSecondarySeriesIsValidatedAgainstTheSecondaryChartType()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Units", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+        chart.SecondaryChartType = XLChartType.LineWithMarkers;
+        var line = chart.SecondarySeries.Add("Price", "Data!$C$1:$C$2", "Data!$A$1:$A$2");
+
+        // Above is a line position, which the primary column type would refuse.
+        Assert.DoesNotThrow(() => line.DataLabels.Position = XLDataLabelPosition.Above);
+        Assert.Throws<ArgumentException>(() => line.DataLabels.Position = XLDataLabelPosition.OutsideEnd);
+
+        line.DataLabels.ShowValue = true;
+        Assert.DoesNotThrow(() =>
+        {
+            using var ms = SaveValidated(wb);
+        });
+    }
+
+    [Test]
+    public void APositionThatBecomesInvalidWhenTheChartTypeChangesIsDropped()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        var series = chart.Series.Add("S", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+        series.DataLabels.ShowValue = true;
+        series.DataLabels.Position = XLDataLabelPosition.OutsideEnd;
+
+        // Area charts offer no explicit position. Writing the one set earlier would make Excel
+        // refuse the file, so it is left out.
+        chart.ChartType = XLChartType.Area;
+
+        using var ms = SaveValidated(wb);
+        var labels = ChartSpaceOf(ms).Descendants<C.DataLabels>().Single();
+        Assert.That(labels.Elements<C.DataLabelPosition>(), Is.Empty);
+        Assert.That(labels.Elements<C.ShowValue>().Single().Val!.Value, Is.True);
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
@@ -43,6 +43,19 @@ public class ChartRoundTripPreservationTests
                     <a:effectLst/>
                   </c:spPr>
                   <c:invertIfNegative val="0"/>
+                  <c:dLbls>
+                    <c:dLbl><c:idx val="0"/><c:delete val="1"/></c:dLbl>
+                    <c:numFmt formatCode="#,##0" sourceLinked="0"/>
+                    <c:spPr><a:noFill/><a:ln><a:noFill/></a:ln></c:spPr>
+                    <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="900"/></a:pPr><a:endParaRPr lang="en-US"/></a:p></c:txPr>
+                    <c:dLblPos val="outEnd"/>
+                    <c:showLegendKey val="0"/>
+                    <c:showVal val="1"/>
+                    <c:showCatName val="0"/>
+                    <c:showSerName val="0"/>
+                    <c:showPercent val="0"/>
+                    <c:showBubbleSize val="0"/>
+                  </c:dLbls>
                   <c:trendline><c:trendlineType val="linear"/></c:trendline>
                   <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
                   <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
@@ -156,6 +169,11 @@ public class ChartRoundTripPreservationTests
         Assert.That(bar.LineColor, Is.EqualTo(XLColor.FromHtml("#203864")));
         Assert.That(bar.LineWidthPt, Is.EqualTo(1.5));
         Assert.That(bar.UseSecondaryAxis, Is.False);
+
+        Assert.That(bar.DataLabels.ShowValue, Is.True);
+        Assert.That(bar.DataLabels.ShowCategoryName, Is.False);
+        Assert.That(bar.DataLabels.NumberFormat, Is.EqualTo("#,##0"));
+        Assert.That(bar.DataLabels.Position, Is.EqualTo(XLDataLabelPosition.OutsideEnd));
 
         var line = chart.SecondarySeries.Single();
         Assert.That(line.Name, Is.EqualTo("Price"), "The name is a literal c:v.");
@@ -277,6 +295,85 @@ public class ChartRoundTripPreservationTests
         {
             Assert.That(wb.Worksheet("Data").Charts.First().Series.Single().FillColor, Is.Null);
         }
+    }
+
+    [Test]
+    public void EditingDataLabelsKeepsTheirTextAndPerPointOverrides()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            var labels = wb.Worksheet("Data").Charts.First().Series.Single().DataLabels;
+            labels.ShowCategoryName = true;
+            labels.Position = XLDataLabelPosition.InsideEnd;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        var xml = ReadChartXml(saved);
+
+        Assert.That(xml, Does.Contain("val=\"inEnd\""));
+        Assert.That(xml, Does.Not.Contain("val=\"outEnd\""));
+        Assert.That(xml, Does.Contain("<c:showCatName val=\"1\""));
+        Assert.That(xml, Does.Contain("<c:showVal val=\"1\""), "A flag nobody touched keeps its value.");
+
+        // Label formatting XLibur does not model, and the hidden first point, are still there.
+        Assert.That(xml, Does.Contain("<c:txPr>"));
+        Assert.That(xml, Does.Contain("sz=\"900\""));
+        Assert.That(xml, Does.Contain("<c:dLbl>"));
+        Assert.That(xml, Does.Contain("formatCode=\"#,##0\""), "The number format was not touched either.");
+    }
+
+    [Test]
+    public void DataLabelsCanBeAddedToASeriesThatHadNone()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            // The line series in the fixture carries no c:dLbls at all.
+            var labels = wb.Worksheet("Data").Charts.First().SecondarySeries.Single().DataLabels;
+            labels.ShowValue = true;
+            labels.Position = XLDataLabelPosition.Above;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        saved.Position = 0;
+        using (var wb = new XLWorkbook(saved))
+        {
+            var labels = wb.Worksheet("Data").Charts.First().SecondarySeries.Single().DataLabels;
+            Assert.That(labels.ShowValue, Is.True);
+            Assert.That(labels.Position, Is.EqualTo(XLDataLabelPosition.Above));
+        }
+    }
+
+    [Test]
+    public void TurningLabelsOnClearsAnExistingDeleteFlag()
+    {
+        // Excel writes <c:dLbls><c:delete val="1"/></c:dLbls> for a series whose labels are switched
+        // off. A c:delete left in place overrides every show flag next to it.
+        var start = ExcelShapedChartXml.IndexOf("<c:dLbls>", StringComparison.Ordinal);
+        var end = ExcelShapedChartXml.IndexOf("</c:dLbls>", StringComparison.Ordinal) + "</c:dLbls>".Length;
+        var chartXml = ExcelShapedChartXml[..start]
+                       + "<c:dLbls><c:delete val=\"1\"/></c:dLbls>"
+                       + ExcelShapedChartXml[end..];
+
+        using var original = CreateWorkbookWithExcelShapedChart(chartXml);
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            wb.Worksheet("Data").Charts.First().Series.Single().DataLabels.ShowValue = true;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        var xml = ReadChartXml(saved);
+        var labels = xml[xml.IndexOf("<c:dLbls>", StringComparison.Ordinal)..
+                         xml.IndexOf("</c:dLbls>", StringComparison.Ordinal)];
+        Assert.That(labels, Does.Contain("<c:showVal val=\"1\""));
+        Assert.That(labels, Does.Not.Contain("<c:delete"));
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
@@ -465,7 +465,7 @@ public class ChartSeriesFormattingTests
         // back and that what it wrote is schema-valid.
         using var wb = new XLWorkbook(path);
         using var ms = SaveValidated(wb);
-        Assert.That(wb.Worksheets.Count, Is.EqualTo(4));
+        Assert.That(wb.Worksheets.Count, Is.EqualTo(5));
     }
 
     [Test]

--- a/XLibur/Excel/Charts/IXLChart.cs
+++ b/XLibur/Excel/Charts/IXLChart.cs
@@ -158,4 +158,10 @@ public interface IXLChart : IXLDrawing<IXLChart>
     /// Only used when <see cref="SecondaryChartType"/> is set.
     /// </summary>
     IXLChartSeriesCollection SecondarySeries { get; }
+
+    /// <summary>
+    /// Gets the data labels that apply to every series of the chart. A series can override them
+    /// through <see cref="IXLChartSeries.DataLabels"/>.
+    /// </summary>
+    IXLDataLabels DataLabels { get; }
 }

--- a/XLibur/Excel/Charts/IXLChartSeries.cs
+++ b/XLibur/Excel/Charts/IXLChartSeries.cs
@@ -110,4 +110,10 @@ public interface IXLChartSeries
     /// <see cref="IXLCharts.Add(XLChartType)"/> instead.
     /// </exception>
     bool UseSecondaryAxis { get; set; }
+
+    /// <summary>
+    /// Gets the data labels of this series. Anything left untouched here falls back to the
+    /// chart-wide <see cref="IXLChart.DataLabels"/>.
+    /// </summary>
+    IXLDataLabels DataLabels { get; }
 }

--- a/XLibur/Excel/Charts/IXLDataLabels.cs
+++ b/XLibur/Excel/Charts/IXLDataLabels.cs
@@ -1,0 +1,109 @@
+namespace XLibur.Excel;
+
+/// <summary>
+/// Where a data label sits relative to its data point.
+/// </summary>
+/// <remarks>
+/// Excel only offers a subset of these for any given chart type, and rejects a file that uses one it
+/// does not offer. <see cref="IXLDataLabels.Position"/> validates the combination when it is set.
+/// </remarks>
+public enum XLDataLabelPosition
+{
+    /// <summary>
+    /// No explicit position: the label element is omitted and Excel places the label itself.
+    /// This is the default, and the only value the chart types that do not offer a position accept.
+    /// </summary>
+    Auto,
+
+    /// <summary>Centred on the data point.</summary>
+    Center,
+
+    /// <summary>Inside the end of the bar, column or slice.</summary>
+    InsideEnd,
+
+    /// <summary>Inside the base of the bar or column.</summary>
+    InsideBase,
+
+    /// <summary>Outside the end of the bar, column or slice.</summary>
+    OutsideEnd,
+
+    /// <summary>Wherever it fits best — pie charts only.</summary>
+    BestFit,
+
+    /// <summary>To the left of the marker.</summary>
+    Left,
+
+    /// <summary>To the right of the marker.</summary>
+    Right,
+
+    /// <summary>Above the marker.</summary>
+    Above,
+
+    /// <summary>Below the marker.</summary>
+    Below
+}
+
+/// <summary>
+/// The labels drawn next to the data points of a chart or one of its series.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every property is off or automatic by default, and nothing is written to the file until one of
+/// them is set — so an untouched chart keeps whatever Excel's own defaults are.
+/// </para>
+/// <para>
+/// Series labels win over the chart-level <see cref="IXLChart.DataLabels"/>: set the chart's to give
+/// every series the same labels, then override the odd series that needs something different.
+/// </para>
+/// <para>
+/// Surface charts and the extended (Office 2016+) types — Sunburst, Treemap, Waterfall, Funnel and
+/// Box &amp; Whisker — have no data label support and ignore these properties.
+/// </para>
+/// </remarks>
+public interface IXLDataLabels
+{
+    /// <summary>
+    /// Gets or sets whether the point's value is shown. Defaults to <c>false</c>.
+    /// </summary>
+    bool ShowValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the point's category name is shown. Defaults to <c>false</c>.
+    /// </summary>
+    bool ShowCategoryName { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the series name is shown. Defaults to <c>false</c>.
+    /// </summary>
+    bool ShowSeriesName { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the point's share of the total is shown as a percentage.
+    /// Pie and doughnut charts only. Defaults to <c>false</c>.
+    /// </summary>
+    bool ShowPercentage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number format the labels are drawn with, e.g. <c>"#,##0"</c> or <c>"0.0%"</c>.
+    /// <c>null</c> — the default — takes the format from the source cells.
+    /// </summary>
+    string? NumberFormat { get; set; }
+
+    /// <summary>
+    /// Gets or sets where the labels sit. Defaults to <see cref="XLDataLabelPosition.Auto"/>.
+    /// </summary>
+    /// <remarks>
+    /// What Excel accepts depends on the chart type:
+    /// <list type="bullet">
+    /// <item>clustered bar and column: <c>Center</c>, <c>InsideEnd</c>, <c>InsideBase</c>, <c>OutsideEnd</c></item>
+    /// <item>stacked bar and column: <c>Center</c>, <c>InsideEnd</c>, <c>InsideBase</c></item>
+    /// <item>line, scatter and radar: <c>Center</c>, <c>Left</c>, <c>Right</c>, <c>Above</c>, <c>Below</c></item>
+    /// <item>pie: <c>BestFit</c>, <c>Center</c>, <c>InsideEnd</c>, <c>OutsideEnd</c></item>
+    /// <item>everything else — area, doughnut, bubble, stock and every 3D type — <c>Auto</c> only</item>
+    /// </list>
+    /// </remarks>
+    /// <exception cref="System.ArgumentException">
+    /// The position is one the chart's current <see cref="IXLChart.ChartType"/> does not offer.
+    /// </exception>
+    XLDataLabelPosition Position { get; set; }
+}

--- a/XLibur/Excel/Charts/XLChart.cs
+++ b/XLibur/Excel/Charts/XLChart.cs
@@ -40,8 +40,9 @@ internal sealed class XLChart : XLDrawing<IXLChart>, IXLChart
         ShapeId = worksheet.Workbook.ShapeIdManager.GetNext();
         RightAngleAxes = true;
         Series = new XLChartSeriesCollection(this);
-        SecondarySeries = new XLChartSeriesCollection(this);
+        SecondarySeries = new XLChartSeriesCollection(this, secondary: true);
         SecondPosition = new XLDrawingPosition();
+        DataLabelsInternal = new XLChartDataLabels(this);
     }
 
     public string? Title { get; set; }
@@ -61,6 +62,13 @@ internal sealed class XLChart : XLDrawing<IXLChart>, IXLChart
     public XLChartType? SecondaryChartType { get; set; }
 
     public IXLChartSeriesCollection SecondarySeries { get; }
+
+    public IXLDataLabels DataLabels => DataLabelsInternal;
+
+    /// <summary>
+    /// The chart-wide data labels, typed for internal use.
+    /// </summary>
+    internal XLChartDataLabels DataLabelsInternal { get; }
 
     /// <summary>
     /// The relationship ID linking this chart to its ChartPart within the DrawingsPart.

--- a/XLibur/Excel/Charts/XLChartDataLabels.cs
+++ b/XLibur/Excel/Charts/XLChartDataLabels.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// Identifies the data label properties a caller has explicitly assigned, so that the patcher which
+/// updates charts loaded from a file can rewrite those and only those.
+/// </summary>
+[Flags]
+internal enum XLDataLabelsFormat
+{
+    None = 0,
+    ShowValue = 1 << 0,
+    ShowCategoryName = 1 << 1,
+    ShowSeriesName = 1 << 2,
+    ShowPercentage = 1 << 3,
+    NumberFormat = 1 << 4,
+    Position = 1 << 5
+}
+
+internal sealed class XLChartDataLabels : IXLDataLabels
+{
+    private static readonly XLDataLabelPosition[] NoPosition = [];
+
+    private static readonly XLDataLabelPosition[] ClusteredBarPositions =
+    [
+        XLDataLabelPosition.Center, XLDataLabelPosition.InsideEnd,
+        XLDataLabelPosition.InsideBase, XLDataLabelPosition.OutsideEnd
+    ];
+
+    private static readonly XLDataLabelPosition[] StackedBarPositions =
+    [
+        XLDataLabelPosition.Center, XLDataLabelPosition.InsideEnd, XLDataLabelPosition.InsideBase
+    ];
+
+    private static readonly XLDataLabelPosition[] MarkerPositions =
+    [
+        XLDataLabelPosition.Center, XLDataLabelPosition.Left,
+        XLDataLabelPosition.Right, XLDataLabelPosition.Above, XLDataLabelPosition.Below
+    ];
+
+    private static readonly XLDataLabelPosition[] PiePositions =
+    [
+        XLDataLabelPosition.BestFit, XLDataLabelPosition.Center,
+        XLDataLabelPosition.InsideEnd, XLDataLabelPosition.OutsideEnd
+    ];
+
+    private readonly XLChart _chart;
+
+    /// <summary>
+    /// Whether these labels belong to a series of the combo chart's secondary type, whose label
+    /// positions are governed by <see cref="IXLChart.SecondaryChartType"/> rather than
+    /// <see cref="IXLChart.ChartType"/>.
+    /// </summary>
+    private readonly bool _secondary;
+
+    private bool _showValue;
+    private bool _showCategoryName;
+    private bool _showSeriesName;
+    private bool _showPercentage;
+    private string? _numberFormat;
+    private XLDataLabelPosition _position;
+
+    internal XLChartDataLabels(XLChart chart, bool secondary = false)
+    {
+        _chart = chart;
+        _secondary = secondary;
+    }
+
+    /// <summary>The chart type whose rules apply to these labels.</summary>
+    private XLChartType OwningChartType => _secondary
+        ? _chart.SecondaryChartType ?? _chart.ChartType
+        : _chart.ChartType;
+
+    public bool ShowValue
+    {
+        get => _showValue;
+        set => Assign(ref _showValue, value, XLDataLabelsFormat.ShowValue);
+    }
+
+    public bool ShowCategoryName
+    {
+        get => _showCategoryName;
+        set => Assign(ref _showCategoryName, value, XLDataLabelsFormat.ShowCategoryName);
+    }
+
+    public bool ShowSeriesName
+    {
+        get => _showSeriesName;
+        set => Assign(ref _showSeriesName, value, XLDataLabelsFormat.ShowSeriesName);
+    }
+
+    public bool ShowPercentage
+    {
+        get => _showPercentage;
+        set => Assign(ref _showPercentage, value, XLDataLabelsFormat.ShowPercentage);
+    }
+
+    public string? NumberFormat
+    {
+        get => _numberFormat;
+        set => Assign(ref _numberFormat, value, XLDataLabelsFormat.NumberFormat);
+    }
+
+    public XLDataLabelPosition Position
+    {
+        get => _position;
+        set
+        {
+            var chartType = OwningChartType;
+            if (value != XLDataLabelPosition.Auto && !IsPositionAllowed(chartType, value))
+            {
+                var allowed = AllowedPositions(chartType);
+                var offered = allowed.Count == 0
+                    ? "only Auto"
+                    : "Auto, " + string.Join(", ", allowed);
+                throw new ArgumentException(
+                    $"A {chartType} chart does not offer the {value} data label position; " +
+                    $"Excel accepts {offered}.",
+                    nameof(Position));
+            }
+
+            Assign(ref _position, value, XLDataLabelsFormat.Position);
+        }
+    }
+
+    /// <summary>
+    /// The properties that have been explicitly assigned through the public API. Nothing is written
+    /// to the file while this is <see cref="XLDataLabelsFormat.None"/>.
+    /// </summary>
+    internal XLDataLabelsFormat AssignedFormat { get; private set; }
+
+    /// <summary>
+    /// Seeds the properties from an existing chart part without marking them as assigned, so that
+    /// labels nobody edited are never written back.
+    /// </summary>
+    internal void SeedLoaded(
+        bool showValue,
+        bool showCategoryName,
+        bool showSeriesName,
+        bool showPercentage,
+        string? numberFormat,
+        XLDataLabelPosition position)
+    {
+        _showValue = showValue;
+        _showCategoryName = showCategoryName;
+        _showSeriesName = showSeriesName;
+        _showPercentage = showPercentage;
+        _numberFormat = numberFormat;
+        _position = position;
+    }
+
+    /// <summary>
+    /// The position to write for a chart of the given type. A position the type does not offer is
+    /// dropped rather than written, because Excel refuses to open a file that uses one — the setter
+    /// rejects those, but the chart type can be changed after the position was set.
+    /// </summary>
+    internal XLDataLabelPosition EffectivePosition(XLChartType chartType) =>
+        IsPositionAllowed(chartType, _position) ? _position : XLDataLabelPosition.Auto;
+
+    private static bool IsPositionAllowed(XLChartType chartType, XLDataLabelPosition position) =>
+        position == XLDataLabelPosition.Auto || AllowedPositions(chartType).Contains(position);
+
+    /// <summary>
+    /// The explicit label positions Excel offers for a chart type, excluding
+    /// <see cref="XLDataLabelPosition.Auto"/>, which is always allowed. Area, doughnut, bubble, stock,
+    /// surface and every 3D type offer none: Excel places their labels itself and rejects a file that
+    /// says otherwise.
+    /// </summary>
+    private static IReadOnlyList<XLDataLabelPosition> AllowedPositions(XLChartType chartType) => chartType switch
+    {
+        XLChartType.BarClustered or XLChartType.ColumnClustered => ClusteredBarPositions,
+
+        XLChartType.BarStacked or XLChartType.BarStacked100Percent
+            or XLChartType.ColumnStacked or XLChartType.ColumnStacked100Percent => StackedBarPositions,
+
+        XLChartType.Line or XLChartType.LineStacked or XLChartType.LineStacked100Percent
+            or XLChartType.LineWithMarkers or XLChartType.LineWithMarkersStacked
+            or XLChartType.LineWithMarkersStacked100Percent
+            or XLChartType.Radar or XLChartType.RadarWithMarkers or XLChartType.RadarFilled
+            or XLChartType.XYScatterMarkers
+            or XLChartType.XYScatterSmoothLinesNoMarkers or XLChartType.XYScatterSmoothLinesWithMarkers
+            or XLChartType.XYScatterStraightLinesNoMarkers
+            or XLChartType.XYScatterStraightLinesWithMarkers => MarkerPositions,
+
+        XLChartType.Pie or XLChartType.PieExploded
+            or XLChartType.PieToPie or XLChartType.PieToBar => PiePositions,
+
+        _ => NoPosition
+    };
+
+    private void Assign<T>(ref T field, T value, XLDataLabelsFormat flag)
+    {
+        field = value;
+        AssignedFormat |= flag;
+    }
+}

--- a/XLibur/Excel/Charts/XLChartSeries.cs
+++ b/XLibur/Excel/Charts/XLChartSeries.cs
@@ -40,9 +40,15 @@ internal sealed class XLChartSeries : IXLChartSeries
     private bool _smooth;
     private bool _useSecondaryAxis;
 
-    internal XLChartSeries(XLChart chart)
+    /// <param name="chart">The chart this series belongs to.</param>
+    /// <param name="secondary">
+    /// <c>true</c> when the series sits in the combo chart's secondary collection, which decides
+    /// which chart type's rules its data labels follow.
+    /// </param>
+    internal XLChartSeries(XLChart chart, bool secondary)
     {
         _chart = chart;
+        DataLabelsInternal = new XLChartDataLabels(chart, secondary);
     }
 
     public string Name { get; set; } = string.Empty;
@@ -121,6 +127,13 @@ internal sealed class XLChartSeries : IXLChartSeries
             _useSecondaryAxis = value;
         }
     }
+
+    public IXLDataLabels DataLabels => DataLabelsInternal;
+
+    /// <summary>
+    /// The data labels of this series, typed for internal use.
+    /// </summary>
+    internal XLChartDataLabels DataLabelsInternal { get; }
 
     /// <summary>
     /// The formatting properties that have been explicitly assigned through the public API.

--- a/XLibur/Excel/Charts/XLChartSeriesCollection.cs
+++ b/XLibur/Excel/Charts/XLChartSeriesCollection.cs
@@ -7,10 +7,17 @@ internal sealed class XLChartSeriesCollection : IXLChartSeriesCollection
 {
     private readonly List<XLChartSeries> _series = [];
     private readonly XLChart _chart;
+    private readonly bool _secondary;
 
-    internal XLChartSeriesCollection(XLChart chart)
+    /// <param name="chart">The chart the series belong to.</param>
+    /// <param name="secondary">
+    /// <c>true</c> for the combo chart's secondary collection, whose series follow
+    /// <see cref="IXLChart.SecondaryChartType"/>.
+    /// </param>
+    internal XLChartSeriesCollection(XLChart chart, bool secondary = false)
     {
         _chart = chart;
+        _secondary = secondary;
     }
 
     public int Count => _series.Count;
@@ -22,7 +29,7 @@ internal sealed class XLChartSeriesCollection : IXLChartSeriesCollection
 
     public IXLChartSeries Add(string name, string valueReferences, string? categoryReferences = null)
     {
-        var series = new XLChartSeries(_chart)
+        var series = new XLChartSeries(_chart, _secondary)
         {
             Name = name,
             ValueReferences = valueReferences,

--- a/XLibur/Excel/IO/ChartFormatting.cs
+++ b/XLibur/Excel/IO/ChartFormatting.cs
@@ -89,6 +89,84 @@ internal static class ChartFormatting
         return smoothByChartType ? new C.Smooth { Val = true } : null;
     }
 
+    /// <summary>
+    /// Builds the <c>c:dLbls</c> element, or returns <c>null</c> when nothing has been asked for.
+    /// </summary>
+    /// <param name="labels">The labels to write.</param>
+    /// <param name="chartType">
+    /// The chart type the labels belong to, which decides whether an explicit position can be
+    /// written at all.
+    /// </param>
+    internal static C.DataLabels? BuildDataLabels(XLChartDataLabels labels, XLChartType chartType)
+    {
+        if (labels.AssignedFormat == XLDataLabelsFormat.None)
+            return null;
+
+        var dataLabels = new C.DataLabels();
+
+        if (labels.NumberFormat != null)
+        {
+            dataLabels.Append(new C.NumberingFormat
+            {
+                FormatCode = labels.NumberFormat,
+                SourceLinked = false
+            });
+        }
+
+        var position = MapLabelPosition(labels.EffectivePosition(chartType));
+        if (position != null)
+            dataLabels.Append(new C.DataLabelPosition { Val = position });
+
+        // Excel writes all of the show flags whenever it writes c:dLbls at all, and reads a missing
+        // one as "inherit", which makes the result depend on the chart style. Writing them out keeps
+        // what the caller asked for unambiguous.
+        dataLabels.Append(new C.ShowLegendKey { Val = false });
+        dataLabels.Append(new C.ShowValue { Val = labels.ShowValue });
+        dataLabels.Append(new C.ShowCategoryName { Val = labels.ShowCategoryName });
+        dataLabels.Append(new C.ShowSeriesName { Val = labels.ShowSeriesName });
+        dataLabels.Append(new C.ShowPercent { Val = labels.ShowPercentage });
+        dataLabels.Append(new C.ShowBubbleSize { Val = false });
+
+        return dataLabels;
+    }
+
+    /// <summary>
+    /// Reads a <c>c:dLbls</c> element into the model, seeding the values without marking them as
+    /// assigned by the caller.
+    /// </summary>
+    internal static void ReadDataLabels(C.DataLabels? dataLabels, XLChartDataLabels labels)
+    {
+        if (dataLabels == null)
+            return;
+
+        labels.SeedLoaded(
+            showValue: dataLabels.Elements<C.ShowValue>().FirstOrDefault()?.Val?.Value ?? false,
+            showCategoryName: dataLabels.Elements<C.ShowCategoryName>().FirstOrDefault()?.Val?.Value ?? false,
+            showSeriesName: dataLabels.Elements<C.ShowSeriesName>().FirstOrDefault()?.Val?.Value ?? false,
+            showPercentage: dataLabels.Elements<C.ShowPercent>().FirstOrDefault()?.Val?.Value ?? false,
+            numberFormat: dataLabels.Elements<C.NumberingFormat>().FirstOrDefault()?.FormatCode?.Value,
+            position: ReadLabelPosition(dataLabels));
+    }
+
+    private static XLDataLabelPosition ReadLabelPosition(C.DataLabels dataLabels)
+    {
+        var position = dataLabels.Elements<C.DataLabelPosition>().FirstOrDefault()?.Val;
+        if (position == null)
+            return XLDataLabelPosition.Auto;
+
+        var value = position.Value;
+        if (value == C.DataLabelPositionValues.Center) return XLDataLabelPosition.Center;
+        if (value == C.DataLabelPositionValues.InsideEnd) return XLDataLabelPosition.InsideEnd;
+        if (value == C.DataLabelPositionValues.InsideBase) return XLDataLabelPosition.InsideBase;
+        if (value == C.DataLabelPositionValues.OutsideEnd) return XLDataLabelPosition.OutsideEnd;
+        if (value == C.DataLabelPositionValues.BestFit) return XLDataLabelPosition.BestFit;
+        if (value == C.DataLabelPositionValues.Left) return XLDataLabelPosition.Left;
+        if (value == C.DataLabelPositionValues.Right) return XLDataLabelPosition.Right;
+        if (value == C.DataLabelPositionValues.Top) return XLDataLabelPosition.Above;
+        if (value == C.DataLabelPositionValues.Bottom) return XLDataLabelPosition.Below;
+        return XLDataLabelPosition.Auto;
+    }
+
     private static A.SolidFill? BuildSolidFill(XLColor? color) =>
         color == null || !color.HasValue ? null : new A.SolidFill(BuildColor(color));
 
@@ -209,12 +287,12 @@ internal static class ChartFormatting
     /// The kind of chart group the series belongs to. Only some series types accept a marker or a
     /// smoothing flag, so the kind decides which properties can be written at all.
     /// </param>
+    /// <param name="chartType">The chart type of the group, which constrains the data label position.</param>
     internal static void PatchSeriesFormat(
-        OpenXmlCompositeElement seriesElement, XLChartSeries series, XLChartGroupKind kind)
+        OpenXmlCompositeElement seriesElement, XLChartSeries series, XLChartGroupKind kind,
+        XLChartType chartType)
     {
         var assigned = series.AssignedFormat;
-        if (assigned == XLChartSeriesFormat.None)
-            return;
 
         if ((assigned & (XLChartSeriesFormat.Fill | XLChartSeriesFormat.Line | XLChartSeriesFormat.LineWidth)) != 0)
             PatchShapeProperties(seriesElement, series, assigned);
@@ -226,6 +304,10 @@ internal static class ChartFormatting
 
         if ((assigned & XLChartSeriesFormat.Smooth) != 0 && SupportsSmooth(kind))
             PatchSmooth(seriesElement, series);
+
+        // Not gated on `assigned`: the labels track their own assignments.
+        if (SupportsDataLabels(kind))
+            PatchSeriesDataLabels(seriesElement, series.DataLabelsInternal, chartType);
     }
 
     /// <summary>Whether the series type of a chart group accepts a <c>c:marker</c> child.</summary>
@@ -235,6 +317,159 @@ internal static class ChartFormatting
     /// <summary>Whether the series type of a chart group accepts a <c>c:smooth</c> child.</summary>
     private static bool SupportsSmooth(XLChartGroupKind kind) => kind is XLChartGroupKind.Line
         or XLChartGroupKind.Scatter or XLChartGroupKind.Stock;
+
+    /// <summary>
+    /// Whether a chart group and its series accept a <c>c:dLbls</c> child. Only the surface types do
+    /// not: neither <c>CT_SurfaceChart</c> nor <c>CT_SurfaceSer</c> has one.
+    /// </summary>
+    internal static bool SupportsDataLabels(XLChartGroupKind kind) => kind != XLChartGroupKind.Surface;
+
+    /// <summary>
+    /// Applies the assigned data label properties onto an existing <c>c:dLbls</c> element, or adds one
+    /// when there is something to say. Individual point overrides (<c>c:dLbl</c>), label text and
+    /// shape properties, and the separator are left alone.
+    /// </summary>
+    internal static void PatchSeriesDataLabels(
+        OpenXmlCompositeElement seriesElement, XLChartDataLabels labels, XLChartType chartType) =>
+        PatchDataLabels(seriesElement, labels, chartType, groupLevel: false);
+
+    /// <summary>
+    /// Applies the chart-wide data labels onto a chart group element (<c>c:barChart</c> and friends),
+    /// where <c>c:dLbls</c> follows the last <c>c:ser</c>.
+    /// </summary>
+    internal static void PatchGroupDataLabels(
+        OpenXmlCompositeElement groupElement, XLChartDataLabels labels, XLChartType chartType) =>
+        PatchDataLabels(groupElement, labels, chartType, groupLevel: true);
+
+    private static void PatchDataLabels(
+        OpenXmlCompositeElement parent, XLChartDataLabels labels, XLChartType chartType, bool groupLevel)
+    {
+        var assigned = labels.AssignedFormat;
+        if (assigned == XLDataLabelsFormat.None)
+            return;
+
+        var dataLabels = parent.Elements<C.DataLabels>().FirstOrDefault();
+        if (dataLabels == null)
+        {
+            dataLabels = BuildDataLabels(labels, chartType)!;
+            if (groupLevel)
+                InsertAfterLastSeries(parent, dataLabels);
+            else
+                InsertOrdered(parent, dataLabels, SeriesChildOrder);
+            return;
+        }
+
+        // A c:delete of the whole label set would override every flag below it.
+        foreach (var deleted in dataLabels.Elements<C.Delete>().ToList())
+            deleted.Remove();
+
+        if ((assigned & XLDataLabelsFormat.NumberFormat) != 0)
+        {
+            foreach (var existing in dataLabels.Elements<C.NumberingFormat>().ToList())
+                existing.Remove();
+
+            if (labels.NumberFormat != null)
+            {
+                InsertOrdered(dataLabels,
+                    new C.NumberingFormat { FormatCode = labels.NumberFormat, SourceLinked = false },
+                    DataLabelsChildOrder);
+            }
+        }
+
+        if ((assigned & XLDataLabelsFormat.Position) != 0)
+        {
+            foreach (var existing in dataLabels.Elements<C.DataLabelPosition>().ToList())
+                existing.Remove();
+
+            var position = MapLabelPosition(labels.EffectivePosition(chartType));
+            if (position != null)
+                InsertOrdered(dataLabels, new C.DataLabelPosition { Val = position }, DataLabelsChildOrder);
+        }
+
+        if ((assigned & XLDataLabelsFormat.ShowValue) != 0)
+            SetLabelFlag<C.ShowValue>(dataLabels, labels.ShowValue);
+        if ((assigned & XLDataLabelsFormat.ShowCategoryName) != 0)
+            SetLabelFlag<C.ShowCategoryName>(dataLabels, labels.ShowCategoryName);
+        if ((assigned & XLDataLabelsFormat.ShowSeriesName) != 0)
+            SetLabelFlag<C.ShowSeriesName>(dataLabels, labels.ShowSeriesName);
+        if ((assigned & XLDataLabelsFormat.ShowPercentage) != 0)
+            SetLabelFlag<C.ShowPercent>(dataLabels, labels.ShowPercentage);
+    }
+
+    private static void SetLabelFlag<TFlag>(C.DataLabels dataLabels, bool value)
+        where TFlag : OpenXmlLeafElement, new()
+    {
+        var existing = dataLabels.Elements<TFlag>().FirstOrDefault();
+        if (existing != null)
+        {
+            existing.SetAttribute(new OpenXmlAttribute("val", string.Empty, value ? "1" : "0"));
+            return;
+        }
+
+        var flag = new TFlag();
+        flag.SetAttribute(new OpenXmlAttribute("val", string.Empty, value ? "1" : "0"));
+        InsertOrdered(dataLabels, flag, DataLabelsChildOrder);
+    }
+
+    /// <summary>
+    /// The schema order of the children of <c>c:ser</c> that this class writes. Only the elements it
+    /// touches need to be listed; anything else keeps its place.
+    /// </summary>
+    private static readonly Type[] SeriesChildOrder =
+    [
+        typeof(C.Index), typeof(C.Order), typeof(C.SeriesText), typeof(C.ChartShapeProperties),
+        typeof(C.Marker), typeof(C.DataLabels), typeof(C.CategoryAxisData), typeof(C.XValues),
+        typeof(C.Values), typeof(C.YValues), typeof(C.Smooth), typeof(C.ExtensionList)
+    ];
+
+    /// <summary>The schema order of the children of <c>c:dLbls</c>.</summary>
+    private static readonly Type[] DataLabelsChildOrder =
+    [
+        typeof(C.DataLabel), typeof(C.Delete), typeof(C.NumberingFormat),
+        typeof(C.ChartShapeProperties), typeof(C.TextProperties), typeof(C.DataLabelPosition),
+        typeof(C.ShowLegendKey), typeof(C.ShowValue), typeof(C.ShowCategoryName),
+        typeof(C.ShowSeriesName), typeof(C.ShowPercent), typeof(C.ShowBubbleSize),
+        typeof(C.Separator), typeof(C.ExtensionList)
+    ];
+
+    /// <summary>
+    /// Inserts <paramref name="element"/> directly after the last <c>c:ser</c> of a chart group, which
+    /// is where <c>c:dLbls</c> belongs in every group type that has one.
+    /// </summary>
+    private static void InsertAfterLastSeries(OpenXmlCompositeElement groupElement, OpenXmlElement element)
+    {
+        var lastSeries = groupElement.ChildElements.LastOrDefault(e => e.LocalName == "ser");
+        if (lastSeries != null)
+            groupElement.InsertAfter(element, lastSeries);
+        else
+            groupElement.InsertAt(element, 0);
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="element"/> at the position the schema order gives it: before the first
+    /// child that must come after it, or at the end when there is none.
+    /// </summary>
+    private static void InsertOrdered(OpenXmlCompositeElement parent, OpenXmlElement element, Type[] order)
+    {
+        var rank = Array.IndexOf(order, element.GetType());
+        if (rank < 0)
+        {
+            parent.Append(element);
+            return;
+        }
+
+        foreach (var child in parent.ChildElements)
+        {
+            var childRank = Array.IndexOf(order, child.GetType());
+            if (childRank > rank)
+            {
+                parent.InsertBefore(element, child);
+                return;
+            }
+        }
+
+        parent.Append(element);
+    }
 
     private static void PatchShapeProperties(
         OpenXmlCompositeElement seriesElement, XLChartSeries series, XLChartSeriesFormat assigned)
@@ -450,6 +685,21 @@ internal static class ChartFormatting
         XLMarkerStyle.Triangle => C.MarkerStyleValues.Triangle,
         XLMarkerStyle.X => C.MarkerStyleValues.X,
         _ => throw new ArgumentOutOfRangeException(nameof(style), style, "Unknown marker style.")
+    };
+
+    private static C.DataLabelPositionValues? MapLabelPosition(XLDataLabelPosition position) => position switch
+    {
+        XLDataLabelPosition.Auto => null,
+        XLDataLabelPosition.Center => C.DataLabelPositionValues.Center,
+        XLDataLabelPosition.InsideEnd => C.DataLabelPositionValues.InsideEnd,
+        XLDataLabelPosition.InsideBase => C.DataLabelPositionValues.InsideBase,
+        XLDataLabelPosition.OutsideEnd => C.DataLabelPositionValues.OutsideEnd,
+        XLDataLabelPosition.BestFit => C.DataLabelPositionValues.BestFit,
+        XLDataLabelPosition.Left => C.DataLabelPositionValues.Left,
+        XLDataLabelPosition.Right => C.DataLabelPositionValues.Right,
+        XLDataLabelPosition.Above => C.DataLabelPositionValues.Top,
+        XLDataLabelPosition.Below => C.DataLabelPositionValues.Bottom,
+        _ => throw new ArgumentOutOfRangeException(nameof(position), position, "Unknown data label position.")
     };
 
     private static A.SchemeColorValues MapSchemeColor(XLThemeColor themeColor) => themeColor switch

--- a/XLibur/Excel/IO/ChartPatcher.cs
+++ b/XLibur/Excel/IO/ChartPatcher.cs
@@ -57,18 +57,42 @@ internal static class ChartPatcher
                 target.Add((seriesElement, group.Kind));
         }
 
-        PatchSeries(xlChart.SeriesInternal, primaryElements);
-        PatchSeries(xlChart.SecondarySeriesInternal, secondaryElements);
+        PatchSeries(xlChart.SeriesInternal, primaryElements, xlChart.ChartType);
+        PatchSeries(xlChart.SecondarySeriesInternal, secondaryElements,
+            xlChart.SecondaryChartType ?? xlChart.ChartType);
+
+        PatchGroupDataLabels(groups, primaryKind.Value, xlChart);
+    }
+
+    /// <summary>
+    /// Writes the chart-wide data labels into every group of the primary chart type.
+    /// </summary>
+    private static void PatchGroupDataLabels(
+        List<XLChartGroup> groups, XLChartGroupKind primaryKind, XLChart xlChart)
+    {
+        if (xlChart.DataLabelsInternal.AssignedFormat == XLDataLabelsFormat.None)
+            return;
+
+        foreach (var group in groups)
+        {
+            if (group.Kind != primaryKind || !ChartFormatting.SupportsDataLabels(group.Kind))
+                continue;
+
+            ChartFormatting.PatchGroupDataLabels(group.Element, xlChart.DataLabelsInternal, xlChart.ChartType);
+        }
     }
 
     private static bool HasPendingChanges(XLChart xlChart) =>
-        HasPendingChanges(xlChart.SeriesInternal) || HasPendingChanges(xlChart.SecondarySeriesInternal);
+        xlChart.DataLabelsInternal.AssignedFormat != XLDataLabelsFormat.None
+        || HasPendingChanges(xlChart.SeriesInternal)
+        || HasPendingChanges(xlChart.SecondarySeriesInternal);
 
     private static bool HasPendingChanges(XLChartSeriesCollection series)
     {
         foreach (var s in series.Items)
         {
-            if (s.AssignedFormat != XLChartSeriesFormat.None)
+            if (s.AssignedFormat != XLChartSeriesFormat.None
+                || s.DataLabelsInternal.AssignedFormat != XLDataLabelsFormat.None)
                 return true;
         }
 
@@ -77,13 +101,14 @@ internal static class ChartPatcher
 
     private static void PatchSeries(
         XLChartSeriesCollection series,
-        List<(OpenXmlCompositeElement Element, XLChartGroupKind Kind)> seriesElements)
+        List<(OpenXmlCompositeElement Element, XLChartGroupKind Kind)> seriesElements,
+        XLChartType chartType)
     {
         var count = Math.Min(series.Count, seriesElements.Count);
         for (var i = 0; i < count; i++)
         {
             var (element, kind) = seriesElements[i];
-            ChartFormatting.PatchSeriesFormat(element, series.Items[i], kind);
+            ChartFormatting.PatchSeriesFormat(element, series.Items[i], kind, chartType);
         }
     }
 

--- a/XLibur/Excel/IO/ChartReader.cs
+++ b/XLibur/Excel/IO/ChartReader.cs
@@ -140,6 +140,10 @@ internal static class ChartReader
                 {
                     xlChart.ChartType = chartType;
                     primarySet = true;
+
+                    // The chart-wide labels live on the primary chart group.
+                    ChartFormatting.ReadDataLabels(
+                        group.Element.Elements<C.DataLabels>().FirstOrDefault(), xlChart.DataLabelsInternal);
                 }
 
                 ReadGroupSeries(group, xlChart.SeriesInternal, useSecondaryAxis);
@@ -183,6 +187,8 @@ internal static class ChartReader
 
             var series = (XLChartSeries)target.Add(name, valRef, catRef);
             ChartFormatting.ReadSeriesFormat(seriesElement, series, useSecondaryAxis);
+            ChartFormatting.ReadDataLabels(
+                seriesElement.Elements<C.DataLabels>().FirstOrDefault(), series.DataLabelsInternal);
         }
     }
 

--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -439,8 +439,10 @@ internal static class ChartWriter
     /// whether those series hang off the secondary value axis.
     /// </summary>
     private readonly struct PlotGroup(
-        XLChartType chartType, List<XLChartSeries> series, bool secondaryAxis, uint indexOffset)
+        XLChart chart, XLChartType chartType, List<XLChartSeries> series,
+        bool secondaryAxis, uint indexOffset)
     {
+        internal XLChart Chart { get; } = chart;
         internal XLChartType ChartType { get; } = chartType;
         internal List<XLChartSeries> Series { get; } = series;
         internal bool SecondaryAxis { get; } = secondaryAxis;
@@ -480,11 +482,11 @@ internal static class ChartWriter
     private static List<PlotGroup> BuildPlotGroups(XLChart xlChart)
     {
         var groups = new List<PlotGroup>(4);
-        AddPlotGroups(groups, xlChart.ChartType, xlChart.SeriesInternal.Items, 0);
+        AddPlotGroups(groups, xlChart, xlChart.ChartType, xlChart.SeriesInternal.Items, 0);
 
         if (xlChart.SecondaryChartType.HasValue && xlChart.SecondarySeries.Count > 0)
         {
-            AddPlotGroups(groups, xlChart.SecondaryChartType.Value,
+            AddPlotGroups(groups, xlChart, xlChart.SecondaryChartType.Value,
                 xlChart.SecondarySeriesInternal.Items, (uint)xlChart.Series.Count);
         }
 
@@ -492,14 +494,15 @@ internal static class ChartWriter
     }
 
     private static void AddPlotGroups(
-        List<PlotGroup> groups, XLChartType chartType, IReadOnlyList<XLChartSeries> series, uint indexOffset)
+        List<PlotGroup> groups, XLChart xlChart, XLChartType chartType,
+        IReadOnlyList<XLChartSeries> series, uint indexOffset)
     {
         if (series.Count == 0)
             return;
 
         if (!SupportsSecondaryAxis(chartType))
         {
-            groups.Add(new PlotGroup(chartType, [.. series], secondaryAxis: false, indexOffset));
+            groups.Add(new PlotGroup(xlChart, chartType, [.. series], secondaryAxis: false, indexOffset));
             return;
         }
 
@@ -509,9 +512,9 @@ internal static class ChartWriter
             (s.UseSecondaryAxis ? secondary : primary).Add(s);
 
         if (primary.Count > 0)
-            groups.Add(new PlotGroup(chartType, primary, secondaryAxis: false, indexOffset));
+            groups.Add(new PlotGroup(xlChart, chartType, primary, secondaryAxis: false, indexOffset));
         if (secondary.Count > 0)
-            groups.Add(new PlotGroup(chartType, secondary, secondaryAxis: true, indexOffset));
+            groups.Add(new PlotGroup(xlChart, chartType, secondary, secondaryAxis: true, indexOffset));
     }
 
     /// <summary>
@@ -626,9 +629,12 @@ internal static class ChartWriter
                 SeriesText = BuildSeriesText(s)
             };
             AppendShapeProperties(series, s);
+            AppendSeriesDataLabels(series, s, xlChart.ChartType);
             AppendCatAndVal(series, s);
             chartElement.Append(series);
         }
+
+        AppendGroupDataLabels(chartElement, xlChart, xlChart.ChartType);
 
         // c:holeSize is required by CT_DoughnutChart; 75% is the size Excel gives a new doughnut.
         if (isDoughnut)
@@ -654,9 +660,11 @@ internal static class ChartWriter
                 SeriesText = BuildSeriesText(s)
             };
             AppendShapeProperties(series, s);
+            AppendSeriesDataLabels(series, s, group.ChartType);
             AppendCatAndVal(series, s);
             areaChart.Append(series);
         }
+        AppendGroupDataLabels(areaChart, group.Chart, group.ChartType);
         AppendAxisIds(areaChart, group);
         plotArea.Append(areaChart);
     }
@@ -681,12 +689,14 @@ internal static class ChartWriter
                 SeriesText = BuildSeriesText(s)
             };
             AppendShapeProperties(series, s);
+            AppendSeriesDataLabels(series, s, xlChart.ChartType);
             AppendXAndY(series, s);
             series.Append(new C.BubbleSize(
                 new C.NumberReference { Formula = new C.Formula(s.ValueReferences) }
             ));
             bubbleChart.Append(series);
         }
+        AppendGroupDataLabels(bubbleChart, xlChart, xlChart.ChartType);
         bubbleChart.Append(new C.AxisId { Val = xAxisId });
         bubbleChart.Append(new C.AxisId { Val = yAxisId });
 
@@ -730,9 +740,11 @@ internal static class ChartWriter
                 SeriesText = BuildSeriesText(s)
             };
             AppendShapeProperties(series, s);
+            AppendSeriesDataLabels(series, s, group.ChartType);
             AppendCatAndVal(series, s);
             barChart.Append(series);
         }
+        AppendGroupDataLabels(barChart, group.Chart, group.ChartType);
         AppendAxisIds(barChart, group);
         plotArea.Append(barChart);
     }
@@ -756,9 +768,11 @@ internal static class ChartWriter
                 SeriesText = BuildSeriesText(s)
             };
             AppendShapeProperties(series, s);
+            AppendSeriesDataLabels(series, s, group.ChartType);
             AppendCatAndVal(series, s);
             bar3DChart.Append(series);
         }
+        AppendGroupDataLabels(bar3DChart, group.Chart, group.ChartType);
         bar3DChart.Append(new C.Shape { Val = GetBar3DShape(group.ChartType) });
         AppendAxisIds(bar3DChart, group);
         plotArea.Append(bar3DChart);
@@ -786,10 +800,12 @@ internal static class ChartWriter
             };
             AppendShapeProperties(series, s);
             AppendMarker(series, s, markersByChartType);
+            AppendSeriesDataLabels(series, s, group.ChartType);
             AppendCatAndVal(series, s);
             AppendSmooth(series, s, smoothByChartType: false);
             lineChart.Append(series);
         }
+        AppendGroupDataLabels(lineChart, group.Chart, group.ChartType);
         AppendAxisIds(lineChart, group);
         plotArea.Append(lineChart);
     }
@@ -817,9 +833,11 @@ internal static class ChartWriter
             };
             AppendShapeProperties(series, s);
             AppendMarker(series, s, autoSymbol: false);
+            AppendSeriesDataLabels(series, s, group.ChartType);
             AppendCatAndVal(series, s);
             radarChart.Append(series);
         }
+        AppendGroupDataLabels(radarChart, group.Chart, group.ChartType);
         AppendAxisIds(radarChart, group);
         plotArea.Append(radarChart);
     }
@@ -845,11 +863,13 @@ internal static class ChartWriter
             };
             AppendShapeProperties(series, s);
             AppendMarker(series, s, autoSymbol: false);
+            AppendSeriesDataLabels(series, s, group.ChartType);
             // Scatter uses XValues + YValues, not CategoryAxisData + Values
             AppendXAndY(series, s);
             AppendSmooth(series, s, smoothByChartType);
             scatterChart.Append(series);
         }
+        AppendGroupDataLabels(scatterChart, group.Chart, group.ChartType);
         AppendAxisIds(scatterChart, group);
         plotArea.Append(scatterChart);
     }
@@ -869,9 +889,11 @@ internal static class ChartWriter
             };
             AppendShapeProperties(series, s);
             AppendMarker(series, s, autoSymbol: false);
+            AppendSeriesDataLabels(series, s, group.ChartType);
             AppendCatAndVal(series, s);
             stockChart.Append(series);
         }
+        AppendGroupDataLabels(stockChart, group.Chart, group.ChartType);
         AppendAxisIds(stockChart, group);
         plotArea.Append(stockChart);
     }
@@ -957,6 +979,30 @@ internal static class ChartWriter
         var smooth = ChartFormatting.BuildSmooth(s, smoothByChartType);
         if (smooth != null)
             series.Append(smooth);
+    }
+
+    /// <summary>
+    /// Appends the series' own <c>c:dLbls</c>. Must be called after <c>c:marker</c> and before
+    /// <c>c:cat</c>/<c>c:val</c>.
+    /// </summary>
+    private static void AppendSeriesDataLabels(
+        OpenXmlCompositeElement series, XLChartSeries s, XLChartType chartType)
+    {
+        var dataLabels = ChartFormatting.BuildDataLabels(s.DataLabelsInternal, chartType);
+        if (dataLabels != null)
+            series.Append(dataLabels);
+    }
+
+    /// <summary>
+    /// Appends the chart-wide <c>c:dLbls</c> to a chart group. Must be called after every
+    /// <c>c:ser</c> and before the group's remaining children.
+    /// </summary>
+    private static void AppendGroupDataLabels(
+        OpenXmlCompositeElement chartElement, XLChart xlChart, XLChartType chartType)
+    {
+        var dataLabels = ChartFormatting.BuildDataLabels(xlChart.DataLabelsInternal, chartType);
+        if (dataLabels != null)
+            chartElement.Append(dataLabels);
     }
 
     /// <summary>

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -132,3 +132,29 @@ XLibur.Excel.XLMarkerStyle.Square = 7 -> XLibur.Excel.XLMarkerStyle
 XLibur.Excel.XLMarkerStyle.Star = 8 -> XLibur.Excel.XLMarkerStyle
 XLibur.Excel.XLMarkerStyle.Triangle = 9 -> XLibur.Excel.XLMarkerStyle
 XLibur.Excel.XLMarkerStyle.X = 10 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.IXLChart.DataLabels.get -> XLibur.Excel.IXLDataLabels!
+XLibur.Excel.IXLChartSeries.DataLabels.get -> XLibur.Excel.IXLDataLabels!
+XLibur.Excel.IXLDataLabels
+XLibur.Excel.IXLDataLabels.NumberFormat.get -> string?
+XLibur.Excel.IXLDataLabels.NumberFormat.set -> void
+XLibur.Excel.IXLDataLabels.Position.get -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.IXLDataLabels.Position.set -> void
+XLibur.Excel.IXLDataLabels.ShowCategoryName.get -> bool
+XLibur.Excel.IXLDataLabels.ShowCategoryName.set -> void
+XLibur.Excel.IXLDataLabels.ShowPercentage.get -> bool
+XLibur.Excel.IXLDataLabels.ShowPercentage.set -> void
+XLibur.Excel.IXLDataLabels.ShowSeriesName.get -> bool
+XLibur.Excel.IXLDataLabels.ShowSeriesName.set -> void
+XLibur.Excel.IXLDataLabels.ShowValue.get -> bool
+XLibur.Excel.IXLDataLabels.ShowValue.set -> void
+XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Auto = 0 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Center = 1 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.InsideEnd = 2 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.InsideBase = 3 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.OutsideEnd = 4 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.BestFit = 5 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Left = 6 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Right = 7 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Above = 8 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Below = 9 -> XLibur.Excel.XLDataLabelPosition

--- a/docs-website/docs/charts.md
+++ b/docs-website/docs/charts.md
@@ -251,12 +251,77 @@ a file** onto a secondary axis would mean regrouping the chart's XML, which XLib
 the setter throws `NotSupportedException`. The colour and marker properties have no such limit.
 :::
 
+## Data labels
+
+`DataLabels` exists on the chart and on each series. Set it on the chart to label every series the
+same way, then override the odd series that needs something different:
+
+```csharp
+var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+chart.Series.Add("Revenue", "Sales!$B$2:$B$5", "Sales!$A$2:$A$5");
+var cost = chart.Series.Add("Cost", "Sales!$C$2:$C$5", "Sales!$A$2:$A$5");
+
+chart.DataLabels.ShowValue = true;
+chart.DataLabels.NumberFormat = "$ #,##0";
+chart.DataLabels.Position = XLDataLabelPosition.OutsideEnd;
+
+cost.DataLabels.ShowValue = true;
+cost.DataLabels.ShowSeriesName = true;
+cost.DataLabels.Position = XLDataLabelPosition.InsideEnd;
+```
+
+Pie and doughnut charts usually want the share rather than the number:
+
+```csharp
+var pie = ws.Charts.Add(XLChartType.Pie);
+var share = pie.Series.Add("Revenue", "Sales!$B$2:$B$5", "Sales!$A$2:$A$5");
+share.DataLabels.ShowCategoryName = true;
+share.DataLabels.ShowPercentage = true;
+share.DataLabels.Position = XLDataLabelPosition.BestFit;
+```
+
+| Property | Meaning | Default |
+|---|---|---|
+| `ShowValue` | the point's value | `false` |
+| `ShowCategoryName` | the category axis label | `false` |
+| `ShowSeriesName` | the series name | `false` |
+| `ShowPercentage` | share of the total, pie and doughnut only | `false` |
+| `NumberFormat` | format code for the label, e.g. `"0.0%"` | from the source cells |
+| `Position` | where the label sits | `Auto` |
+
+Nothing is written to the file until one of these is set, so an untouched chart keeps Excel's own
+defaults.
+
+### Label positions
+
+What Excel offers depends on the chart type, and it refuses to open a file that uses a position it
+does not offer — so the setter throws `ArgumentException` for a combination Excel would reject, with
+the allowed values in the message:
+
+| Chart type | Positions |
+|---|---|
+| clustered bar and column | `Center`, `InsideEnd`, `InsideBase`, `OutsideEnd` |
+| stacked bar and column | `Center`, `InsideEnd`, `InsideBase` |
+| line, scatter, radar | `Center`, `Left`, `Right`, `Above`, `Below` |
+| pie | `BestFit`, `Center`, `InsideEnd`, `OutsideEnd` |
+| area, doughnut, bubble, stock, every 3D type | `Auto` only |
+
+`Auto` — the default — writes no position and lets Excel place the label. In a combo chart, a
+secondary series is judged against `SecondaryChartType`, so a line series over columns takes the line
+positions.
+
+:::note
+Surface charts and the extended (Office 2016+) types have no data label support in the file format
+and ignore these properties. If a chart type change makes an already-set position invalid, the
+position is dropped on save rather than written — the alternative is a file Excel refuses to open.
+:::
+
 ### Editing charts loaded from a file
 
 XLibur never regenerates the XML of a chart it read from a file — it patches in just the
 properties you assign. Everything it does not model stays exactly as Excel wrote it: trendlines,
-error bars, gradient and picture fills, per-point colours, data labels, the chart's style and
-colour parts.
+error bars, gradient and picture fills, per-point colours and label overrides, label fonts, the
+chart's style and colour parts.
 
 ```csharp
 using var workbook = new XLWorkbook("Report.xlsx");
@@ -368,8 +433,8 @@ chart.Title = null;               // remove the title
 
 ## What is not covered
 
-The chart API is deliberately narrow: type, title, series, series formatting, and placement. Axis
-titles and scaling, legend placement, gridlines, data labels, and trend lines are not exposed. If
+The chart API is deliberately narrow: type, title, series, series formatting, data labels, and
+placement. Axis titles and scaling, legend placement, gridlines, and trend lines are not exposed. If
 you need that level of control, the usual approach is to build a template workbook in Excel with
 the chart formatted exactly as you want it, then use XLibur to write the source data the chart
 already points at:

--- a/docs/specs/10-chart-formatting-depth.md
+++ b/docs/specs/10-chart-formatting-depth.md
@@ -3,7 +3,7 @@
 **Area:** Feature (flagship differentiator — upstream ClosedXML has no charts at all)
 **Effort:** L total, but splits into 4 independent PRs
 **Dependencies:** None.
-**Status:** In progress — PR 1 implemented; see [Results](#results-pr-1). PRs 2–4 open.
+**Status:** In progress — PRs 1 and 2 implemented; see [Results](#results-pr-1). PRs 3–4 open.
 
 ## Summary
 
@@ -183,10 +183,10 @@ reported a plain `Line` chart as `LineWithMarkers`.
 | 4 | Existing chart tests green; ChartEx unaffected | ✅ extended charts ignore series formatting and are not patched |
 | 5 | `XLibur.Examples` gains a formatted-chart sample | ✅ `FormattedChartExamples` — four sheets, validated by a test |
 
-### Notes for PRs 2–4
+### Notes for PRs 3–4
 
-- Build data labels, legend and axes on `ChartPatcher`/`ChartFormatting`, not on a second mechanism:
-  add flags to the assignment set and a patch step per element. The "only write what was assigned"
+- Build legend and axes on `ChartPatcher`/`ChartFormatting`, not on a second mechanism: add flags to
+  the assignment set and a patch step per element, as PR 2 did. The "only write what was assigned"
   rule is what keeps preservation free.
 - `ChartPlotAreaScanner` is the place to add group kinds the reader still ignores: `c:pie3DChart`,
   `c:line3DChart`, `c:area3DChart`, `c:surface3DChart`, `c:ofPieChart`. Today a chart built from
@@ -194,3 +194,46 @@ reported a plain `Line` chart as `LineWithMarkers`.
 - Title, chart type and series references are still write-only for new charts; editing them on a
   loaded chart does nothing. If PR 3 wants `chart.Title` to work on loaded charts, that is another
   patch step.
+
+## Results (PR 2)
+
+`IXLDataLabels` landed on both `IXLChartSeries.DataLabels` (per series, `c:dLbls` under `c:ser`) and
+`IXLChart.DataLabels` (chart-wide, `c:dLbls` on the primary chart group), with `ShowValue`,
+`ShowCategoryName`, `ShowSeriesName`, `ShowPercentage`, `NumberFormat` and `Position`. 6383 tests pass
+on net8.0 and net10.0.
+
+### It reuses PR 1's machinery, as intended
+
+`XLChartDataLabels` carries its own `XLDataLabelsFormat` assignment flags, the reader seeds values
+through `SeedLoaded` without setting them, and `ChartPatcher` patches element by element. A chart
+whose labels nobody touched is still not modified; editing one keeps the label font (`c:txPr`), the
+label fill, the per-point overrides (`c:dLbl`) and the separator. Two bugs the tests caught, both
+from bolting a second concern onto the same code path:
+
+- `ChartPatcher.HasPendingChanges` and `ChartFormatting.PatchSeriesFormat` both bailed out on
+  `XLChartSeriesFormat.None`, so a chart where *only* labels had been set was never patched. The
+  label step is now outside that gate — worth remembering when PR 3 adds legend and axis flags.
+- Data label positions are validated against the chart type, and a series in `SecondarySeries` follows
+  `SecondaryChartType`, not `ChartType`. `XLChartSeriesCollection` now knows which of the two it is
+  and passes that down, so a line series over columns takes the line positions.
+
+### Position validation
+
+The spec asked for Excel's rules for bar, line and pie, and "others accept Center". The rules landed
+as specified for those three families, but **"others" accept only `Auto`, not `Center`** — Excel does
+not merely ignore `c:dLblPos` on an area, doughnut, bubble, stock or 3D chart, it refuses to open the
+file. Accepting `Center` there would have produced workbooks Excel repairs, which is a worse outcome
+than a clear exception. The setter throws `ArgumentException` naming the chart type, the rejected
+position and the allowed set; on save an already-set position that a later chart type change
+invalidated is dropped rather than written.
+
+`c:dLblPos` is also not the only thing the file format withholds: neither `CT_SurfaceChart` nor
+`CT_SurfaceSer` has a `c:dLbls` child at all, so surface charts ignore data labels entirely.
+
+### Emission detail worth knowing
+
+When any label property is set, all six `show*` flags are written, not just the ones that were
+assigned. Excel treats a missing flag as "inherit from the chart style", which makes the rendered
+result depend on the style part; writing them out makes what the caller asked for unambiguous.
+`c:delete` — how Excel records "labels switched off" — is removed when a flag is turned on, otherwise
+it would override everything next to it.


### PR DESCRIPTION
## Summary

PR 2 of 4 for [spec 10 — Chart formatting depth](https://github.com/XLibur/XLibur/blob/main/docs/specs/10-chart-formatting-depth.md). Adds data labels, per series and chart-wide.

> **Stacked on #220** — this PR targets `feat/chart-series-formatting`, not `main`, so its diff shows only the data label work. Merge #220 first; GitHub will retarget this one at `main` automatically.
>
> 1. #220 — series formatting + secondary axis + preservation groundwork
> 2. **this PR** — data labels
> 3. #222 — legend + axes
> 4. #223 — anchor reader gaps

## Changes

- `IXLDataLabels` with `ShowValue`, `ShowCategoryName`, `ShowSeriesName`, `ShowPercentage`, `NumberFormat` and `Position`, reachable from `IXLChart.DataLabels` (chart-wide, `c:dLbls` on the primary chart group) and `IXLChartSeries.DataLabels` (per series, `c:dLbls` under `c:ser`, overriding the chart's).
- Nothing is written until a property is set, so an untouched chart keeps Excel's own defaults.
- Reuses #220's machinery: `XLChartDataLabels` carries its own `XLDataLabelsFormat` assignment flags, the reader seeds values through `SeedLoaded` without setting them, and `ChartPatcher` patches element by element. Editing labels on a loaded chart keeps the label font (`c:txPr`), the label fill, the per-point overrides (`c:dLbl`) and the separator.

### Position validation diverges from the spec, on purpose

The spec said Excel's rules for bar/line/pie and *"others accept Center"*. Those three families landed as specified, but **"others" accept only `Auto`**: Excel does not merely ignore `c:dLblPos` on an area, doughnut, bubble, stock or 3D chart — it refuses to open the file. Accepting `Center` there would produce workbooks Excel repairs, which is worse than a clear exception.

The setter throws `ArgumentException` naming the chart type, the rejected position and the allowed set. On save, a position that a later `ChartType` change invalidated is dropped rather than written.

| Chart type | Positions |
|---|---|
| clustered bar and column | `Center`, `InsideEnd`, `InsideBase`, `OutsideEnd` |
| stacked bar and column | `Center`, `InsideEnd`, `InsideBase` |
| line, scatter, radar | `Center`, `Left`, `Right`, `Above`, `Below` |
| pie | `BestFit`, `Center`, `InsideEnd`, `OutsideEnd` |
| everything else | `Auto` only |

Surface charts ignore data labels entirely — neither `CT_SurfaceChart` nor `CT_SurfaceSer` has a `c:dLbls` child.

### Two bugs the tests caught, from bolting a second concern onto one code path

- `ChartPatcher.HasPendingChanges` and `ChartFormatting.PatchSeriesFormat` both bailed out on `XLChartSeriesFormat.None`, so a chart where *only* labels had been set was never patched. The label step now sits outside that gate — worth remembering when the next PR adds legend and axis flags.
- Data label positions are validated against the chart type, and a series in `SecondarySeries` follows `SecondaryChartType`, not `ChartType`. `XLChartSeriesCollection` now knows which of the two it is and passes that down, so a line series over columns takes the line positions.

### Emission detail

When any label property is set, **all six** `show*` flags are written, not just the assigned ones: Excel reads a missing flag as "inherit from the chart style", which makes the rendered result depend on the style part. An existing `c:delete` — how Excel records "labels switched off" — is removed when a flag is turned on, otherwise it would override everything next to it.

## Related Issues

Implements PR 2 of `docs/specs/10-chart-formatting-depth.md`. Findings recorded in that spec's "Results (PR 2)" section.

## Testing

- [x] Added or updated unit tests — `ChartDataLabelTests` (14), plus label cases in `ChartRoundTripPreservationTests`
- [x] All existing tests pass — 6383 on net8.0 and net10.0
- [ ] Tested manually

Every property is round-tripped; every chart family that supports labels is saved through `OpenXmlValidator`. The preservation fixture's `c:dLbls` carries a `c:dLbl` override, a `c:txPr` and a `c:numFmt`, and the patch test asserts they survive an edit. The `FormattedChartExamples` sample gains a "Labels" sheet.

Same two caveats as #220: no Excel available for the render check, and `XLibur.Tests/Resource/Charts/` is still empty — Excel-shaped fixtures are built in-test instead.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [ ] PR targets the `main` branch — targets #220 instead; see the stack note above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chart data labels with configurable values, categories, series names, percentages, number formats, and positions.
  * Supports chart-wide labels and per-series overrides, including pie and doughnut chart percentages.
  * Added validation for label positions based on chart type.

* **Bug Fixes**
  * Chart data labels and formatting now persist when editing and saving charts loaded from files.
  * Preserves existing chart content and per-point label settings during updates.

* **Documentation**
  * Added chart data-label guidance and supported position details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->