### PR TITLE
feat: read one-cell and absolute anchored charts, 3D and of-pie groups (spec 10 PR 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,13 @@
 
 - **Charts loaded from a file can be restyled**: setting the series formatting, data labels, legend or axes on a loaded chart now writes back on save. Only the properties actually assigned are patched into the existing chart part, so trendlines, error bars, gradient fills, per-point colours and label overrides, label and axis fonts, tick marks and the chart's style/colour parts are all preserved — and a chart nobody edited is left byte for byte as it was.
 
+- **Chart anchoring**: `IXLChart.Anchor` (`MoveAndSizeWithCells`, `MoveWithCells`, `Absolute`) with `Width`, `Height`, `Left` and `Top` in pixels, so a chart can keep its size as rows are inserted or be pinned to a spot on the sheet. Two-cell anchoring via `Position`/`SecondPosition` remains the default.
+
 ### Fixed
+
+- **Charts anchored with a one-cell or absolute anchor are no longer dropped on load.** The reader only looked at `xdr:twoCellAnchor`, so a chart Excel had anchored either of the other two ways was missing from `IXLWorksheet.Charts` entirely (its XML survived a round trip, but the chart was invisible to the API).
+
+- **3D and of-pie chart groups are read.** `c:pie3DChart`, `c:line3DChart`, `c:area3DChart`, `c:surface3DChart` and `c:ofPieChart` were not recognised, so an Excel-authored chart using one loaded with no series and the wrong chart type. Their series and series formatting now read the same as the 2D groups', and pie-of-pie and bar-of-pie are told apart.
 
 - **Chart XML now passes OpenXML schema validation.** Three long-standing violations in the chart writer are fixed: series names were written as a `c:strRef` with no required `c:f` (a literal name now uses `<c:tx><c:v>`, and both forms are read back), `c:doughnutChart` omitted the required `c:holeSize`, and `c:marker` was written after `c:cat`/`c:val` instead of before. Excel tolerated all three, but stricter readers and `SaveOptions.ValidatePackage` did not.
 

--- a/XLibur.Examples/Charts/FormattedChartExamples.cs
+++ b/XLibur.Examples/Charts/FormattedChartExamples.cs
@@ -18,6 +18,7 @@ public class FormattedChartExamples : IXLExample
         HighlightOneSeries(wb);
         Labels(wb);
         LegendAndAxes(wb);
+        Anchoring(wb);
 
         wb.SaveAs(filePath);
     }
@@ -251,6 +252,39 @@ public class FormattedChartExamples : IXLExample
         growth.CategoryAxis.Title = "Quarter";
         growth.Position.SetColumn(6).SetRow(24);
         growth.SecondPosition.SetColumn(16).SetRow(42);
+    }
+
+    /// <summary>
+    /// The three ways a chart can be tied to the grid. Insert a row above row 5 in Excel to see the
+    /// difference: the first chart resizes, the second slides down, the third does not move.
+    /// </summary>
+    private static void Anchoring(XLWorkbook wb)
+    {
+        var ws = wb.Worksheets.Add("Anchoring");
+        WriteQuarterlyData(ws);
+
+        var moveAndSize = ws.Charts.Add(XLChartType.ColumnClustered);
+        moveAndSize.SetTitle("Moves and resizes");
+        moveAndSize.Series.Add("Revenue", "Anchoring!$B$2:$B$5", "Anchoring!$A$2:$A$5");
+        moveAndSize.Position.SetColumn(5).SetRow(1);
+        moveAndSize.SecondPosition.SetColumn(12).SetRow(15);
+
+        var move = ws.Charts.Add(XLChartType.ColumnClustered);
+        move.SetTitle("Keeps its size");
+        move.Series.Add("Revenue", "Anchoring!$B$2:$B$5", "Anchoring!$A$2:$A$5");
+        move.Anchor = XLDrawingAnchor.MoveWithCells;
+        move.Position.SetColumn(5).SetRow(17);
+        move.Width = 460;
+        move.Height = 260;
+
+        var pinned = ws.Charts.Add(XLChartType.ColumnClustered);
+        pinned.SetTitle("Pinned to the sheet");
+        pinned.Series.Add("Revenue", "Anchoring!$B$2:$B$5", "Anchoring!$A$2:$A$5");
+        pinned.Anchor = XLDrawingAnchor.Absolute;
+        pinned.Left = 960;
+        pinned.Top = 16;
+        pinned.Width = 460;
+        pinned.Height = 260;
     }
 
     private static void WriteQuarterlyData(IXLWorksheet ws)

