### PR TITLE
chore: strip redundant null-forgiving operators in examples (S8970)

### DIFF
--- a/XLibur.Examples/Columns/ColumnCells.cs
+++ b/XLibur.Examples/Columns/ColumnCells.cs
@@ -18,7 +18,7 @@ public class ColumnCells : IXLExample
 
         var columnFromRange = ws.Range("B1:B9").FirstColumn();
 
-        columnFromRange!.Cell(1).Style.Fill.BackgroundColor = XLColor.Red;
+        columnFromRange.Cell(1).Style.Fill.BackgroundColor = XLColor.Red;
         columnFromRange.Cells("2").Style.Fill.BackgroundColor = XLColor.Blue;
         columnFromRange.Cells("3,5:6").Style.Fill.BackgroundColor = XLColor.Red;
         columnFromRange.Cells(8, 9).Style.Fill.BackgroundColor = XLColor.Blue;

--- a/XLibur.Examples/ConditionalFormatting/ConditionalFormatting.cs
+++ b/XLibur.Examples/ConditionalFormatting/ConditionalFormatting.cs
@@ -14,7 +14,7 @@ public class CFColorScaleLowMidHigh : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().ColorScale()
+        ws.RangeUsed().AddConditionalFormat().ColorScale()
             .LowestValue(XLColor.Red)
             .Midpoint(XLCFContentType.Percent, "50", XLColor.Yellow)
             .HighestValue(XLColor.Green);
@@ -35,7 +35,7 @@ public class CFColorScaleLowHigh : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().ColorScale()
+        ws.RangeUsed().AddConditionalFormat().ColorScale()
             .Minimum(XLCFContentType.Number, "2", XLColor.Red)
             .Maximum(XLCFContentType.Percentile, "90", XLColor.Green);
 
@@ -55,7 +55,7 @@ public class CFColorScaleMinimumMaximum : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().ColorScale()
+        ws.RangeUsed().AddConditionalFormat().ColorScale()
             .LowestValue(XLColor.FromHtml("#FFFF7128"))
             .HighestValue(XLColor.FromHtml("#FFFFEF9C"));
 
@@ -75,7 +75,7 @@ public class CFStartsWith : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenStartsWith("Hell")
+        ws.RangeUsed().AddConditionalFormat().WhenStartsWith("Hell")
             .Fill.SetBackgroundColor(XLColor.Red)
             .Border.SetOutsideBorder(XLBorderStyleValues.Thick)
             .Border.SetOutsideBorderColor(XLColor.Blue)
@@ -97,7 +97,7 @@ public class CFEndsWith : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenEndsWith("ll")
+        ws.RangeUsed().AddConditionalFormat().WhenEndsWith("ll")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -116,7 +116,7 @@ public class CFIsBlank : IXLExample
             .CellBelow().SetValue("")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenIsBlank()
+        ws.RangeUsed().AddConditionalFormat().WhenIsBlank()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -135,7 +135,7 @@ public class CFNotBlank : IXLExample
             .CellBelow().SetValue("")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenNotBlank()
+        ws.RangeUsed().AddConditionalFormat().WhenNotBlank()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -154,7 +154,7 @@ public class CFIsError : IXLExample
             .CellBelow().SetFormulaA1("1/0")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenIsError()
+        ws.RangeUsed().AddConditionalFormat().WhenIsError()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -173,7 +173,7 @@ public class CFNotError : IXLExample
             .CellBelow().SetFormulaA1("1/0")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenNotError()
