### PR TITLE
feat: chart legend and axis API (spec 10 PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 - **Chart data labels**: `IXLDataLabels` on both `IXLChart.DataLabels` (chart-wide) and `IXLChartSeries.DataLabels` (per series, overriding the chart's), with `ShowValue`, `ShowCategoryName`, `ShowSeriesName`, `ShowPercentage`, `NumberFormat` and `Position`. `Position` is validated against the chart type — Excel refuses to open a file that uses a position it does not offer for that type, so the setter throws with the allowed values listed rather than producing a workbook Excel has to repair.
 
-- **Charts loaded from a file can be restyled**: setting the series formatting or data labels on a loaded chart now writes back on save. Only the properties actually assigned are patched into the existing chart part, so trendlines, error bars, gradient fills, per-point colours and label overrides, label fonts and the chart's style/colour parts are all preserved — and a chart nobody edited is left byte for byte as it was.
+- **Chart legend**: `IXLChart.Legend` with `Visible`, `Position` (right, bottom, left, top, top-right) and `Overlay`. Charts XLibur creates still have no legend unless one is asked for; setting `Visible = false` on a chart read from a file removes the legend it came with.
+
+- **Chart axes**: `IXLChart.CategoryAxis`, `ValueAxis` and `SecondaryValueAxis`, each with `Title`, `NumberFormat`, `Min`, `Max`, `MajorUnit`, `MinorUnit`, `Visible`, `MajorGridlines`, `Orientation` (reversed axes) and `LogScale`/`LogBase`. The unit and log-scale properties belong to a value axis in the file format and are skipped on a category axis — except on scatter and bubble charts, whose horizontal axis holds numbers.
+
+- **Charts loaded from a file can be restyled**: setting the series formatting, data labels, legend or axes on a loaded chart now writes back on save. Only the properties actually assigned are patched into the existing chart part, so trendlines, error bars, gradient fills, per-point colours and label overrides, label and axis fonts, tick marks and the chart's style/colour parts are all preserved — and a chart nobody edited is left byte for byte as it was.
 
 ### Fixed
 

--- a/XLibur.Examples/Charts/FormattedChartExamples.cs
+++ b/XLibur.Examples/Charts/FormattedChartExamples.cs
@@ -17,6 +17,7 @@ public class FormattedChartExamples : IXLExample
         TwoScales(wb);
         HighlightOneSeries(wb);
         Labels(wb);
+        LegendAndAxes(wb);
 
         wb.SaveAs(filePath);
     }
@@ -189,6 +190,67 @@ public class FormattedChartExamples : IXLExample
 
         pie.Position.SetColumn(6).SetRow(21);
         pie.SecondPosition.SetColumn(15).SetRow(39);
+    }
+
+    /// <summary>
+    /// A titled, scaled chart with a legend — roughly what you would set by hand in Excel before
+    /// putting a chart in front of anyone.
+    /// </summary>
+    private static void LegendAndAxes(XLWorkbook wb)
+    {
+        var ws = wb.Worksheets.Add("Legend and axes");
+        WriteQuarterlyData(ws);
+        ws.Cell("D1").Value = "Margin %";
+        for (var row = 2; row <= 5; row++)
+            ws.Cell(row, 4).FormulaA1 = $"=(B{row}-C{row})/B{row}";
+        ws.Range("D2:D5").Style.NumberFormat.Format = "0.0%";
+
+        var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+        chart.SetTitle("Revenue, cost and margin");
+        chart.Series.Add("Revenue", "'Legend and axes'!$B$2:$B$5", "'Legend and axes'!$A$2:$A$5");
+        chart.Series.Add("Cost", "'Legend and axes'!$C$2:$C$5", "'Legend and axes'!$A$2:$A$5");
+
+        chart.SecondaryChartType = XLChartType.LineWithMarkers;
+        var margin = chart.SecondarySeries.Add(
+            "Margin %", "'Legend and axes'!$D$2:$D$5", "'Legend and axes'!$A$2:$A$5");
+        margin.UseSecondaryAxis = true;
+        margin.MarkerStyle = XLMarkerStyle.Circle;
+        margin.MarkerSize = 7;
+
+        chart.Legend.Visible = true;
+        chart.Legend.Position = XLLegendPosition.Bottom;
+
+        chart.CategoryAxis.Title = "Quarter";
+
+        chart.ValueAxis.Title = "Currency";
+        chart.ValueAxis.NumberFormat = "$ #,##0";
+        chart.ValueAxis.Min = 0;
+        chart.ValueAxis.MajorUnit = 10_000;
+        chart.ValueAxis.MajorGridlines = true;
+
+        chart.SecondaryValueAxis.Title = "Margin";
+        chart.SecondaryValueAxis.NumberFormat = "0%";
+        chart.SecondaryValueAxis.Min = 0;
+        chart.SecondaryValueAxis.Max = 0.5;
+
+        chart.Position.SetColumn(6).SetRow(1);
+        chart.SecondPosition.SetColumn(16).SetRow(22);
+
+        // A log scale is worth having when the values span orders of magnitude.
+        ws.Cell("F1").Value = "Users";
+        double[] users = [12, 340, 9_800, 210_000];
+        for (var i = 0; i < users.Length; i++)
+            ws.Cell(i + 2, 6).Value = users[i];
+
+        var growth = ws.Charts.Add(XLChartType.Line);
+        growth.SetTitle("Users, log scale");
+        growth.Series.Add("Users", "'Legend and axes'!$F$2:$F$5", "'Legend and axes'!$A$2:$A$5");
+        growth.ValueAxis.LogScale = true;
+        growth.ValueAxis.LogBase = 10;
+        growth.ValueAxis.MajorGridlines = true;
+        growth.CategoryAxis.Title = "Quarter";
+        growth.Position.SetColumn(6).SetRow(24);
+        growth.SecondPosition.SetColumn(16).SetRow(42);
     }
 
     private static void WriteQuarterlyData(IXLWorksheet ws)