--- a/XLibur.Tests/Excel/Charts/ChartAnchorTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartAnchorTests.cs
@@ -1,0 +1,220 @@
+using DocumentFormat.OpenXml.Packaging;
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+using XLibur.Excel;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// The three ways a chart can be anchored to the sheet: two-cell, one-cell and absolute.
+/// </summary>
+[TestFixture]
+public class ChartAnchorTests
+{
+    private static IXLWorksheet AddDataSheet(XLWorkbook wb)
+    {
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = "Q1";
+        ws.Cell("A2").Value = "Q2";
+        ws.Cell("B1").Value = 100;
+        ws.Cell("B2").Value = 200;
+        return ws;
+    }
+
+    private static MemoryStream SaveValidated(XLWorkbook wb)
+    {
+        var ms = new MemoryStream();
+        wb.SaveAs(ms, validate: true);
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static Xdr.WorksheetDrawing DrawingOf(Stream stream)
+    {
+        stream.Position = 0;
+        using var doc = SpreadsheetDocument.Open(stream, false);
+        var drawing = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.WorksheetDrawing!;
+        return (Xdr.WorksheetDrawing)drawing.CloneNode(true);
+    }
+
+    [Test]
+    public void TwoCellAnchorIsStillTheDefault()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+        chart.Position.SetColumn(3).SetRow(2);
+        chart.SecondPosition.SetColumn(10).SetRow(16);
+
+        Assert.That(chart.Anchor, Is.EqualTo(XLDrawingAnchor.MoveAndSizeWithCells));
+
+        using var ms = SaveValidated(wb);
+        var drawing = DrawingOf(ms);
+        Assert.That(drawing.Elements<Xdr.TwoCellAnchor>().Count(), Is.EqualTo(1));
+        Assert.That(drawing.Elements<Xdr.OneCellAnchor>(), Is.Empty);
+    }
+
+    [Test]
+    public void OneCellAnchoredChartRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Anchor = XLDrawingAnchor.MoveWithCells;
+            chart.Position.SetColumn(4).SetRow(3);
+            chart.Width = 480;
+            chart.Height = 288;
+
+            using var saved = SaveValidated(wb);
+            var drawing = DrawingOf(saved);
+            Assert.That(drawing.Elements<Xdr.OneCellAnchor>().Count(), Is.EqualTo(1));
+
+            saved.Position = 0;
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.Single();
+            Assert.That(chart.Anchor, Is.EqualTo(XLDrawingAnchor.MoveWithCells));
+            Assert.That(chart.Position.Column, Is.EqualTo(4));
+            Assert.That(chart.Position.Row, Is.EqualTo(3));
+            Assert.That(chart.Width, Is.EqualTo(480));
+            Assert.That(chart.Height, Is.EqualTo(288));
+            Assert.That(chart.Series.Single().Name, Is.EqualTo("Sales"));
+        }
+    }
+
+    [Test]
+    public void AbsolutelyAnchoredChartRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = ws.Charts.Add(XLChartType.Line);
+            chart.SetTitle("Pinned");
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Anchor = XLDrawingAnchor.Absolute;
+            chart.Left = 200;
+            chart.Top = 120;
+            chart.Width = 400;
+            chart.Height = 250;
+
+            using var saved = SaveValidated(wb);
+            var drawing = DrawingOf(saved);
+            Assert.That(drawing.Elements<Xdr.AbsoluteAnchor>().Count(), Is.EqualTo(1));
+
+            saved.Position = 0;
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.Single();
+            Assert.That(chart.Anchor, Is.EqualTo(XLDrawingAnchor.Absolute));
+            Assert.That(chart.Title, Is.EqualTo("Pinned"));
+            Assert.That(chart.Left, Is.EqualTo(200));
+            Assert.That(chart.Top, Is.EqualTo(120));
+            Assert.That(chart.Width, Is.EqualTo(400));
+            Assert.That(chart.Height, Is.EqualTo(250));
+        }
+    }
+
+    [Test]
+    public void ChartsUnderEveryAnchorKindAreFoundOnOneSheet()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+
+            var twoCell = ws.Charts.Add(XLChartType.ColumnClustered);
+            twoCell.SetTitle("Two cell");
+            twoCell.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            twoCell.Position.SetColumn(3).SetRow(1);
+            twoCell.SecondPosition.SetColumn(9).SetRow(14);
+
+            var oneCell = ws.Charts.Add(XLChartType.Line);
+            oneCell.SetTitle("One cell");
+            oneCell.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            oneCell.Anchor = XLDrawingAnchor.MoveWithCells;
+            oneCell.Position.SetColumn(3).SetRow(16);
+            oneCell.Width = 400;
+            oneCell.Height = 250;
+
+            var absolute = ws.Charts.Add(XLChartType.Pie);
+            absolute.SetTitle("Absolute");
+            absolute.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            absolute.Anchor = XLDrawingAnchor.Absolute;
+            absolute.Left = 700;
+            absolute.Top = 20;
+            absolute.Width = 320;
+            absolute.Height = 240;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var charts = wb.Worksheet("Data").Charts.ToList();
+            Assert.That(charts, Has.Count.EqualTo(3),
+                "A one-cell or absolute anchored chart used to be skipped on read.");
+            Assert.That(charts.Select(c => c.Title),
+                Is.EquivalentTo(new[] { "Two cell", "One cell", "Absolute" }));
+            Assert.That(charts.Select(c => c.Anchor), Is.EquivalentTo(new[]
+            {
+                XLDrawingAnchor.MoveAndSizeWithCells,
+                XLDrawingAnchor.MoveWithCells,
+                XLDrawingAnchor.Absolute
+            }));
+        }
+    }
+
+    [Test]
+    public void FormattingAnAnchorlessChartStillReachesItsChartPart()
+    {
+        // The patcher finds the chart part through its relationship id, not through the anchor, so
+        // editing a one-cell anchored chart has to work the same way.
+        using var original = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Anchor = XLDrawingAnchor.MoveWithCells;
+            chart.Position.SetColumn(3).SetRow(1);
+            chart.Width = 400;
+            chart.Height = 250;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(original);
+        }
+
+        using var edited = new MemoryStream();
+        original.Position = 0;
+        using (var wb = new XLWorkbook(original))
+        {
+            wb.Worksheet("Data").Charts.Single().Series.Single().FillColor = XLColor.FromHtml("#C00000");
+            wb.SaveAs(edited, validate: true);
+        }
+
+        edited.Position = 0;
+        using (var wb = new XLWorkbook(edited))
+        {
+            var chart = wb.Worksheet("Data").Charts.Single();
+            Assert.That(chart.Anchor, Is.EqualTo(XLDrawingAnchor.MoveWithCells));
+            Assert.That(chart.Series.Single().FillColor, Is.EqualTo(XLColor.FromHtml("#C00000")));
+        }
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartGroupKindReaderTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartGroupKindReaderTests.cs
@@ -1,0 +1,198 @@
+using DocumentFormat.OpenXml.Packaging;
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+using System.Text;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// The chart group elements Excel writes that XLibur does not write itself: the 3D variants and
+/// pie-of-pie / bar-of-pie. They used to read as a chart with no series at all.
+/// </summary>
+[TestFixture]
+public class ChartGroupKindReaderTests
+{
+    /// <summary>
+    /// Wraps a plot area body in the rest of a chart part, and puts it in a workbook.
+    /// </summary>
+    private static MemoryStream CreateWorkbookWithPlotArea(string plotAreaBody)
+    {
+        var chartXml = $"""
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <c:chart>
+                <c:plotArea>
+                  <c:layout/>
+                  {plotAreaBody}
+                </c:plotArea>
+                <c:plotVisOnly val="1"/>
+              </c:chart>
+            </c:chartSpace>
+            """;
+
+        var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Data");
+            ws.Cell("A1").Value = "Q1";
+            ws.Cell("A2").Value = "Q2";
+            ws.Cell("B1").Value = 100;
+            ws.Cell("B2").Value = 200;
+
+            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+            chart.Series.Add("Placeholder", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Position.SetColumn(5).SetRow(1);
+            chart.SecondPosition.SetColumn(12).SetRow(15);
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        using (var doc = SpreadsheetDocument.Open(ms, true))
+        {
+            var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
+            using var source = new MemoryStream(Encoding.UTF8.GetBytes(chartXml));
+            chartPart.FeedData(source);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static string CategoryAndValueSeries(string name) => $"""
+        <c:ser>
+          <c:idx val="0"/>
+          <c:order val="0"/>
+          <c:tx><c:v>{name}</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+        </c:ser>
+        """;
+
+    private const string CategoryAndValueAxes = """
+        <c:catAx><c:axId val="1"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="2"/></c:catAx>
+        <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
+        """;
+
+    private static IXLChart LoadChart(string plotAreaBody, out XLWorkbook workbook)
+    {
+        var ms = CreateWorkbookWithPlotArea(plotAreaBody);
+        workbook = new XLWorkbook(ms);
+        return workbook.Worksheet("Data").Charts.Single();
+    }
+
+    [Test]
+    public void Pie3DChartIsRead()
+    {
+        var chart = LoadChart($"<c:pie3DChart><c:varyColors val=\"1\"/>{CategoryAndValueSeries("Share")}</c:pie3DChart>",
+            out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ChartType, Is.EqualTo(XLChartType.Pie3D));
+            Assert.That(chart.Series.Single().Name, Is.EqualTo("Share"));
+            Assert.That(chart.Series.Single().ValueReferences, Is.EqualTo("Data!$B$1:$B$2"));
+        }
+    }
+
+    [Test]
+    public void PieOfPieAndBarOfPieAreToldApart()
+    {
+        var pieOfPie = LoadChart(
+            $"<c:ofPieChart><c:ofPieType val=\"pie\"/>{CategoryAndValueSeries("Share")}</c:ofPieChart>", out var wb1);
+        using (wb1)
+        {
+            Assert.That(pieOfPie.ChartType, Is.EqualTo(XLChartType.PieToPie));
+        }
+
+        var barOfPie = LoadChart(
+            $"<c:ofPieChart><c:ofPieType val=\"bar\"/>{CategoryAndValueSeries("Share")}</c:ofPieChart>", out var wb2);
+        using (wb2)
+        {
+            Assert.That(barOfPie.ChartType, Is.EqualTo(XLChartType.PieToBar));
+        }
+    }
+
+    [Test]
+    public void Line3DChartIsRead()
+    {
+        var chart = LoadChart(
+            $"<c:line3DChart><c:grouping val=\"standard\"/>{CategoryAndValueSeries("Trend")}<c:axId val=\"1\"/><c:axId val=\"2\"/></c:line3DChart>{CategoryAndValueAxes}",
+            out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ChartType, Is.EqualTo(XLChartType.Line3D));
+            Assert.That(chart.Series.Single().Name, Is.EqualTo("Trend"));
+        }
+    }
+
+    [TestCase("standard", XLChartType.Area3D)]
+    [TestCase("stacked", XLChartType.AreaStacked3D)]
+    [TestCase("percentStacked", XLChartType.AreaStacked100Percent3D)]
+    public void Area3DGroupingIsRead(string grouping, XLChartType expected)
+    {
+        var chart = LoadChart(
+            $"<c:area3DChart><c:grouping val=\"{grouping}\"/>{CategoryAndValueSeries("Area")}<c:axId val=\"1\"/><c:axId val=\"2\"/></c:area3DChart>{CategoryAndValueAxes}",
+            out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ChartType, Is.EqualTo(expected));
+            Assert.That(chart.Series, Has.Exactly(1).Items);
+        }
+    }
+
+    [Test]
+    public void Surface3DChartIsRead()
+    {
+        var chart = LoadChart(
+            $"<c:surface3DChart>{CategoryAndValueSeries("Height")}<c:axId val=\"1\"/><c:axId val=\"2\"/><c:axId val=\"3\"/></c:surface3DChart>{CategoryAndValueAxes}<c:serAx><c:axId val=\"3\"/><c:scaling><c:orientation val=\"minMax\"/></c:scaling><c:delete val=\"0\"/><c:axPos val=\"b\"/><c:crossAx val=\"2\"/></c:serAx>",
+            out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ChartType, Is.EqualTo(XLChartType.Surface));
+            Assert.That(chart.Series.Single().Name, Is.EqualTo("Height"));
+        }
+    }
+
+    [Test]
+    public void A3DBarChartStillReadsAsBefore()
+    {
+        var chart = LoadChart(
+            $"<c:bar3DChart><c:barDir val=\"col\"/><c:grouping val=\"clustered\"/>{CategoryAndValueSeries("Sales")}<c:shape val=\"box\"/><c:axId val=\"1\"/><c:axId val=\"2\"/></c:bar3DChart>{CategoryAndValueAxes}",
+            out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ChartType, Is.EqualTo(XLChartType.ColumnClustered3D));
+        }
+    }
+
+    [Test]
+    public void SeriesFormattingOnA3DGroupIsRead()
+    {
+        var series = """
+            <c:ser>
+              <c:idx val="0"/>
+              <c:order val="0"/>
+              <c:tx><c:v>Trend</c:v></c:tx>
+              <c:spPr><a:ln w="19050"><a:solidFill><a:srgbClr val="ED7D31"/></a:solidFill></a:ln></c:spPr>
+              <c:marker><c:symbol val="square"/><c:size val="6"/></c:marker>
+              <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+              <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+              <c:smooth val="1"/>
+            </c:ser>
+            """;
+
+        var chart = LoadChart(
+            $"<c:line3DChart><c:grouping val=\"standard\"/>{series}<c:axId val=\"1\"/><c:axId val=\"2\"/></c:line3DChart>{CategoryAndValueAxes}",
+            out var wb);
+        using (wb)
+        {
+            var s = chart.Series.Single();
+            Assert.That(s.LineColor, Is.EqualTo(XLColor.FromHtml("#ED7D31")));
+            Assert.That(s.LineWidthPt, Is.EqualTo(1.5));
+            Assert.That(s.MarkerStyle, Is.EqualTo(XLMarkerStyle.Square));
+            Assert.That(s.MarkerSize, Is.EqualTo(6));
+            Assert.That(s.Smooth, Is.True);
+        }
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
@@ -57,6 +57,13 @@ public class ChartRoundTripPreservationTests
                     <c:showBubbleSize val="0"/>
                   </c:dLbls>
                   <c:trendline><c:trendlineType val="linear"/></c:trendline>
+                  <c:errBars>
+                    <c:errDir val="y"/>
+                    <c:errBarType val="both"/>
+                    <c:errValType val="percentage"/>
+                    <c:noEndCap val="0"/>
+                    <c:val val="5"/>
+                  </c:errBars>
                   <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
                   <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
                 </c:ser>
@@ -268,6 +275,8 @@ public class ChartRoundTripPreservationTests
 
         // Everything XLibur does not model survived.
         Assert.That(xml, Does.Contain("<c:trendline>"));
+        Assert.That(xml, Does.Contain("<c:errBars>"));
+        Assert.That(xml, Does.Contain("<c:errValType val=\"percentage\""));
         Assert.That(xml, Does.Contain("cap=\"rnd\""));
         Assert.That(xml, Does.Contain("<a:round"));
         Assert.That(xml, Does.Contain("<a:effectLst"));

--- a/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
@@ -465,7 +465,7 @@ public class ChartSeriesFormattingTests
         // back and that what it wrote is schema-valid.
         using var wb = new XLWorkbook(path);
         using var ms = SaveValidated(wb);
-        Assert.That(wb.Worksheets.Count, Is.EqualTo(6));
+        Assert.That(wb.Worksheets.Count, Is.EqualTo(7));
     }
 
     [Test]

