### PR TITLE
chore: strip redundant null-forgiving operators in benchmarks (S8970)

### DIFF
--- a/XLibur.Benchmarks/AllocationBenchmarks.cs
+++ b/XLibur.Benchmarks/AllocationBenchmarks.cs
@@ -67,10 +67,10 @@ public class AllocationBenchmarks
         "E10-F20/G30", "AVERAGE(H1:H50)", "\"literal:A1\"&B2", "C5*D5+E5", "MAX(A1:Z1)", "MIN(B2:B200)",
     ];
 
-    private XLWorkbook _workbook = null!;
-    private XLWorksheet _worksheet = null!;
-    private XLRange _shiftRange = null!;
-    private XLCell[] _emptyCells = null!;
+    private XLWorkbook _workbook = null;
+    private XLWorksheet _worksheet = null;
+    private XLRange _shiftRange = null;
+    private XLCell[] _emptyCells = null;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/ClosedXmlReadBenchmarks.cs
+++ b/XLibur.Benchmarks/ClosedXmlReadBenchmarks.cs
@@ -12,7 +12,7 @@ public class ClosedXmlReadBenchmarks
     private const int RowCount = 250_000;
     private const int ColCount = 15;
 
-    private byte[] _fileBytes = null!;
+    private byte[] _fileBytes = null;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/ClosedXmlWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/ClosedXmlWorkbookBenchmarks.cs
@@ -11,9 +11,9 @@ public class ClosedXmlWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
 
-    private string[] _strings = null!;
-    private double[] _numbers = null!;
-    private DateTime[] _dates = null!;
+    private string[] _strings = null;
+    private double[] _numbers = null;
+    private DateTime[] _dates = null;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/EpPlusReadBenchmarks.cs
+++ b/XLibur.Benchmarks/EpPlusReadBenchmarks.cs
@@ -12,7 +12,7 @@ public class EpPlusReadBenchmarks
     private const int RowCount = 250_000;
     private const int ColCount = 15;
 
-    private byte[] _fileBytes = null!;
+    private byte[] _fileBytes = null;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/EpPlusWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/EpPlusWorkbookBenchmarks.cs
@@ -13,9 +13,9 @@ public class EpPlusWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
 
-    private string[] _strings = null!;
-    private double[] _numbers = null!;
-    private DateTime[] _dates = null!;
+    private string[] _strings = null;
+    private double[] _numbers = null;
+    private DateTime[] _dates = null;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs
@@ -26,9 +26,9 @@ public class OpenXmlWorkbookBenchmarks
     private const int RowCount = 50_000;
     private const string Ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
 
-    private string[] _strings = null!;
-    private double[] _numbers = null!;
-    private DateTime[] _dates = null!;
+    private string[] _strings = null;
+    private double[] _numbers = null;
+    private DateTime[] _dates = null;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/StyleKeyHashCodeBenchmarks.cs
+++ b/XLibur.Benchmarks/StyleKeyHashCodeBenchmarks.cs
@@ -15,11 +15,11 @@ public class StyleKeyHashCodeBenchmarks
 {
     private const int Iterations = 100_000;
 
-    private XLFontKey[] _fontKeys = null!;
-    private XLBorderKey[] _borderKeys = null!;
-    private XLFillKey[] _fillKeys = null!;
-    private XLColorKey[] _colorKeys = null!;
-    private XLStyleKey[] _styleKeys = null!;
+    private XLFontKey[] _fontKeys = null;
+    private XLBorderKey[] _borderKeys = null;
+    private XLFillKey[] _fillKeys = null;
+    private XLColorKey[] _colorKeys = null;
+    private XLStyleKey[] _styleKeys = null;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/XLiburReadBenchmarks.cs
+++ b/XLibur.Benchmarks/XLiburReadBenchmarks.cs
@@ -13,7 +13,7 @@ public class XLiburReadBenchmarks
     private const int RowCount = 250_000;
     private const int ColCount = 15;
 
-    private byte[] _fileBytes = null!;
+    private byte[] _fileBytes = null;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs
@@ -15,10 +15,10 @@ public class XLiburWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
 
-    private BenchmarkData _data = null!;
-    private string[] _strings = null!;
-    private double[] _numbers = null!;
-    private DateTime[] _dates = null!;
+    private BenchmarkData _data = null;
+    private string[] _strings = null;
+    private double[] _numbers = null;
+    private DateTime[] _dates = null;
 
     [GlobalSetup]
     public void Setup()


### PR DESCRIPTION
## Summary
- Strip redundant `null!` → `null` across `XLibur.Benchmarks` (Option A from [#194](https://github.com/XLibur/XLibur/issues/194); nullable stays disabled).
- Clears SonarCloud [S8970](https://sonarcloud.io/project/issues?id=XLibur_XLibur&rules=csharpsquid%3AS8970&issueStatuses=OPEN%2CCONFIRMED) findings in the benchmarks project (including [AZ-RMXA25kwUMMc1N3sZ](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-RMXA25kwUMMc1N3sZ)).

## Test plan
- [x] `dotnet build XLibur.Benchmarks/XLibur.Benchmarks.csproj` succeeds
- [x] SonarCloud S8970 issues in benchmarks close after merge analysis


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark field initialization to use standard null defaults.
  * Benchmark setup, data generation, workbook operations, and performance measurements remain unchanged.
  * No end-user-visible functionality or behavior was modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->