--- a/XLibur.Tests/Excel/Charts/ChartLegendAndAxisTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartLegendAndAxisTests.cs
@@ -1,0 +1,432 @@
+using DocumentFormat.OpenXml.Packaging;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using XLibur.Excel;
+using A = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// The legend, and the axis title, scale, number format, gridlines and orientation.
+/// </summary>
+[TestFixture]
+public class ChartLegendAndAxisTests
+{
+    private static IXLWorksheet AddDataSheet(XLWorkbook wb)
+    {
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = "Q1";
+        ws.Cell("A2").Value = "Q2";
+        ws.Cell("B1").Value = 100;
+        ws.Cell("B2").Value = 200;
+        ws.Cell("C1").Value = 5;
+        ws.Cell("C2").Value = 8;
+        return ws;
+    }
+
+    private static IXLChart AddChart(IXLWorksheet ws, XLChartType type)
+    {
+        var chart = ws.Charts.Add(type);
+        chart.Position.SetColumn(5).SetRow(1);
+        chart.SecondPosition.SetColumn(12).SetRow(15);
+        return chart;
+    }
+
+    private static MemoryStream SaveValidated(XLWorkbook wb)
+    {
+        var ms = new MemoryStream();
+        wb.SaveAs(ms, validate: true);
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static C.ChartSpace ChartSpaceOf(Stream stream)
+    {
+        stream.Position = 0;
+        using var doc = SpreadsheetDocument.Open(stream, false);
+        var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
+        return (C.ChartSpace)chartPart.ChartSpace!.CloneNode(true);
+    }
+
+    // ── Legend ──────────────────────────────────────────────────────────
+
+    [Test]
+    public void NoLegendIsWrittenUntilItIsAskedFor()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+
+        using var ms = SaveValidated(wb);
+        Assert.That(ChartSpaceOf(ms).Descendants<C.Legend>(), Is.Empty);
+    }
+
+    [Test]
+    public void LegendRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Legend.Visible = true;
+            chart.Legend.Position = XLLegendPosition.Bottom;
+            chart.Legend.Overlay = true;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var legend = wb.Worksheet("Data").Charts.First().Legend;
+            Assert.That(legend.Visible, Is.True);
+            Assert.That(legend.Position, Is.EqualTo(XLLegendPosition.Bottom));
+            Assert.That(legend.Overlay, Is.True);
+        }
+    }
+
+    [Test]
+    public void LegendSitsBetweenThePlotAreaAndPlotVisibleOnly()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+        chart.Legend.Visible = true;
+
+        using var ms = SaveValidated(wb);
+        var chartElement = ChartSpaceOf(ms).Elements<C.Chart>().Single();
+        var children = chartElement.ChildElements.Select(e => e.LocalName).ToList();
+
+        Assert.That(children.IndexOf("plotArea"), Is.LessThan(children.IndexOf("legend")));
+        Assert.That(children.IndexOf("legend"), Is.LessThan(children.IndexOf("plotVisOnly")));
+    }
+
+    [Test]
+    public void HidingTheLegendOfALoadedChartRemovesIt()
+    {
+        using var withLegend = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Legend.Visible = true;
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(withLegend);
+        }
+
+        using var withoutLegend = new MemoryStream();
+        withLegend.Position = 0;
+        using (var wb = new XLWorkbook(withLegend))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.Legend.Visible, Is.True);
+            chart.Legend.Visible = false;
+            wb.SaveAs(withoutLegend, validate: true);
+        }
+
+        Assert.That(ChartSpaceOf(withoutLegend).Descendants<C.Legend>(), Is.Empty);
+    }
+
+    // ── Axes ────────────────────────────────────────────────────────────
+
+    [Test]
+    public void AxisTitleAndNumberFormatRoundTrip()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.CategoryAxis.Title = "Quarter";
+            chart.ValueAxis.Title = "Revenue";
+            chart.ValueAxis.NumberFormat = "$ #,##0";
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.CategoryAxis.Title, Is.EqualTo("Quarter"));
+            Assert.That(chart.ValueAxis.Title, Is.EqualTo("Revenue"));
+            Assert.That(chart.ValueAxis.NumberFormat, Is.EqualTo("$ #,##0"));
+            Assert.That(chart.CategoryAxis.NumberFormat, Is.Null);
+        }
+    }
+
+    [Test]
+    public void AxisScaleRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.ValueAxis.Min = 0;
+            chart.ValueAxis.Max = 250;
+            chart.ValueAxis.MajorUnit = 50;
+            chart.ValueAxis.MinorUnit = 10;
+            chart.ValueAxis.MajorGridlines = true;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var axis = wb.Worksheet("Data").Charts.First().ValueAxis;
+            Assert.That(axis.Min, Is.EqualTo(0));
+            Assert.That(axis.Max, Is.EqualTo(250));
+            Assert.That(axis.MajorUnit, Is.EqualTo(50));
+            Assert.That(axis.MinorUnit, Is.EqualTo(10));
+            Assert.That(axis.MajorGridlines, Is.True);
+        }
+    }
+
+    [Test]
+    public void ScalingChildrenAreWrittenInSchemaOrder()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+        chart.ValueAxis.LogScale = true;
+        chart.ValueAxis.LogBase = 2;
+        chart.ValueAxis.Orientation = XLAxisOrientation.MaxMin;
+        chart.ValueAxis.Min = 1;
+        chart.ValueAxis.Max = 1000;
+
+        using var ms = SaveValidated(wb);
+        var valueAxis = ChartSpaceOf(ms).Descendants<C.ValueAxis>().Single();
+        var scaling = valueAxis.Elements<C.Scaling>().Single();
+
+        Assert.That(scaling.ChildElements.Select(e => e.LocalName),
+            Is.EqualTo(new[] { "logBase", "orientation", "max", "min" }));
+        Assert.That(scaling.Elements<C.LogBase>().Single().Val!.Value, Is.EqualTo(2));
+        Assert.That(scaling.Elements<C.Orientation>().Single().Val!.Value,
+            Is.EqualTo(C.OrientationValues.MaxMin));
+    }
+
+    [Test]
+    public void LogScaleRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.ValueAxis.LogScale = true;
+            chart.ValueAxis.LogBase = 2;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var axis = wb.Worksheet("Data").Charts.First().ValueAxis;
+            Assert.That(axis.LogScale, Is.True);
+            Assert.That(axis.LogBase, Is.EqualTo(2));
+        }
+    }
+
+    [Test]
+    public void ValueAxisOnlyPropertiesAreSkippedOnTheCategoryAxis()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+        chart.CategoryAxis.MajorUnit = 1;
+        chart.CategoryAxis.LogScale = true;
+
+        // CT_CatAx has neither a unit nor room for c:logBase, so writing them would make Excel
+        // refuse the file.
+        using var ms = SaveValidated(wb);
+        var categoryAxis = ChartSpaceOf(ms).Descendants<C.CategoryAxis>().Single();
+
+        Assert.That(categoryAxis.Elements<C.MajorUnit>(), Is.Empty);
+        Assert.That(categoryAxis.Elements<C.Scaling>().Single().Elements<C.LogBase>(), Is.Empty);
+    }
+
+    [Test]
+    public void HiddenAxisRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.ValueAxis.Visible = false;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.ValueAxis.Visible, Is.False);
+            Assert.That(chart.CategoryAxis.Visible, Is.True);
+        }
+    }
+
+    [Test]
+    public void SecondaryValueAxisCanBeTitledAndScaled()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.ColumnClustered);
+            chart.Series.Add("Units", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Series.Add("Price", "Data!$C$1:$C$2", "Data!$A$1:$A$2").UseSecondaryAxis = true;
+
+            chart.ValueAxis.Title = "Units";
+            chart.SecondaryValueAxis.Title = "Price";
+            chart.SecondaryValueAxis.Max = 10;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.ValueAxis.Title, Is.EqualTo("Units"));
+            Assert.That(chart.SecondaryValueAxis.Title, Is.EqualTo("Price"));
+            Assert.That(chart.SecondaryValueAxis.Max, Is.EqualTo(10));
+        }
+    }
+
+    [Test]
+    public void ScatterChartsTakeANumberFormatOnBothAxes()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.XYScatterMarkers);
+            chart.Series.Add("Points", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.CategoryAxis.Title = "X";
+            chart.CategoryAxis.MajorUnit = 25;
+            chart.ValueAxis.Title = "Y";
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.CategoryAxis.Title, Is.EqualTo("X"));
+            Assert.That(chart.CategoryAxis.MajorUnit, Is.EqualTo(25),
+                "The horizontal axis of a scatter chart is a value axis, so it takes units.");
+            Assert.That(chart.ValueAxis.Title, Is.EqualTo("Y"));
+        }
+    }
+
+    [Test]
+    public void AxisTitleTextIsWrittenAsRichText()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = AddChart(ws, XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+        chart.ValueAxis.Title = "Revenue";
+
+        using var ms = SaveValidated(wb);
+        var valueAxis = ChartSpaceOf(ms).Descendants<C.ValueAxis>().Single();
+        var title = valueAxis.Elements<C.Title>().Single();
+
+        Assert.That(title.Descendants<A.Text>().Single().Text, Is.EqualTo("Revenue"));
+
+        // c:title has to follow c:axPos and precede c:crossAx.
+        var children = valueAxis.ChildElements.Select(e => e.LocalName).ToList();
+        Assert.That(children.IndexOf("axPos"), Is.LessThan(children.IndexOf("title")));
+        Assert.That(children.IndexOf("title"), Is.LessThan(children.IndexOf("crossAx")));
+    }
+
+    [Test]
+    public void AxesSurviveEveryChartFamilyThatHasThem()
+    {
+        XLChartType[] types =
+        [
+            XLChartType.ColumnClustered, XLChartType.BarStacked, XLChartType.ColumnClustered3D,
+            XLChartType.Line, XLChartType.Area, XLChartType.Radar, XLChartType.XYScatterMarkers,
+            XLChartType.Bubble, XLChartType.StockHighLowClose, XLChartType.Surface,
+            XLChartType.ConeClustered
+        ];
+
+        foreach (var type in types)
+        {
+            using var wb = new XLWorkbook();
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, type);
+
+            var seriesCount = type == XLChartType.StockHighLowClose ? 3 : 1;
+            for (var i = 0; i < seriesCount; i++)
+                chart.Series.Add($"S{i}", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+
+            chart.Legend.Visible = true;
+            chart.CategoryAxis.Title = "Category";
+            chart.ValueAxis.Title = "Value";
+            chart.ValueAxis.NumberFormat = "#,##0";
+            chart.ValueAxis.MajorGridlines = true;
+            chart.ValueAxis.Min = 0;
+            chart.ValueAxis.MajorUnit = 50;
+            chart.ValueAxis.Orientation = XLAxisOrientation.MaxMin;
+
+            Assert.DoesNotThrow(() =>
+            {
+                using var ms = SaveValidated(wb);
+            }, $"{type} produced invalid chart XML.");
+        }
+    }
+
+    // ── Validation ──────────────────────────────────────────────────────
+
+    [Test]
+    public void AxisUnitsMustBePositive()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var axis = AddChart(ws, XLChartType.ColumnClustered).ValueAxis;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => axis.MajorUnit = 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => axis.MinorUnit = -1);
+        Assert.DoesNotThrow(() => axis.MajorUnit = null);
+    }
+
+    [Test]
+    public void LogBaseOutsideExcelsRangeIsRejected()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var axis = AddChart(ws, XLChartType.ColumnClustered).ValueAxis;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => axis.LogBase = 1);
+        Assert.Throws<ArgumentOutOfRangeException>(() => axis.LogBase = 1001);
+        Assert.DoesNotThrow(() => axis.LogBase = 1000);
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
@@ -90,7 +90,22 @@ public class ChartRoundTripPreservationTests
                 <c:axId val="444444444"/>
               </c:lineChart>
               <c:catAx><c:axId val="111111111"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="222222222"/></c:catAx>
-              <c:valAx><c:axId val="222222222"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="111111111"/></c:valAx>
+              <c:valAx>
+                <c:axId val="222222222"/>
+                <c:scaling><c:orientation val="minMax"/></c:scaling>
+                <c:delete val="0"/>
+                <c:axPos val="l"/>
+                <c:majorGridlines/>
+                <c:title><c:tx><c:rich><a:bodyPr rot="-5400000" vert="horz"/><a:lstStyle/><a:p><a:r><a:rPr lang="en-US"/><a:t>Units</a:t></a:r></a:p></c:rich></c:tx><c:overlay val="0"/></c:title>
+                <c:numFmt formatCode="#,##0" sourceLinked="0"/>
+                <c:majorTickMark val="out"/>
+                <c:minorTickMark val="none"/>
+                <c:tickLblPos val="nextTo"/>
+                <c:spPr><a:noFill/><a:ln><a:noFill/></a:ln></c:spPr>
+                <c:txPr><a:bodyPr rot="-60000000" spcFirstLastPara="1"/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="900"/></a:pPr><a:endParaRPr lang="en-US"/></a:p></c:txPr>
+                <c:crossAx val="111111111"/>
+                <c:crossBetween val="between"/>
+              </c:valAx>
               <c:valAx><c:axId val="444444444"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="r"/><c:crossAx val="333333333"/><c:crosses val="max"/></c:valAx>
               <c:catAx><c:axId val="333333333"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="1"/><c:axPos val="b"/><c:crossAx val="444444444"/></c:catAx>
             </c:plotArea>
@@ -186,6 +201,30 @@ public class ChartRoundTripPreservationTests
         Assert.That(line.Smooth, Is.True);
         Assert.That(line.UseSecondaryAxis, Is.True,
             "The line group is plotted against the value axis on the right.");
+    }
+
+    [Test]
+    public void ExcelShapedLegendAndAxesAreRead()
+    {
+        using var ms = CreateWorkbookWithExcelShapedChart();
+        using var wb = new XLWorkbook(ms);
+        var chart = wb.Worksheet("Data").Charts.First();
+
+        Assert.That(chart.Legend.Visible, Is.True);
+        Assert.That(chart.Legend.Position, Is.EqualTo(XLLegendPosition.Bottom));
+        Assert.That(chart.Legend.Overlay, Is.False);
+
+        Assert.That(chart.CategoryAxis.Visible, Is.True);
+        Assert.That(chart.CategoryAxis.Title, Is.Null);
+
+        Assert.That(chart.ValueAxis.Title, Is.EqualTo("Units"));
+        Assert.That(chart.ValueAxis.NumberFormat, Is.EqualTo("#,##0"));
+        Assert.That(chart.ValueAxis.MajorGridlines, Is.True);
+        Assert.That(chart.ValueAxis.Visible, Is.True);
+        Assert.That(chart.ValueAxis.LogScale, Is.False);
+
+        Assert.That(chart.SecondaryValueAxis.Visible, Is.True,
+            "The fixture's line group hangs off a second value axis.");
     }
 
     // ── Preservation ────────────────────────────────────────────────────
@@ -374,6 +413,71 @@ public class ChartRoundTripPreservationTests
                          xml.IndexOf("</c:dLbls>", StringComparison.Ordinal)];
         Assert.That(labels, Does.Contain("<c:showVal val=\"1\""));
         Assert.That(labels, Does.Not.Contain("<c:delete"));
+    }
+
+    [Test]
+    public void EditingAnAxisKeepsItsTickMarksAndTextFormatting()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            chart.ValueAxis.Title = "Units sold";
+            chart.ValueAxis.Min = 0;
+            chart.ValueAxis.Max = 250;
+            chart.ValueAxis.MajorGridlines = false;
+            chart.Legend.Position = XLLegendPosition.Right;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        var xml = ReadChartXml(saved);
+
+        // The edits landed.
+        Assert.That(xml, Does.Contain("Units sold"));
+        Assert.That(xml, Does.Not.Contain("<a:t>Units</a:t>"));
+        Assert.That(xml, Does.Contain("<c:max val=\"250\""));
+        Assert.That(xml, Does.Contain("<c:min val=\"0\""));
+        Assert.That(xml, Does.Not.Contain("<c:majorGridlines"));
+        Assert.That(xml, Does.Contain("<c:legendPos val=\"r\""));
+
+        // Everything on the axis that XLibur does not model is untouched.
+        Assert.That(xml, Does.Contain("<c:majorTickMark val=\"out\""));
+        Assert.That(xml, Does.Contain("<c:tickLblPos val=\"nextTo\""));
+        Assert.That(xml, Does.Contain("<c:crossBetween val=\"between\""));
+        Assert.That(xml, Does.Contain("spcFirstLastPara=\"1\""));
+        Assert.That(xml, Does.Contain("formatCode=\"#,##0\""), "The number format was not touched.");
+    }
+
+    [Test]
+    public void EditedAxisAndLegendReloadWithTheNewValues()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            chart.CategoryAxis.Title = "Quarter";
+            chart.ValueAxis.Orientation = XLAxisOrientation.MaxMin;
+            chart.ValueAxis.MajorUnit = 25;
+            chart.SecondaryValueAxis.Title = "Price";
+            chart.Legend.Visible = false;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        saved.Position = 0;
+        using (var wb = new XLWorkbook(saved))
+        {
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.CategoryAxis.Title, Is.EqualTo("Quarter"));
+            Assert.That(chart.ValueAxis.Orientation, Is.EqualTo(XLAxisOrientation.MaxMin));
+            Assert.That(chart.ValueAxis.MajorUnit, Is.EqualTo(25));
+            Assert.That(chart.ValueAxis.Title, Is.EqualTo("Units"), "An untouched property is kept.");
+            Assert.That(chart.SecondaryValueAxis.Title, Is.EqualTo("Price"));
+            Assert.That(chart.Legend.Visible, Is.False);
+        }
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
@@ -465,7 +465,7 @@ public class ChartSeriesFormattingTests
         // back and that what it wrote is schema-valid.
         using var wb = new XLWorkbook(path);
         using var ms = SaveValidated(wb);