--- a/XLibur/Excel/Charts/IXLChart.cs
+++ b/XLibur/Excel/Charts/IXLChart.cs
@@ -143,8 +143,56 @@ public interface IXLChart : IXLDrawing<IXLChart>
     /// <summary>
     /// Gets the bottom-right anchor position of the chart's two-cell anchor.
     /// Use together with <see cref="IXLDrawing{T}.Position"/> (top-left) to define the chart's size and location.
+    /// Only used while <see cref="Anchor"/> is <see cref="XLDrawingAnchor.MoveAndSizeWithCells"/>.
     /// </summary>
     IXLDrawingPosition SecondPosition { get; }
+
+    /// <summary>
+    /// Gets or sets how the chart is tied to the grid.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item>
+    /// <see cref="XLDrawingAnchor.MoveAndSizeWithCells"/> — the default — spans the rectangle between
+    /// <see cref="IXLDrawing{T}.Position"/> and <see cref="SecondPosition"/>, so inserting rows or
+    /// columns moves and resizes the chart.
+    /// </item>
+    /// <item>
+    /// <see cref="XLDrawingAnchor.MoveWithCells"/> keeps <see cref="Width"/> and <see cref="Height"/>
+    /// and hangs the top-left corner off <see cref="IXLDrawing{T}.Position"/>.
+    /// </item>
+    /// <item>
+    /// <see cref="XLDrawingAnchor.Absolute"/> pins the chart to <see cref="Left"/>/<see cref="Top"/>
+    /// with <see cref="Width"/> and <see cref="Height"/>, ignoring the grid entirely.
+    /// </item>
+    /// </list>
+    /// </remarks>
+    XLDrawingAnchor Anchor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the chart width in pixels. Used when <see cref="Anchor"/> is
+    /// <see cref="XLDrawingAnchor.MoveWithCells"/> or <see cref="XLDrawingAnchor.Absolute"/>; a
+    /// two-cell anchored chart takes its width from <see cref="SecondPosition"/> instead.
+    /// </summary>
+    int Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the chart height in pixels. Used when <see cref="Anchor"/> is
+    /// <see cref="XLDrawingAnchor.MoveWithCells"/> or <see cref="XLDrawingAnchor.Absolute"/>.
+    /// </summary>
+    int Height { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance in pixels from the left edge of the sheet. Used only when
+    /// <see cref="Anchor"/> is <see cref="XLDrawingAnchor.Absolute"/>.
+    /// </summary>
+    int Left { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance in pixels from the top edge of the sheet. Used only when
+    /// <see cref="Anchor"/> is <see cref="XLDrawingAnchor.Absolute"/>.
+    /// </summary>
+    int Top { get; set; }
 
     /// <summary>
     /// Gets or sets the secondary chart type for combo charts.

--- a/XLibur/Excel/Charts/XLChart.cs
+++ b/XLibur/Excel/Charts/XLChart.cs
@@ -62,6 +62,16 @@ internal sealed class XLChart : XLDrawing<IXLChart>, IXLChart
 
     public IXLDrawingPosition SecondPosition { get; }
 
+    public XLDrawingAnchor Anchor { get; set; } = XLDrawingAnchor.MoveAndSizeWithCells;
+
+    public int Width { get; set; }
+
+    public int Height { get; set; }
+
+    public int Left { get; set; }
+
+    public int Top { get; set; }
+
     public XLChartType? SecondaryChartType { get; set; }
 
     public IXLChartSeriesCollection SecondarySeries { get; }

--- a/XLibur/Excel/IO/ChartFormatting.cs
+++ b/XLibur/Excel/IO/ChartFormatting.cs
@@ -657,17 +657,19 @@ internal static class ChartFormatting
 
     /// <summary>Whether the series type of a chart group accepts a <c>c:marker</c> child.</summary>
     private static bool SupportsMarker(XLChartGroupKind kind) => kind is XLChartGroupKind.Line
-        or XLChartGroupKind.Scatter or XLChartGroupKind.Radar or XLChartGroupKind.Stock;
+        or XLChartGroupKind.Line3D or XLChartGroupKind.Scatter or XLChartGroupKind.Radar
+        or XLChartGroupKind.Stock;
 
     /// <summary>Whether the series type of a chart group accepts a <c>c:smooth</c> child.</summary>
     private static bool SupportsSmooth(XLChartGroupKind kind) => kind is XLChartGroupKind.Line
-        or XLChartGroupKind.Scatter or XLChartGroupKind.Stock;
+        or XLChartGroupKind.Line3D or XLChartGroupKind.Scatter or XLChartGroupKind.Stock;
 
     /// <summary>
     /// Whether a chart group and its series accept a <c>c:dLbls</c> child. Only the surface types do
     /// not: neither <c>CT_SurfaceChart</c> nor <c>CT_SurfaceSer</c> has one.
     /// </summary>
-    internal static bool SupportsDataLabels(XLChartGroupKind kind) => kind != XLChartGroupKind.Surface;
+    internal static bool SupportsDataLabels(XLChartGroupKind kind) =>
+        kind is not (XLChartGroupKind.Surface or XLChartGroupKind.Surface3D);
 
     /// <summary>
     /// Applies the assigned data label properties onto an existing <c>c:dLbls</c> element, or adds one

--- a/XLibur/Excel/IO/ChartPlotAreaScanner.cs
+++ b/XLibur/Excel/IO/ChartPlotAreaScanner.cs
@@ -14,14 +14,21 @@ internal enum XLChartGroupKind
     Bar,
     Bar3D,
     Pie,
+    Pie3D,
+
+    /// <summary>A pie-of-pie or bar-of-pie chart (<c>c:ofPieChart</c>).</summary>
+    OfPie,
     Doughnut,
     Area,
+    Area3D,
     Line,
+    Line3D,
     Radar,
     Bubble,
     Scatter,
     Stock,
-    Surface
+    Surface,
+    Surface3D
 }
 
 /// <summary>
@@ -67,6 +74,10 @@ internal sealed class XLChartGroup
     /// values (<c>c:cat</c>/<c>c:val</c>).
     /// </summary>
     internal bool IsXyBased => Kind is XLChartGroupKind.Scatter or XLChartGroupKind.Bubble;
+
+    /// <summary>Whether this is one of the 3D group types, which XLibur reads but never writes.</summary>
+    internal bool Is3D => Kind is XLChartGroupKind.Bar3D or XLChartGroupKind.Pie3D
+        or XLChartGroupKind.Area3D or XLChartGroupKind.Line3D or XLChartGroupKind.Surface3D;
 }
 
 /// <summary>