+        ws.RangeUsed().AddConditionalFormat().WhenNotError()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -192,7 +192,7 @@ public class CFContains : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenContains("Hell")
+        ws.RangeUsed().AddConditionalFormat().WhenContains("Hell")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -211,7 +211,7 @@ public class CFNotContains : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenNotContains("Hell")
+        ws.RangeUsed().AddConditionalFormat().WhenNotContains("Hell")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -230,7 +230,7 @@ public class CFEqualsString : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenEquals("Hell")
+        ws.RangeUsed().AddConditionalFormat().WhenEquals("Hell")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -249,7 +249,7 @@ public class CFEqualsNumber : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenEquals(2)
+        ws.RangeUsed().AddConditionalFormat().WhenEquals(2)
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -268,7 +268,7 @@ public class CFNotEqualsString : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenNotEquals("Hell")
+        ws.RangeUsed().AddConditionalFormat().WhenNotEquals("Hell")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -287,7 +287,7 @@ public class CFNotEqualsNumber : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenNotEquals(2)
+        ws.RangeUsed().AddConditionalFormat().WhenNotEquals(2)
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -306,7 +306,7 @@ public class CFGreaterThan : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenGreaterThan("2")
+        ws.RangeUsed().AddConditionalFormat().WhenGreaterThan("2")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -325,7 +325,7 @@ public class CFEqualOrGreaterThan : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenEqualOrGreaterThan("2")
+        ws.RangeUsed().AddConditionalFormat().WhenEqualOrGreaterThan("2")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -344,7 +344,7 @@ public class CFLessThan : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenLessThan("2")
+        ws.RangeUsed().AddConditionalFormat().WhenLessThan("2")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -363,7 +363,7 @@ public class CFEqualOrLessThan : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenEqualOrLessThan("2")
+        ws.RangeUsed().AddConditionalFormat().WhenEqualOrLessThan("2")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -382,7 +382,7 @@ public class CFBetween : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenBetween("2", "3")
+        ws.RangeUsed().AddConditionalFormat().WhenBetween("2", "3")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -401,7 +401,7 @@ public class CFNotBetween : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenNotBetween("2", "3")
+        ws.RangeUsed().AddConditionalFormat().WhenNotBetween("2", "3")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -420,7 +420,7 @@ public class CFUnique : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenIsUnique()
+        ws.RangeUsed().AddConditionalFormat().WhenIsUnique()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -439,7 +439,7 @@ public class CFDuplicate : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenIsDuplicate()
+        ws.RangeUsed().AddConditionalFormat().WhenIsDuplicate()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -458,7 +458,7 @@ public class CFIsTrue : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenIsTrue("TRUE")
+        ws.RangeUsed().AddConditionalFormat().WhenIsTrue("TRUE")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -477,7 +477,7 @@ public class CFTop : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenIsTop(2)
+        ws.RangeUsed().AddConditionalFormat().WhenIsTop(2)
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -496,7 +496,7 @@ public class CFBottom : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenIsBottom(10, XLTopBottomType.Percent)
+        ws.RangeUsed().AddConditionalFormat().WhenIsBottom(10, XLTopBottomType.Percent)
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -515,7 +515,7 @@ public class CFDataBar : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().DataBar(XLColor.Red, true)
+        ws.RangeUsed().AddConditionalFormat().DataBar(XLColor.Red, true)
             .LowestValue()
             .Maximum(XLCFContentType.Percent, "100");
 
@@ -568,7 +568,7 @@ public class CFIconSet : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
+        ws.RangeUsed().AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "0", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "2", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "3", XLCFContentType.Number);
@@ -589,12 +589,12 @@ public class CFTwoConditions : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
+        ws.RangeUsed().AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "0", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "2", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "3", XLCFContentType.Number);
 
-        ws.RangeUsed()!.AddConditionalFormat().WhenContains("1")
+        ws.RangeUsed().AddConditionalFormat().WhenContains("1")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -634,7 +634,7 @@ public class CFTest : IXLExample
             .CellBelow().SetValue(3)
             .CellBelow().SetValue(4);
 
-        ws.RangeUsed()!.AddConditionalFormat().DataBar(XLColor.Red, XLColor.Green)
+        ws.RangeUsed().AddConditionalFormat().DataBar(XLColor.Red, XLColor.Green)
             .LowestValue()
             .HighestValue();
 
@@ -673,9 +673,9 @@ public class CFStopIfTrue : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed()!.AddConditionalFormat().SetStopIfTrue().WhenGreaterThan(5);
+        ws.RangeUsed().AddConditionalFormat().SetStopIfTrue().WhenGreaterThan(5);
 
-        ws.RangeUsed()!.AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
+        ws.RangeUsed().AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "0", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "2", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "3", XLCFContentType.Number);

--- a/XLibur.Examples/Ranges/AddingRowToTables.cs
+++ b/XLibur.Examples/Ranges/AddingRowToTables.cs
@@ -17,8 +17,8 @@ public class AddingRowToTables : IXLExample
 
             var firstCell = ws.FirstCellUsed();
             var lastCell = ws.LastCellUsed();
