### PR TITLE
chore: initialize XLCFConverters dictionary inline (S3963)

### DIFF
--- a/XLibur/Excel/ConditionalFormats/Save/XLCFConverters.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFConverters.cs
@@ -6,30 +6,26 @@ namespace XLibur.Excel;
 
 internal static class XLCFConverters
 {
-    private static readonly Dictionary<XLConditionalFormatType, IXLCFConverter> Converters;
-    static XLCFConverters()
+    private static readonly Dictionary<XLConditionalFormatType, IXLCFConverter> Converters = new()
     {
-        Converters = new Dictionary<XLConditionalFormatType, IXLCFConverter>
-        {
-            {XLConditionalFormatType.ColorScale, new XLCFColorScaleConverter()},
-            {XLConditionalFormatType.StartsWith, new XLCFStartsWithConverter()},
-            {XLConditionalFormatType.EndsWith, new XLCFEndsWithConverter()},
-            {XLConditionalFormatType.IsBlank, new XLCFIsBlankConverter()},
-            {XLConditionalFormatType.NotBlank, new XLCFNotBlankConverter()},
-            {XLConditionalFormatType.IsError, new XLCFIsErrorConverter()},
-            {XLConditionalFormatType.NotError, new XLCFNotErrorConverter()},
-            {XLConditionalFormatType.ContainsText, new XLCFContainsConverter()},
-            {XLConditionalFormatType.NotContainsText, new XLCFNotContainsConverter()},
-            {XLConditionalFormatType.CellIs, new XLCFCellIsConverter()},
-            {XLConditionalFormatType.IsUnique, new XLCFUniqueConverter()},
-            {XLConditionalFormatType.IsDuplicate, new XLCFUniqueConverter()},
-            {XLConditionalFormatType.Expression, new XLCFCellIsConverter()},
-            {XLConditionalFormatType.Top10, new XLCFTopConverter()},
-            {XLConditionalFormatType.DataBar, new XLCFDataBarConverter()},
-            {XLConditionalFormatType.IconSet, new XLCFIconSetConverter()},
-            {XLConditionalFormatType.TimePeriod, new XLCFDatesOccurringConverter()}
-        };
-    }
+        {XLConditionalFormatType.ColorScale, new XLCFColorScaleConverter()},
+        {XLConditionalFormatType.StartsWith, new XLCFStartsWithConverter()},
+        {XLConditionalFormatType.EndsWith, new XLCFEndsWithConverter()},
+        {XLConditionalFormatType.IsBlank, new XLCFIsBlankConverter()},
+        {XLConditionalFormatType.NotBlank, new XLCFNotBlankConverter()},
+        {XLConditionalFormatType.IsError, new XLCFIsErrorConverter()},
+        {XLConditionalFormatType.NotError, new XLCFNotErrorConverter()},
+        {XLConditionalFormatType.ContainsText, new XLCFContainsConverter()},
+        {XLConditionalFormatType.NotContainsText, new XLCFNotContainsConverter()},
+        {XLConditionalFormatType.CellIs, new XLCFCellIsConverter()},
+        {XLConditionalFormatType.IsUnique, new XLCFUniqueConverter()},
+        {XLConditionalFormatType.IsDuplicate, new XLCFUniqueConverter()},
+        {XLConditionalFormatType.Expression, new XLCFCellIsConverter()},
+        {XLConditionalFormatType.Top10, new XLCFTopConverter()},
+        {XLConditionalFormatType.DataBar, new XLCFDataBarConverter()},
+        {XLConditionalFormatType.IconSet, new XLCFIconSetConverter()},
+        {XLConditionalFormatType.TimePeriod, new XLCFDatesOccurringConverter()}
+    };
 
     public static ConditionalFormattingRule Convert(IXLConditionalFormat conditionalFormat, int priority, XLWorkbook.SaveContext context)
     {


### PR DESCRIPTION
## Summary
- Initialize the static `Converters` dictionary inline and remove the static constructor in `XLCFConverters.cs` (SonarCloud [S3963](https://sonarcloud.io/project/issues?impactSeverities=LOW&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZzs6w_vnvODKcpvTk3n)).

## Test plan
- [x] `dotnet build XLibur/XLibur.csproj` succeeds
- [ ] SonarCloud S3963 issue closes after merge analysis