@@ -87,14 +98,19 @@ internal static class ChartPlotAreaScanner
         XLChartGroupKind.Bar,
         XLChartGroupKind.Bar3D,
         XLChartGroupKind.Pie,
+        XLChartGroupKind.Pie3D,
+        XLChartGroupKind.OfPie,
         XLChartGroupKind.Doughnut,
         XLChartGroupKind.Area,
+        XLChartGroupKind.Area3D,
         XLChartGroupKind.Line,
+        XLChartGroupKind.Line3D,
         XLChartGroupKind.Radar,
         XLChartGroupKind.Bubble,
         XLChartGroupKind.Scatter,
         XLChartGroupKind.Stock,
-        XLChartGroupKind.Surface
+        XLChartGroupKind.Surface,
+        XLChartGroupKind.Surface3D
     ];
 
     /// <summary>
@@ -117,14 +133,26 @@ internal static class ChartPlotAreaScanner
                 case C.PieChart pie:
                     groups.Add(Build(XLChartGroupKind.Pie, pie, pie.Elements<C.PieChartSeries>()));
                     break;
+                case C.Pie3DChart pie3D:
+                    groups.Add(Build(XLChartGroupKind.Pie3D, pie3D, pie3D.Elements<C.PieChartSeries>()));
+                    break;
+                case C.OfPieChart ofPie:
+                    groups.Add(Build(XLChartGroupKind.OfPie, ofPie, ofPie.Elements<C.PieChartSeries>()));
+                    break;
                 case C.DoughnutChart doughnut:
                     groups.Add(Build(XLChartGroupKind.Doughnut, doughnut, doughnut.Elements<C.PieChartSeries>()));
                     break;
                 case C.AreaChart area:
                     groups.Add(Build(XLChartGroupKind.Area, area, area.Elements<C.AreaChartSeries>()));
                     break;
+                case C.Area3DChart area3D:
+                    groups.Add(Build(XLChartGroupKind.Area3D, area3D, area3D.Elements<C.AreaChartSeries>()));
+                    break;
                 case C.LineChart line:
                     groups.Add(Build(XLChartGroupKind.Line, line, line.Elements<C.LineChartSeries>()));
+                    break;
+                case C.Line3DChart line3D:
+                    groups.Add(Build(XLChartGroupKind.Line3D, line3D, line3D.Elements<C.LineChartSeries>()));
                     break;
                 case C.RadarChart radar:
                     groups.Add(Build(XLChartGroupKind.Radar, radar, radar.Elements<C.RadarChartSeries>()));
@@ -140,6 +168,10 @@ internal static class ChartPlotAreaScanner
                     break;
                 case C.SurfaceChart surface:
                     groups.Add(Build(XLChartGroupKind.Surface, surface, surface.Elements<C.SurfaceChartSeries>()));
+                    break;
+                case C.Surface3DChart surface3D:
+                    groups.Add(Build(XLChartGroupKind.Surface3D, surface3D,
+                        surface3D.Elements<C.SurfaceChartSeries>()));
                     break;
             }
         }

