### PR TITLE
fix: write runs that had no rPr back without one (#219)

### DIFF
--- a/XLibur.Tests/Excel/RichText/RichTextColorRoundTripTests.cs
+++ b/XLibur.Tests/Excel/RichText/RichTextColorRoundTripTests.cs
@@ -122,35 +122,78 @@ public class RichTextColorRoundTripTests
         });
     }
 
+    // A run with no rPr states no formatting of its own; per ECMA-376 CT_RElt it inherits the cell
+    // font. The cell font here is explicitly green, so nothing about this run is ambiguous - the
+    // only faithful output is a run with no rPr at all.
+    private const string GreenFontStyles =
+        """
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+          <fonts count="1"><font><sz val="11"/><color rgb="FF00FF00"/><name val="Calibri"/></font></fonts>
+          <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+          <borders count="1"><border/></borders>
+          <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+          <cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyFont="1"/></cellXfs>
+        </styleSheet>
+        """;
+
+    private const string BareRunSharedStrings =
+        """
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">
+          <si><r><t>Inherited</t></r></si>
+        </sst>
+        """;
+
     [Test]
-    public void RunWithoutRunProperties_StillInheritsAnExplicitCellFontColor()
+    public void RunWithoutRunProperties_IsWrittenBackWithoutRunProperties()
     {
-        // A run with no rPr inherits the cell font (ECMA-376 CT_RElt). Dropping the color is only
-        // correct when it is the ambiguous black default - an explicitly styled cell font must
-        // still be materialized onto the run.
-        const string greenFontStyles =
-            """
-            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-            <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-              <fonts count="1"><font><sz val="11"/><color rgb="FF00FF00"/><name val="Calibri"/></font></fonts>
-              <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
-              <borders count="1"><border/></borders>
-              <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
-              <cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyFont="1"/></cellXfs>
-            </styleSheet>
-            """;
-        const string bareRun =
-            """
-            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-            <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">
-              <si><r><t>Inherited</t></r></si>
-            </sst>
-            """;
+        var savedSharedStrings = RoundTripSharedStrings(BareRunSharedStrings, siCount: 1, styles: GreenFontStyles);
 
-        var savedSharedStrings = RoundTripSharedStrings(bareRun, siCount: 1, styles: greenFontStyles);
+        Assert.Multiple(() =>
+        {
+            Assert.That(savedSharedStrings, Does.Not.Contain("rPr"),
+                $"A run that had no rPr must not gain one.\n\n{savedSharedStrings}");
+            Assert.That(savedSharedStrings, Does.Contain("Inherited"), "Run text was lost.");
+        });
+    }
 
-        Assert.That(savedSharedStrings, Does.Contain("FF00FF00").IgnoreCase,
-            $"A run without rPr must keep the cell font's explicit color.\n\n{savedSharedStrings}");
+    [Test]
+    public void RunWithoutRunProperties_StillReadsTheInheritedCellFont()
+    {
+        // Writing no rPr must not mean the run has no font in the object model - reading and
+        // measuring it still needs the inherited cell font.
+        var input = BuildWorkbook(BareRunSharedStrings, siCount: 1, styles: GreenFontStyles);
+
+        using var wb = new XLWorkbook(new MemoryStream(input));
+        var run = wb.Worksheets.First().Cell("A1").GetRichText().First();
+
+        Assert.That(run.FontColor, Is.EqualTo(XLColor.FromArgb(0xFF, 0x00, 0xFF, 0x00)));
+    }
+
+    [Test]
+    public void EditingRunWithoutRunProperties_MakesTheFormattingItsOwn()
+    {
+        // Once the caller sets a font property the run does state its own formatting, so it must be
+        // written back with a full rPr - otherwise the edit would be silently dropped.
+        var input = BuildWorkbook(BareRunSharedStrings, siCount: 1, styles: GreenFontStyles);
+
+        using var outMs = new MemoryStream();
+        using (var wb = new XLWorkbook(new MemoryStream(input)))
+        {
+            wb.Worksheets.First().Cell("A1").GetRichText().First().SetBold();
+            wb.SaveAs(outMs);
+        }
+
+        var savedSharedStrings = ReadPart(outMs.ToArray(), "xl/sharedStrings.xml");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(savedSharedStrings, Does.Contain("rPr"), "An edited run must state its formatting.");
+            Assert.That(savedSharedStrings, Does.Contain("<x:b "), "Bold was lost.");
+            Assert.That(savedSharedStrings, Does.Contain("FF00FF00").IgnoreCase,
+                $"The inherited color must be materialized once the run owns its formatting.\n\n{savedSharedStrings}");
+        });
     }
 
     [Test]

--- a/XLibur.Tests/Excel/RichText/RichTextColorRoundTripTests.cs
+++ b/XLibur.Tests/Excel/RichText/RichTextColorRoundTripTests.cs
@@ -197,6 +197,27 @@ public class RichTextColorRoundTripTests
     }
 
     [Test]
