### PR TITLE
fix: bind the primary chart axis without relying on group order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 - **`Smooth` is honoured on a new stock chart.** A stock chart's series are `CT_LineSer` and take `c:smooth`, but the writer never emitted it, so the property worked on a stock chart read from a file and was silently dropped on one XLibur created.
 
+- **Positioning a legend that is not there no longer creates one.** `IXLChartLegend.Position` and `Overlay` are documented as ignored while `Visible` is `false`, and a new chart gets no legend from them — but assigning one of them on a *loaded* chart that had no legend added one.
+
 - **Chart-wide data labels reach every group of a loaded combo chart.** `IXLChart.DataLabels` applies to the whole chart, and a new combo chart gets them on both of its plot groups, but a loaded one was patched on the primary group only — so turning labels on left the secondary series unlabelled.
 
 - **`Series.Add(...)` on a chart loaded from a file throws instead of being discarded on save.** A loaded chart is patched, not regenerated, so a new series had nowhere to be written and vanished without a word. It now throws `NotSupportedException`, as `UseSecondaryAxis` already did.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
 
 - **Charts with more than one plot group of the same type now read all of their series.** The reader took only the first `c:barChart` (or `c:lineChart`, …) of a plot area, so the series of a second group — which is how Excel stores a secondary axis — were dropped.
 