--- a/XLibur/Excel/IO/ChartReader.cs
+++ b/XLibur/Excel/IO/ChartReader.cs
@@ -22,19 +22,25 @@ internal static class ChartReader
         if (drawingsPart?.WorksheetDrawing == null)
             return;
 
-        foreach (var anchor in drawingsPart.WorksheetDrawing.Elements<Xdr.TwoCellAnchor>())
+        // Excel writes a chart under any of the three anchor kinds. A one-cell or absolute anchored
+        // chart used to be skipped here, which left it out of ws.Charts entirely.
+        foreach (var anchor in drawingsPart.WorksheetDrawing.ChildElements)
         {
-            var xlChart = TryLoadChartFromAnchor(drawingsPart, anchor, ws);
-            if (xlChart != null)
-            {
-                ReadPositions(anchor, xlChart);
-                ws.Charts.Add(xlChart);
-            }
+            if (anchor is not (Xdr.TwoCellAnchor or Xdr.OneCellAnchor or Xdr.AbsoluteAnchor))
+                continue;
+
+            var composite = (OpenXmlCompositeElement)anchor;
+            var xlChart = TryLoadChartFromAnchor(drawingsPart, composite, ws);
+            if (xlChart == null)
+                continue;
+
+            ReadAnchor(composite, xlChart);
+            ws.Charts.Add(xlChart);
         }
     }
 
     private static XLChart? TryLoadChartFromAnchor(
-        DrawingsPart drawingsPart, Xdr.TwoCellAnchor anchor, XLWorksheet ws)
+        DrawingsPart drawingsPart, OpenXmlCompositeElement anchor, XLWorksheet ws)
     {
         // GraphicFrame may be direct child or inside mc:AlternateContent > mc:Choice
         var graphicFrame = anchor.Elements<Xdr.GraphicFrame>().FirstOrDefault()
@@ -191,14 +197,19 @@ internal static class ChartReader
         XLChartGroupKind.Bar => DetermineBarChartType((C.BarChart)group.Element),
         XLChartGroupKind.Bar3D => DetermineBar3DChartType((C.Bar3DChart)group.Element),
         XLChartGroupKind.Pie => XLChartType.Pie,
+        XLChartGroupKind.Pie3D => XLChartType.Pie3D,
+        XLChartGroupKind.OfPie => DetermineOfPieChartType((C.OfPieChart)group.Element),
         XLChartGroupKind.Doughnut => XLChartType.Doughnut,
         XLChartGroupKind.Area => DetermineAreaChartType((C.AreaChart)group.Element),
+        XLChartGroupKind.Area3D => DetermineArea3DChartType((C.Area3DChart)group.Element),
         XLChartGroupKind.Line => DetermineLineChartType((C.LineChart)group.Element),
+        XLChartGroupKind.Line3D => XLChartType.Line3D,
         XLChartGroupKind.Radar => DetermineRadarChartType((C.RadarChart)group.Element),
         XLChartGroupKind.Bubble => XLChartType.Bubble,
         XLChartGroupKind.Scatter => DetermineScatterChartType((C.ScatterChart)group.Element),
         XLChartGroupKind.Stock => XLChartType.StockHighLowClose,
         XLChartGroupKind.Surface => DetermineSurfaceChartType((C.SurfaceChart)group.Element),
+        XLChartGroupKind.Surface3D => DetermineSurface3DChartType((C.Surface3DChart)group.Element),
         _ => XLChartType.ColumnClustered
     };
 
@@ -432,10 +443,39 @@ internal static class ChartReader
         return XLChartType.Area;
     }
 
+    /// <summary>
+    /// A <c>c:surfaceChart</c> is strictly the flat contour variant, but XLibur's writer emits every
+    /// surface type as one, so it is read back as the plain surface type its own writer meant.
+    /// </summary>
     private static XLChartType DetermineSurfaceChartType(C.SurfaceChart surfaceChart)
     {
         var wireframe = surfaceChart.Elements<C.Wireframe>().FirstOrDefault()?.Val?.Value ?? false;
         return wireframe ? XLChartType.SurfaceWireframe : XLChartType.Surface;
+    }
+
+    private static XLChartType DetermineSurface3DChartType(C.Surface3DChart surfaceChart)
+    {
+        var wireframe = surfaceChart.Elements<C.Wireframe>().FirstOrDefault()?.Val?.Value ?? false;
+        return wireframe ? XLChartType.SurfaceWireframe : XLChartType.Surface;
+    }
+
+    /// <summary>
+    /// A <c>c:ofPieChart</c> is either pie-of-pie or bar-of-pie, told apart by <c>c:ofPieType</c>.
+    /// </summary>
+    private static XLChartType DetermineOfPieChartType(C.OfPieChart ofPieChart)
+    {
+        var type = ofPieChart.Elements<C.OfPieType>().FirstOrDefault()?.Val;
+        return type != null && type.Value == C.OfPieValues.Bar
+            ? XLChartType.PieToBar
+            : XLChartType.PieToPie;
+    }
+
+    private static XLChartType DetermineArea3DChartType(C.Area3DChart areaChart)
+    {
+        var grouping = areaChart.Grouping?.Val?.Value;
+        if (grouping == C.GroupingValues.Stacked) return XLChartType.AreaStacked3D;
+        if (grouping == C.GroupingValues.PercentStacked) return XLChartType.AreaStacked100Percent3D;
+        return XLChartType.Area3D;
     }
 
     private static XLChartType DetermineScatterChartType(C.ScatterChart scatterChart)
@@ -507,11 +547,49 @@ internal static class ChartReader
 
     // ── Position reading ────────────────────────────────────────────────
 
-    private static void ReadPositions(Xdr.TwoCellAnchor anchor, XLChart xlChart)
+    /// <summary>EMU per pixel, the unit the drawing markers and extents are stored in.</summary>
+    private const double EmuPerPixel = 9525;
+
+    private static void ReadAnchor(OpenXmlCompositeElement anchor, XLChart xlChart)
     {
-        ReadMarker(anchor.FromMarker, xlChart.Position);
-        ReadMarker(anchor.ToMarker, xlChart.SecondPosition);
+        switch (anchor)
+        {
+            case Xdr.TwoCellAnchor twoCell:
+                xlChart.Anchor = XLDrawingAnchor.MoveAndSizeWithCells;
+                ReadMarker(twoCell.FromMarker, xlChart.Position);
+                ReadMarker(twoCell.ToMarker, xlChart.SecondPosition);
+                break;
+
+            case Xdr.OneCellAnchor oneCell:
+                xlChart.Anchor = XLDrawingAnchor.MoveWithCells;
+                ReadMarker(oneCell.FromMarker, xlChart.Position);
+                ReadExtent(oneCell.Extent, xlChart);
+                break;
+
+            case Xdr.AbsoluteAnchor absolute:
+                xlChart.Anchor = XLDrawingAnchor.Absolute;
+                if (absolute.Position != null)
+                {
+                    xlChart.Left = ToPixels(absolute.Position.X?.Value);
+                    xlChart.Top = ToPixels(absolute.Position.Y?.Value);
+                }
+
+                ReadExtent(absolute.Extent, xlChart);
+                break;
+        }
     }