+    public void SubstringOfInheritedRun_DoesNotMaterializeTheDefaultBlack()
+    {
+        // Splitting a run that states no formatting must yield runs that also state none - the
+        // sub-runs carry the same font, so re-materializing it would reintroduce the very
+        // rgb="FF000000" this whole fix removes.
+        var input = BuildWorkbook(BareRunSharedStrings, siCount: 1);
+
+        using var outMs = new MemoryStream();
+        using (var wb = new XLWorkbook(new MemoryStream(input)))
+        {
+            wb.Worksheets.First().Cell("A1").GetRichText().Substring(0, 3);
+            wb.SaveAs(outMs);
+        }
+
+        var savedSharedStrings = ReadPart(outMs.ToArray(), "xl/sharedStrings.xml");
+
+        Assert.That(savedSharedStrings, Does.Not.Contain("FF000000").IgnoreCase,
+            $"Splitting an inherited run re-materialized the ambiguous black.\n\n{savedSharedStrings}");
+    }
+
+    [Test]
     public void EditingPhoneticOnlyString_MaterializesARunWithoutLosingText()
     {
         // The stored rich text has no runs, but the mutable API is run-based. Touching it must

--- a/XLibur/Excel/IO/TextSerializer.cs
+++ b/XLibur/Excel/IO/TextSerializer.cs
@@ -27,7 +27,7 @@ internal static class TextSerializer
                 var text = richText.GetRunText(textRun);
                 if (text.Length > 0)
                 {
-                    WriteRun(w, text, textRun.Font);
+                    WriteRun(w, text, textRun.Font, textRun.InheritsCellFont);
                 }
             }
         }
@@ -73,12 +73,26 @@ internal static class TextSerializer
     internal static void WriteRun(XmlWriter w, XLImmutableRichText richText, XLImmutableRichText.RichTextRun run)
     {
         var runText = richText.GetRunText(run);
-        WriteRun(w, runText, run.Font);
+        WriteRun(w, runText, run.Font, run.InheritsCellFont);
     }
 