-            var range = ws.Range(firstCell!.Address, lastCell!.Address);
-            range.FirstRow()!.Delete(); // Deleting the "Contacts" header (we don't need it for our purposes)
+            var range = ws.Range(firstCell.Address, lastCell.Address);
+            range.FirstRow().Delete(); // Deleting the "Contacts" header (we don't need it for our purposes)
 
             // We want to use a theme for table, not the hard coded format of the BasicTable
             range.Clear(XLClearOptions.AllFormats);
@@ -30,7 +30,7 @@ public class AddingRowToTables : IXLExample
 
             ws.Cell("Q6000").Value = "dummy value";
 
-            table.DataRange!.InsertRowsBelow(1);
+            table.DataRange.InsertRowsBelow(1);
 
             wb.SaveAs(filePath);
         }

--- a/XLibur.Examples/Ranges/SortExample.cs
+++ b/XLibur.Examples/Ranges/SortExample.cs
@@ -14,13 +14,13 @@ public class SortExample : IXLExample
         var wsTable = wb.Worksheets.Add("Table");
         AddTestTable(wsTable);
         var header = wsTable.Row(1).InsertRowsAbove(1).First();
-        for (var co = 1; co <= wsTable.LastColumnUsed()!.ColumnNumber(); co++)
+        for (var co = 1; co <= wsTable.LastColumnUsed().ColumnNumber(); co++)
         {
             header.Cell(co).Value = "Column" + co;
         }
 
         var rangeTable = wsTable.RangeUsed();
-        var table = rangeTable!.CopyTo(wsTable.Column(wsTable.LastColumnUsed()!.ColumnNumber() + 3)).CreateTable();
+        var table = rangeTable.CopyTo(wsTable.Column(wsTable.LastColumnUsed().ColumnNumber() + 3)).CreateTable();
 
         table.Sort("Column2, Column3 Desc, Column1 ASC");
 
@@ -36,9 +36,9 @@ public class SortExample : IXLExample
 
         var wsLeftToRight = wb.Worksheets.Add("Sort Left to Right");
         AddTestTable(wsLeftToRight);
-        wsLeftToRight.RangeUsed()!.Transpose(XLTransposeOptions.MoveCells);
+        wsLeftToRight.RangeUsed().Transpose(XLTransposeOptions.MoveCells);
         var rangeLeftToRight = wsLeftToRight.RangeUsed();
-        var copyLeftToRight = rangeLeftToRight!.CopyTo(wsLeftToRight.Row(wsLeftToRight.LastRowUsed()!.RowNumber() + 3));
+        var copyLeftToRight = rangeLeftToRight.CopyTo(wsLeftToRight.Row(wsLeftToRight.LastRowUsed().RowNumber() + 3));
 
         copyLeftToRight.SortLeftToRight();
 
@@ -54,7 +54,7 @@ public class SortExample : IXLExample
         var wsComplex2 = wb.Worksheets.Add("Complex 2");
         AddTestTable(wsComplex2);
         var rangeComplex2 = wsComplex2.RangeUsed();
-        var copyComplex2 = rangeComplex2!.CopyTo(wsComplex2.Column(wsComplex2.LastColumnUsed()!.ColumnNumber() + 3));
+        var copyComplex2 = rangeComplex2.CopyTo(wsComplex2.Column(wsComplex2.LastColumnUsed().ColumnNumber() + 3));
 
         copyComplex2.SortColumns.Add(1, XLSortOrder.Ascending, false, true);
         copyComplex2.SortColumns.Add(3, XLSortOrder.Descending);
@@ -78,7 +78,7 @@ public class SortExample : IXLExample
         var wsComplex1 = wb.Worksheets.Add("Complex 1");
         AddTestTable(wsComplex1);
         var rangeComplex1 = wsComplex1.RangeUsed();
-        var copyComplex1 = rangeComplex1!.CopyTo(wsComplex1.Column(wsComplex1.LastColumnUsed()!.ColumnNumber() + 3));
+        var copyComplex1 = rangeComplex1.CopyTo(wsComplex1.Column(wsComplex1.LastColumnUsed().ColumnNumber() + 3));
 
         copyComplex1.Sort("2, 1 DESC", XLSortOrder.Ascending, true);
 
@@ -96,9 +96,9 @@ public class SortExample : IXLExample
         AddTestColumn(wsSimpleColumn);
         var rangeSimpleColumn = wsSimpleColumn.RangeUsed();
         var copySimpleColumn =