+
+    private static void ReadExtent(Xdr.Extent? extent, XLChart xlChart)
+    {
+        if (extent == null)
+            return;
+
+        xlChart.Width = ToPixels(extent.Cx?.Value);
+        xlChart.Height = ToPixels(extent.Cy?.Value);
+    }
+
+    private static int ToPixels(long? emu) =>
+        emu == null ? 0 : (int)System.Math.Round(emu.Value / EmuPerPixel);
 
     private static void ReadMarker(Xdr.MarkerType? marker, IXLDrawingPosition position)
     {

--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -1033,6 +1033,9 @@ internal static class ChartWriter
     private static C.SeriesText BuildSeriesText(IXLChartSeries s) =>
         new(new C.NumericValue(s.Name));
 
+    /// <summary>EMU per pixel, the unit the drawing markers and extents are stored in.</summary>
+    private const double EmuPerPixel = 9525;
+
     private static void AppendAnchor(Xdr.WorksheetDrawing worksheetDrawing, XLChart xlChart, A.GraphicData graphicData)
     {
         var nvps = worksheetDrawing.Descendants<Xdr.NonVisualDrawingProperties>();
@@ -1040,39 +1043,69 @@ internal static class ChartWriter
             ? (UInt32Value)nvps.Max(p => p.Id!.Value) + 1
             : 1U;
 
-        var fromPos = xlChart.Position;
-        var toPos = xlChart.SecondPosition;
-
-        var anchor = new Xdr.TwoCellAnchor(
-            new Xdr.FromMarker
-            {
-                ColumnId = new Xdr.ColumnId(fromPos.Column.ToString()),
-                RowId = new Xdr.RowId(fromPos.Row.ToString()),
-                ColumnOffset = new Xdr.ColumnOffset(((long)(fromPos.ColumnOffset * 9525)).ToString()),
-                RowOffset = new Xdr.RowOffset(((long)(fromPos.RowOffset * 9525)).ToString())
-            },
-            new Xdr.ToMarker
-            {
-                ColumnId = new Xdr.ColumnId(toPos.Column.ToString()),
-                RowId = new Xdr.RowId(toPos.Row.ToString()),
-                ColumnOffset = new Xdr.ColumnOffset(((long)(toPos.ColumnOffset * 9525)).ToString()),
-                RowOffset = new Xdr.RowOffset(((long)(toPos.RowOffset * 9525)).ToString())
-            },
-            new Xdr.GraphicFrame(
-                new Xdr.NonVisualGraphicFrameProperties(
-                    new Xdr.NonVisualDrawingProperties { Id = nvpId, Name = xlChart.Name },
-                    new Xdr.NonVisualGraphicFrameDrawingProperties()
-                ),
-                new Xdr.Transform(
-                    new A.Offset { X = 0, Y = 0 },
-                    new A.Extents { Cx = 0, Cy = 0 }
-                ),
-                new A.Graphic(graphicData)
+        var graphicFrame = new Xdr.GraphicFrame(
+            new Xdr.NonVisualGraphicFrameProperties(
+                new Xdr.NonVisualDrawingProperties { Id = nvpId, Name = xlChart.Name },
+                new Xdr.NonVisualGraphicFrameDrawingProperties()
             ),
-            new Xdr.ClientData()
+            new Xdr.Transform(
+                new A.Offset { X = 0, Y = 0 },
+                new A.Extents { Cx = 0, Cy = 0 }
+            ),
+            new A.Graphic(graphicData)
         );
+
+        OpenXmlCompositeElement anchor = xlChart.Anchor switch
+        {
+            XLDrawingAnchor.MoveWithCells => new Xdr.OneCellAnchor(
+                BuildFromMarker(xlChart.Position),
+                BuildExtent(xlChart),
+                graphicFrame,
+                new Xdr.ClientData()),
+
+            XLDrawingAnchor.Absolute => new Xdr.AbsoluteAnchor(
+                new Xdr.Position
+                {
+                    X = ToEmu(xlChart.Left),
+                    Y = ToEmu(xlChart.Top)
+                },
+                BuildExtent(xlChart),
+                graphicFrame,
+                new Xdr.ClientData()),
+
+            _ => new Xdr.TwoCellAnchor(
+                BuildFromMarker(xlChart.Position),
+                BuildToMarker(xlChart.SecondPosition),
+                graphicFrame,
+                new Xdr.ClientData())
+        };
+
         worksheetDrawing.Append(anchor);
     }
+
+    private static Xdr.FromMarker BuildFromMarker(IXLDrawingPosition position) => new()
+    {
+        ColumnId = new Xdr.ColumnId(position.Column.ToString()),
+        RowId = new Xdr.RowId(position.Row.ToString()),
+        ColumnOffset = new Xdr.ColumnOffset(ToEmu(position.ColumnOffset).ToString()),
+        RowOffset = new Xdr.RowOffset(ToEmu(position.RowOffset).ToString())
+    };
+
+    private static Xdr.ToMarker BuildToMarker(IXLDrawingPosition position) => new()
+    {
+        ColumnId = new Xdr.ColumnId(position.Column.ToString()),
+        RowId = new Xdr.RowId(position.Row.ToString()),
+        ColumnOffset = new Xdr.ColumnOffset(ToEmu(position.ColumnOffset).ToString()),
+        RowOffset = new Xdr.RowOffset(ToEmu(position.RowOffset).ToString())
+    };
+
+    private static Xdr.Extent BuildExtent(XLChart xlChart) => new()
+    {
+        Cx = ToEmu(xlChart.Width),
+        Cy = ToEmu(xlChart.Height)
+    };
+
+    private static long ToEmu(double pixels) => (long)(pixels * EmuPerPixel);
 
     /// <summary>
     /// Appends a TwoCellAnchor for an extended chart, wrapping the GraphicFrame in mc:AlternateContent

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -201,3 +201,13 @@ XLibur.Excel.IXLChartAxis.LogBase.set -> void
 XLibur.Excel.XLAxisOrientation
 XLibur.Excel.XLAxisOrientation.MinMax = 0 -> XLibur.Excel.XLAxisOrientation
 XLibur.Excel.XLAxisOrientation.MaxMin = 1 -> XLibur.Excel.XLAxisOrientation
+XLibur.Excel.IXLChart.Anchor.get -> XLibur.Excel.XLDrawingAnchor
+XLibur.Excel.IXLChart.Anchor.set -> void
+XLibur.Excel.IXLChart.Width.get -> int
+XLibur.Excel.IXLChart.Width.set -> void
+XLibur.Excel.IXLChart.Height.get -> int
+XLibur.Excel.IXLChart.Height.set -> void
+XLibur.Excel.IXLChart.Left.get -> int
+XLibur.Excel.IXLChart.Left.set -> void
+XLibur.Excel.IXLChart.Top.get -> int
+XLibur.Excel.IXLChart.Top.set -> void

--- a/docs-website/docs/charts.md
+++ b/docs-website/docs/charts.md
@@ -153,6 +153,30 @@ PlaceChart(revenueChart, row: 1, column: 4);
 PlaceChart(marginChart, row: 17, column: 4);
 ```
 
+### Anchoring
+
+By default a chart spans the rectangle between `Position` and `SecondPosition`, so inserting rows or
+columns moves and resizes it. `Anchor` picks a different rule:
+
+```csharp
+// Keep the size, move with the cell underneath the top-left corner
+chart.Anchor = XLDrawingAnchor.MoveWithCells;
+chart.Position.SetColumn(4).SetRow(3);
+chart.Width = 480;    // pixels
+chart.Height = 288;
+
+// Pin to a spot on the sheet, ignoring the grid
+chart.Anchor = XLDrawingAnchor.Absolute;
+chart.Left = 200;     // pixels from the left edge
+chart.Top = 120;
+chart.Width = 480;
+chart.Height = 288;
+```
+
+`SecondPosition` is only used by the default `MoveAndSizeWithCells`; `Width`/`Height` are only used
+by the other two, and `Left`/`Top` only by `Absolute`. All four are read back from a file, whichever
+anchor the chart came with.
+
 ## Combo charts
 
 Set `SecondaryChartType` and add series to `SecondarySeries`. Both types share one plot area —
@@ -477,6 +501,9 @@ foreach (var chart in ws.Charts)
     Console.WriteLine($"{chart.Title} ({chart.ChartType}), {chart.Series.Count} series");
 }
 ```
+
+Charts anchored any of the three ways are listed, as are the chart types XLibur reads but does not
+write itself: 3D pie, line, area and surface groups, and pie-of-pie / bar-of-pie.
 
 Chart type and title are settable after creation:
 

--- a/docs/specs/10-chart-formatting-depth.md
+++ b/docs/specs/10-chart-formatting-depth.md
@@ -3,7 +3,7 @@
 **Area:** Feature (flagship differentiator — upstream ClosedXML has no charts at all)
 **Effort:** L total, but splits into 4 independent PRs
 **Dependencies:** None.
-**Status:** In progress — PRs 1, 2 and 3 implemented; see [Results](#results-pr-1). PR 4 open.
+**Status:** ✅ All four PRs implemented — see [Results](#results-pr-1) per PR.
 
 ## Summary
 
@@ -183,14 +183,12 @@ reported a plain `Line` chart as `LineWithMarkers`.
 | 4 | Existing chart tests green; ChartEx unaffected | ✅ extended charts ignore series formatting and are not patched |
 | 5 | `XLibur.Examples` gains a formatted-chart sample | ✅ `FormattedChartExamples` — four sheets, validated by a test |
 
-### Notes for PR 4
+### Left for later
 
-- `ChartPlotAreaScanner` is the place to add group kinds the reader still ignores: `c:pie3DChart`,
-  `c:line3DChart`, `c:area3DChart`, `c:surface3DChart`, `c:ofPieChart`. Today a chart built from
-  those reads as zero series with a default chart type.
 - Title, chart type and series references are still write-only for new charts; editing them on a
   loaded chart does nothing. Making `chart.Title` work on a loaded chart is one more patch step on
   `ChartFormatting`.
+- Chart sheets still land in `UnsupportedSheets` (spec 09's territory).
 
 ## Results (PR 2)
 
@@ -279,3 +277,49 @@ editing the legend keeps its layout and text properties. `Legend.Visible = false
 what the writer did before this PR. Excel's own new charts do have value axis gridlines, so this is a
 plausible thing to change, but doing it silently would alter the output of every existing caller. Left
 as a deliberate decision to revisit, not an oversight.
+
+## Results (PR 4)
+
+Both reader gaps closed. 6416 tests pass on net8.0 and net10.0.
+
+### Anchors
+
+`ChartReader.LoadCharts` iterated `Elements<Xdr.TwoCellAnchor>()`, so a chart Excel had anchored with
+`xdr:oneCellAnchor` or `xdr:absoluteAnchor` never reached `ws.Charts` — invisible to the API, though
+its XML did survive a save because the writer never touches a loaded chart. It now walks every anchor
+child.
+
+Following the picture pattern the spec pointed at, the anchor kind is exposed as
+`IXLChart.Anchor` of the already-public `XLDrawingAnchor` enum, whose three values line up exactly
+with the three anchor elements, plus `Width`, `Height`, `Left` and `Top` in pixels — the same unit and
+the same 9525 EMU conversion `IXLPicture` uses. `XLPicturePlacement` would have been the closer
+analogue by name, but it lives in `XLibur.Excel.Drawings` and reads oddly on a chart;
+`XLDrawingAnchor` is in `XLibur.Excel` and was already public.
+
+The writer emits whichever anchor `Anchor` asks for. It defaults to `MoveAndSizeWithCells`, so charts
+built by existing callers are byte-identical to before.
+
+### Trendlines and error bars
+
+Preservation-only, as specified, and it needed no code: PR 1's patch approach never rewrites a series
+element wholesale. The fixture in `ChartRoundTripPreservationTests` now carries both a `c:trendline`
+and a `c:errBars`, and the test that edits the series' fill and line width asserts they are still
+there afterwards.
+
+### Also closed: the 3D and of-pie group kinds
+
+Not in the spec's PR 4 list, but the same class of bug and one line of the spec's "Current state":
+`c:pie3DChart`, `c:line3DChart`, `c:area3DChart`, `c:surface3DChart` and `c:ofPieChart` were not
+recognised by the plot-area scan, so an Excel-authored chart using one produced a chart object with no
+series and whatever `XLChartType` happens to be zero. They are now scanned like the 2D groups, their
+series and series formatting read the same way, `c:ofPieType` tells pie-of-pie from bar-of-pie, and
+`c:grouping` on `c:area3DChart` picks the stacked variants.
+
+**The writer is still asymmetric here** and this PR deliberately did not change it: XLibur writes
+`Pie3D` as a plain `c:pieChart`, `Line3D` as `c:lineChart`, `Area3D` as `c:areaChart` and every surface
+type as `c:surfaceChart`. Its own 3D charts therefore round-trip as their 2D equivalents. Fixing the
+writer would change the output of existing callers and is a separate, larger job — the 3D groups carry
+`c:view3D`, `c:floor`, `c:sideWall` and `c:backWall` on the chart, none of which is modelled. For the
+same reason `c:surfaceChart` is still read back as `Surface` rather than the `SurfaceContour` it
+strictly means: the writer emits it for `Surface`, and matching the reader to the spec's semantics
+would break XLibur's own round trip.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -19,7 +19,7 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 07 | [Formula function coverage (257→~420)](07-formula-function-coverage.md) | Feature | L | Proposed | **6 fully independent waves** |
 | 08 | [LET / LAMBDA](08-let-lambda.md) | Feature | L | Proposed | Single owner (engine core) |
 | 09 | [Threaded comments + round-trip fidelity](09-threaded-comments-roundtrip.md) | Feature · Compat | M | Proposed | Comments vs fidelity-audit split |
-| 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | 🚧 **PR 1 done** | 4 PRs, 2–3 independent |
+| 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | ✅ **Done** (PRs 1–4) | 4 PRs, 2–3 independent |
 | 11 | [Create-path allocation reduction](11-create-path-allocations.md) | Perf (write) | M | ✅ **Tasks 1–4 done** | Task 4 lands in 11; 05 rebases |
 
 Spec 11 was added after spec 03 landed: 03 halved the *save* phase and showed the rest of it is
@@ -31,17 +31,20 @@ Spec 02 delivered **−16.5% load time and −61.5% allocations** (4.750 s / 102
 correction to spec 03's number-formatting task, and a reusable `XmlReader.ReadValueChunk` technique
 for the IO layer. Both are recorded in spec 02's Results section.
 
-Spec 10's PR 1 settled the question the spec flagged as its own hard part: the chart writer never
-regenerates a chart it loaded, so unmodeled chart XML round-trips byte for byte, and edits are
-patched into the existing part instead. **PRs 2–4 should extend that patcher rather than add a second
-write path** — see spec 10's Results section. Turning the OpenXML validator on for the new chart
-tests also surfaced three long-standing schema violations in the chart writer, now fixed.
+Spec 10 landed in four PRs. Its PR 1 settled the question the spec flagged as its own hard part: the
+chart writer never regenerates a chart it loaded, so unmodeled chart XML round-trips byte for byte,
+and edits are patched into the existing part instead — PRs 2–4 extended that patcher rather than
+adding a second write path. Along the way, turning the OpenXML validator on for the new chart tests
+surfaced three long-standing schema violations in the chart writer, and the reader turned out to drop
+one-cell/absolute anchored charts and every 3D or of-pie chart group. All fixed; see spec 10's four
+Results sections. **Still open there:** the writer emits 3D pie/line/area and every surface type as
+their 2D group elements, so XLibur's own 3D charts round-trip as 2D.
 
 ## Why these ten (01–10)
 
 **Performance (specs 02, 03, 04, 05).** The write cell-loop and the sheetData parse have both had a round of tuning; what remains, in measured order: per-cell string allocations on load (`<v>` + attributes + SST DOM), the ~543 MB formatted save (number formatting, inherited-style resolution, StyleKey hashing), the full-workbook-recalc cliff when reading one dirty formula cell (can build a 176 MB dependency tree to answer one read), and O(all-ranges·log) work per single row insert. Specs 02–05 attack each with concrete targets.
 
-**Features (specs 01, 07, 08, 10).** The fork already leads upstream on charts, dynamic arrays, in-cell images, sparklines, WebP/SVG. The gaps that matter: no bounded-memory export path for huge files (01), ~250 missing formula functions with a clean registry to extend (07), no LET/LAMBDA (08 — the one function family that needs engine work), and charts that can't be styled (10 — depth on the flagship differentiator).
+**Features (specs 01, 07, 08, 10).** The fork already leads upstream on charts, dynamic arrays, in-cell images, sparklines, WebP/SVG. The gaps that matter: no bounded-memory export path for huge files (01), ~250 missing formula functions with a clean registry to extend (07), no LET/LAMBDA (08 — the one function family that needs engine work), and charts that couldn't be styled (10 — depth on the flagship differentiator, now done).
 
 **Compatibility (specs 06, 09).** Password-encrypted files can't be opened or written at all (06 — hard blocker, zero code exists). Threaded comments are read lossily and silently downgraded on save; chartsheets, form controls, and slicers are dropped on round-trip (09).
 
@@ -55,7 +58,7 @@ Wave 1 (independent, start anytime):
   11 Tasks 1–4 ✅ done (−28.8% on the write benchmark; bulk styling −86% per cell)
 Wave 2 (after 03 lands, or coordinated):
   01 streaming write (Phase 1 seam shared with 03's territory) · 06 encryption
-  10 charts PR1 ✅ done (series formatting, secondary axis, preservation groundwork) · PRs 2–4 open
+  10 charts ✅ done (PRs 1–4: series formatting, data labels, legend/axes, reader gaps)
 Wave 3 (single-owner, correctness-critical — don't parallelize internally):
   04 demand-driven eval · 05 structural edits · 08 LET/LAMBDA (08 after or alongside 04)
 ```


### PR DESCRIPTION
## Summary

PR 4 of 4 for [spec 10 — Chart formatting depth](https://github.com/XLibur/XLibur/blob/main/docs/specs/10-chart-formatting-depth.md). Closes the reader gaps: charts anchored one-cell or absolute, and the chart group elements XLibur reads but never writes.

> **Stacked on #222** — this PR targets `feat/chart-legend-axes`, not `main`, so its diff shows only the reader work. Merge #220 → #221 → #222 first; GitHub retargets automatically as each lands.
>
> 1. #220 — series formatting + secondary axis + preservation groundwork
> 2. #221 — data labels
> 3. #222 — legend + axes
> 4. **this PR** — anchor reader gaps

## Changes

### Anchors

`ChartReader.LoadCharts` iterated `Elements<Xdr.TwoCellAnchor>()`, so a chart Excel had anchored with `xdr:oneCellAnchor` or `xdr:absoluteAnchor` **never reached `ws.Charts`** — invisible to the API, though its XML did survive a save because the writer never touches a loaded chart. It now walks every anchor child.

Following the picture pattern the spec pointed at, the anchor kind is exposed as `IXLChart.Anchor` of the already-public `XLDrawingAnchor` enum, whose three values line up exactly with the three anchor elements, plus `Width`, `Height`, `Left` and `Top` in pixels — the same unit and the same 9525 EMU conversion `IXLPicture` uses. `XLPicturePlacement` would have been the closer analogue by name, but it lives in `XLibur.Excel.Drawings` and reads oddly on a chart; `XLDrawingAnchor` is in `XLibur.Excel` and was already public.

The writer emits whichever anchor `Anchor` asks for and still defaults to `MoveAndSizeWithCells`, so charts built by existing callers are byte-identical to before.

### Trendlines and error bars

Preservation-only as specified, and it needed no code: #220's patcher never rewrites a series element wholesale. The `ChartRoundTripPreservationTests` fixture now carries both a `c:trendline` and a `c:errBars`, and the test that edits the series' fill and line width asserts they are still there afterwards.

### Also closed: the 3D and of-pie group kinds

Not in the spec's PR 4 list, but the same class of bug and one line of the spec's "Current state". `c:pie3DChart`, `c:line3DChart`, `c:area3DChart`, `c:surface3DChart` and `c:ofPieChart` were not recognised by the plot-area scan, so an Excel-authored chart using one loaded with **no series** and whatever `XLChartType` happens to be zero. They are now scanned like the 2D groups, their series and series formatting read the same way, `c:ofPieType` tells pie-of-pie from bar-of-pie, and `c:grouping` on `c:area3DChart` picks the stacked variants.

**The writer is left asymmetric here, deliberately.** XLibur writes `Pie3D` as a plain `c:pieChart`, `Line3D` as `c:lineChart`, `Area3D` as `c:areaChart` and every surface type as `c:surfaceChart`, so its own 3D charts still round-trip as their 2D equivalents. Fixing that would change existing callers' output and is a larger job — the 3D groups carry `c:view3D`, `c:floor`, `c:sideWall` and `c:backWall`, none of which is modelled. For the same reason `c:surfaceChart` is still read back as `Surface` rather than the `SurfaceContour` it strictly means: the writer emits it for `Surface`, and matching the reader to the format's semantics would break XLibur's own round trip.

## Related Issues

Implements PR 4 of `docs/specs/10-chart-formatting-depth.md`, which is complete with this PR. Findings recorded in that spec's "Results (PR 4)" section; the remaining known gaps are listed there under "Left for later".

## Testing

- [x] Added or updated unit tests — `ChartAnchorTests` (5) and `ChartGroupKindReaderTests` (9), plus error-bar preservation in `ChartRoundTripPreservationTests`
- [x] All existing tests pass — 6416 on net8.0 and net10.0
- [ ] Tested manually

All three anchor kinds are round-tripped and validated, one test puts all three on one sheet and asserts every chart is found, and one edits a one-cell anchored chart to confirm the patcher reaches its chart part (which it finds by relationship id, not through the anchor). The group-kind tests feed Excel-shaped plot areas through the reader. The `FormattedChartExamples` sample gains an "Anchoring" sheet.

Same two caveats as #220: no Excel available for the render check, and `XLibur.Tests/Resource/Charts/` is still empty.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [ ] PR targets the `main` branch — targets #222 instead; see the stack note above