+- **Which of those groups is on the secondary axis no longer depends on the order they appear in the file.** The primary axis pair was taken from whichever group came first, so a file that wrote its secondary group ahead of the primary one read back with `UseSecondaryAxis` inverted on every series and the two axis models swapped. The group whose value axis crosses at the maximum — how a secondary axis comes to be drawn on the right — is now passed over instead.
+
+- **`Smooth` is honoured on a new stock chart.** A stock chart's series are `CT_LineSer` and take `c:smooth`, but the writer never emitted it, so the property worked on a stock chart read from a file and was silently dropped on one XLibur created.
+
+- **`Series.Add(...)` on a chart loaded from a file throws instead of being discarded on save.** A loaded chart is patched, not regenerated, so a new series had nowhere to be written and vanished without a word. It now throws `NotSupportedException`, as `UseSecondaryAxis` already did.
+
 ## v0.106.0 - 2026-07-25
 
 First XLibur release since forking [ClosedXML v0.105.0](https://github.com/ClosedXML/ClosedXML/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 - **`Smooth` is honoured on a new stock chart.** A stock chart's series are `CT_LineSer` and take `c:smooth`, but the writer never emitted it, so the property worked on a stock chart read from a file and was silently dropped on one XLibur created.
 
+- **Chart-wide data labels reach every group of a loaded combo chart.** `IXLChart.DataLabels` applies to the whole chart, and a new combo chart gets them on both of its plot groups, but a loaded one was patched on the primary group only — so turning labels on left the secondary series unlabelled.
+
 - **`Series.Add(...)` on a chart loaded from a file throws instead of being discarded on save.** A loaded chart is patched, not regenerated, so a new series had nowhere to be written and vanished without a word. It now throws `NotSupportedException`, as `UseSecondaryAxis` already did.
 
 ## v0.106.0 - 2026-07-25

--- a/XLibur.Tests/Excel/Charts/ChartGroupKindReaderTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartGroupKindReaderTests.cs
@@ -1,8 +1,5 @@
-using DocumentFormat.OpenXml.Packaging;
 using NUnit.Framework;
-using System.IO;
 using System.Linq;
-using System.Text;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.Charts;
@@ -14,73 +11,13 @@ namespace XLibur.Tests.Excel.Charts;
 [TestFixture]
 public class ChartGroupKindReaderTests
 {
-    /// <summary>
-    /// Wraps a plot area body in the rest of a chart part, and puts it in a workbook.
-    /// </summary>
-    private static MemoryStream CreateWorkbookWithPlotArea(string plotAreaBody)
-    {
-        var chartXml = $"""
-            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-            <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-              <c:chart>
-                <c:plotArea>
-                  <c:layout/>
-                  {plotAreaBody}
-                </c:plotArea>
-                <c:plotVisOnly val="1"/>
-              </c:chart>
-            </c:chartSpace>
-            """;
+    private const string CategoryAndValueAxes = ChartPartFixture.CategoryAndValueAxes;
 
-        var ms = new MemoryStream();
-        using (var wb = new XLWorkbook())
-        {
-            var ws = wb.AddWorksheet("Data");
-            ws.Cell("A1").Value = "Q1";
-            ws.Cell("A2").Value = "Q2";
-            ws.Cell("B1").Value = 100;
-            ws.Cell("B2").Value = 200;
+    private static string CategoryAndValueSeries(string name) =>
+        ChartPartFixture.CategoryAndValueSeries(name);
 
-            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
-            chart.Series.Add("Placeholder", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
-            chart.Position.SetColumn(5).SetRow(1);
-            chart.SecondPosition.SetColumn(12).SetRow(15);
-            wb.SaveAs(ms);
-        }
-
-        ms.Position = 0;
-        using (var doc = SpreadsheetDocument.Open(ms, true))
-        {
-            var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
-            using var source = new MemoryStream(Encoding.UTF8.GetBytes(chartXml));
-            chartPart.FeedData(source);
-        }
-
-        ms.Position = 0;
-        return ms;
-    }
-
-    private static string CategoryAndValueSeries(string name) => $"""
-        <c:ser>
-          <c:idx val="0"/>
-          <c:order val="0"/>
-          <c:tx><c:v>{name}</c:v></c:tx>
-          <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
-          <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
-        </c:ser>
-        """;
-
-    private const string CategoryAndValueAxes = """
-        <c:catAx><c:axId val="1"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="2"/></c:catAx>
-        <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
-        """;
-
-    private static IXLChart LoadChart(string plotAreaBody, out XLWorkbook workbook)
-    {
-        var ms = CreateWorkbookWithPlotArea(plotAreaBody);
-        workbook = new XLWorkbook(ms);
-        return workbook.Worksheet("Data").Charts.Single();
-    }
+    private static IXLChart LoadChart(string plotAreaBody, out XLWorkbook workbook) =>
+        ChartPartFixture.LoadChart(plotAreaBody, out workbook);
 
     [Test]
     public void Pie3DChartIsRead()

--- a/XLibur.Tests/Excel/Charts/ChartLegendAndAxisTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartLegendAndAxisTests.cs
@@ -136,6 +136,67 @@ public class ChartLegendAndAxisTests
         Assert.That(ChartSpaceOf(withoutLegend).Descendants<C.Legend>(), Is.Empty);
     }
 
+    [Test]
+    public void PositioningALegendThatIsNotThereDoesNotCreateOne()
+    {
+        using var original = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            AddChart(ws, XLChartType.ColumnClustered)
+                .Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(original);
+        }
+
+        using var edited = new MemoryStream();
+        original.Position = 0;
+        using (var wb = new XLWorkbook(original))
+        {
+            // Position is documented as ignored while the legend is hidden, and a new chart gets no
+            // legend from it either. A loaded one must behave the same way.
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.Legend.Visible, Is.False);
+            chart.Legend.Position = XLLegendPosition.Bottom;
+            chart.Legend.Overlay = true;
+            wb.SaveAs(edited, validate: true);
+        }
+
+        Assert.That(ChartSpaceOf(edited).Descendants<C.Legend>(), Is.Empty);
+    }
+
+    [Test]
+    public void ShowingALegendOnALoadedChartStillHonoursThePositionSetWithIt()
+    {
+        using var original = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            AddChart(ws, XLChartType.ColumnClustered)
+                .Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(original);
+        }
+
+        using var edited = new MemoryStream();
+        original.Position = 0;
+        using (var wb = new XLWorkbook(original))
+        {
+            var legend = wb.Worksheet("Data").Charts.First().Legend;
+            legend.Visible = true;
+            legend.Position = XLLegendPosition.Left;
+            wb.SaveAs(edited, validate: true);
+        }
+
+        edited.Position = 0;
+        using (var wb = new XLWorkbook(edited))
+        {
+            var legend = wb.Worksheet("Data").Charts.First().Legend;
+            Assert.That(legend.Visible, Is.True);
+            Assert.That(legend.Position, Is.EqualTo(XLLegendPosition.Left));
+        }
+    }
+
     // ── Axes ────────────────────────────────────────────────────────────
 
     [Test]