-        Assert.That(wb.Worksheets.Count, Is.EqualTo(5));
+        Assert.That(wb.Worksheets.Count, Is.EqualTo(6));
     }
 
     [Test]

--- a/XLibur/Excel/Charts/IXLChart.cs
+++ b/XLibur/Excel/Charts/IXLChart.cs
@@ -164,4 +164,26 @@ public interface IXLChart : IXLDrawing<IXLChart>
     /// through <see cref="IXLChartSeries.DataLabels"/>.
     /// </summary>
     IXLDataLabels DataLabels { get; }
+
+    /// <summary>
+    /// Gets the chart's legend.
+    /// </summary>
+    IXLChartLegend Legend { get; }
+
+    /// <summary>
+    /// Gets the horizontal axis — the category axis, or the X value axis of a scatter or bubble chart.
+    /// Pie and doughnut charts have no axes and ignore it.
+    /// </summary>
+    IXLChartAxis CategoryAxis { get; }
+
+    /// <summary>
+    /// Gets the vertical value axis. Pie and doughnut charts have no axes and ignore it.
+    /// </summary>
+    IXLChartAxis ValueAxis { get; }
+
+    /// <summary>
+    /// Gets the value axis on the right, which exists only while at least one series has
+    /// <see cref="IXLChartSeries.UseSecondaryAxis"/> set.
+    /// </summary>
+    IXLChartAxis SecondaryValueAxis { get; }
 }