-    private static void WriteRun(XmlWriter w, string text, XLFontValue font)
+    /// <summary>
+    /// Writes one <c>&lt;r&gt;</c>. When <paramref name="inheritsCellFont"/> the run stated no
+    /// formatting of its own, so no <c>&lt;rPr&gt;</c> is written and the run keeps inheriting the
+    /// cell font on the way back in - writing the inherited font out would turn it into formatting
+    /// the source never asked for.
+    /// </summary>
+    private static void WriteRun(XmlWriter w, string text, XLFontValue font, bool inheritsCellFont)
     {
         w.WriteStartElement("r", Main2006SsNs);
+
+        if (inheritsCellFont)
+        {
+            WriteText(w, text);
+            w.WriteEndElement(); // r
+            return;
+        }
+
         w.WriteStartElement("rPr", Main2006SsNs);
 
         if (font.Bold)

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -732,15 +732,11 @@ internal static class WorksheetSheetDataReader
 
             if (runProperties == null)
             {
-                // No rPr at all: the run inherits the cell font (ECMA-376 CT_RElt), so materializing
-                // that font is faithful - except for a color the cell font only carries because it
-                // was itself defaulted to black, which would invent a color the source never had.
-                var cellFont = xlCell.Style.Font;
-                var font = cellFont.FontColor.Key == XLFontValue.Default.Key.FontColor
-                    ? ColorlessFont(cellFont, ref colorlessCellFont)
-                    : cellFont;
-
-                xlCell.GetRichText().AddText(text, font);
+                // No rPr at all: the run inherits the cell font (ECMA-376 CT_RElt). Record it as
+                // stating no formatting of its own, so the save writes it back without an rPr rather
+                // than materializing the inherited font - including a color the cell font may only
+                // carry because it was itself defaulted to black.
+                xlCell.GetRichText().AddInheritedText(text);
             }
             else
             {

--- a/XLibur/Excel/RichText/XLFormattedText.cs
+++ b/XLibur/Excel/RichText/XLFormattedText.cs
@@ -153,10 +153,15 @@ internal class XLFormattedText<T> : IXLFormattedText<T>
     {
         var startIndex = index - lastPosition;
 
+        // Splitting a run only divides its text - each piece keeps the very same font, so a run that
+        // stated no formatting of its own yields pieces that state none either. Dropping the flag
+        // here would materialize the inherited cell font as an explicit rPr on save.
+        var inherits = rt.InheritsContainerFont;
+
         switch (startIndex)
         {
             case > 0:
-                newRichTexts.Add(new XLRichString(rt.Text.Substring(0, startIndex), rt, this, OnContentChanged));
+                newRichTexts.Add(new XLRichString(rt.Text.Substring(0, startIndex), rt, this, OnContentChanged, inherits));
                 break;
             case < 0:
                 startIndex = 0;
@@ -167,12 +172,12 @@ internal class XLFormattedText<T> : IXLFormattedText<T>
         if (leftToTake > rt.Text.Length - startIndex)
             leftToTake = rt.Text.Length - startIndex;
 
-        var newRt = new XLRichString(rt.Text.Substring(startIndex, leftToTake), rt, this, OnContentChanged);
+        var newRt = new XLRichString(rt.Text.Substring(startIndex, leftToTake), rt, this, OnContentChanged, inherits);
         newRichTexts.Add(newRt);
         retVal.AddText(newRt);
 
         if (startIndex + leftToTake < rt.Text.Length)
-            newRichTexts.Add(new XLRichString(rt.Text.Substring(startIndex + leftToTake), rt, this, OnContentChanged));
+            newRichTexts.Add(new XLRichString(rt.Text.Substring(startIndex + leftToTake), rt, this, OnContentChanged, inherits));
     }
 
     public IXLFormattedText<T> CopyFrom(IXLFormattedText<T> original)

--- a/XLibur/Excel/RichText/XLFormattedText.cs
+++ b/XLibur/Excel/RichText/XLFormattedText.cs
@@ -64,6 +64,17 @@ internal class XLFormattedText<T> : IXLFormattedText<T>
         return AddText(richText);
     }
 
+    /// <summary>
+    /// Add a run that states no formatting of its own and simply inherits the container's font,
+    /// i.e. an <c>&lt;r&gt;</c> read with no <c>&lt;rPr&gt;</c>. Used only by the loader - a run
+    /// created through the public API always states its own formatting.
+    /// </summary>
+    internal IXLRichString AddInheritedText(string text)
+    {
+        var richText = new XLRichString(text, _defaultFont, this, OnContentChanged, inheritsContainerFont: true);
+        return AddText(richText);
+    }
+
     public IXLRichString AddText(XLRichString richText)
     {
         _richTexts.Add(richText);

--- a/XLibur/Excel/RichText/XLImmutableRichText.cs
+++ b/XLibur/Excel/RichText/XLImmutableRichText.cs
@@ -153,17 +153,26 @@ internal sealed class XLImmutableRichText : IEquatable<XLImmutableRichText>
         internal readonly int Length;
         internal readonly XLFontValue Font;
 
+        /// <summary>
+        /// The run states no formatting of its own: <see cref="Font"/> is the cell font it inherits,
+        /// not something the source asked for, so it must be written back without an
+        /// <c>&lt;rPr&gt;</c>. See <see cref="XLRichString.InheritsContainerFont"/>.
+        /// </summary>
+        internal readonly bool InheritsCellFont;
+
         internal RichTextRun(XLRichString richString, int startIndex, int length)
         {
             var key = XLFont.GenerateKey(richString);
             Font = XLFontValue.FromKey(ref key);
             StartIndex = startIndex;
             Length = length;
+            InheritsCellFont = richString.InheritsContainerFont;
         }
 
         public bool Equals(RichTextRun other)
         {
-            return StartIndex == other.StartIndex && Length == other.Length && Font.Equals(other.Font);
+            return StartIndex == other.StartIndex && Length == other.Length && Font.Equals(other.Font)
+                   && InheritsCellFont == other.InheritsCellFont;
         }
 
         public override bool Equals(object? obj)
@@ -178,6 +187,7 @@ internal sealed class XLImmutableRichText : IEquatable<XLImmutableRichText>
                 var hashCode = StartIndex;
                 hashCode = (hashCode * 397) ^ Length;
                 hashCode = (hashCode * 397) ^ Font.GetHashCode();
+                hashCode = (hashCode * 397) ^ (InheritsCellFont ? 1 : 0);
                 return hashCode;
             }
         }

--- a/XLibur/Excel/RichText/XLRichString.cs
+++ b/XLibur/Excel/RichText/XLRichString.cs
@@ -11,13 +11,25 @@ internal sealed class XLRichString : IXLRichString
     private readonly Action _onChange;
     private string _text;
 
-    public XLRichString(string text, IXLFontBase font, IXLWithRichString withRichString, Action? onChange)
+    public XLRichString(string text, IXLFontBase font, IXLWithRichString withRichString, Action? onChange,
+        bool inheritsContainerFont = false)
     {
         _text = text;
         _font = new XLFont(font);
         _withRichString = withRichString;
         _onChange = onChange ?? (() => { });
+        InheritsContainerFont = inheritsContainerFont;
     }
+
+    /// <summary>
+    /// The run carries no formatting of its own and merely reflects the font of its container - it
+    /// was read from an <c>&lt;r&gt;</c> with no <c>&lt;rPr&gt;</c>, which per ECMA-376 CT_RElt
+    /// inherits the cell font. <see cref="_font"/> holds that inherited font so the run can still be
+    /// read and measured, but nothing about it was ever stated by the source, so it must be written
+    /// back without an <c>&lt;rPr&gt;</c>. Any change to the font makes the formatting the run's own
+    /// and clears this.
+    /// </summary>
+    internal bool InheritsContainerFont { get; private set; }
 
     public string Text
     {
@@ -27,6 +39,16 @@ internal sealed class XLRichString : IXLRichString
             _text = value;
             _onChange();
         }
+    }
+
+    /// <summary>
+    /// Signals a change to this run's font. Distinct from a text-only change, because setting any
+    /// font property means the run now states its own formatting.
+    /// </summary>
+    private void OnFontChanged()
+    {
+        InheritsContainerFont = false;
+        _onChange();
     }
 
     public IXLRichString AddText(string text)