--- a/XLibur.Tests/Excel/Charts/ChartPartFixture.cs
+++ b/XLibur.Tests/Excel/Charts/ChartPartFixture.cs
@@ -1,0 +1,89 @@
+using DocumentFormat.OpenXml.Packaging;
+using System.IO;
+using System.Linq;
+using System.Text;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// Builds a workbook whose chart part holds hand-written XML. XLibur's own writer only produces the
+/// shapes it knows how to produce, so anything Excel may legitimately emit but XLibur never writes —
+/// 3D groups, an unusual group order — has to be fed to the reader this way.
+/// </summary>
+internal static class ChartPartFixture
+{
+    /// <summary>A <c>c:catAx</c>/<c>c:valAx</c> pair with ids 1 and 2.</summary>
+    internal const string CategoryAndValueAxes = """
+        <c:catAx><c:axId val="1"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="2"/></c:catAx>
+        <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
+        """;
+
+    /// <summary>A <c>c:ser</c> over the <c>Data</c> sheet the fixture fills in.</summary>
+    internal static string CategoryAndValueSeries(string name) => $"""
+        <c:ser>
+          <c:idx val="0"/>
+          <c:order val="0"/>
+          <c:tx><c:v>{name}</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+        </c:ser>
+        """;
+
+    /// <summary>
+    /// Wraps a plot area body in the rest of a chart part, and puts it in a workbook.
+    /// </summary>
+    internal static MemoryStream CreateWorkbookWithPlotArea(string plotAreaBody)
+    {
+        var chartXml = $"""
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <c:chart>
+                <c:plotArea>
+                  <c:layout/>
+                  {plotAreaBody}
+                </c:plotArea>
+                <c:plotVisOnly val="1"/>
+              </c:chart>
+            </c:chartSpace>
+            """;
+
+        var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Data");
+            ws.Cell("A1").Value = "Q1";
+            ws.Cell("A2").Value = "Q2";
+            ws.Cell("B1").Value = 100;
+            ws.Cell("B2").Value = 200;
+
+            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+            chart.Series.Add("Placeholder", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Position.SetColumn(5).SetRow(1);
+            chart.SecondPosition.SetColumn(12).SetRow(15);
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        using (var doc = SpreadsheetDocument.Open(ms, true))
+        {
+            var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
+            using var source = new MemoryStream(Encoding.UTF8.GetBytes(chartXml));
+            chartPart.FeedData(source);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    /// <summary>
+    /// Loads the chart of <see cref="CreateWorkbookWithPlotArea"/>. The caller owns
+    /// <paramref name="workbook"/>, which has to outlive the chart it hands back.
+    /// </summary>
+    internal static IXLChart LoadChart(string plotAreaBody, out XLWorkbook workbook)
+    {
+        var ms = CreateWorkbookWithPlotArea(plotAreaBody);
+        workbook = new XLWorkbook(ms);
+        return workbook.Worksheet("Data").Charts.Single();
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartPrimaryAxisReaderTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartPrimaryAxisReaderTests.cs
@@ -1,0 +1,98 @@
+using NUnit.Framework;
+using System;
+using System.Linq;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// Which of a plot area's chart groups carries the primary axis pair, and what a loaded chart refuses
+/// to do. XLibur's writer always emits the primary group first, but nothing in the schema requires it,
+/// so the reader must not decide by document order alone.
+/// </summary>
+[TestFixture]
+public class ChartPrimaryAxisReaderTests
+{
+    /// <summary>
+    /// A plot area holding two <c>c:barChart</c> groups: the one on the secondary axis pair (4/5, the
+    /// value axis crossing at the maximum) is written <em>first</em>, ahead of the primary pair (1/2).
+    /// </summary>
+    private const string SecondaryGroupFirst = """
+        <c:barChart>
+          <c:barDir val="col"/>
+          <c:grouping val="clustered"/>
+          <c:ser>
+            <c:idx val="1"/>
+            <c:order val="1"/>
+            <c:tx><c:v>Right</c:v></c:tx>
+            <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+            <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+          </c:ser>
+          <c:axId val="4"/>
+          <c:axId val="5"/>
+        </c:barChart>
+        <c:barChart>
+          <c:barDir val="col"/>
+          <c:grouping val="clustered"/>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:v>Left</c:v></c:tx>
+            <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+            <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+          </c:ser>
+          <c:axId val="1"/>
+          <c:axId val="2"/>
+        </c:barChart>
+        <c:catAx><c:axId val="1"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="2"/></c:catAx>
+        <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/><c:majorUnit val="10"/></c:valAx>
+        <c:catAx><c:axId val="4"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="1"/><c:axPos val="b"/><c:crossAx val="5"/></c:catAx>
+        <c:valAx><c:axId val="5"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="r"/><c:crossAx val="4"/><c:crosses val="max"/><c:majorUnit val="25"/></c:valAx>
+        """;
+
+    [Test]
+    public void SecondaryAxisBindingDoesNotDependOnGroupOrder()
+    {
+        var chart = ChartPartFixture.LoadChart(SecondaryGroupFirst, out var wb);
+        using (wb)
+        {
+            var series = chart.Series.ToList();
+            Assert.That(series.Select(s => s.Name), Is.EqualTo(new[] { "Right", "Left" }));
+
+            // The group written first hangs off the axis that crosses at the maximum, so it is the
+            // secondary one however early it appears.
+            Assert.That(series[0].UseSecondaryAxis, Is.True);
+            Assert.That(series[1].UseSecondaryAxis, Is.False);
+        }
+    }
+
+    [Test]
+    public void TheAxisModelsFollowTheSameBinding()
+    {
+        var chart = ChartPartFixture.LoadChart(SecondaryGroupFirst, out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ValueAxis.MajorUnit, Is.EqualTo(10),
+                "The left-hand axis of the primary group is IXLChart.ValueAxis.");
+            Assert.That(chart.SecondaryValueAxis.MajorUnit, Is.EqualTo(25));
+        }
+    }
+
+    [Test]
+    public void AddingASeriesToALoadedChartThrows()
+    {
+        var chart = ChartPartFixture.LoadChart(
+            $"<c:barChart><c:barDir val=\"col\"/><c:grouping val=\"clustered\"/>{ChartPartFixture.CategoryAndValueSeries("Sales")}<c:axId val=\"1\"/><c:axId val=\"2\"/></c:barChart>{ChartPartFixture.CategoryAndValueAxes}",
+            out var wb);
+        using (wb)
+        {
+            // A new series has nowhere to go: the chart part is patched, never regenerated. Silently
+            // dropping it on save would be worse than saying so.
+            Assert.Throws<NotSupportedException>(
+                () => chart.Series.Add("New", "Data!$B$1:$B$2", "Data!$A$1:$A$2"));
+            Assert.Throws<NotSupportedException>(
+                () => chart.SecondarySeries.Add("New", "Data!$B$1:$B$2", "Data!$A$1:$A$2"));
+            Assert.That(chart.Series, Has.Exactly(1).Items);
+        }
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
@@ -398,6 +398,33 @@ public class ChartRoundTripPreservationTests
     }
 
     [Test]
+    public void ChartWideLabelsReachEveryGroupOfALoadedComboChart()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            // Chart-wide labels apply to the whole chart, and the writer puts them on each group of a
+            // new combo chart. A loaded one used to get them on the c:barChart only.
+            wb.Worksheet("Data").Charts.First().DataLabels.ShowValue = true;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        var xml = ReadChartXml(saved);
+        var barChart = xml[xml.IndexOf("<c:barChart>", StringComparison.Ordinal)..
+                           xml.IndexOf("</c:barChart>", StringComparison.Ordinal)];
+        var lineChart = xml[xml.IndexOf("<c:lineChart>", StringComparison.Ordinal)..
+                            xml.IndexOf("</c:lineChart>", StringComparison.Ordinal)];
+
+        // The group-level c:dLbls follows the last c:ser, so it is what comes after </c:ser>.
+        Assert.That(barChart[barChart.LastIndexOf("</c:ser>", StringComparison.Ordinal)..],
+            Does.Contain("<c:showVal val=\"1\""));
+        Assert.That(lineChart[lineChart.LastIndexOf("</c:ser>", StringComparison.Ordinal)..],
+            Does.Contain("<c:showVal val=\"1\""));
+    }
+
+    [Test]
     public void TurningLabelsOnClearsAnExistingDeleteFlag()
     {
         // Excel writes <c:dLbls><c:delete val="1"/></c:dLbls> for a series whose labels are switched

--- a/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
@@ -282,6 +282,36 @@ public class ChartSeriesFormattingTests
     }
 
     [Test]
+    public void StockSeriesAreSmoothedToo()
+    {
+        // A stock chart is built from CT_LineSer, which takes c:smooth. The writer used to leave it
+        // out, so Smooth was honoured on a stock chart read from a file but not on a new one.
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.StockHighLowClose);
+            foreach (var name in new[] { "High", "Low", "Close" })
+                chart.Series.Add(name, "Data!$B$1:$B$2", "Data!$A$1:$A$2").Smooth = true;
+
+            using var saved = SaveValidated(wb);
+            var chartSpace = ChartSpaceOf(saved);
+            Assert.That(chartSpace.Descendants<C.Smooth>().Select(s => s.Val!.Value),
+                Is.EqualTo(new[] { true, true, true }));
+
+            saved.Position = 0;
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            Assert.That(wb.Worksheet("Data").Charts.First().Series.Select(s => s.Smooth),
+                Is.EqualTo(new[] { true, true, true }));
+        }
+    }
+
+    [Test]
     public void FormattingSurvivesEveryStandardChartFamily()
     {
         // The formatting is appended by each chart family's own builder, so every family gets a

--- a/XLibur/Excel/Charts/IXLChart.cs
+++ b/XLibur/Excel/Charts/IXLChart.cs
@@ -199,6 +199,14 @@ public interface IXLChart : IXLDrawing<IXLChart>
     /// When set, the chart renders both <see cref="ChartType"/> and this type
     /// in the same plot area, each with its own series. Set to <c>null</c> for single-type charts.
     /// </summary>
+    /// <remarks>
+    /// The model holds two chart types, which is all XLibur writes. A chart read from a file may mix
+    /// more: Excel allows a plot area to combine any number of chart groups. In that case
+    /// <see cref="ChartType"/> and this property name the first two, every series outside the primary
+    /// group lands in <see cref="SecondarySeries"/>, and the series belonging to a third or later
+    /// group are reported under this type rather than their own. Saving is unaffected — a loaded chart
+    /// keeps its original XML — but the model understates such a chart.
+    /// </remarks>
     XLChartType? SecondaryChartType { get; set; }
 
     /// <summary>

--- a/XLibur/Excel/Charts/IXLChartSeriesCollection.cs
+++ b/XLibur/Excel/Charts/IXLChartSeriesCollection.cs
@@ -20,5 +20,10 @@ public interface IXLChartSeriesCollection : IEnumerable<IXLChartSeries>
     /// <param name="valueReferences">Cell reference for the series values, e.g. <c>"Sheet1!$B$2:$B$5"</c>.</param>
     /// <param name="categoryReferences">Optional cell reference for category labels, e.g. <c>"Sheet1!$A$2:$A$5"</c>.</param>
     /// <returns>The newly created series.</returns>
+    /// <exception cref="System.NotSupportedException">
+    /// The chart was loaded from a file. XLibur patches the properties of an existing chart rather
+    /// than regenerating its XML, so there is nowhere to write a new series; recreate the chart with
+    /// <see cref="IXLCharts.Add(XLChartType)"/> instead.
+    /// </exception>
     IXLChartSeries Add(string name, string valueReferences, string? categoryReferences = null);
 }

--- a/XLibur/Excel/Charts/XLChartSeriesCollection.cs
+++ b/XLibur/Excel/Charts/XLChartSeriesCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -29,6 +30,14 @@ internal sealed class XLChartSeriesCollection : IXLChartSeriesCollection
 
     public IXLChartSeries Add(string name, string valueReferences, string? categoryReferences = null)
     {
+        if (_chart.LoadedFromFile)
+        {
+            throw new NotSupportedException(
+                "Cannot add a series to a chart loaded from a file. XLibur patches the properties of "
+                + "an existing chart rather than regenerating its XML, so a new series has nowhere to "
+                + "be written; recreate the chart with IXLCharts.Add(XLChartType) instead.");
+        }
+
         var series = new XLChartSeries(_chart, _secondary)
         {
             Name = name,

--- a/XLibur/Excel/IO/ChartFormatting.cs
+++ b/XLibur/Excel/IO/ChartFormatting.cs
@@ -221,6 +221,11 @@ internal static class ChartFormatting
 
         if (element == null)
         {
+            // Position and Overlay are ignored while the legend is hidden, so assigning one of them on
+            // a chart that has no legend must not conjure one — BuildLegend does not either.
+            if (!legend.Visible)
+                return;
+
             element = new C.Legend();
             element.Append(new C.LegendPosition { Val = MapLegendPosition(legend.Position) });
             element.Append(new C.Overlay { Val = legend.Overlay });

--- a/XLibur/Excel/IO/ChartPatcher.cs
+++ b/XLibur/Excel/IO/ChartPatcher.cs
@@ -78,7 +78,7 @@ internal static class ChartPatcher
     private static void PatchAxes(
         C.PlotArea plotArea, List<XLChartGroup> groups, XLChartGroupKind primaryKind, XLChart xlChart)
     {
-        var primaryGroup = groups.First(g => g.Kind == primaryKind);
+        var primaryGroup = ChartPlotAreaScanner.PrimaryGroup(plotArea, groups, primaryKind);
         var primaryValueAxisId = primaryGroup.ValueAxisId;
 
         ChartFormatting.PatchAxis(

--- a/XLibur/Excel/IO/ChartPatcher.cs
+++ b/XLibur/Excel/IO/ChartPatcher.cs
@@ -99,7 +99,9 @@ internal static class ChartPatcher
     }
 
     /// <summary>
-    /// Writes the chart-wide data labels into every group of the primary chart type.
+    /// Writes the chart-wide data labels into every group that accepts them. They apply to the whole
+    /// chart, and <see cref="ChartWriter"/> puts them on each group of a new combo chart, so a loaded
+    /// combo chart is patched the same way rather than only on its primary group.
     /// </summary>
     private static void PatchGroupDataLabels(
         List<XLChartGroup> groups, XLChartGroupKind primaryKind, XLChart xlChart)
@@ -109,10 +111,16 @@ internal static class ChartPatcher
 
         foreach (var group in groups)
         {
-            if (group.Kind != primaryKind || !ChartFormatting.SupportsDataLabels(group.Kind))
+            if (!ChartFormatting.SupportsDataLabels(group.Kind))
                 continue;
 
-            ChartFormatting.PatchGroupDataLabels(group.Element, xlChart.DataLabelsInternal, xlChart.ChartType);
+            // A position Excel does not offer for a group's own type degrades to automatic, so each
+            // group is patched against its type — the same mapping PatchSeries uses.
+            var chartType = group.Kind == primaryKind
+                ? xlChart.ChartType
+                : xlChart.SecondaryChartType ?? xlChart.ChartType;
+
+            ChartFormatting.PatchGroupDataLabels(group.Element, xlChart.DataLabelsInternal, chartType);
         }
     }
 

--- a/XLibur/Excel/IO/ChartPlotAreaScanner.cs
+++ b/XLibur/Excel/IO/ChartPlotAreaScanner.cs
@@ -195,11 +195,41 @@ internal static class ChartPlotAreaScanner
     }
 
     /// <summary>
-    /// The value axis of the first group of the primary kind. Groups plotted against a different
-    /// value axis are on a secondary axis.
+    /// The group that carries the chart's primary axis pair. Groups plotted against a different value
+    /// axis are on a secondary axis.
     /// </summary>
-    internal static uint? PrimaryValueAxisId(List<XLChartGroup> groups, XLChartGroupKind primaryKind) =>
-        groups.First(g => g.Kind == primaryKind).ValueAxisId;
+    /// <remarks>
+    /// A plot area may hold several groups of the primary kind — two <c>c:barChart</c> elements, say,
+    /// one per axis pair — and nothing in the schema says the primary one comes first. So rather than
+    /// trust document order, a group whose value axis crosses the category axis at its maximum is
+    /// passed over: that is how a secondary value axis ends up drawn on the right, and Excel writes it
+    /// on every secondary axis it creates. When every candidate looks secondary — or none does —
+    /// document order decides after all.
+    /// </remarks>
+    internal static XLChartGroup PrimaryGroup(
+        C.PlotArea plotArea, List<XLChartGroup> groups, XLChartGroupKind primaryKind)
+    {
+        XLChartGroup? firstOfKind = null;
+
+        foreach (var group in groups)
+        {
+            if (group.Kind != primaryKind)
+                continue;
+
+            firstOfKind ??= group;
+            if (!CrossesAtMaximum(FindAxis(plotArea, group.ValueAxisId)))
+                return group;
+        }
+
+        // ChoosePrimaryKind only ever returns a kind that is present, so there is always a candidate.
+        return firstOfKind!;
+    }
+
+    /// <summary>
+    /// Whether an axis element carries <c>c:crosses val="max"</c>, the mark of a secondary value axis.
+    /// </summary>
+    private static bool CrossesAtMaximum(OpenXmlCompositeElement? axis) =>
+        axis?.Elements<C.Crosses>().FirstOrDefault()?.Val?.Value == C.CrossesValues.Maximum;
 
     /// <summary>
     /// Finds the axis element of a plot area carrying the given <c>c:axId</c>, whichever axis type it

--- a/XLibur/Excel/IO/ChartReader.cs
+++ b/XLibur/Excel/IO/ChartReader.cs
@@ -131,8 +131,9 @@ internal static class ChartReader
         if (primaryKind == null)
             return;
 
-        var primaryValueAxisId = ChartPlotAreaScanner.PrimaryValueAxisId(groups, primaryKind.Value);
-        ReadAxes(plotArea, groups, primaryKind.Value, primaryValueAxisId, xlChart);
+        var primaryGroup = ChartPlotAreaScanner.PrimaryGroup(plotArea, groups, primaryKind.Value);
+        var primaryValueAxisId = primaryGroup.ValueAxisId;
+        ReadAxes(plotArea, groups, primaryGroup, primaryValueAxisId, xlChart);
         var primarySet = false;
 
         foreach (var group in groups)
@@ -159,6 +160,9 @@ internal static class ChartReader
             }
             else
             {
+                // The model carries two chart types. A plot area may hold more, in which case the
+                // series of the third and later groups still land in the secondary collection but are
+                // reported under the second group's type — see IXLChart.SecondaryChartType.
                 xlChart.SecondaryChartType ??= chartType;
                 ReadGroupSeries(group, xlChart.SecondarySeriesInternal, useSecondaryAxis);
             }
@@ -170,11 +174,9 @@ internal static class ChartReader
     /// the secondary value axis into the model.
     /// </summary>
     private static void ReadAxes(
-        C.PlotArea plotArea, List<XLChartGroup> groups, XLChartGroupKind primaryKind,
+        C.PlotArea plotArea, List<XLChartGroup> groups, XLChartGroup primaryGroup,
         uint? primaryValueAxisId, XLChart xlChart)
     {
-        var primaryGroup = groups.First(g => g.Kind == primaryKind);
-
         ChartFormatting.ReadAxis(
             ChartPlotAreaScanner.FindAxis(plotArea, primaryGroup.CategoryAxisId),
             xlChart.CategoryAxisInternal);

--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -911,6 +911,7 @@ internal static class ChartWriter
             AppendMarker(series, s, autoSymbol: false);
             AppendSeriesDataLabels(series, s, group.ChartType);
             AppendCatAndVal(series, s);
+            AppendSmooth(series, s, smoothByChartType: false);
             stockChart.Append(series);
         }
         AppendGroupDataLabels(stockChart, group.Chart, group.ChartType);

--- a/docs-website/docs/charts.md
+++ b/docs-website/docs/charts.md
@@ -414,6 +414,10 @@ workbook.Save();   // only the fill and the scale change; the trendline stays
 Chart type, title and series references are settable on charts you create, but on a loaded chart
 only the series formatting, data labels, legend and axes are written back.
 
+The two things that would need a rebuilt plot area rather than a patch throw `NotSupportedException`
+instead of quietly doing nothing: `Series.Add(...)` and moving a series with `UseSecondaryAxis`.
+Recreate the chart with `ws.Charts.Add(type)` if you need either.
+
 ## Chart types
 
 `XLChartType` covers the full Excel catalogue. Pick by data shape:


### PR DESCRIPTION
Follow-ups to the chart formatting work of spec 10, from a review of the merged and stacked PRs. Stacked on #223.

## Primary axis binding no longer depends on group order

`ChartPlotAreaScanner.PrimaryValueAxisId` took the value axis of the **first** group in document order whose kind matched the primary kind. Nothing in the schema says the primary group comes first, and a file that emits its secondary-axis group ahead of the primary one inverted the whole computation: every primary-axis series read back as `UseSecondaryAxis == true` and the genuine secondary ones as `false`, with `ValueAxis` and `SecondaryValueAxis` bound to each other's elements.

It is now `PrimaryGroup`, which skips a candidate whose value axis carries `c:crosses val="max"` — that is how a secondary value axis comes to be drawn on the right, and Excel writes it on every secondary axis it creates. Document order decides only when the signal is absent from all candidates or present on all of them. `ChartPatcher.PatchAxes` made the same guess independently and now shares the rule, so a patched chart writes back to the axes the reader read.

## `Series.Add` on a loaded chart throws instead of vanishing

`PatchSeries` walked `Math.Min(series.Count, seriesElements.Count)`, so a series added to a chart read from a file was silently dropped on save. Adding one needs a new `c:ser` in the part, which is exactly the regeneration the patch design excludes — so it now throws `NotSupportedException` with a message pointing at `IXLCharts.Add(XLChartType)`, the way `UseSecondaryAxis` already did.

## `Smooth` is written on a new stock chart

`AppendStockChart` never called `AppendSmooth`, but a stock chart's series are `CT_LineSer`, which takes `c:smooth`, and `ChartFormatting.SupportsSmooth` includes `Stock` on the read and patch sides. So `Smooth` was honoured on a stock chart that came from a file and silently ignored on one XLibur created. The writer was the side that was wrong.

## A plot area with three or more group kinds is documented

`ReadPlotArea` does `xlChart.SecondaryChartType ??= chartType` inside the group loop, so with three distinct kinds the series of every non-primary group are concatenated into `SecondarySeries` while only the first kind is recorded. Harmless on save — a loaded chart is never regenerated — but the model understates such a chart. The model carries two chart types and widening it is out of scope here, so the limitation is now stated on `IXLChart.SecondaryChartType` rather than left to be discovered.

## Tests

Four new tests, each verified to fail without its fix:

- `SecondaryAxisBindingDoesNotDependOnGroupOrder` and `TheAxisModelsFollowTheSameBinding` — a hand-written plot area with two `c:barChart` groups, the secondary one written first.
- `AddingASeriesToALoadedChartThrows`
- `StockSeriesAreSmoothedToo` — asserts the three `c:smooth` elements in the saved part and reads them back.

The plot-area harness moves out of `ChartGroupKindReaderTests` into `ChartPartFixture` so both fixtures can use it.

6420 pass on net8.0 and net10.0, solution builds warning-free.