--- a/XLibur/Excel/Charts/IXLChartAxis.cs
+++ b/XLibur/Excel/Charts/IXLChartAxis.cs
@@ -1,0 +1,101 @@
+namespace XLibur.Excel;
+
+/// <summary>
+/// The direction an axis runs in.
+/// </summary>
+public enum XLAxisOrientation
+{
+    /// <summary>Smallest value first — left to right, or bottom to top. This is the default.</summary>
+    MinMax,
+
+    /// <summary>Reversed: largest value first.</summary>
+    MaxMin
+}
+
+/// <summary>
+/// One axis of a chart.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="IXLChart.CategoryAxis"/> is the horizontal axis and <see cref="IXLChart.ValueAxis"/>
+/// the vertical one. On a scatter or bubble chart both are value axes, so the "category" axis takes
+/// numbers there too.
+/// </para>
+/// <para>
+/// Not every property reaches every axis: <see cref="MajorUnit"/>, <see cref="MinorUnit"/> and
+/// <see cref="LogScale"/> exist only on a value axis in the file format, and are skipped on a
+/// category axis. Pie and doughnut charts have no axes at all and ignore everything here.
+/// </para>
+/// </remarks>
+public interface IXLChartAxis
+{
+    /// <summary>
+    /// Gets or sets the axis title. <c>null</c> — the default — means no title.
+    /// </summary>
+    string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number format the axis labels are drawn with, e.g. <c>"#,##0"</c>.
+    /// <c>null</c> — the default — takes the format from the source cells.
+    /// </summary>
+    string? NumberFormat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the smallest value shown on the axis. <c>null</c> — the default — lets Excel
+    /// choose it from the data. Value axes only.
+    /// </summary>
+    double? Min { get; set; }
+
+    /// <summary>
+    /// Gets or sets the largest value shown on the axis. <c>null</c> — the default — lets Excel
+    /// choose it from the data. Value axes only.
+    /// </summary>
+    double? Max { get; set; }
+
+    /// <summary>
+    /// Gets or sets the interval between major tick marks and labels. <c>null</c> — the default —
+    /// lets Excel choose. Value axes only.
+    /// </summary>
+    /// <exception cref="System.ArgumentOutOfRangeException">The value is zero or negative.</exception>
+    double? MajorUnit { get; set; }
+
+    /// <summary>
+    /// Gets or sets the interval between minor tick marks. <c>null</c> — the default — lets Excel
+    /// choose. Value axes only.
+    /// </summary>
+    /// <exception cref="System.ArgumentOutOfRangeException">The value is zero or negative.</exception>
+    double? MinorUnit { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the axis is drawn. Defaults to <c>true</c>. A hidden axis still scales
+    /// the plot — it just is not painted.
+    /// </summary>
+    bool Visible { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether major gridlines are drawn across the plot area from this axis.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    bool MajorGridlines { get; set; }
+
+    /// <summary>
+    /// Gets or sets the direction the axis runs in. Defaults to
+    /// <see cref="XLAxisOrientation.MinMax"/>.
+    /// </summary>
+    XLAxisOrientation Orientation { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the axis is scaled logarithmically. Defaults to <c>false</c>.
+    /// Value axes only.
+    /// </summary>
+    bool LogScale { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base of the logarithmic scale, used when <see cref="LogScale"/> is
+    /// <c>true</c>. Defaults to 10.
+    /// </summary>
+    /// <exception cref="System.ArgumentOutOfRangeException">
+    /// The value is outside the range Excel accepts (2 to 1000).
+    /// </exception>
+    double LogBase { get; set; }
+}

--- a/XLibur/Excel/Charts/IXLChartLegend.cs
+++ b/XLibur/Excel/Charts/IXLChartLegend.cs
@@ -1,0 +1,49 @@
+namespace XLibur.Excel;
+
+/// <summary>
+/// Where the legend sits relative to the plot area.
+/// </summary>
+public enum XLLegendPosition
+{
+    /// <summary>To the right of the plot area. This is the default.</summary>
+    Right,
+
+    /// <summary>Below the plot area.</summary>
+    Bottom,
+
+    /// <summary>To the left of the plot area.</summary>
+    Left,
+
+    /// <summary>Above the plot area.</summary>
+    Top,
+
+    /// <summary>In the top right corner.</summary>
+    TopRight
+}
+
+/// <summary>
+/// The legend of a chart — the key that names each series.
+/// </summary>
+/// <remarks>
+/// Charts XLibur creates have no legend until <see cref="Visible"/> is set, and a chart read from a
+/// file keeps the legend it came with unless one of these properties is assigned.
+/// </remarks>
+public interface IXLChartLegend
+{
+    /// <summary>
+    /// Gets or sets whether the legend is shown. Defaults to <c>false</c>.
+    /// </summary>
+    bool Visible { get; set; }
+
+    /// <summary>
+    /// Gets or sets where the legend sits. Defaults to <see cref="XLLegendPosition.Right"/>.
+    /// Ignored while <see cref="Visible"/> is <c>false</c>.
+    /// </summary>
+    XLLegendPosition Position { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the legend is drawn on top of the plot area rather than beside it,
+    /// which gives the plot more room. Defaults to <c>false</c>.
+    /// </summary>
+    bool Overlay { get; set; }
+}

--- a/XLibur/Excel/Charts/XLChart.cs
+++ b/XLibur/Excel/Charts/XLChart.cs
@@ -43,6 +43,9 @@ internal sealed class XLChart : XLDrawing<IXLChart>, IXLChart
         SecondarySeries = new XLChartSeriesCollection(this, secondary: true);
         SecondPosition = new XLDrawingPosition();
         DataLabelsInternal = new XLChartDataLabels(this);
+        CategoryAxisInternal = new XLChartAxis(this, XLChartAxisRole.Category);
+        ValueAxisInternal = new XLChartAxis(this, XLChartAxisRole.Value);
+        SecondaryValueAxisInternal = new XLChartAxis(this, XLChartAxisRole.SecondaryValue);
     }
 
     public string? Title { get; set; }
@@ -69,6 +72,26 @@ internal sealed class XLChart : XLDrawing<IXLChart>, IXLChart
     /// The chart-wide data labels, typed for internal use.
     /// </summary>
     internal XLChartDataLabels DataLabelsInternal { get; }
+
+    public IXLChartLegend Legend => LegendInternal;
+
+    /// <summary>The chart's legend, typed for internal use.</summary>
+    internal XLChartLegend LegendInternal { get; } = new();
+
+    public IXLChartAxis CategoryAxis => CategoryAxisInternal;
+
+    public IXLChartAxis ValueAxis => ValueAxisInternal;
+
+    public IXLChartAxis SecondaryValueAxis => SecondaryValueAxisInternal;
+
+    /// <summary>The horizontal axis, typed for internal use.</summary>
+    internal XLChartAxis CategoryAxisInternal { get; }
+
+    /// <summary>The vertical value axis, typed for internal use.</summary>
+    internal XLChartAxis ValueAxisInternal { get; }
+
+    /// <summary>The right-hand value axis, typed for internal use.</summary>
+    internal XLChartAxis SecondaryValueAxisInternal { get; }
 
     /// <summary>
     /// The relationship ID linking this chart to its ChartPart within the DrawingsPart.

--- a/XLibur/Excel/Charts/XLChartAxis.cs
+++ b/XLibur/Excel/Charts/XLChartAxis.cs
@@ -1,0 +1,210 @@
+using System;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// Which axis of a chart an <see cref="XLChartAxis"/> is, which decides both the properties the file
+/// format lets it carry and where the patcher finds it.
+/// </summary>
+internal enum XLChartAxisRole
+{
+    /// <summary>The horizontal axis — a category axis, or the X value axis of a scatter chart.</summary>
+    Category,
+
+    /// <summary>The vertical value axis.</summary>
+    Value,
+
+    /// <summary>The value axis on the right, used by series bound to the secondary axis.</summary>
+    SecondaryValue
+}
+
+/// <summary>
+/// Identifies the axis properties a caller has explicitly assigned, so that the patcher which updates
+/// charts loaded from a file can rewrite those and only those.
+/// </summary>
+[Flags]
+internal enum XLChartAxisFormat
+{
+    None = 0,
+    Title = 1 << 0,
+    NumberFormat = 1 << 1,
+    Min = 1 << 2,
+    Max = 1 << 3,
+    MajorUnit = 1 << 4,
+    MinorUnit = 1 << 5,
+    Visible = 1 << 6,
+    MajorGridlines = 1 << 7,
+    Orientation = 1 << 8,
+    LogScale = 1 << 9,
+    LogBase = 1 << 10
+}
+
+internal sealed class XLChartAxis : IXLChartAxis
+{
+    private const double MinLogBase = 2;
+    private const double MaxLogBase = 1000;
+
+    private string? _title;
+    private string? _numberFormat;
+    private double? _min;
+    private double? _max;
+    private double? _majorUnit;
+    private double? _minorUnit;
+    private bool _visible = true;
+    private bool _majorGridlines;
+    private XLAxisOrientation _orientation;
+    private bool _logScale;
+    private double _logBase = 10;
+
+    private readonly XLChart _chart;
+
+    internal XLChartAxis(XLChart chart, XLChartAxisRole role)
+    {
+        _chart = chart;
+        Role = role;
+    }
+
+    internal XLChartAxisRole Role { get; }
+
+    /// <summary>
+    /// Whether this axis can carry the value-axis-only properties: the unit intervals and the
+    /// logarithmic scale. True for the vertical axes always, and for the horizontal axis of the chart
+    /// types that plot numbers along it — scatter and bubble, where <c>c:catAx</c> is really a
+    /// <c>c:valAx</c>.
+    /// </summary>
+    internal bool IsValueAxis => Role != XLChartAxisRole.Category || HasNumericHorizontalAxis(_chart.ChartType);
+
+    private static bool HasNumericHorizontalAxis(XLChartType chartType) => chartType
+        is XLChartType.XYScatterMarkers
+        or XLChartType.XYScatterSmoothLinesNoMarkers or XLChartType.XYScatterSmoothLinesWithMarkers
+        or XLChartType.XYScatterStraightLinesNoMarkers or XLChartType.XYScatterStraightLinesWithMarkers
+        or XLChartType.Bubble or XLChartType.Bubble3D;
+
+    public string? Title
+    {
+        get => _title;
+        set => Assign(ref _title, value, XLChartAxisFormat.Title);
+    }
+
+    public string? NumberFormat
+    {
+        get => _numberFormat;
+        set => Assign(ref _numberFormat, value, XLChartAxisFormat.NumberFormat);
+    }
+
+    public double? Min
+    {
+        get => _min;
+        set => Assign(ref _min, value, XLChartAxisFormat.Min);
+    }
+
+    public double? Max
+    {
+        get => _max;
+        set => Assign(ref _max, value, XLChartAxisFormat.Max);
+    }
+
+    public double? MajorUnit
+    {
+        get => _majorUnit;
+        set
+        {
+            if (value <= 0)
+                throw new ArgumentOutOfRangeException(nameof(MajorUnit), value,
+                    "An axis unit must be greater than zero.");
+
+            Assign(ref _majorUnit, value, XLChartAxisFormat.MajorUnit);
+        }
+    }
+
+    public double? MinorUnit
+    {
+        get => _minorUnit;
+        set
+        {
+            if (value <= 0)
+                throw new ArgumentOutOfRangeException(nameof(MinorUnit), value,
+                    "An axis unit must be greater than zero.");
+
+            Assign(ref _minorUnit, value, XLChartAxisFormat.MinorUnit);
+        }
+    }
+
+    public bool Visible
+    {
+        get => _visible;
+        set => Assign(ref _visible, value, XLChartAxisFormat.Visible);
+    }
+
+    public bool MajorGridlines
+    {
+        get => _majorGridlines;
+        set => Assign(ref _majorGridlines, value, XLChartAxisFormat.MajorGridlines);
+    }
+
+    public XLAxisOrientation Orientation
+    {
+        get => _orientation;
+        set => Assign(ref _orientation, value, XLChartAxisFormat.Orientation);
+    }
+
+    public bool LogScale
+    {
+        get => _logScale;
+        set => Assign(ref _logScale, value, XLChartAxisFormat.LogScale);
+    }
+
+    public double LogBase
+    {
+        get => _logBase;
+        set
+        {
+            if (value is < MinLogBase or > MaxLogBase)
+                throw new ArgumentOutOfRangeException(nameof(LogBase), value,
+                    $"The base of a logarithmic axis must be between {MinLogBase} and {MaxLogBase}.");
+
+            Assign(ref _logBase, value, XLChartAxisFormat.LogBase);
+        }
+    }
+
+    /// <summary>
+    /// The properties that have been explicitly assigned through the public API.
+    /// </summary>
+    internal XLChartAxisFormat AssignedFormat { get; private set; }
+
+    /// <summary>
+    /// Seeds the properties from an existing chart part without marking them as assigned, so that an
+    /// axis nobody edited is never written back.
+    /// </summary>
+    internal void SeedLoaded(
+        string? title,
+        string? numberFormat,
+        double? min,
+        double? max,
+        double? majorUnit,
+        double? minorUnit,
+        bool visible,
+        bool majorGridlines,
+        XLAxisOrientation orientation,
+        bool logScale,
+        double logBase)
+    {
+        _title = title;
+        _numberFormat = numberFormat;
+        _min = min;
+        _max = max;
+        _majorUnit = majorUnit;
+        _minorUnit = minorUnit;
+        _visible = visible;
+        _majorGridlines = majorGridlines;
+        _orientation = orientation;
+        _logScale = logScale;
+        _logBase = logBase;
+    }
+
+    private void Assign<T>(ref T field, T value, XLChartAxisFormat flag)
+    {
+        field = value;
+        AssignedFormat |= flag;
+    }
+}

--- a/XLibur/Excel/Charts/XLChartLegend.cs
+++ b/XLibur/Excel/Charts/XLChartLegend.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// Identifies the legend properties a caller has explicitly assigned.
+/// </summary>
+[Flags]
+internal enum XLChartLegendFormat
+{
+    None = 0,
+    Visible = 1 << 0,
+    Position = 1 << 1,
+    Overlay = 1 << 2
+}
+
+internal sealed class XLChartLegend : IXLChartLegend
+{
+    private bool _visible;
+    private XLLegendPosition _position;
+    private bool _overlay;
+
+    public bool Visible
+    {
+        get => _visible;
+        set => Assign(ref _visible, value, XLChartLegendFormat.Visible);
+    }
+
+    public XLLegendPosition Position
+    {
+        get => _position;
+        set => Assign(ref _position, value, XLChartLegendFormat.Position);
+    }
+
+    public bool Overlay
+    {
+        get => _overlay;
+        set => Assign(ref _overlay, value, XLChartLegendFormat.Overlay);
+    }
+
+    /// <summary>
+    /// The properties that have been explicitly assigned through the public API.
+    /// </summary>
+    internal XLChartLegendFormat AssignedFormat { get; private set; }
+
+    /// <summary>
+    /// Seeds the properties from an existing chart part without marking them as assigned, so that a
+    /// legend nobody edited is never written back.
+    /// </summary>
+    internal void SeedLoaded(bool visible, XLLegendPosition position, bool overlay)
+    {
+        _visible = visible;
+        _position = position;
+        _overlay = overlay;
+    }
+
+    private void Assign<T>(ref T field, T value, XLChartLegendFormat flag)
+    {
+        field = value;
+        AssignedFormat |= flag;
+    }
+}

--- a/XLibur/Excel/IO/ChartFormatting.cs
+++ b/XLibur/Excel/IO/ChartFormatting.cs
@@ -167,6 +167,351 @@ internal static class ChartFormatting
         return XLDataLabelPosition.Auto;
     }
 
+    // ── Legend ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds the <c>c:legend</c> element, or returns <c>null</c> when the chart has no legend.
+    /// </summary>
+    internal static C.Legend? BuildLegend(XLChartLegend legend)
+    {
+        if (legend.AssignedFormat == XLChartLegendFormat.None || !legend.Visible)
+            return null;
+
+        var element = new C.Legend();
+        element.Append(new C.LegendPosition { Val = MapLegendPosition(legend.Position) });
+        element.Append(new C.Overlay { Val = legend.Overlay });
+        return element;
+    }
+
+    /// <summary>
+    /// Reads a <c>c:legend</c> element into the model. A chart with no legend element seeds
+    /// <see cref="IXLChartLegend.Visible"/> as <c>false</c>.
+    /// </summary>
+    internal static void ReadLegend(C.Legend? element, XLChartLegend legend)
+    {
+        if (element == null)
+        {
+            legend.SeedLoaded(visible: false, XLLegendPosition.Right, overlay: false);
+            return;
+        }
+
+        legend.SeedLoaded(
+            visible: true,
+            position: ReadLegendPosition(element),
+            overlay: element.Elements<C.Overlay>().FirstOrDefault()?.Val?.Value ?? false);
+    }
+
+    /// <summary>
+    /// Applies the assigned legend properties to a <c>c:chart</c> element, adding or removing the
+    /// <c>c:legend</c> child as needed. The legend's own text and shape properties are left alone.
+    /// </summary>
+    internal static void PatchLegend(C.Chart chart, XLChartLegend legend)
+    {
+        var assigned = legend.AssignedFormat;
+        if (assigned == XLChartLegendFormat.None)
+            return;
+
+        var element = chart.Elements<C.Legend>().FirstOrDefault();
+
+        if ((assigned & XLChartLegendFormat.Visible) != 0 && !legend.Visible)
+        {
+            element?.Remove();
+            return;
+        }
+
+        if (element == null)
+        {
+            element = new C.Legend();
+            element.Append(new C.LegendPosition { Val = MapLegendPosition(legend.Position) });
+            element.Append(new C.Overlay { Val = legend.Overlay });
+            InsertOrdered(chart, element, ChartChildOrder);
+            return;
+        }
+
+        if ((assigned & XLChartLegendFormat.Position) != 0)
+        {
+            foreach (var existing in element.Elements<C.LegendPosition>().ToList())
+                existing.Remove();
+            InsertOrdered(element, new C.LegendPosition { Val = MapLegendPosition(legend.Position) },
+                LegendChildOrder);
+        }
+
+        if ((assigned & XLChartLegendFormat.Overlay) != 0)
+        {
+            foreach (var existing in element.Elements<C.Overlay>().ToList())
+                existing.Remove();
+            InsertOrdered(element, new C.Overlay { Val = legend.Overlay }, LegendChildOrder);
+        }
+    }
+
+    private static XLLegendPosition ReadLegendPosition(C.Legend element)
+    {
+        var position = element.Elements<C.LegendPosition>().FirstOrDefault()?.Val;
+        if (position == null)
+            return XLLegendPosition.Right;
+
+        var value = position.Value;
+        if (value == C.LegendPositionValues.Bottom) return XLLegendPosition.Bottom;
+        if (value == C.LegendPositionValues.Left) return XLLegendPosition.Left;
+        if (value == C.LegendPositionValues.Top) return XLLegendPosition.Top;
+        if (value == C.LegendPositionValues.TopRight) return XLLegendPosition.TopRight;
+        return XLLegendPosition.Right;
+    }
+
+    private static C.LegendPositionValues MapLegendPosition(XLLegendPosition position) => position switch
+    {
+        XLLegendPosition.Right => C.LegendPositionValues.Right,
+        XLLegendPosition.Bottom => C.LegendPositionValues.Bottom,
+        XLLegendPosition.Left => C.LegendPositionValues.Left,
+        XLLegendPosition.Top => C.LegendPositionValues.Top,
+        XLLegendPosition.TopRight => C.LegendPositionValues.TopRight,
+        _ => throw new ArgumentOutOfRangeException(nameof(position), position, "Unknown legend position.")
+    };
+
+    // ── Axes ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Appends the optional children an axis model asks for to a freshly built <c>c:catAx</c> or
+    /// <c>c:valAx</c>, in schema order. The caller has already added <c>c:axId</c>, <c>c:scaling</c>,
+    /// <c>c:delete</c> and <c>c:axPos</c>; <c>c:crossAx</c> and what follows it come afterwards.
+    /// </summary>
+    internal static void AppendAxisBody(OpenXmlCompositeElement axis, XLChartAxis model)
+    {
+        if (model.MajorGridlines)
+            axis.Append(new C.MajorGridlines());
+
+        if (model.Title != null)
+            axis.Append(BuildAxisTitle(model.Title));
+
+        if (model.NumberFormat != null)
+            axis.Append(new C.NumberingFormat { FormatCode = model.NumberFormat, SourceLinked = false });
+    }
+
+    /// <summary>
+    /// Appends the children that follow <c>c:crossAx</c> on a value axis. Skipped for a category axis,
+    /// where <c>CT_CatAx</c> has no unit elements.
+    /// </summary>
+    internal static void AppendAxisUnits(OpenXmlCompositeElement axis, XLChartAxis model)
+    {
+        if (!model.IsValueAxis)
+            return;
+
+        if (model.MajorUnit != null)
+            axis.Append(new C.MajorUnit { Val = model.MajorUnit.Value });
+
+        if (model.MinorUnit != null)
+            axis.Append(new C.MinorUnit { Val = model.MinorUnit.Value });
+    }
+
+    /// <summary>
+    /// Builds the <c>c:scaling</c> element for an axis. Its children are ordered
+    /// <c>logBase</c>, <c>orientation</c>, <c>max</c>, <c>min</c>.
+    /// </summary>
+    internal static C.Scaling BuildScaling(XLChartAxis model)
+    {
+        var scaling = new C.Scaling();
+
+        // c:logBase belongs to a value axis; Excel rejects it on a category axis.
+        if (model.LogScale && model.IsValueAxis)
+            scaling.Append(new C.LogBase { Val = model.LogBase });
+
+        scaling.Append(new C.Orientation
+        {
+            Val = model.Orientation == XLAxisOrientation.MaxMin
+                ? C.OrientationValues.MaxMin
+                : C.OrientationValues.MinMax
+        });
+
+        if (model.Max != null)
+            scaling.Append(new C.MaxAxisValue { Val = model.Max.Value });
+        if (model.Min != null)
+            scaling.Append(new C.MinAxisValue { Val = model.Min.Value });
+
+        return scaling;
+    }
+
+    /// <summary>
+    /// Reads a <c>c:catAx</c> or <c>c:valAx</c> element into the model.
+    /// </summary>
+    internal static void ReadAxis(OpenXmlCompositeElement? axis, XLChartAxis model)
+    {
+        if (axis == null)
+            return;
+
+        var scaling = axis.Elements<C.Scaling>().FirstOrDefault();
+        var logBase = scaling?.Elements<C.LogBase>().FirstOrDefault()?.Val?.Value;
+        var orientation = scaling?.Elements<C.Orientation>().FirstOrDefault()?.Val;
+
+        model.SeedLoaded(
+            title: ReadAxisTitle(axis),
+            numberFormat: axis.Elements<C.NumberingFormat>().FirstOrDefault()?.FormatCode?.Value,
+            min: scaling?.Elements<C.MinAxisValue>().FirstOrDefault()?.Val?.Value,
+            max: scaling?.Elements<C.MaxAxisValue>().FirstOrDefault()?.Val?.Value,
+            majorUnit: axis.Elements<C.MajorUnit>().FirstOrDefault()?.Val?.Value,
+            minorUnit: axis.Elements<C.MinorUnit>().FirstOrDefault()?.Val?.Value,
+            // c:delete says the axis is hidden, and defaults to false when absent.
+            visible: !(axis.Elements<C.Delete>().FirstOrDefault()?.Val?.Value ?? false),
+            majorGridlines: axis.Elements<C.MajorGridlines>().Any(),
+            orientation: orientation != null && orientation.Value == C.OrientationValues.MaxMin
+                ? XLAxisOrientation.MaxMin
+                : XLAxisOrientation.MinMax,
+            logScale: logBase != null,
+            logBase: logBase ?? 10);
+    }
+
+    /// <summary>
+    /// Applies the assigned axis properties onto an existing <c>c:catAx</c> or <c>c:valAx</c>, leaving
+    /// its tick marks, label positions, line and text formatting as they were.
+    /// </summary>
+    internal static void PatchAxis(OpenXmlCompositeElement? axis, XLChartAxis model)
+    {
+        var assigned = model.AssignedFormat;
+        if (axis == null || assigned == XLChartAxisFormat.None)
+            return;
+
+        if ((assigned & XLChartAxisFormat.Visible) != 0)
+        {
+            foreach (var existing in axis.Elements<C.Delete>().ToList())
+                existing.Remove();
+            InsertOrdered(axis, new C.Delete { Val = !model.Visible }, AxisChildOrder);
+        }
+
+        if ((assigned & XLChartAxisFormat.MajorGridlines) != 0)
+        {
+            foreach (var existing in axis.Elements<C.MajorGridlines>().ToList())
+                existing.Remove();
+            if (model.MajorGridlines)
+                InsertOrdered(axis, new C.MajorGridlines(), AxisChildOrder);
+        }
+
+        if ((assigned & XLChartAxisFormat.Title) != 0)
+        {
+            foreach (var existing in axis.Elements<C.Title>().ToList())
+                existing.Remove();
+            if (model.Title != null)
+                InsertOrdered(axis, BuildAxisTitle(model.Title), AxisChildOrder);
+        }
+
+        if ((assigned & XLChartAxisFormat.NumberFormat) != 0)
+        {
+            foreach (var existing in axis.Elements<C.NumberingFormat>().ToList())
+                existing.Remove();
+            if (model.NumberFormat != null)
+            {
+                InsertOrdered(axis,
+                    new C.NumberingFormat { FormatCode = model.NumberFormat, SourceLinked = false },
+                    AxisChildOrder);
+            }
+        }
+
+        if ((assigned & (XLChartAxisFormat.Min | XLChartAxisFormat.Max
+                         | XLChartAxisFormat.Orientation | XLChartAxisFormat.LogScale
+                         | XLChartAxisFormat.LogBase)) != 0)
+        {
+            PatchScaling(axis, model, assigned);
+        }
+
+        if (model.IsValueAxis)
+            PatchAxisUnits(axis, model, assigned);
+    }
+
+    private static void PatchScaling(
+        OpenXmlCompositeElement axis, XLChartAxis model, XLChartAxisFormat assigned)
+    {
+        var scaling = axis.Elements<C.Scaling>().FirstOrDefault();
+        if (scaling == null)
+        {
+            scaling = new C.Scaling();
+            InsertOrdered(axis, scaling, AxisChildOrder);
+        }
+
+        if ((assigned & (XLChartAxisFormat.LogScale | XLChartAxisFormat.LogBase)) != 0)
+        {
+            foreach (var existing in scaling.Elements<C.LogBase>().ToList())
+                existing.Remove();
+            if (model.LogScale && model.IsValueAxis)
+                InsertOrdered(scaling, new C.LogBase { Val = model.LogBase }, ScalingChildOrder);
+        }
+
+        if ((assigned & XLChartAxisFormat.Orientation) != 0)
+        {
+            foreach (var existing in scaling.Elements<C.Orientation>().ToList())
+                existing.Remove();
+            InsertOrdered(scaling, new C.Orientation
+            {
+                Val = model.Orientation == XLAxisOrientation.MaxMin
+                    ? C.OrientationValues.MaxMin
+                    : C.OrientationValues.MinMax
+            }, ScalingChildOrder);
+        }
+
+        if ((assigned & XLChartAxisFormat.Max) != 0)
+        {
+            foreach (var existing in scaling.Elements<C.MaxAxisValue>().ToList())
+                existing.Remove();
+            if (model.Max != null)
+                InsertOrdered(scaling, new C.MaxAxisValue { Val = model.Max.Value }, ScalingChildOrder);
+        }
+
+        if ((assigned & XLChartAxisFormat.Min) != 0)
+        {
+            foreach (var existing in scaling.Elements<C.MinAxisValue>().ToList())
+                existing.Remove();
+            if (model.Min != null)
+                InsertOrdered(scaling, new C.MinAxisValue { Val = model.Min.Value }, ScalingChildOrder);
+        }
+    }
+
+    private static void PatchAxisUnits(
+        OpenXmlCompositeElement axis, XLChartAxis model, XLChartAxisFormat assigned)
+    {
+        if ((assigned & XLChartAxisFormat.MajorUnit) != 0)
+        {
+            foreach (var existing in axis.Elements<C.MajorUnit>().ToList())
+                existing.Remove();
+            if (model.MajorUnit != null)
+                InsertOrdered(axis, new C.MajorUnit { Val = model.MajorUnit.Value }, AxisChildOrder);
+        }
+
+        if ((assigned & XLChartAxisFormat.MinorUnit) != 0)
+        {
+            foreach (var existing in axis.Elements<C.MinorUnit>().ToList())
+                existing.Remove();
+            if (model.MinorUnit != null)
+                InsertOrdered(axis, new C.MinorUnit { Val = model.MinorUnit.Value }, AxisChildOrder);
+        }
+    }
+
+    /// <summary>
+    /// Builds the <c>c:title</c> of an axis: a rich text run holding the literal title.
+    /// </summary>
+    private static C.Title BuildAxisTitle(string title) =>
+        new(
+            new C.ChartText(
+                new C.RichText(
+                    new A.BodyProperties(),
+                    new A.ListStyle(),
+                    new A.Paragraph(
+                        new A.Run(
+                            new A.RunProperties { Language = "en-US" },
+                            new A.Text(title)
+                        )
+                    )
+                )
+            ),
+            new C.Overlay { Val = false }
+        );
+
+    private static string? ReadAxisTitle(OpenXmlCompositeElement axis)
+    {
+        var title = axis.Elements<C.Title>().FirstOrDefault();
+        if (title == null)
+            return null;
+
+        var text = string.Concat(title.Descendants<A.Text>().Select(t => t.Text));
+        return string.IsNullOrEmpty(text) ? null : text;
+    }
+
     private static A.SolidFill? BuildSolidFill(XLColor? color) =>
         color == null || !color.HasValue ? null : new A.SolidFill(BuildColor(color));
 
@@ -420,6 +765,41 @@ internal static class ChartFormatting
         typeof(C.Index), typeof(C.Order), typeof(C.SeriesText), typeof(C.ChartShapeProperties),
         typeof(C.Marker), typeof(C.DataLabels), typeof(C.CategoryAxisData), typeof(C.XValues),
         typeof(C.Values), typeof(C.YValues), typeof(C.Smooth), typeof(C.ExtensionList)
+    ];
+
+    /// <summary>The schema order of the children of <c>c:chart</c> that this class touches.</summary>
+    private static readonly Type[] ChartChildOrder =
+    [
+        typeof(C.Title), typeof(C.AutoTitleDeleted), typeof(C.PlotArea), typeof(C.Legend),
+        typeof(C.PlotVisibleOnly), typeof(C.DisplayBlanksAs), typeof(C.ExtensionList)
+    ];
+
+    /// <summary>The schema order of the children of <c>c:legend</c>.</summary>
+    private static readonly Type[] LegendChildOrder =
+    [
+        typeof(C.LegendPosition), typeof(C.LegendEntry), typeof(C.Layout), typeof(C.Overlay),
+        typeof(C.ChartShapeProperties), typeof(C.TextProperties), typeof(C.ExtensionList)
+    ];
+
+    /// <summary>
+    /// The schema order of the children of <c>c:catAx</c> and <c>c:valAx</c> that this class touches.
+    /// The two types agree on the elements they share; the unit elements exist on <c>c:valAx</c> only.
+    /// </summary>
+    private static readonly Type[] AxisChildOrder =
+    [
+        typeof(C.AxisId), typeof(C.Scaling), typeof(C.Delete), typeof(C.AxisPosition),
+        typeof(C.MajorGridlines), typeof(C.MinorGridlines), typeof(C.Title),
+        typeof(C.NumberingFormat), typeof(C.MajorTickMark), typeof(C.MinorTickMark),
+        typeof(C.TickLabelPosition), typeof(C.ChartShapeProperties), typeof(C.TextProperties),
+        typeof(C.CrossingAxis), typeof(C.Crosses), typeof(C.CrossesAt), typeof(C.CrossBetween),
+        typeof(C.MajorUnit), typeof(C.MinorUnit), typeof(C.DisplayUnits), typeof(C.ExtensionList)
+    ];
+
+    /// <summary>The schema order of the children of <c>c:scaling</c>.</summary>
+    private static readonly Type[] ScalingChildOrder =
+    [
+        typeof(C.LogBase), typeof(C.Orientation), typeof(C.MaxAxisValue), typeof(C.MinAxisValue),
+        typeof(C.ExtensionList)
     ];
 
     /// <summary>The schema order of the children of <c>c:dLbls</c>.</summary>

--- a/XLibur/Excel/IO/ChartPatcher.cs
+++ b/XLibur/Excel/IO/ChartPatcher.cs
@@ -37,7 +37,13 @@ internal static class ChartPatcher
         // Extended (ChartEx) charts model their series in the cx namespace and do not support the
         // series formatting properties, so there is nothing to patch.
         var chartPart = ResolveChartPart(worksheetPart, xlChart);
-        var plotArea = chartPart?.ChartSpace?.Elements<C.Chart>().FirstOrDefault()?.PlotArea;
+        var chart = chartPart?.ChartSpace?.Elements<C.Chart>().FirstOrDefault();
+        if (chart == null)
+            return;
+
+        ChartFormatting.PatchLegend(chart, xlChart.LegendInternal);
+
+        var plotArea = chart.PlotArea;
         if (plotArea == null)
             return;
 
@@ -62,6 +68,34 @@ internal static class ChartPatcher
             xlChart.SecondaryChartType ?? xlChart.ChartType);
 
         PatchGroupDataLabels(groups, primaryKind.Value, xlChart);
+        PatchAxes(plotArea, groups, primaryKind.Value, xlChart);
+    }
+
+    /// <summary>
+    /// Writes the pending axis properties back. The axes are found by the identifiers the chart groups
+    /// point at, the same way the reader found them.
+    /// </summary>
+    private static void PatchAxes(
+        C.PlotArea plotArea, List<XLChartGroup> groups, XLChartGroupKind primaryKind, XLChart xlChart)
+    {
+        var primaryGroup = groups.First(g => g.Kind == primaryKind);
+        var primaryValueAxisId = primaryGroup.ValueAxisId;
+
+        ChartFormatting.PatchAxis(
+            ChartPlotAreaScanner.FindAxis(plotArea, primaryGroup.CategoryAxisId),
+            xlChart.CategoryAxisInternal);
+        ChartFormatting.PatchAxis(
+            ChartPlotAreaScanner.FindAxis(plotArea, primaryValueAxisId),
+            xlChart.ValueAxisInternal);
+
+        var secondaryGroup = groups.Find(g =>
+            g.ValueAxisId != null && primaryValueAxisId != null && g.ValueAxisId != primaryValueAxisId);
+        if (secondaryGroup != null)
+        {
+            ChartFormatting.PatchAxis(
+                ChartPlotAreaScanner.FindAxis(plotArea, secondaryGroup.ValueAxisId),
+                xlChart.SecondaryValueAxisInternal);
+        }
     }
 
     /// <summary>