@@ -45,7 +67,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.Bold = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -55,7 +77,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.Italic = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -65,7 +87,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.Underline = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -75,7 +97,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.Strikethrough = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -85,7 +107,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.VerticalAlignment = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -95,7 +117,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.Shadow = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -105,7 +127,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.FontSize = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -115,7 +137,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.FontColor = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -125,7 +147,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.FontName = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -135,7 +157,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.FontFamilyNumbering = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -145,7 +167,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.FontCharSet = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 
@@ -155,7 +177,7 @@ internal sealed class XLRichString : IXLRichString
         set
         {
             _font.FontScheme = value;
-            _onChange();
+            OnFontChanged();
         }
     }
 

--- a/XLibur/Excel/RichText/XLRichText.cs
+++ b/XLibur/Excel/RichText/XLRichText.cs
@@ -28,7 +28,8 @@ internal sealed class XLRichText : XLFormattedText<IXLRichText>, IXLRichText
         foreach (var originalRun in original.Runs)
         {
             var runText = original.GetRunText(originalRun);
-            AddText(new XLRichString(runText, new XLFont(originalRun.Font.Key), this, OnContentChanged));
+            AddText(new XLRichString(runText, new XLFont(originalRun.Font.Key), this, OnContentChanged,
+                originalRun.InheritsCellFont));
         }
 
         var hasPhonetics = original.PhoneticRuns.Any() || original.PhoneticsProperties.HasValue;


### PR DESCRIPTION
> **Stacked on #225** — it contains that PR's commit as well. Please merge #225 first; this PR's diff will then reduce to its own single commit. Addresses the first judgement call listed in #225.

## Problem

A rich-text run read from an `<r>` with no `<rPr>` inherits the cell font per ECMA-376 CT_RElt. The loader materialised that inherited font onto the run, so the save wrote it back as an explicit `<rPr>` — turning inheritance into formatting the source never stated, and dragging the cell font's colour along with it.

#225 worked around this by dropping the run colour when it was the ambiguous black default. **That heuristic is removed here.** The run now records that it states no formatting of its own, and the writer emits `<r><t>..</t></r>` with no `rPr` at all. The result round-trips exactly, and a cell font with an explicit colour is no longer a special case.

## Changes

- `XLRichString.InheritsContainerFont` marks a run as carrying no formatting of its own. Every font setter now goes through `OnFontChanged`, which clears it — once the caller sets any font property the formatting is the run's own and a full `rPr` is written. A text-only change does not clear it.
- `XLFormattedText.AddInheritedText` is the loader's entry point. Runs created through the public API are never flagged, so **workbooks built with XLibur are unaffected**.
- The flag is carried on `XLImmutableRichText.RichTextRun` and participates in equality and hashing, so two shared strings that differ only in `rPr` presence don't dedupe into one.

The inherited font is still held on the run, so reading and measuring (`XLCellGlyphHelper`, `cell.GetRichText()`) are unchanged. Comment runs load through `XLComment.AddText` and are never flagged, so comment output is unchanged.

No public API change.

## Tests

`RunWithoutRunProperties_StillInheritsAnExplicitCellFontColor` from #225 asserted the heuristic and is replaced by three tests, all against a workbook whose cell font is explicitly green (`FF00FF00`) with an `<r>` that has no `rPr`:

- `RunWithoutRunProperties_IsWrittenBackWithoutRunProperties` — no `rPr` appears in the output
- `RunWithoutRunProperties_StillReadsTheInheritedCellFont` — the run still reports the green colour in the object model
- `EditingRunWithoutRunProperties_MakesTheFormattingItsOwn` — after `SetBold()` the run writes a full `rPr` including the materialised green, so the edit isn't dropped

No reference fixtures needed regenerating. Full suite green on net8.0 and net10.0 (6342 passed); Release solution build clean under `TreatWarningsAsErrors`.