-            rangeSimpleColumn!.CopyTo(wsSimpleColumn.Column(wsSimpleColumn.LastColumnUsed()!.ColumnNumber() + 3));
+            rangeSimpleColumn.CopyTo(wsSimpleColumn.Column(wsSimpleColumn.LastColumnUsed().ColumnNumber() + 3));
 
-        copySimpleColumn.FirstColumn()!.Sort(XLSortOrder.Descending, true);
+        copySimpleColumn.FirstColumn().Sort(XLSortOrder.Descending, true);
 
         wsSimpleColumn.Row(1).InsertRowsAbove(2);
         wsSimpleColumn.Cell(1, 1)
@@ -113,7 +113,7 @@ public class SortExample : IXLExample
         var wsSimple = wb.Worksheets.Add("Simple");
         AddTestTable(wsSimple);
         var rangeSimple = wsSimple.RangeUsed();
-        var copySimple = rangeSimple!.CopyTo(wsSimple.Column(wsSimple.LastColumnUsed()!.ColumnNumber() + 3));
+        var copySimple = rangeSimple.CopyTo(wsSimple.Column(wsSimple.LastColumnUsed().ColumnNumber() + 3));
 
         copySimple.Sort();
 

--- a/XLibur.Examples/Ranges/Sorting.cs
+++ b/XLibur.Examples/Ranges/Sorting.cs
@@ -15,11 +15,11 @@ public class Sorting : IXLExample
         AddTestTable(wsTable);
 
         wsTable.Row(1).InsertRowsAbove(1);
-        var lastCo = wsTable.LastColumnUsed()!.ColumnNumber();
+        var lastCo = wsTable.LastColumnUsed().ColumnNumber();
         for (var co = 1; co <= lastCo; co++)
             wsTable.Cell(1, co).Value = "Column" + co;
 
-        var table = wsTable.RangeUsed()!.AsTable();
+        var table = wsTable.RangeUsed().AsTable();
         table.Sort("Column2 Desc, 1, 3 Asc");
 
         // Sort table another way
@@ -27,11 +27,11 @@ public class Sorting : IXLExample
         AddTestTable(wsTable);
 
         wsTable.Row(1).InsertRowsAbove(1);
-        lastCo = wsTable.LastColumnUsed()!.ColumnNumber();
+        lastCo = wsTable.LastColumnUsed().ColumnNumber();
         for (var co = 1; co <= lastCo; co++)
             wsTable.Cell(1, co).Value = "Column" + co;
 
-        table = wsTable.RangeUsed()!.AsTable();
+        table = wsTable.RangeUsed().AsTable();
         table.Sort("Column2", XLSortOrder.Descending);
 
         #endregion Sort Table
@@ -41,8 +41,8 @@ public class Sorting : IXLExample
         var wsRows = wb.Worksheets.Add("Rows");
         AddTestTable(wsRows);
         wsRows.Row(1).Sort();
-        wsRows.RangeUsed()!.Row(2).Sort();
-        wsRows.Rows(3, wsRows.LastRowUsed()!.RowNumber()).Delete();
+        wsRows.RangeUsed().Row(2).Sort();
+        wsRows.Rows(3, wsRows.LastRowUsed().RowNumber()).Delete();
 
         #endregion Sort Rows
 
@@ -50,9 +50,9 @@ public class Sorting : IXLExample
 
         var wsColumns = wb.Worksheets.Add("Columns");
         AddTestTable(wsColumns);
-        wsColumns.LastColumnUsed()!.Delete();
+        wsColumns.LastColumnUsed().Delete();
         wsColumns.Column(1).Sort();
-        wsColumns.RangeUsed()!.Column(2).Sort();
+        wsColumns.RangeUsed().Column(2).Sort();
 
         #endregion Sort Columns
 


### PR DESCRIPTION
## Summary
- Strip redundant null-forgiving operators (`expr!`) across `XLibur.Examples` (Option A from [#194](https://github.com/XLibur/XLibur/issues/194); nullable stays disabled).
- Clears the remaining open SonarCloud [S8970](https://sonarcloud.io/project/issues?id=XLibur_XLibur&rules=csharpsquid%3AS8970&issueStatuses=OPEN%2CCONFIRMED) findings in the examples project (61 sites in 5 files).

## Test plan
- [x] `dotnet build XLibur.Examples/XLibur.Examples.csproj` succeeds
- [ ] SonarCloud S8970 issues in examples close after merge analysis