@@ -84,6 +118,10 @@ internal static class ChartPatcher
 
     private static bool HasPendingChanges(XLChart xlChart) =>
         xlChart.DataLabelsInternal.AssignedFormat != XLDataLabelsFormat.None
+        || xlChart.LegendInternal.AssignedFormat != XLChartLegendFormat.None
+        || xlChart.CategoryAxisInternal.AssignedFormat != XLChartAxisFormat.None
+        || xlChart.ValueAxisInternal.AssignedFormat != XLChartAxisFormat.None
+        || xlChart.SecondaryValueAxisInternal.AssignedFormat != XLChartAxisFormat.None
         || HasPendingChanges(xlChart.SeriesInternal)
         || HasPendingChanges(xlChart.SecondarySeriesInternal);
 

--- a/XLibur/Excel/IO/ChartPlotAreaScanner.cs
+++ b/XLibur/Excel/IO/ChartPlotAreaScanner.cs
@@ -34,11 +34,13 @@ internal sealed class XLChartGroup
         XLChartGroupKind kind,
         OpenXmlCompositeElement element,
         List<OpenXmlCompositeElement> seriesElements,
+        uint? categoryAxisId,
         uint? valueAxisId)
     {
         Kind = kind;
         Element = element;
         SeriesElements = seriesElements;
+        CategoryAxisId = categoryAxisId;
         ValueAxisId = valueAxisId;
     }
 
@@ -47,6 +49,12 @@ internal sealed class XLChartGroup
     internal OpenXmlCompositeElement Element { get; }
 
     internal List<OpenXmlCompositeElement> SeriesElements { get; }
+
+    /// <summary>
+    /// The identifier of the horizontal axis this group is plotted against — the first <c>c:axId</c>
+    /// of the group — or <c>null</c> for the axis-less pie and doughnut groups.
+    /// </summary>
+    internal uint? CategoryAxisId { get; }
 
     /// <summary>
     /// The identifier of the value axis this group is plotted against — the second <c>c:axId</c> of
@@ -161,12 +169,36 @@ internal static class ChartPlotAreaScanner
     internal static uint? PrimaryValueAxisId(List<XLChartGroup> groups, XLChartGroupKind primaryKind) =>
         groups.First(g => g.Kind == primaryKind).ValueAxisId;
 
+    /// <summary>
+    /// Finds the axis element of a plot area carrying the given <c>c:axId</c>, whichever axis type it
+    /// happens to be.
+    /// </summary>
+    internal static OpenXmlCompositeElement? FindAxis(C.PlotArea plotArea, uint? axisId)
+    {
+        if (axisId == null)
+            return null;
+
+        foreach (var child in plotArea.ChildElements)
+        {
+            if (child is not (C.CategoryAxis or C.ValueAxis or C.DateAxis or C.SeriesAxis))
+                continue;
+
+            var composite = (OpenXmlCompositeElement)child;
+            if (composite.Elements<C.AxisId>().FirstOrDefault()?.Val?.Value == axisId)
+                return composite;
+        }
+
+        return null;
+    }
+
     private static XLChartGroup Build<TSeries>(
         XLChartGroupKind kind, OpenXmlCompositeElement element, IEnumerable<TSeries> seriesElements)
         where TSeries : OpenXmlCompositeElement
     {
         var axisIds = element.Elements<C.AxisId>().ToList();
+        var categoryAxisId = axisIds.Count >= 1 ? axisIds[0].Val?.Value : null;
         var valueAxisId = axisIds.Count >= 2 ? axisIds[1].Val?.Value : null;
-        return new XLChartGroup(kind, element, seriesElements.Cast<OpenXmlCompositeElement>().ToList(), valueAxisId);
+        return new XLChartGroup(kind, element, seriesElements.Cast<OpenXmlCompositeElement>().ToList(),
+            categoryAxisId, valueAxisId);
     }
 }

--- a/XLibur/Excel/IO/ChartReader.cs
+++ b/XLibur/Excel/IO/ChartReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
@@ -91,6 +92,7 @@ internal static class ChartReader
 
         var xlChart = new XLChart(ws) { IsNew = false, RelId = relId };
         ReadTitle(chart, xlChart);
+        ChartFormatting.ReadLegend(chart.Elements<C.Legend>().FirstOrDefault(), xlChart.LegendInternal);
 
         var plotArea = chart.PlotArea;
         if (plotArea != null)
@@ -124,6 +126,7 @@ internal static class ChartReader
             return;
 
         var primaryValueAxisId = ChartPlotAreaScanner.PrimaryValueAxisId(groups, primaryKind.Value);
+        ReadAxes(plotArea, groups, primaryKind.Value, primaryValueAxisId, xlChart);
         var primarySet = false;
 
         foreach (var group in groups)
@@ -153,6 +156,33 @@ internal static class ChartReader
                 xlChart.SecondaryChartType ??= chartType;
                 ReadGroupSeries(group, xlChart.SecondarySeriesInternal, useSecondaryAxis);
             }
+        }
+    }
+
+    /// <summary>
+    /// Reads the horizontal axis, the value axis and — when a group hangs off a different value axis —
+    /// the secondary value axis into the model.
+    /// </summary>
+    private static void ReadAxes(
+        C.PlotArea plotArea, List<XLChartGroup> groups, XLChartGroupKind primaryKind,
+        uint? primaryValueAxisId, XLChart xlChart)
+    {
+        var primaryGroup = groups.First(g => g.Kind == primaryKind);
+
+        ChartFormatting.ReadAxis(
+            ChartPlotAreaScanner.FindAxis(plotArea, primaryGroup.CategoryAxisId),
+            xlChart.CategoryAxisInternal);
+        ChartFormatting.ReadAxis(
+            ChartPlotAreaScanner.FindAxis(plotArea, primaryValueAxisId),
+            xlChart.ValueAxisInternal);
+
+        var secondaryGroup = groups.Find(g =>
+            g.ValueAxisId != null && primaryValueAxisId != null && g.ValueAxisId != primaryValueAxisId);
+        if (secondaryGroup != null)
+        {
+            ChartFormatting.ReadAxis(
+                ChartPlotAreaScanner.FindAxis(plotArea, secondaryGroup.ValueAxisId),
+                xlChart.SecondaryValueAxisInternal);
         }
     }
 

--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -423,6 +423,11 @@ internal static class ChartWriter
         }
 
         chart.Append(BuildPlotArea(xlChart));
+
+        var legend = ChartFormatting.BuildLegend(xlChart.LegendInternal);
+        if (legend != null)
+            chart.Append(legend);
+
         chart.Append(new C.PlotVisibleOnly { Val = true });
 
         return new C.ChartSpace(chart);
@@ -470,7 +475,7 @@ internal static class ChartWriter
             AppendChartElement(plotArea, group);
 
         // Every chart group has to precede every axis in CT_PlotArea.
-        AppendAxes(plotArea, xlChart.ChartType, groups.Exists(g => g.SecondaryAxis));
+        AppendAxes(plotArea, xlChart, groups.Exists(g => g.SecondaryAxis));
 
         return plotArea;
     }
@@ -526,18 +531,22 @@ internal static class ChartWriter
         !IsScatterType(ct) && !IsBubbleType(ct) && !IsSurfaceType(ct)
         && !IsPieType(ct) && !IsDoughnutType(ct);
 
-    private static void AppendAxes(C.PlotArea plotArea, XLChartType primaryChartType, bool hasSecondaryAxis)
+    private static void AppendAxes(C.PlotArea plotArea, XLChart xlChart, bool hasSecondaryAxis)
     {
+        var primaryChartType = xlChart.ChartType;
+        var horizontal = xlChart.CategoryAxisInternal;
+        var vertical = xlChart.ValueAxisInternal;
+
         if (IsScatterType(primaryChartType))
         {
             // Scatter uses two ValueAxis (X and Y)
-            plotArea.Append(BuildValueAxis(CatAxisId, ValAxisId, C.AxisPositionValues.Bottom));
-            plotArea.Append(BuildValueAxis(ValAxisId, CatAxisId, C.AxisPositionValues.Left));
+            plotArea.Append(BuildValueAxis(CatAxisId, ValAxisId, C.AxisPositionValues.Bottom, horizontal));
+            plotArea.Append(BuildValueAxis(ValAxisId, CatAxisId, C.AxisPositionValues.Left, vertical));
         }
         else if (IsSurfaceType(primaryChartType))
         {
-            plotArea.Append(BuildCategoryAxis(CatAxisId, ValAxisId));
-            plotArea.Append(BuildValueAxis(ValAxisId, CatAxisId, C.AxisPositionValues.Left));
+            plotArea.Append(BuildCategoryAxis(CatAxisId, ValAxisId, horizontal));
+            plotArea.Append(BuildValueAxis(ValAxisId, CatAxisId, C.AxisPositionValues.Left, vertical));
             plotArea.Append(new C.SeriesAxis(
                 new C.AxisId { Val = SerAxisId },
                 new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
@@ -548,8 +557,8 @@ internal static class ChartWriter
         }
         else
         {
-            plotArea.Append(BuildCategoryAxis(CatAxisId, ValAxisId));
-            plotArea.Append(BuildValueAxis(ValAxisId, CatAxisId, C.AxisPositionValues.Left));
+            plotArea.Append(BuildCategoryAxis(CatAxisId, ValAxisId, horizontal));
+            plotArea.Append(BuildValueAxis(ValAxisId, CatAxisId, C.AxisPositionValues.Left, vertical));
         }
 
         if (!hasSecondaryAxis)
@@ -557,35 +566,58 @@ internal static class ChartWriter
 
         // The secondary group needs its own axis pair. Excel hides the extra category axis and puts
         // the extra value axis on the right, crossing the category axis at its maximum.
-        plotArea.Append(BuildCategoryAxis(SecondaryCatAxisId, SecondaryValAxisId, deleted: true));
+        plotArea.Append(BuildCategoryAxis(SecondaryCatAxisId, SecondaryValAxisId,
+            model: null, deleted: true));
         plotArea.Append(BuildValueAxis(SecondaryValAxisId, SecondaryCatAxisId,
-            C.AxisPositionValues.Right, crossesMaximum: true));
+            C.AxisPositionValues.Right, xlChart.SecondaryValueAxisInternal, crossesMaximum: true));
     }
 
-    private static C.CategoryAxis BuildCategoryAxis(uint axisId, uint crossingAxisId, bool deleted = false)
+    /// <summary>
+    /// Builds a <c>c:catAx</c>. Its children follow the CT_CatAx order: identity and position first,
+    /// then the optional gridlines, title and number format, then the crossing axis.
+    /// </summary>
+    /// <param name="axisId">The identifier this axis is known by.</param>
+    /// <param name="crossingAxisId">The identifier of the axis this one crosses.</param>
+    /// <param name="model">
+    /// The axis model to take the optional properties from, or <c>null</c> for the hidden helper axis
+    /// of a secondary group, which has no public counterpart.
+    /// </param>
+    /// <param name="deleted">Whether the axis is hidden regardless of what the model says.</param>
+    private static C.CategoryAxis BuildCategoryAxis(
+        uint axisId, uint crossingAxisId, XLChartAxis? model, bool deleted = false)
     {
-        var axis = new C.CategoryAxis(
-            new C.AxisId { Val = axisId },
-            new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-            new C.Delete { Val = deleted },
-            new C.AxisPosition { Val = C.AxisPositionValues.Bottom },
-            new C.CrossingAxis { Val = crossingAxisId }
-        );
+        var axis = new C.CategoryAxis();
+        axis.Append(new C.AxisId { Val = axisId });
+        axis.Append(model == null
+            ? new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax })
+            : ChartFormatting.BuildScaling(model));
+        axis.Append(new C.Delete { Val = deleted || model is { Visible: false } });
+        axis.Append(new C.AxisPosition { Val = C.AxisPositionValues.Bottom });
+
+        if (model != null)
+            ChartFormatting.AppendAxisBody(axis, model);
+
+        axis.Append(new C.CrossingAxis { Val = crossingAxisId });
         return axis;
     }
 
     private static C.ValueAxis BuildValueAxis(
-        uint axisId, uint crossingAxisId, C.AxisPositionValues position, bool crossesMaximum = false)
+        uint axisId, uint crossingAxisId, C.AxisPositionValues position, XLChartAxis model,
+        bool crossesMaximum = false)
     {
-        var axis = new C.ValueAxis(
-            new C.AxisId { Val = axisId },
-            new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-            new C.Delete { Val = false },
-            new C.AxisPosition { Val = position },
-            new C.CrossingAxis { Val = crossingAxisId }
-        );
+        var axis = new C.ValueAxis();
+        axis.Append(new C.AxisId { Val = axisId });
+        axis.Append(ChartFormatting.BuildScaling(model));
+        axis.Append(new C.Delete { Val = !model.Visible });
+        axis.Append(new C.AxisPosition { Val = position });
+
+        ChartFormatting.AppendAxisBody(axis, model);
+
+        axis.Append(new C.CrossingAxis { Val = crossingAxisId });
         if (crossesMaximum)
             axis.Append(new C.Crosses { Val = C.CrossesValues.Maximum });
+
+        ChartFormatting.AppendAxisUnits(axis, model);
         return axis;
     }
 
@@ -703,20 +735,8 @@ internal static class ChartWriter
         var plotArea = new C.PlotArea(
             new C.Layout(),
             bubbleChart,
-            new C.ValueAxis(
-                new C.AxisId { Val = xAxisId },
-                new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-                new C.Delete { Val = false },
-                new C.AxisPosition { Val = C.AxisPositionValues.Bottom },
-                new C.CrossingAxis { Val = yAxisId }
-            ),
-            new C.ValueAxis(
-                new C.AxisId { Val = yAxisId },
-                new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }),
-                new C.Delete { Val = false },
-                new C.AxisPosition { Val = C.AxisPositionValues.Left },
-                new C.CrossingAxis { Val = xAxisId }
-            )
+            BuildValueAxis(xAxisId, yAxisId, C.AxisPositionValues.Bottom, xlChart.CategoryAxisInternal),
+            BuildValueAxis(yAxisId, xAxisId, C.AxisPositionValues.Left, xlChart.ValueAxisInternal)
         );
         return plotArea;
     }

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -158,3 +158,46 @@ XLibur.Excel.XLDataLabelPosition.Left = 6 -> XLibur.Excel.XLDataLabelPosition
 XLibur.Excel.XLDataLabelPosition.Right = 7 -> XLibur.Excel.XLDataLabelPosition
 XLibur.Excel.XLDataLabelPosition.Above = 8 -> XLibur.Excel.XLDataLabelPosition
 XLibur.Excel.XLDataLabelPosition.Below = 9 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.IXLChart.Legend.get -> XLibur.Excel.IXLChartLegend!
+XLibur.Excel.IXLChart.CategoryAxis.get -> XLibur.Excel.IXLChartAxis!
+XLibur.Excel.IXLChart.ValueAxis.get -> XLibur.Excel.IXLChartAxis!
+XLibur.Excel.IXLChart.SecondaryValueAxis.get -> XLibur.Excel.IXLChartAxis!
+XLibur.Excel.IXLChartLegend
+XLibur.Excel.IXLChartLegend.Visible.get -> bool
+XLibur.Excel.IXLChartLegend.Visible.set -> void
+XLibur.Excel.IXLChartLegend.Position.get -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.IXLChartLegend.Position.set -> void
+XLibur.Excel.IXLChartLegend.Overlay.get -> bool
+XLibur.Excel.IXLChartLegend.Overlay.set -> void
+XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLLegendPosition.Right = 0 -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLLegendPosition.Bottom = 1 -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLLegendPosition.Left = 2 -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLLegendPosition.Top = 3 -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLLegendPosition.TopRight = 4 -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.IXLChartAxis
+XLibur.Excel.IXLChartAxis.Title.get -> string?
+XLibur.Excel.IXLChartAxis.Title.set -> void
+XLibur.Excel.IXLChartAxis.NumberFormat.get -> string?
+XLibur.Excel.IXLChartAxis.NumberFormat.set -> void
+XLibur.Excel.IXLChartAxis.Min.get -> double?
+XLibur.Excel.IXLChartAxis.Min.set -> void
+XLibur.Excel.IXLChartAxis.Max.get -> double?
+XLibur.Excel.IXLChartAxis.Max.set -> void
+XLibur.Excel.IXLChartAxis.MajorUnit.get -> double?
+XLibur.Excel.IXLChartAxis.MajorUnit.set -> void
+XLibur.Excel.IXLChartAxis.MinorUnit.get -> double?
+XLibur.Excel.IXLChartAxis.MinorUnit.set -> void
+XLibur.Excel.IXLChartAxis.Visible.get -> bool
+XLibur.Excel.IXLChartAxis.Visible.set -> void
+XLibur.Excel.IXLChartAxis.MajorGridlines.get -> bool
+XLibur.Excel.IXLChartAxis.MajorGridlines.set -> void
+XLibur.Excel.IXLChartAxis.Orientation.get -> XLibur.Excel.XLAxisOrientation
+XLibur.Excel.IXLChartAxis.Orientation.set -> void
+XLibur.Excel.IXLChartAxis.LogScale.get -> bool
+XLibur.Excel.IXLChartAxis.LogScale.set -> void
+XLibur.Excel.IXLChartAxis.LogBase.get -> double
+XLibur.Excel.IXLChartAxis.LogBase.set -> void
+XLibur.Excel.XLAxisOrientation
+XLibur.Excel.XLAxisOrientation.MinMax = 0 -> XLibur.Excel.XLAxisOrientation
+XLibur.Excel.XLAxisOrientation.MaxMin = 1 -> XLibur.Excel.XLAxisOrientation

--- a/docs-website/docs/charts.md
+++ b/docs-website/docs/charts.md
@@ -316,23 +316,79 @@ and ignore these properties. If a chart type change makes an already-set positio
 position is dropped on save rather than written — the alternative is a file Excel refuses to open.
 :::
 
+## Legend
+
+A chart XLibur creates has no legend until you ask for one:
+
+```csharp
+chart.Legend.Visible = true;
+chart.Legend.Position = XLLegendPosition.Bottom;   // Right (default), Bottom, Left, Top, TopRight
+chart.Legend.Overlay = true;                       // draw over the plot area rather than beside it
+```
+
+Setting `Visible = false` on a chart read from a file removes the legend it came with.
+
+## Axes
+
+`CategoryAxis` is the horizontal axis and `ValueAxis` the vertical one. `SecondaryValueAxis` is the
+one on the right, which exists while a series has `UseSecondaryAxis` set:
+
+```csharp
+chart.CategoryAxis.Title = "Quarter";
+
+chart.ValueAxis.Title = "Revenue";
+chart.ValueAxis.NumberFormat = "$ #,##0";
+chart.ValueAxis.Min = 0;
+chart.ValueAxis.Max = 60_000;
+chart.ValueAxis.MajorUnit = 10_000;
+chart.ValueAxis.MajorGridlines = true;
+
+chart.SecondaryValueAxis.Title = "Margin";
+chart.SecondaryValueAxis.NumberFormat = "0%";
+```
+
+| Property | Meaning | Default |
+|---|---|---|
+| `Title` | axis title text | `null` — no title |
+| `NumberFormat` | format code for the labels | from the source cells |
+| `Min` / `Max` | ends of the scale | chosen from the data |
+| `MajorUnit` / `MinorUnit` | tick intervals | chosen by Excel |
+| `Visible` | whether the axis is drawn | `true` |
+| `MajorGridlines` | gridlines across the plot | `false` |
+| `Orientation` | `MinMax`, or `MaxMin` to reverse the axis | `MinMax` |
+| `LogScale` / `LogBase` | logarithmic scale, base 2 to 1000 | `false` / `10` |
+
+A log scale is what makes values spanning orders of magnitude readable:
+
+```csharp
+chart.ValueAxis.LogScale = true;
+chart.ValueAxis.LogBase = 10;
+```
+
+:::note
+`MajorUnit`, `MinorUnit` and `LogScale` belong to a value axis in the file format and are skipped on
+a category axis — except on a scatter or bubble chart, where the horizontal axis holds numbers and
+takes them too. Pie and doughnut charts have no axes at all and ignore everything here.
+:::
+
 ### Editing charts loaded from a file
 
 XLibur never regenerates the XML of a chart it read from a file — it patches in just the
 properties you assign. Everything it does not model stays exactly as Excel wrote it: trendlines,
-error bars, gradient and picture fills, per-point colours and label overrides, label fonts, the
-chart's style and colour parts.
+error bars, gradient and picture fills, per-point colours and label overrides, label and axis fonts,
+tick marks, the chart's style and colour parts.
 
 ```csharp
 using var workbook = new XLWorkbook("Report.xlsx");
 var chart = workbook.Worksheet("Data").Charts.First();
 
 chart.Series.First().FillColor = XLColor.FromHtml("#C00000");
-workbook.Save();   // only the fill changes; the trendline stays
+chart.ValueAxis.Max = 60_000;
+workbook.Save();   // only the fill and the scale change; the trendline stays
 ```
 
 Chart type, title and series references are settable on charts you create, but on a loaded chart
-only the series formatting is written back.
+only the series formatting, data labels, legend and axes are written back.
 
 ## Chart types
 
@@ -433,11 +489,12 @@ chart.Title = null;               // remove the title
 
 ## What is not covered
 
-The chart API is deliberately narrow: type, title, series, series formatting, data labels, and
-placement. Axis titles and scaling, legend placement, gridlines, and trend lines are not exposed. If
-you need that level of control, the usual approach is to build a template workbook in Excel with
-the chart formatted exactly as you want it, then use XLibur to write the source data the chart
-already points at:
+The chart API covers type, title, series, series formatting, data labels, legend, axes and placement.
+Fonts, fills and borders of the chart furniture, gradient and picture fills, per-data-point
+formatting, trend lines and error bars are not exposed — though a chart read from a file keeps all of
+them. If you need that level of control over a chart you are creating, the usual approach is to build
+a template workbook in Excel with the chart formatted exactly as you want it, then use XLibur to write
+the source data the chart already points at:
 
 ```csharp
 using var workbook = new XLWorkbook("ChartTemplate.xlsx");
@@ -521,10 +578,21 @@ margin.MarkerSize = 7;
 combo.Position.SetColumn(5).SetRow(18);
 combo.SecondPosition.SetColumn(13).SetRow(33);
 
+combo.Legend.Visible = true;
+combo.Legend.Position = XLLegendPosition.Bottom;
+combo.ValueAxis.Title = "Currency";
+combo.ValueAxis.NumberFormat = "$ #,##0";
+combo.ValueAxis.MajorGridlines = true;
+combo.SecondaryValueAxis.Title = "Margin";
+combo.SecondaryValueAxis.NumberFormat = "0%";
+
 // Chart 3: share of annual revenue
 var pie = ws.Charts.Add(XLChartType.Pie);
 pie.SetTitle("Share of annual revenue");
-pie.Series.Add("Revenue", $"{sheet}!$B$2:$B${last}", categories);
+var share = pie.Series.Add("Revenue", $"{sheet}!$B$2:$B${last}", categories);
+share.DataLabels.ShowCategoryName = true;
+share.DataLabels.ShowPercentage = true;
+share.DataLabels.Position = XLDataLabelPosition.BestFit;
 pie.Position.SetColumn(14).SetRow(1);
 pie.SecondPosition.SetColumn(21).SetRow(16);
 

--- a/docs/specs/10-chart-formatting-depth.md
+++ b/docs/specs/10-chart-formatting-depth.md
@@ -3,7 +3,7 @@
 **Area:** Feature (flagship differentiator — upstream ClosedXML has no charts at all)
 **Effort:** L total, but splits into 4 independent PRs
 **Dependencies:** None.
-**Status:** In progress — PRs 1 and 2 implemented; see [Results](#results-pr-1). PRs 3–4 open.
+**Status:** In progress — PRs 1, 2 and 3 implemented; see [Results](#results-pr-1). PR 4 open.
 
 ## Summary
 
@@ -183,17 +183,14 @@ reported a plain `Line` chart as `LineWithMarkers`.
 | 4 | Existing chart tests green; ChartEx unaffected | ✅ extended charts ignore series formatting and are not patched |
 | 5 | `XLibur.Examples` gains a formatted-chart sample | ✅ `FormattedChartExamples` — four sheets, validated by a test |
 
-### Notes for PRs 3–4
+### Notes for PR 4
 
-- Build legend and axes on `ChartPatcher`/`ChartFormatting`, not on a second mechanism: add flags to
-  the assignment set and a patch step per element, as PR 2 did. The "only write what was assigned"
-  rule is what keeps preservation free.
 - `ChartPlotAreaScanner` is the place to add group kinds the reader still ignores: `c:pie3DChart`,
   `c:line3DChart`, `c:area3DChart`, `c:surface3DChart`, `c:ofPieChart`. Today a chart built from
-  those reads as zero series with a default chart type — worth folding into PR 3 or 4.
+  those reads as zero series with a default chart type.
 - Title, chart type and series references are still write-only for new charts; editing them on a
-  loaded chart does nothing. If PR 3 wants `chart.Title` to work on loaded charts, that is another
-  patch step.
+  loaded chart does nothing. Making `chart.Title` work on a loaded chart is one more patch step on
+  `ChartFormatting`.
 
 ## Results (PR 2)
 
@@ -237,3 +234,48 @@ assigned. Excel treats a missing flag as "inherit from the chart style", which m
 result depend on the style part; writing them out makes what the caller asked for unambiguous.
 `c:delete` — how Excel records "labels switched off" — is removed when a flag is turned on, otherwise
 it would override everything next to it.
+
+## Results (PR 3)
+
+`IXLChartLegend` and `IXLChartAxis` landed as specified, reachable through `IXLChart.Legend`,
+`CategoryAxis`, `ValueAxis` and `SecondaryValueAxis`. 6402 tests pass on net8.0 and net10.0.
+
+### The writer now parameterises the axes it already emitted
+
+`BuildCategoryAxis`/`BuildValueAxis` take the axis model and fill in `c:scaling`
+(`logBase`/`orientation`/`max`/`min`, in that order), `c:delete`, `c:majorGridlines`, `c:title`,
+`c:numFmt` and — after `c:crossAx` — `c:majorUnit`/`c:minorUnit`. The defaults reproduce exactly what
+the writer emitted before this PR, so an unformatted chart's XML is unchanged: `delete` false,
+`orientation` minMax, nothing else. `c:legend` is emitted between `c:plotArea` and `c:plotVisOnly`
+only when `Legend.Visible` is set.
+
+### Three places the file format is narrower than one shared axis interface
+
+- **`CT_CatAx` has no unit elements and no room for `c:logBase`.** `MajorUnit`, `MinorUnit` and
+  `LogScale` are therefore skipped on a category axis rather than written — Excel refuses a file that
+  has them. The spec put all of them on one `IXLChartAxis`, which is the right shape for callers; the
+  narrowing is documented on the interface and in the docs.
+- **Except on scatter and bubble charts.** There the horizontal axis is a `c:valAx` holding numbers,
+  so the same properties do apply. `XLChartAxis` asks the chart for its type to decide, which is why
+  the axis models are constructed with a back-reference to the chart rather than standing alone.
+- **The hidden helper category axis of a secondary group has no public counterpart.** It exists only
+  to give the secondary value axis something to cross, so `BuildCategoryAxis` accepts a null model for
+  it. `SecondaryValueAxis` maps to the visible right-hand axis, which is the one callers mean.
+
+### Patching
+
+The legend and both axes follow PR 2's pattern: their own assignment flag sets, seeded (not assigned)
+by the reader, patched element by element. `ChartPlotAreaScanner` gained `CategoryAxisId` and a
+`FindAxis` helper so the reader and the patcher locate the same axis element by the identifier the
+chart group points at — the axis elements themselves carry no marker saying which is which.
+
+Editing an axis keeps its tick marks, tick label position, `c:crossBetween`, line and text formatting;
+editing the legend keeps its layout and text properties. `Legend.Visible = false` removes the
+`c:legend` element, which is how Excel records a chart without a legend.
+
+### Gridlines are still off by default
+
+`MajorGridlines` defaults to false, so a chart XLibur creates has no gridlines unless asked — which is
+what the writer did before this PR. Excel's own new charts do have value axis gridlines, so this is a
+plausible thing to change, but doing it silently would alter the output of every existing caller. Left
+as a deliberate decision to revisit, not an oversight.


### PR DESCRIPTION
## Summary

PR 3 of 4 for [spec 10 — Chart formatting depth](https://github.com/XLibur/XLibur/blob/main/docs/specs/10-chart-formatting-depth.md). Adds the legend and the axis API.

> **Stacked on #221** — this PR targets `feat/chart-data-labels`, not `main`, so its diff shows only the legend and axis work. Merge #220 and #221 first; GitHub retargets automatically as each lands.
>
> 1. #220 — series formatting + secondary axis + preservation groundwork
> 2. #221 — data labels
> 3. **this PR** — legend + axes
> 4. #223 — anchor reader gaps

## Changes

- `IXLChartLegend` on `IXLChart.Legend` — `Visible`, `Position` (right/bottom/left/top/top-right), `Overlay`. `c:legend` is written between `c:plotArea` and `c:plotVisOnly` only when asked for; `Visible = false` on a loaded chart removes the element it came with.
- `IXLChartAxis` on `IXLChart.CategoryAxis`, `ValueAxis` and `SecondaryValueAxis` — `Title`, `NumberFormat`, `Min`, `Max`, `MajorUnit`, `MinorUnit`, `Visible`, `MajorGridlines`, `Orientation` (reversed axes) and `LogScale`/`LogBase`.
- The writer already emitted the axes; it now fills them in from the model. **The defaults reproduce exactly what it emitted before**, so the XML of an unformatted chart is unchanged: `delete` false, `orientation` minMax, nothing else.
- Legend and axes follow #221's patching pattern — their own assignment flag sets, seeded rather than assigned by the reader, patched element by element. `ChartPlotAreaScanner` gained `CategoryAxisId` and a `FindAxis` helper so the reader and the patcher locate the same axis element by the identifier its chart group points at; the axis elements carry no marker saying which is which.

### Three places the file format is narrower than one shared axis interface

All documented on `IXLChartAxis`:

- **`CT_CatAx` has no unit elements and no room for `c:logBase`.** `MajorUnit`, `MinorUnit` and `LogScale` are therefore skipped on a category axis rather than written into a file Excel would refuse. The spec put all of them on one interface, which is the right shape for callers; the narrowing is in the docs.
- **Except on scatter and bubble charts**, where the horizontal axis is a `c:valAx` holding numbers, so the same properties do apply. `XLChartAxis` asks its chart for the type to decide, which is why the axis models are constructed with a back-reference to the chart rather than standing alone.
- **The hidden helper category axis of a secondary group has no public counterpart** — it exists only to give the secondary value axis something to cross, so `BuildCategoryAxis` accepts a null model for it. `SecondaryValueAxis` maps to the visible right-hand axis, which is what callers mean.

### Gridlines are still off by default

`MajorGridlines` defaults to false, matching what the writer did before this PR. Excel's own new charts *do* have value axis gridlines, so this is a plausible thing to change — but doing it silently would alter the output of every existing caller. Flagged in the spec as a deliberate decision to revisit, not an oversight.

## Related Issues

Implements PR 3 of `docs/specs/10-chart-formatting-depth.md`. Findings recorded in that spec's "Results (PR 3)" section.

## Testing

- [x] Added or updated unit tests — `ChartLegendAndAxisTests` (16), plus axis and legend cases in `ChartRoundTripPreservationTests`
- [x] All existing tests pass — 6402 on net8.0 and net10.0
- [ ] Tested manually

Every property is round-tripped, `c:scaling` child order is asserted explicitly, and every chart family that has axes is saved through `OpenXmlValidator`. The preservation fixture's value axis carries a title, number format, gridlines, tick marks, `c:crossBetween`, `c:spPr` and `c:txPr`; the patch test edits the title and scale and asserts the rest is untouched. The `FormattedChartExamples` sample gains a "Legend and axes" sheet, including a log-scale chart.

Same two caveats as #220: no Excel available for the render check, and `XLibur.Tests/Resource/Charts/` is still empty.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [ ] PR targets the `main` branch — targets #221 instead; see the stack note above
