### PR TITLE
fix: land spec 10 PR 4 and the chart follow-ups on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@
 
 - **Charts with more than one plot group of the same type now read all of their series.** The reader took only the first `c:barChart` (or `c:lineChart`, …) of a plot area, so the series of a second group — which is how Excel stores a secondary axis — were dropped.
 
+- **Which of those groups is on the secondary axis no longer depends on the order they appear in the file.** The primary axis pair was taken from whichever group came first, so a file that wrote its secondary group ahead of the primary one read back with `UseSecondaryAxis` inverted on every series and the two axis models swapped. The group whose value axis crosses at the maximum — how a secondary axis comes to be drawn on the right — is now passed over instead.
+
+- **`Smooth` is honoured on a new stock chart.** A stock chart's series are `CT_LineSer` and take `c:smooth`, but the writer never emitted it, so the property worked on a stock chart read from a file and was silently dropped on one XLibur created.
+
+- **Positioning a legend that is not there no longer creates one.** `IXLChartLegend.Position` and `Overlay` are documented as ignored while `Visible` is `false`, and a new chart gets no legend from them — but assigning one of them on a *loaded* chart that had no legend added one.
+
+- **Chart-wide data labels reach every group of a loaded combo chart.** `IXLChart.DataLabels` applies to the whole chart, and a new combo chart gets them on both of its plot groups, but a loaded one was patched on the primary group only — so turning labels on left the secondary series unlabelled.
+
+- **`Series.Add(...)` on a chart loaded from a file throws instead of being discarded on save.** A loaded chart is patched, not regenerated, so a new series had nowhere to be written and vanished without a word. It now throws `NotSupportedException`, as `UseSecondaryAxis` already did.
+
 ## v0.106.0 - 2026-07-25
 
 First XLibur release since forking [ClosedXML v0.105.0](https://github.com/ClosedXML/ClosedXML/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,13 @@
 
 - **Charts loaded from a file can be restyled**: setting the series formatting, data labels, legend or axes on a loaded chart now writes back on save. Only the properties actually assigned are patched into the existing chart part, so trendlines, error bars, gradient fills, per-point colours and label overrides, label and axis fonts, tick marks and the chart's style/colour parts are all preserved — and a chart nobody edited is left byte for byte as it was.
 
+- **Chart anchoring**: `IXLChart.Anchor` (`MoveAndSizeWithCells`, `MoveWithCells`, `Absolute`) with `Width`, `Height`, `Left` and `Top` in pixels, so a chart can keep its size as rows are inserted or be pinned to a spot on the sheet. Two-cell anchoring via `Position`/`SecondPosition` remains the default.
+
 ### Fixed
+
+- **Charts anchored with a one-cell or absolute anchor are no longer dropped on load.** The reader only looked at `xdr:twoCellAnchor`, so a chart Excel had anchored either of the other two ways was missing from `IXLWorksheet.Charts` entirely (its XML survived a round trip, but the chart was invisible to the API).
+
+- **3D and of-pie chart groups are read.** `c:pie3DChart`, `c:line3DChart`, `c:area3DChart`, `c:surface3DChart` and `c:ofPieChart` were not recognised, so an Excel-authored chart using one loaded with no series and the wrong chart type. Their series and series formatting now read the same as the 2D groups', and pie-of-pie and bar-of-pie are told apart.
 
 - **Chart XML now passes OpenXML schema validation.** Three long-standing violations in the chart writer are fixed: series names were written as a `c:strRef` with no required `c:f` (a literal name now uses `<c:tx><c:v>`, and both forms are read back), `c:doughnutChart` omitted the required `c:holeSize`, and `c:marker` was written after `c:cat`/`c:val` instead of before. Excel tolerated all three, but stricter readers and `SaveOptions.ValidatePackage` did not.
 

--- a/XLibur.Examples/Charts/FormattedChartExamples.cs
+++ b/XLibur.Examples/Charts/FormattedChartExamples.cs
@@ -18,6 +18,7 @@ public class FormattedChartExamples : IXLExample
         HighlightOneSeries(wb);
         Labels(wb);
         LegendAndAxes(wb);
+        Anchoring(wb);
 
         wb.SaveAs(filePath);
     }
@@ -251,6 +252,39 @@ public class FormattedChartExamples : IXLExample
         growth.CategoryAxis.Title = "Quarter";
         growth.Position.SetColumn(6).SetRow(24);
         growth.SecondPosition.SetColumn(16).SetRow(42);
+    }
+
+    /// <summary>
+    /// The three ways a chart can be tied to the grid. Insert a row above row 5 in Excel to see the
+    /// difference: the first chart resizes, the second slides down, the third does not move.
+    /// </summary>
+    private static void Anchoring(XLWorkbook wb)
+    {
+        var ws = wb.Worksheets.Add("Anchoring");
+        WriteQuarterlyData(ws);
+
+        var moveAndSize = ws.Charts.Add(XLChartType.ColumnClustered);
+        moveAndSize.SetTitle("Moves and resizes");
+        moveAndSize.Series.Add("Revenue", "Anchoring!$B$2:$B$5", "Anchoring!$A$2:$A$5");
+        moveAndSize.Position.SetColumn(5).SetRow(1);
+        moveAndSize.SecondPosition.SetColumn(12).SetRow(15);
+
+        var move = ws.Charts.Add(XLChartType.ColumnClustered);
+        move.SetTitle("Keeps its size");
+        move.Series.Add("Revenue", "Anchoring!$B$2:$B$5", "Anchoring!$A$2:$A$5");
+        move.Anchor = XLDrawingAnchor.MoveWithCells;
+        move.Position.SetColumn(5).SetRow(17);
+        move.Width = 460;
+        move.Height = 260;
+
+        var pinned = ws.Charts.Add(XLChartType.ColumnClustered);
+        pinned.SetTitle("Pinned to the sheet");
+        pinned.Series.Add("Revenue", "Anchoring!$B$2:$B$5", "Anchoring!$A$2:$A$5");
+        pinned.Anchor = XLDrawingAnchor.Absolute;
+        pinned.Left = 960;
+        pinned.Top = 16;
+        pinned.Width = 460;
+        pinned.Height = 260;
     }
 
     private static void WriteQuarterlyData(IXLWorksheet ws)

--- a/XLibur.Tests/Excel/Charts/ChartAnchorTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartAnchorTests.cs
@@ -1,0 +1,220 @@
+using DocumentFormat.OpenXml.Packaging;
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+using XLibur.Excel;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// The three ways a chart can be anchored to the sheet: two-cell, one-cell and absolute.
+/// </summary>
+[TestFixture]
+public class ChartAnchorTests
+{
+    private static IXLWorksheet AddDataSheet(XLWorkbook wb)
+    {
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = "Q1";
+        ws.Cell("A2").Value = "Q2";
+        ws.Cell("B1").Value = 100;
+        ws.Cell("B2").Value = 200;
+        return ws;
+    }
+
+    private static MemoryStream SaveValidated(XLWorkbook wb)
+    {
+        var ms = new MemoryStream();
+        wb.SaveAs(ms, validate: true);
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static Xdr.WorksheetDrawing DrawingOf(Stream stream)
+    {
+        stream.Position = 0;
+        using var doc = SpreadsheetDocument.Open(stream, false);
+        var drawing = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.WorksheetDrawing!;
+        return (Xdr.WorksheetDrawing)drawing.CloneNode(true);
+    }
+
+    [Test]
+    public void TwoCellAnchorIsStillTheDefault()
+    {
+        using var wb = new XLWorkbook();
+        var ws = AddDataSheet(wb);
+        var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+        chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+        chart.Position.SetColumn(3).SetRow(2);
+        chart.SecondPosition.SetColumn(10).SetRow(16);
+
+        Assert.That(chart.Anchor, Is.EqualTo(XLDrawingAnchor.MoveAndSizeWithCells));
+
+        using var ms = SaveValidated(wb);
+        var drawing = DrawingOf(ms);
+        Assert.That(drawing.Elements<Xdr.TwoCellAnchor>().Count(), Is.EqualTo(1));
+        Assert.That(drawing.Elements<Xdr.OneCellAnchor>(), Is.Empty);
+    }
+
+    [Test]
+    public void OneCellAnchoredChartRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Anchor = XLDrawingAnchor.MoveWithCells;
+            chart.Position.SetColumn(4).SetRow(3);
+            chart.Width = 480;
+            chart.Height = 288;
+
+            using var saved = SaveValidated(wb);
+            var drawing = DrawingOf(saved);
+            Assert.That(drawing.Elements<Xdr.OneCellAnchor>().Count(), Is.EqualTo(1));
+
+            saved.Position = 0;
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.Single();
+            Assert.That(chart.Anchor, Is.EqualTo(XLDrawingAnchor.MoveWithCells));
+            Assert.That(chart.Position.Column, Is.EqualTo(4));
+            Assert.That(chart.Position.Row, Is.EqualTo(3));
+            Assert.That(chart.Width, Is.EqualTo(480));
+            Assert.That(chart.Height, Is.EqualTo(288));
+            Assert.That(chart.Series.Single().Name, Is.EqualTo("Sales"));
+        }
+    }
+
+    [Test]
+    public void AbsolutelyAnchoredChartRoundTrips()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = ws.Charts.Add(XLChartType.Line);
+            chart.SetTitle("Pinned");
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Anchor = XLDrawingAnchor.Absolute;
+            chart.Left = 200;
+            chart.Top = 120;
+            chart.Width = 400;
+            chart.Height = 250;
+
+            using var saved = SaveValidated(wb);
+            var drawing = DrawingOf(saved);
+            Assert.That(drawing.Elements<Xdr.AbsoluteAnchor>().Count(), Is.EqualTo(1));
+
+            saved.Position = 0;
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var chart = wb.Worksheet("Data").Charts.Single();
+            Assert.That(chart.Anchor, Is.EqualTo(XLDrawingAnchor.Absolute));
+            Assert.That(chart.Title, Is.EqualTo("Pinned"));
+            Assert.That(chart.Left, Is.EqualTo(200));
+            Assert.That(chart.Top, Is.EqualTo(120));
+            Assert.That(chart.Width, Is.EqualTo(400));
+            Assert.That(chart.Height, Is.EqualTo(250));
+        }
+    }
+
+    [Test]
+    public void ChartsUnderEveryAnchorKindAreFoundOnOneSheet()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+
+            var twoCell = ws.Charts.Add(XLChartType.ColumnClustered);
+            twoCell.SetTitle("Two cell");
+            twoCell.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            twoCell.Position.SetColumn(3).SetRow(1);
+            twoCell.SecondPosition.SetColumn(9).SetRow(14);
+
+            var oneCell = ws.Charts.Add(XLChartType.Line);
+            oneCell.SetTitle("One cell");
+            oneCell.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            oneCell.Anchor = XLDrawingAnchor.MoveWithCells;
+            oneCell.Position.SetColumn(3).SetRow(16);
+            oneCell.Width = 400;
+            oneCell.Height = 250;
+
+            var absolute = ws.Charts.Add(XLChartType.Pie);
+            absolute.SetTitle("Absolute");
+            absolute.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            absolute.Anchor = XLDrawingAnchor.Absolute;
+            absolute.Left = 700;
+            absolute.Top = 20;
+            absolute.Width = 320;
+            absolute.Height = 240;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            var charts = wb.Worksheet("Data").Charts.ToList();
+            Assert.That(charts, Has.Count.EqualTo(3),
+                "A one-cell or absolute anchored chart used to be skipped on read.");
+            Assert.That(charts.Select(c => c.Title),
+                Is.EquivalentTo(new[] { "Two cell", "One cell", "Absolute" }));
+            Assert.That(charts.Select(c => c.Anchor), Is.EquivalentTo(new[]
+            {
+                XLDrawingAnchor.MoveAndSizeWithCells,
+                XLDrawingAnchor.MoveWithCells,
+                XLDrawingAnchor.Absolute
+            }));
+        }
+    }
+
+    [Test]
+    public void FormattingAnAnchorlessChartStillReachesItsChartPart()
+    {
+        // The patcher finds the chart part through its relationship id, not through the anchor, so
+        // editing a one-cell anchored chart has to work the same way.
+        using var original = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+            chart.Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Anchor = XLDrawingAnchor.MoveWithCells;
+            chart.Position.SetColumn(3).SetRow(1);
+            chart.Width = 400;
+            chart.Height = 250;
+
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(original);
+        }
+
+        using var edited = new MemoryStream();
+        original.Position = 0;
+        using (var wb = new XLWorkbook(original))
+        {
+            wb.Worksheet("Data").Charts.Single().Series.Single().FillColor = XLColor.FromHtml("#C00000");
+            wb.SaveAs(edited, validate: true);
+        }
+
+        edited.Position = 0;
+        using (var wb = new XLWorkbook(edited))
+        {
+            var chart = wb.Worksheet("Data").Charts.Single();
+            Assert.That(chart.Anchor, Is.EqualTo(XLDrawingAnchor.MoveWithCells));
+            Assert.That(chart.Series.Single().FillColor, Is.EqualTo(XLColor.FromHtml("#C00000")));
+        }
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartGroupKindReaderTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartGroupKindReaderTests.cs
@@ -1,8 +1,5 @@
-using DocumentFormat.OpenXml.Packaging;
 using NUnit.Framework;
-using System.IO;
 using System.Linq;
-using System.Text;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.Charts;
@@ -14,73 +11,13 @@ namespace XLibur.Tests.Excel.Charts;
 [TestFixture]
 public class ChartGroupKindReaderTests
 {
-    /// <summary>
-    /// Wraps a plot area body in the rest of a chart part, and puts it in a workbook.
-    /// </summary>
-    private static MemoryStream CreateWorkbookWithPlotArea(string plotAreaBody)
-    {
-        var chartXml = $"""
-            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-            <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-              <c:chart>
-                <c:plotArea>
-                  <c:layout/>
-                  {plotAreaBody}
-                </c:plotArea>
-                <c:plotVisOnly val="1"/>
-              </c:chart>
-            </c:chartSpace>
-            """;
+    private const string CategoryAndValueAxes = ChartPartFixture.CategoryAndValueAxes;
 
-        var ms = new MemoryStream();
-        using (var wb = new XLWorkbook())
-        {
-            var ws = wb.AddWorksheet("Data");
-            ws.Cell("A1").Value = "Q1";
-            ws.Cell("A2").Value = "Q2";
-            ws.Cell("B1").Value = 100;
-            ws.Cell("B2").Value = 200;
+    private static string CategoryAndValueSeries(string name) =>
+        ChartPartFixture.CategoryAndValueSeries(name);
 
-            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
-            chart.Series.Add("Placeholder", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
-            chart.Position.SetColumn(5).SetRow(1);
-            chart.SecondPosition.SetColumn(12).SetRow(15);
-            wb.SaveAs(ms);
-        }
-
-        ms.Position = 0;
-        using (var doc = SpreadsheetDocument.Open(ms, true))
-        {
-            var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
-            using var source = new MemoryStream(Encoding.UTF8.GetBytes(chartXml));
-            chartPart.FeedData(source);
-        }
-
-        ms.Position = 0;
-        return ms;
-    }
-
-    private static string CategoryAndValueSeries(string name) => $"""
-        <c:ser>
-          <c:idx val="0"/>
-          <c:order val="0"/>
-          <c:tx><c:v>{name}</c:v></c:tx>
-          <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
-          <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
-        </c:ser>
-        """;
-
-    private const string CategoryAndValueAxes = """
-        <c:catAx><c:axId val="1"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="2"/></c:catAx>
-        <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
-        """;
-
-    private static IXLChart LoadChart(string plotAreaBody, out XLWorkbook workbook)
-    {
-        var ms = CreateWorkbookWithPlotArea(plotAreaBody);
-        workbook = new XLWorkbook(ms);
-        return workbook.Worksheet("Data").Charts.Single();
-    }
+    private static IXLChart LoadChart(string plotAreaBody, out XLWorkbook workbook) =>
+        ChartPartFixture.LoadChart(plotAreaBody, out workbook);
 
     [Test]
     public void Pie3DChartIsRead()

--- a/XLibur.Tests/Excel/Charts/ChartGroupKindReaderTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartGroupKindReaderTests.cs
@@ -1,0 +1,198 @@
+using DocumentFormat.OpenXml.Packaging;
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+using System.Text;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// The chart group elements Excel writes that XLibur does not write itself: the 3D variants and
+/// pie-of-pie / bar-of-pie. They used to read as a chart with no series at all.
+/// </summary>
+[TestFixture]
+public class ChartGroupKindReaderTests
+{
+    /// <summary>
+    /// Wraps a plot area body in the rest of a chart part, and puts it in a workbook.
+    /// </summary>
+    private static MemoryStream CreateWorkbookWithPlotArea(string plotAreaBody)
+    {
+        var chartXml = $"""
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <c:chart>
+                <c:plotArea>
+                  <c:layout/>
+                  {plotAreaBody}
+                </c:plotArea>
+                <c:plotVisOnly val="1"/>
+              </c:chart>
+            </c:chartSpace>
+            """;
+
+        var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Data");
+            ws.Cell("A1").Value = "Q1";
+            ws.Cell("A2").Value = "Q2";
+            ws.Cell("B1").Value = 100;
+            ws.Cell("B2").Value = 200;
+
+            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+            chart.Series.Add("Placeholder", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Position.SetColumn(5).SetRow(1);
+            chart.SecondPosition.SetColumn(12).SetRow(15);
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        using (var doc = SpreadsheetDocument.Open(ms, true))
+        {
+            var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
+            using var source = new MemoryStream(Encoding.UTF8.GetBytes(chartXml));
+            chartPart.FeedData(source);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static string CategoryAndValueSeries(string name) => $"""
+        <c:ser>
+          <c:idx val="0"/>
+          <c:order val="0"/>
+          <c:tx><c:v>{name}</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+        </c:ser>
+        """;
+
+    private const string CategoryAndValueAxes = """
+        <c:catAx><c:axId val="1"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="2"/></c:catAx>
+        <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
+        """;
+
+    private static IXLChart LoadChart(string plotAreaBody, out XLWorkbook workbook)
+    {
+        var ms = CreateWorkbookWithPlotArea(plotAreaBody);
+        workbook = new XLWorkbook(ms);
+        return workbook.Worksheet("Data").Charts.Single();
+    }
+
+    [Test]
+    public void Pie3DChartIsRead()
+    {
+        var chart = LoadChart($"<c:pie3DChart><c:varyColors val=\"1\"/>{CategoryAndValueSeries("Share")}</c:pie3DChart>",
+            out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ChartType, Is.EqualTo(XLChartType.Pie3D));
+            Assert.That(chart.Series.Single().Name, Is.EqualTo("Share"));
+            Assert.That(chart.Series.Single().ValueReferences, Is.EqualTo("Data!$B$1:$B$2"));
+        }
+    }
+
+    [Test]
+    public void PieOfPieAndBarOfPieAreToldApart()
+    {
+        var pieOfPie = LoadChart(
+            $"<c:ofPieChart><c:ofPieType val=\"pie\"/>{CategoryAndValueSeries("Share")}</c:ofPieChart>", out var wb1);
+        using (wb1)
+        {
+            Assert.That(pieOfPie.ChartType, Is.EqualTo(XLChartType.PieToPie));
+        }
+
+        var barOfPie = LoadChart(
+            $"<c:ofPieChart><c:ofPieType val=\"bar\"/>{CategoryAndValueSeries("Share")}</c:ofPieChart>", out var wb2);
+        using (wb2)
+        {
+            Assert.That(barOfPie.ChartType, Is.EqualTo(XLChartType.PieToBar));
+        }
+    }
+
+    [Test]
+    public void Line3DChartIsRead()
+    {
+        var chart = LoadChart(
+            $"<c:line3DChart><c:grouping val=\"standard\"/>{CategoryAndValueSeries("Trend")}<c:axId val=\"1\"/><c:axId val=\"2\"/></c:line3DChart>{CategoryAndValueAxes}",
+            out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ChartType, Is.EqualTo(XLChartType.Line3D));
+            Assert.That(chart.Series.Single().Name, Is.EqualTo("Trend"));
+        }
+    }
+
+    [TestCase("standard", XLChartType.Area3D)]
+    [TestCase("stacked", XLChartType.AreaStacked3D)]
+    [TestCase("percentStacked", XLChartType.AreaStacked100Percent3D)]
+    public void Area3DGroupingIsRead(string grouping, XLChartType expected)
+    {
+        var chart = LoadChart(
+            $"<c:area3DChart><c:grouping val=\"{grouping}\"/>{CategoryAndValueSeries("Area")}<c:axId val=\"1\"/><c:axId val=\"2\"/></c:area3DChart>{CategoryAndValueAxes}",
+            out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ChartType, Is.EqualTo(expected));
+            Assert.That(chart.Series, Has.Exactly(1).Items);
+        }
+    }
+
+    [Test]
+    public void Surface3DChartIsRead()
+    {
+        var chart = LoadChart(
+            $"<c:surface3DChart>{CategoryAndValueSeries("Height")}<c:axId val=\"1\"/><c:axId val=\"2\"/><c:axId val=\"3\"/></c:surface3DChart>{CategoryAndValueAxes}<c:serAx><c:axId val=\"3\"/><c:scaling><c:orientation val=\"minMax\"/></c:scaling><c:delete val=\"0\"/><c:axPos val=\"b\"/><c:crossAx val=\"2\"/></c:serAx>",
+            out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ChartType, Is.EqualTo(XLChartType.Surface));
+            Assert.That(chart.Series.Single().Name, Is.EqualTo("Height"));
+        }
+    }
+
+    [Test]
+    public void A3DBarChartStillReadsAsBefore()
+    {
+        var chart = LoadChart(
+            $"<c:bar3DChart><c:barDir val=\"col\"/><c:grouping val=\"clustered\"/>{CategoryAndValueSeries("Sales")}<c:shape val=\"box\"/><c:axId val=\"1\"/><c:axId val=\"2\"/></c:bar3DChart>{CategoryAndValueAxes}",
+            out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ChartType, Is.EqualTo(XLChartType.ColumnClustered3D));
+        }
+    }
+
+    [Test]
+    public void SeriesFormattingOnA3DGroupIsRead()
+    {
+        var series = """
+            <c:ser>
+              <c:idx val="0"/>
+              <c:order val="0"/>
+              <c:tx><c:v>Trend</c:v></c:tx>
+              <c:spPr><a:ln w="19050"><a:solidFill><a:srgbClr val="ED7D31"/></a:solidFill></a:ln></c:spPr>
+              <c:marker><c:symbol val="square"/><c:size val="6"/></c:marker>
+              <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+              <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+              <c:smooth val="1"/>
+            </c:ser>
+            """;
+
+        var chart = LoadChart(
+            $"<c:line3DChart><c:grouping val=\"standard\"/>{series}<c:axId val=\"1\"/><c:axId val=\"2\"/></c:line3DChart>{CategoryAndValueAxes}",
+            out var wb);
+        using (wb)
+        {
+            var s = chart.Series.Single();
+            Assert.That(s.LineColor, Is.EqualTo(XLColor.FromHtml("#ED7D31")));
+            Assert.That(s.LineWidthPt, Is.EqualTo(1.5));
+            Assert.That(s.MarkerStyle, Is.EqualTo(XLMarkerStyle.Square));
+            Assert.That(s.MarkerSize, Is.EqualTo(6));
+            Assert.That(s.Smooth, Is.True);
+        }
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartLegendAndAxisTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartLegendAndAxisTests.cs
@@ -136,6 +136,67 @@ public class ChartLegendAndAxisTests
         Assert.That(ChartSpaceOf(withoutLegend).Descendants<C.Legend>(), Is.Empty);
     }
 
+    [Test]
+    public void PositioningALegendThatIsNotThereDoesNotCreateOne()
+    {
+        using var original = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            AddChart(ws, XLChartType.ColumnClustered)
+                .Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(original);
+        }
+
+        using var edited = new MemoryStream();
+        original.Position = 0;
+        using (var wb = new XLWorkbook(original))
+        {
+            // Position is documented as ignored while the legend is hidden, and a new chart gets no
+            // legend from it either. A loaded one must behave the same way.
+            var chart = wb.Worksheet("Data").Charts.First();
+            Assert.That(chart.Legend.Visible, Is.False);
+            chart.Legend.Position = XLLegendPosition.Bottom;
+            chart.Legend.Overlay = true;
+            wb.SaveAs(edited, validate: true);
+        }
+
+        Assert.That(ChartSpaceOf(edited).Descendants<C.Legend>(), Is.Empty);
+    }
+
+    [Test]
+    public void ShowingALegendOnALoadedChartStillHonoursThePositionSetWithIt()
+    {
+        using var original = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            AddChart(ws, XLChartType.ColumnClustered)
+                .Series.Add("Sales", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            using var saved = SaveValidated(wb);
+            saved.CopyTo(original);
+        }
+
+        using var edited = new MemoryStream();
+        original.Position = 0;
+        using (var wb = new XLWorkbook(original))
+        {
+            var legend = wb.Worksheet("Data").Charts.First().Legend;
+            legend.Visible = true;
+            legend.Position = XLLegendPosition.Left;
+            wb.SaveAs(edited, validate: true);
+        }
+
+        edited.Position = 0;
+        using (var wb = new XLWorkbook(edited))
+        {
+            var legend = wb.Worksheet("Data").Charts.First().Legend;
+            Assert.That(legend.Visible, Is.True);
+            Assert.That(legend.Position, Is.EqualTo(XLLegendPosition.Left));
+        }
+    }
+
     // ── Axes ────────────────────────────────────────────────────────────
 
     [Test]

--- a/XLibur.Tests/Excel/Charts/ChartPartFixture.cs
+++ b/XLibur.Tests/Excel/Charts/ChartPartFixture.cs
@@ -1,0 +1,89 @@
+using DocumentFormat.OpenXml.Packaging;
+using System.IO;
+using System.Linq;
+using System.Text;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// Builds a workbook whose chart part holds hand-written XML. XLibur's own writer only produces the
+/// shapes it knows how to produce, so anything Excel may legitimately emit but XLibur never writes —
+/// 3D groups, an unusual group order — has to be fed to the reader this way.
+/// </summary>
+internal static class ChartPartFixture
+{
+    /// <summary>A <c>c:catAx</c>/<c>c:valAx</c> pair with ids 1 and 2.</summary>
+    internal const string CategoryAndValueAxes = """
+        <c:catAx><c:axId val="1"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="2"/></c:catAx>
+        <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
+        """;
+
+    /// <summary>A <c>c:ser</c> over the <c>Data</c> sheet the fixture fills in.</summary>
+    internal static string CategoryAndValueSeries(string name) => $"""
+        <c:ser>
+          <c:idx val="0"/>
+          <c:order val="0"/>
+          <c:tx><c:v>{name}</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+        </c:ser>
+        """;
+
+    /// <summary>
+    /// Wraps a plot area body in the rest of a chart part, and puts it in a workbook.
+    /// </summary>
+    internal static MemoryStream CreateWorkbookWithPlotArea(string plotAreaBody)
+    {
+        var chartXml = $"""
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <c:chart>
+                <c:plotArea>
+                  <c:layout/>
+                  {plotAreaBody}
+                </c:plotArea>
+                <c:plotVisOnly val="1"/>
+              </c:chart>
+            </c:chartSpace>
+            """;
+
+        var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Data");
+            ws.Cell("A1").Value = "Q1";
+            ws.Cell("A2").Value = "Q2";
+            ws.Cell("B1").Value = 100;
+            ws.Cell("B2").Value = 200;
+
+            var chart = ws.Charts.Add(XLChartType.ColumnClustered);
+            chart.Series.Add("Placeholder", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+            chart.Position.SetColumn(5).SetRow(1);
+            chart.SecondPosition.SetColumn(12).SetRow(15);
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        using (var doc = SpreadsheetDocument.Open(ms, true))
+        {
+            var chartPart = doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ChartParts.First();
+            using var source = new MemoryStream(Encoding.UTF8.GetBytes(chartXml));
+            chartPart.FeedData(source);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    /// <summary>
+    /// Loads the chart of <see cref="CreateWorkbookWithPlotArea"/>. The caller owns
+    /// <paramref name="workbook"/>, which has to outlive the chart it hands back.
+    /// </summary>
+    internal static IXLChart LoadChart(string plotAreaBody, out XLWorkbook workbook)
+    {
+        var ms = CreateWorkbookWithPlotArea(plotAreaBody);
+        workbook = new XLWorkbook(ms);
+        return workbook.Worksheet("Data").Charts.Single();
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartPrimaryAxisReaderTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartPrimaryAxisReaderTests.cs
@@ -1,0 +1,98 @@
+using NUnit.Framework;
+using System;
+using System.Linq;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Charts;
+
+/// <summary>
+/// Which of a plot area's chart groups carries the primary axis pair, and what a loaded chart refuses
+/// to do. XLibur's writer always emits the primary group first, but nothing in the schema requires it,
+/// so the reader must not decide by document order alone.
+/// </summary>
+[TestFixture]
+public class ChartPrimaryAxisReaderTests
+{
+    /// <summary>
+    /// A plot area holding two <c>c:barChart</c> groups: the one on the secondary axis pair (4/5, the
+    /// value axis crossing at the maximum) is written <em>first</em>, ahead of the primary pair (1/2).
+    /// </summary>
+    private const string SecondaryGroupFirst = """
+        <c:barChart>
+          <c:barDir val="col"/>
+          <c:grouping val="clustered"/>
+          <c:ser>
+            <c:idx val="1"/>
+            <c:order val="1"/>
+            <c:tx><c:v>Right</c:v></c:tx>
+            <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+            <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+          </c:ser>
+          <c:axId val="4"/>
+          <c:axId val="5"/>
+        </c:barChart>
+        <c:barChart>
+          <c:barDir val="col"/>
+          <c:grouping val="clustered"/>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:v>Left</c:v></c:tx>
+            <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
+            <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+          </c:ser>
+          <c:axId val="1"/>
+          <c:axId val="2"/>
+        </c:barChart>
+        <c:catAx><c:axId val="1"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="2"/></c:catAx>
+        <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/><c:majorUnit val="10"/></c:valAx>
+        <c:catAx><c:axId val="4"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="1"/><c:axPos val="b"/><c:crossAx val="5"/></c:catAx>
+        <c:valAx><c:axId val="5"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="r"/><c:crossAx val="4"/><c:crosses val="max"/><c:majorUnit val="25"/></c:valAx>
+        """;
+
+    [Test]
+    public void SecondaryAxisBindingDoesNotDependOnGroupOrder()
+    {
+        var chart = ChartPartFixture.LoadChart(SecondaryGroupFirst, out var wb);
+        using (wb)
+        {
+            var series = chart.Series.ToList();
+            Assert.That(series.Select(s => s.Name), Is.EqualTo(new[] { "Right", "Left" }));
+
+            // The group written first hangs off the axis that crosses at the maximum, so it is the
+            // secondary one however early it appears.
+            Assert.That(series[0].UseSecondaryAxis, Is.True);
+            Assert.That(series[1].UseSecondaryAxis, Is.False);
+        }
+    }
+
+    [Test]
+    public void TheAxisModelsFollowTheSameBinding()
+    {
+        var chart = ChartPartFixture.LoadChart(SecondaryGroupFirst, out var wb);
+        using (wb)
+        {
+            Assert.That(chart.ValueAxis.MajorUnit, Is.EqualTo(10),
+                "The left-hand axis of the primary group is IXLChart.ValueAxis.");
+            Assert.That(chart.SecondaryValueAxis.MajorUnit, Is.EqualTo(25));
+        }
+    }
+
+    [Test]
+    public void AddingASeriesToALoadedChartThrows()
+    {
+        var chart = ChartPartFixture.LoadChart(
+            $"<c:barChart><c:barDir val=\"col\"/><c:grouping val=\"clustered\"/>{ChartPartFixture.CategoryAndValueSeries("Sales")}<c:axId val=\"1\"/><c:axId val=\"2\"/></c:barChart>{ChartPartFixture.CategoryAndValueAxes}",
+            out var wb);
+        using (wb)
+        {
+            // A new series has nowhere to go: the chart part is patched, never regenerated. Silently
+            // dropping it on save would be worse than saying so.
+            Assert.Throws<NotSupportedException>(
+                () => chart.Series.Add("New", "Data!$B$1:$B$2", "Data!$A$1:$A$2"));
+            Assert.Throws<NotSupportedException>(
+                () => chart.SecondarySeries.Add("New", "Data!$B$1:$B$2", "Data!$A$1:$A$2"));
+            Assert.That(chart.Series, Has.Exactly(1).Items);
+        }
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
@@ -398,6 +398,33 @@ public class ChartRoundTripPreservationTests
     }
 
     [Test]
+    public void ChartWideLabelsReachEveryGroupOfALoadedComboChart()
+    {
+        using var original = CreateWorkbookWithExcelShapedChart();
+        using var saved = new MemoryStream();
+
+        using (var wb = new XLWorkbook(original))
+        {
+            // Chart-wide labels apply to the whole chart, and the writer puts them on each group of a
+            // new combo chart. A loaded one used to get them on the c:barChart only.
+            wb.Worksheet("Data").Charts.First().DataLabels.ShowValue = true;
+            wb.SaveAs(saved, validate: true);
+        }
+
+        var xml = ReadChartXml(saved);
+        var barChart = xml[xml.IndexOf("<c:barChart>", StringComparison.Ordinal)..
+                           xml.IndexOf("</c:barChart>", StringComparison.Ordinal)];
+        var lineChart = xml[xml.IndexOf("<c:lineChart>", StringComparison.Ordinal)..
+                            xml.IndexOf("</c:lineChart>", StringComparison.Ordinal)];
+
+        // The group-level c:dLbls follows the last c:ser, so it is what comes after </c:ser>.
+        Assert.That(barChart[barChart.LastIndexOf("</c:ser>", StringComparison.Ordinal)..],
+            Does.Contain("<c:showVal val=\"1\""));
+        Assert.That(lineChart[lineChart.LastIndexOf("</c:ser>", StringComparison.Ordinal)..],
+            Does.Contain("<c:showVal val=\"1\""));
+    }
+
+    [Test]
     public void TurningLabelsOnClearsAnExistingDeleteFlag()
     {
         // Excel writes <c:dLbls><c:delete val="1"/></c:dLbls> for a series whose labels are switched

--- a/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
@@ -57,6 +57,13 @@ public class ChartRoundTripPreservationTests
                     <c:showBubbleSize val="0"/>
                   </c:dLbls>
                   <c:trendline><c:trendlineType val="linear"/></c:trendline>
+                  <c:errBars>
+                    <c:errDir val="y"/>
+                    <c:errBarType val="both"/>
+                    <c:errValType val="percentage"/>
+                    <c:noEndCap val="0"/>
+                    <c:val val="5"/>
+                  </c:errBars>
                   <c:cat><c:strRef><c:f>Data!$A$1:$A$2</c:f></c:strRef></c:cat>
                   <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
                 </c:ser>
@@ -268,6 +275,8 @@ public class ChartRoundTripPreservationTests
 
         // Everything XLibur does not model survived.
         Assert.That(xml, Does.Contain("<c:trendline>"));
+        Assert.That(xml, Does.Contain("<c:errBars>"));
+        Assert.That(xml, Does.Contain("<c:errValType val=\"percentage\""));
         Assert.That(xml, Does.Contain("cap=\"rnd\""));
         Assert.That(xml, Does.Contain("<a:round"));
         Assert.That(xml, Does.Contain("<a:effectLst"));

--- a/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
@@ -282,6 +282,36 @@ public class ChartSeriesFormattingTests
     }
 
     [Test]
+    public void StockSeriesAreSmoothedToo()
+    {
+        // A stock chart is built from CT_LineSer, which takes c:smooth. The writer used to leave it
+        // out, so Smooth was honoured on a stock chart read from a file but not on a new one.
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = AddDataSheet(wb);
+            var chart = AddChart(ws, XLChartType.StockHighLowClose);
+            foreach (var name in new[] { "High", "Low", "Close" })
+                chart.Series.Add(name, "Data!$B$1:$B$2", "Data!$A$1:$A$2").Smooth = true;
+
+            using var saved = SaveValidated(wb);
+            var chartSpace = ChartSpaceOf(saved);
+            Assert.That(chartSpace.Descendants<C.Smooth>().Select(s => s.Val!.Value),
+                Is.EqualTo(new[] { true, true, true }));
+
+            saved.Position = 0;
+            saved.CopyTo(ms);
+        }
+
+        ms.Position = 0;
+        using (var wb = new XLWorkbook(ms))
+        {
+            Assert.That(wb.Worksheet("Data").Charts.First().Series.Select(s => s.Smooth),
+                Is.EqualTo(new[] { true, true, true }));
+        }
+    }
+
+    [Test]
     public void FormattingSurvivesEveryStandardChartFamily()
     {
         // The formatting is appended by each chart family's own builder, so every family gets a

--- a/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
@@ -465,7 +465,7 @@ public class ChartSeriesFormattingTests
         // back and that what it wrote is schema-valid.
         using var wb = new XLWorkbook(path);
         using var ms = SaveValidated(wb);
-        Assert.That(wb.Worksheets.Count, Is.EqualTo(6));
+        Assert.That(wb.Worksheets.Count, Is.EqualTo(7));
     }
 
     [Test]

--- a/XLibur/Excel/Charts/IXLChart.cs
+++ b/XLibur/Excel/Charts/IXLChart.cs
@@ -143,8 +143,56 @@ public interface IXLChart : IXLDrawing<IXLChart>
     /// <summary>
     /// Gets the bottom-right anchor position of the chart's two-cell anchor.
     /// Use together with <see cref="IXLDrawing{T}.Position"/> (top-left) to define the chart's size and location.
+    /// Only used while <see cref="Anchor"/> is <see cref="XLDrawingAnchor.MoveAndSizeWithCells"/>.
     /// </summary>
     IXLDrawingPosition SecondPosition { get; }
+
+    /// <summary>
+    /// Gets or sets how the chart is tied to the grid.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item>
+    /// <see cref="XLDrawingAnchor.MoveAndSizeWithCells"/> — the default — spans the rectangle between
+    /// <see cref="IXLDrawing{T}.Position"/> and <see cref="SecondPosition"/>, so inserting rows or
+    /// columns moves and resizes the chart.
+    /// </item>
+    /// <item>
+    /// <see cref="XLDrawingAnchor.MoveWithCells"/> keeps <see cref="Width"/> and <see cref="Height"/>
+    /// and hangs the top-left corner off <see cref="IXLDrawing{T}.Position"/>.
+    /// </item>
+    /// <item>
+    /// <see cref="XLDrawingAnchor.Absolute"/> pins the chart to <see cref="Left"/>/<see cref="Top"/>
+    /// with <see cref="Width"/> and <see cref="Height"/>, ignoring the grid entirely.
+    /// </item>
+    /// </list>
+    /// </remarks>
+    XLDrawingAnchor Anchor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the chart width in pixels. Used when <see cref="Anchor"/> is
+    /// <see cref="XLDrawingAnchor.MoveWithCells"/> or <see cref="XLDrawingAnchor.Absolute"/>; a
+    /// two-cell anchored chart takes its width from <see cref="SecondPosition"/> instead.
+    /// </summary>
+    int Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the chart height in pixels. Used when <see cref="Anchor"/> is
+    /// <see cref="XLDrawingAnchor.MoveWithCells"/> or <see cref="XLDrawingAnchor.Absolute"/>.
+    /// </summary>
+    int Height { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance in pixels from the left edge of the sheet. Used only when
+    /// <see cref="Anchor"/> is <see cref="XLDrawingAnchor.Absolute"/>.
+    /// </summary>
+    int Left { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance in pixels from the top edge of the sheet. Used only when
+    /// <see cref="Anchor"/> is <see cref="XLDrawingAnchor.Absolute"/>.
+    /// </summary>
+    int Top { get; set; }
 
     /// <summary>
     /// Gets or sets the secondary chart type for combo charts.

--- a/XLibur/Excel/Charts/IXLChart.cs
+++ b/XLibur/Excel/Charts/IXLChart.cs
@@ -199,6 +199,14 @@ public interface IXLChart : IXLDrawing<IXLChart>
     /// When set, the chart renders both <see cref="ChartType"/> and this type
     /// in the same plot area, each with its own series. Set to <c>null</c> for single-type charts.
     /// </summary>
+    /// <remarks>
+    /// The model holds two chart types, which is all XLibur writes. A chart read from a file may mix
+    /// more: Excel allows a plot area to combine any number of chart groups. In that case
+    /// <see cref="ChartType"/> and this property name the first two, every series outside the primary
+    /// group lands in <see cref="SecondarySeries"/>, and the series belonging to a third or later
+    /// group are reported under this type rather than their own. Saving is unaffected — a loaded chart
+    /// keeps its original XML — but the model understates such a chart.
+    /// </remarks>
     XLChartType? SecondaryChartType { get; set; }
 
     /// <summary>

--- a/XLibur/Excel/Charts/IXLChartSeriesCollection.cs
+++ b/XLibur/Excel/Charts/IXLChartSeriesCollection.cs
@@ -20,5 +20,10 @@ public interface IXLChartSeriesCollection : IEnumerable<IXLChartSeries>
     /// <param name="valueReferences">Cell reference for the series values, e.g. <c>"Sheet1!$B$2:$B$5"</c>.</param>
     /// <param name="categoryReferences">Optional cell reference for category labels, e.g. <c>"Sheet1!$A$2:$A$5"</c>.</param>
     /// <returns>The newly created series.</returns>
+    /// <exception cref="System.NotSupportedException">
+    /// The chart was loaded from a file. XLibur patches the properties of an existing chart rather
+    /// than regenerating its XML, so there is nowhere to write a new series; recreate the chart with
+    /// <see cref="IXLCharts.Add(XLChartType)"/> instead.
+    /// </exception>
     IXLChartSeries Add(string name, string valueReferences, string? categoryReferences = null);
 }

--- a/XLibur/Excel/Charts/XLChart.cs
+++ b/XLibur/Excel/Charts/XLChart.cs
@@ -62,6 +62,16 @@ internal sealed class XLChart : XLDrawing<IXLChart>, IXLChart
 
     public IXLDrawingPosition SecondPosition { get; }
 
+    public XLDrawingAnchor Anchor { get; set; } = XLDrawingAnchor.MoveAndSizeWithCells;
+
+    public int Width { get; set; }
+
+    public int Height { get; set; }
+
+    public int Left { get; set; }
+
+    public int Top { get; set; }
+
     public XLChartType? SecondaryChartType { get; set; }
 
     public IXLChartSeriesCollection SecondarySeries { get; }

--- a/XLibur/Excel/Charts/XLChartSeriesCollection.cs
+++ b/XLibur/Excel/Charts/XLChartSeriesCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -29,6 +30,14 @@ internal sealed class XLChartSeriesCollection : IXLChartSeriesCollection
 
     public IXLChartSeries Add(string name, string valueReferences, string? categoryReferences = null)
     {
+        if (_chart.LoadedFromFile)
+        {
+            throw new NotSupportedException(
+                "Cannot add a series to a chart loaded from a file. XLibur patches the properties of "
+                + "an existing chart rather than regenerating its XML, so a new series has nowhere to "
+                + "be written; recreate the chart with IXLCharts.Add(XLChartType) instead.");
+        }
+
         var series = new XLChartSeries(_chart, _secondary)
         {
             Name = name,

--- a/XLibur/Excel/IO/ChartFormatting.cs
+++ b/XLibur/Excel/IO/ChartFormatting.cs
@@ -221,6 +221,11 @@ internal static class ChartFormatting
 
         if (element == null)
         {
+            // Position and Overlay are ignored while the legend is hidden, so assigning one of them on
+            // a chart that has no legend must not conjure one — BuildLegend does not either.
+            if (!legend.Visible)
+                return;
+
             element = new C.Legend();
             element.Append(new C.LegendPosition { Val = MapLegendPosition(legend.Position) });
             element.Append(new C.Overlay { Val = legend.Overlay });

--- a/XLibur/Excel/IO/ChartFormatting.cs
+++ b/XLibur/Excel/IO/ChartFormatting.cs
@@ -657,17 +657,19 @@ internal static class ChartFormatting
 
     /// <summary>Whether the series type of a chart group accepts a <c>c:marker</c> child.</summary>
     private static bool SupportsMarker(XLChartGroupKind kind) => kind is XLChartGroupKind.Line
-        or XLChartGroupKind.Scatter or XLChartGroupKind.Radar or XLChartGroupKind.Stock;
+        or XLChartGroupKind.Line3D or XLChartGroupKind.Scatter or XLChartGroupKind.Radar
+        or XLChartGroupKind.Stock;
 
     /// <summary>Whether the series type of a chart group accepts a <c>c:smooth</c> child.</summary>
     private static bool SupportsSmooth(XLChartGroupKind kind) => kind is XLChartGroupKind.Line
-        or XLChartGroupKind.Scatter or XLChartGroupKind.Stock;
+        or XLChartGroupKind.Line3D or XLChartGroupKind.Scatter or XLChartGroupKind.Stock;
 
     /// <summary>
     /// Whether a chart group and its series accept a <c>c:dLbls</c> child. Only the surface types do
     /// not: neither <c>CT_SurfaceChart</c> nor <c>CT_SurfaceSer</c> has one.
     /// </summary>
-    internal static bool SupportsDataLabels(XLChartGroupKind kind) => kind != XLChartGroupKind.Surface;
+    internal static bool SupportsDataLabels(XLChartGroupKind kind) =>
+        kind is not (XLChartGroupKind.Surface or XLChartGroupKind.Surface3D);
 
     /// <summary>
     /// Applies the assigned data label properties onto an existing <c>c:dLbls</c> element, or adds one

--- a/XLibur/Excel/IO/ChartPatcher.cs
+++ b/XLibur/Excel/IO/ChartPatcher.cs
@@ -78,7 +78,7 @@ internal static class ChartPatcher
     private static void PatchAxes(
         C.PlotArea plotArea, List<XLChartGroup> groups, XLChartGroupKind primaryKind, XLChart xlChart)
     {
-        var primaryGroup = groups.First(g => g.Kind == primaryKind);
+        var primaryGroup = ChartPlotAreaScanner.PrimaryGroup(plotArea, groups, primaryKind);
         var primaryValueAxisId = primaryGroup.ValueAxisId;
 
         ChartFormatting.PatchAxis(
@@ -99,7 +99,9 @@ internal static class ChartPatcher
     }
 
     /// <summary>
-    /// Writes the chart-wide data labels into every group of the primary chart type.
+    /// Writes the chart-wide data labels into every group that accepts them. They apply to the whole
+    /// chart, and <see cref="ChartWriter"/> puts them on each group of a new combo chart, so a loaded
+    /// combo chart is patched the same way rather than only on its primary group.
     /// </summary>
     private static void PatchGroupDataLabels(
         List<XLChartGroup> groups, XLChartGroupKind primaryKind, XLChart xlChart)
@@ -109,10 +111,16 @@ internal static class ChartPatcher
 
         foreach (var group in groups)
         {
-            if (group.Kind != primaryKind || !ChartFormatting.SupportsDataLabels(group.Kind))
+            if (!ChartFormatting.SupportsDataLabels(group.Kind))
                 continue;
 
-            ChartFormatting.PatchGroupDataLabels(group.Element, xlChart.DataLabelsInternal, xlChart.ChartType);
+            // A position Excel does not offer for a group's own type degrades to automatic, so each
+            // group is patched against its type — the same mapping PatchSeries uses.
+            var chartType = group.Kind == primaryKind
+                ? xlChart.ChartType
+                : xlChart.SecondaryChartType ?? xlChart.ChartType;
+
+            ChartFormatting.PatchGroupDataLabels(group.Element, xlChart.DataLabelsInternal, chartType);
         }
     }
 

--- a/XLibur/Excel/IO/ChartPlotAreaScanner.cs
+++ b/XLibur/Excel/IO/ChartPlotAreaScanner.cs
@@ -14,14 +14,21 @@ internal enum XLChartGroupKind
     Bar,
     Bar3D,
     Pie,
+    Pie3D,
+
+    /// <summary>A pie-of-pie or bar-of-pie chart (<c>c:ofPieChart</c>).</summary>
+    OfPie,
     Doughnut,
     Area,
+    Area3D,
     Line,
+    Line3D,
     Radar,
     Bubble,
     Scatter,
     Stock,
-    Surface
+    Surface,
+    Surface3D
 }
 
 /// <summary>
@@ -67,6 +74,10 @@ internal sealed class XLChartGroup
     /// values (<c>c:cat</c>/<c>c:val</c>).
     /// </summary>
     internal bool IsXyBased => Kind is XLChartGroupKind.Scatter or XLChartGroupKind.Bubble;
+
+    /// <summary>Whether this is one of the 3D group types, which XLibur reads but never writes.</summary>
+    internal bool Is3D => Kind is XLChartGroupKind.Bar3D or XLChartGroupKind.Pie3D
+        or XLChartGroupKind.Area3D or XLChartGroupKind.Line3D or XLChartGroupKind.Surface3D;
 }
 
 /// <summary>
@@ -87,14 +98,19 @@ internal static class ChartPlotAreaScanner
         XLChartGroupKind.Bar,
         XLChartGroupKind.Bar3D,
         XLChartGroupKind.Pie,
+        XLChartGroupKind.Pie3D,
+        XLChartGroupKind.OfPie,
         XLChartGroupKind.Doughnut,
         XLChartGroupKind.Area,
+        XLChartGroupKind.Area3D,
         XLChartGroupKind.Line,
+        XLChartGroupKind.Line3D,
         XLChartGroupKind.Radar,
         XLChartGroupKind.Bubble,
         XLChartGroupKind.Scatter,
         XLChartGroupKind.Stock,
-        XLChartGroupKind.Surface
+        XLChartGroupKind.Surface,
+        XLChartGroupKind.Surface3D
     ];
 
     /// <summary>
@@ -117,14 +133,26 @@ internal static class ChartPlotAreaScanner
                 case C.PieChart pie:
                     groups.Add(Build(XLChartGroupKind.Pie, pie, pie.Elements<C.PieChartSeries>()));
                     break;
+                case C.Pie3DChart pie3D:
+                    groups.Add(Build(XLChartGroupKind.Pie3D, pie3D, pie3D.Elements<C.PieChartSeries>()));
+                    break;
+                case C.OfPieChart ofPie:
+                    groups.Add(Build(XLChartGroupKind.OfPie, ofPie, ofPie.Elements<C.PieChartSeries>()));
+                    break;
                 case C.DoughnutChart doughnut:
                     groups.Add(Build(XLChartGroupKind.Doughnut, doughnut, doughnut.Elements<C.PieChartSeries>()));
                     break;
                 case C.AreaChart area:
                     groups.Add(Build(XLChartGroupKind.Area, area, area.Elements<C.AreaChartSeries>()));
                     break;
+                case C.Area3DChart area3D:
+                    groups.Add(Build(XLChartGroupKind.Area3D, area3D, area3D.Elements<C.AreaChartSeries>()));
+                    break;
                 case C.LineChart line:
                     groups.Add(Build(XLChartGroupKind.Line, line, line.Elements<C.LineChartSeries>()));
+                    break;
+                case C.Line3DChart line3D:
+                    groups.Add(Build(XLChartGroupKind.Line3D, line3D, line3D.Elements<C.LineChartSeries>()));
                     break;
                 case C.RadarChart radar:
                     groups.Add(Build(XLChartGroupKind.Radar, radar, radar.Elements<C.RadarChartSeries>()));
@@ -140,6 +168,10 @@ internal static class ChartPlotAreaScanner
                     break;
                 case C.SurfaceChart surface:
                     groups.Add(Build(XLChartGroupKind.Surface, surface, surface.Elements<C.SurfaceChartSeries>()));
+                    break;
+                case C.Surface3DChart surface3D:
+                    groups.Add(Build(XLChartGroupKind.Surface3D, surface3D,
+                        surface3D.Elements<C.SurfaceChartSeries>()));
                     break;
             }
         }

--- a/XLibur/Excel/IO/ChartPlotAreaScanner.cs
+++ b/XLibur/Excel/IO/ChartPlotAreaScanner.cs
@@ -195,11 +195,41 @@ internal static class ChartPlotAreaScanner
     }
 
     /// <summary>
-    /// The value axis of the first group of the primary kind. Groups plotted against a different
-    /// value axis are on a secondary axis.
+    /// The group that carries the chart's primary axis pair. Groups plotted against a different value
+    /// axis are on a secondary axis.
     /// </summary>
-    internal static uint? PrimaryValueAxisId(List<XLChartGroup> groups, XLChartGroupKind primaryKind) =>
-        groups.First(g => g.Kind == primaryKind).ValueAxisId;
+    /// <remarks>
+    /// A plot area may hold several groups of the primary kind — two <c>c:barChart</c> elements, say,
+    /// one per axis pair — and nothing in the schema says the primary one comes first. So rather than
+    /// trust document order, a group whose value axis crosses the category axis at its maximum is
+    /// passed over: that is how a secondary value axis ends up drawn on the right, and Excel writes it
+    /// on every secondary axis it creates. When every candidate looks secondary — or none does —
+    /// document order decides after all.
+    /// </remarks>
+    internal static XLChartGroup PrimaryGroup(
+        C.PlotArea plotArea, List<XLChartGroup> groups, XLChartGroupKind primaryKind)
+    {
+        XLChartGroup? firstOfKind = null;
+
+        foreach (var group in groups)
+        {
+            if (group.Kind != primaryKind)
+                continue;
+
+            firstOfKind ??= group;
+            if (!CrossesAtMaximum(FindAxis(plotArea, group.ValueAxisId)))
+                return group;
+        }
+
+        // ChoosePrimaryKind only ever returns a kind that is present, so there is always a candidate.
+        return firstOfKind!;
+    }
+
+    /// <summary>
+    /// Whether an axis element carries <c>c:crosses val="max"</c>, the mark of a secondary value axis.
+    /// </summary>
+    private static bool CrossesAtMaximum(OpenXmlCompositeElement? axis) =>
+        axis?.Elements<C.Crosses>().FirstOrDefault()?.Val?.Value == C.CrossesValues.Maximum;
 
     /// <summary>
     /// Finds the axis element of a plot area carrying the given <c>c:axId</c>, whichever axis type it

--- a/XLibur/Excel/IO/ChartReader.cs
+++ b/XLibur/Excel/IO/ChartReader.cs
@@ -131,8 +131,9 @@ internal static class ChartReader
         if (primaryKind == null)
             return;
 
-        var primaryValueAxisId = ChartPlotAreaScanner.PrimaryValueAxisId(groups, primaryKind.Value);
-        ReadAxes(plotArea, groups, primaryKind.Value, primaryValueAxisId, xlChart);
+        var primaryGroup = ChartPlotAreaScanner.PrimaryGroup(plotArea, groups, primaryKind.Value);
+        var primaryValueAxisId = primaryGroup.ValueAxisId;
+        ReadAxes(plotArea, groups, primaryGroup, primaryValueAxisId, xlChart);
         var primarySet = false;
 
         foreach (var group in groups)
@@ -159,6 +160,9 @@ internal static class ChartReader
             }
             else
             {
+                // The model carries two chart types. A plot area may hold more, in which case the
+                // series of the third and later groups still land in the secondary collection but are
+                // reported under the second group's type — see IXLChart.SecondaryChartType.
                 xlChart.SecondaryChartType ??= chartType;
                 ReadGroupSeries(group, xlChart.SecondarySeriesInternal, useSecondaryAxis);
             }
@@ -170,11 +174,9 @@ internal static class ChartReader
     /// the secondary value axis into the model.
     /// </summary>
     private static void ReadAxes(
-        C.PlotArea plotArea, List<XLChartGroup> groups, XLChartGroupKind primaryKind,
+        C.PlotArea plotArea, List<XLChartGroup> groups, XLChartGroup primaryGroup,
         uint? primaryValueAxisId, XLChart xlChart)
     {
-        var primaryGroup = groups.First(g => g.Kind == primaryKind);
-
         ChartFormatting.ReadAxis(
             ChartPlotAreaScanner.FindAxis(plotArea, primaryGroup.CategoryAxisId),
             xlChart.CategoryAxisInternal);

--- a/XLibur/Excel/IO/ChartReader.cs
+++ b/XLibur/Excel/IO/ChartReader.cs
@@ -22,19 +22,25 @@ internal static class ChartReader
         if (drawingsPart?.WorksheetDrawing == null)
             return;
 
-        foreach (var anchor in drawingsPart.WorksheetDrawing.Elements<Xdr.TwoCellAnchor>())
+        // Excel writes a chart under any of the three anchor kinds. A one-cell or absolute anchored
+        // chart used to be skipped here, which left it out of ws.Charts entirely.
+        foreach (var anchor in drawingsPart.WorksheetDrawing.ChildElements)
         {
-            var xlChart = TryLoadChartFromAnchor(drawingsPart, anchor, ws);
-            if (xlChart != null)
-            {
-                ReadPositions(anchor, xlChart);
-                ws.Charts.Add(xlChart);
-            }
+            if (anchor is not (Xdr.TwoCellAnchor or Xdr.OneCellAnchor or Xdr.AbsoluteAnchor))
+                continue;
+
+            var composite = (OpenXmlCompositeElement)anchor;
+            var xlChart = TryLoadChartFromAnchor(drawingsPart, composite, ws);
+            if (xlChart == null)
+                continue;
+
+            ReadAnchor(composite, xlChart);
+            ws.Charts.Add(xlChart);
         }
     }
 
     private static XLChart? TryLoadChartFromAnchor(
-        DrawingsPart drawingsPart, Xdr.TwoCellAnchor anchor, XLWorksheet ws)
+        DrawingsPart drawingsPart, OpenXmlCompositeElement anchor, XLWorksheet ws)
     {
         // GraphicFrame may be direct child or inside mc:AlternateContent > mc:Choice
         var graphicFrame = anchor.Elements<Xdr.GraphicFrame>().FirstOrDefault()
@@ -191,14 +197,19 @@ internal static class ChartReader
         XLChartGroupKind.Bar => DetermineBarChartType((C.BarChart)group.Element),
         XLChartGroupKind.Bar3D => DetermineBar3DChartType((C.Bar3DChart)group.Element),
         XLChartGroupKind.Pie => XLChartType.Pie,
+        XLChartGroupKind.Pie3D => XLChartType.Pie3D,
+        XLChartGroupKind.OfPie => DetermineOfPieChartType((C.OfPieChart)group.Element),
         XLChartGroupKind.Doughnut => XLChartType.Doughnut,
         XLChartGroupKind.Area => DetermineAreaChartType((C.AreaChart)group.Element),
+        XLChartGroupKind.Area3D => DetermineArea3DChartType((C.Area3DChart)group.Element),
         XLChartGroupKind.Line => DetermineLineChartType((C.LineChart)group.Element),
+        XLChartGroupKind.Line3D => XLChartType.Line3D,
         XLChartGroupKind.Radar => DetermineRadarChartType((C.RadarChart)group.Element),
         XLChartGroupKind.Bubble => XLChartType.Bubble,
         XLChartGroupKind.Scatter => DetermineScatterChartType((C.ScatterChart)group.Element),
         XLChartGroupKind.Stock => XLChartType.StockHighLowClose,
         XLChartGroupKind.Surface => DetermineSurfaceChartType((C.SurfaceChart)group.Element),
+        XLChartGroupKind.Surface3D => DetermineSurface3DChartType((C.Surface3DChart)group.Element),
         _ => XLChartType.ColumnClustered
     };
 
@@ -432,10 +443,39 @@ internal static class ChartReader
         return XLChartType.Area;
     }
 
+    /// <summary>
+    /// A <c>c:surfaceChart</c> is strictly the flat contour variant, but XLibur's writer emits every
+    /// surface type as one, so it is read back as the plain surface type its own writer meant.
+    /// </summary>
     private static XLChartType DetermineSurfaceChartType(C.SurfaceChart surfaceChart)
     {
         var wireframe = surfaceChart.Elements<C.Wireframe>().FirstOrDefault()?.Val?.Value ?? false;
         return wireframe ? XLChartType.SurfaceWireframe : XLChartType.Surface;
+    }
+
+    private static XLChartType DetermineSurface3DChartType(C.Surface3DChart surfaceChart)
+    {
+        var wireframe = surfaceChart.Elements<C.Wireframe>().FirstOrDefault()?.Val?.Value ?? false;
+        return wireframe ? XLChartType.SurfaceWireframe : XLChartType.Surface;
+    }
+
+    /// <summary>
+    /// A <c>c:ofPieChart</c> is either pie-of-pie or bar-of-pie, told apart by <c>c:ofPieType</c>.
+    /// </summary>
+    private static XLChartType DetermineOfPieChartType(C.OfPieChart ofPieChart)
+    {
+        var type = ofPieChart.Elements<C.OfPieType>().FirstOrDefault()?.Val;
+        return type != null && type.Value == C.OfPieValues.Bar
+            ? XLChartType.PieToBar
+            : XLChartType.PieToPie;
+    }
+
+    private static XLChartType DetermineArea3DChartType(C.Area3DChart areaChart)
+    {
+        var grouping = areaChart.Grouping?.Val?.Value;
+        if (grouping == C.GroupingValues.Stacked) return XLChartType.AreaStacked3D;
+        if (grouping == C.GroupingValues.PercentStacked) return XLChartType.AreaStacked100Percent3D;
+        return XLChartType.Area3D;
     }
 
     private static XLChartType DetermineScatterChartType(C.ScatterChart scatterChart)
@@ -507,11 +547,49 @@ internal static class ChartReader
 
     // ── Position reading ────────────────────────────────────────────────
 
-    private static void ReadPositions(Xdr.TwoCellAnchor anchor, XLChart xlChart)
+    /// <summary>EMU per pixel, the unit the drawing markers and extents are stored in.</summary>
+    private const double EmuPerPixel = 9525;
+
+    private static void ReadAnchor(OpenXmlCompositeElement anchor, XLChart xlChart)
     {
-        ReadMarker(anchor.FromMarker, xlChart.Position);
-        ReadMarker(anchor.ToMarker, xlChart.SecondPosition);
+        switch (anchor)
+        {
+            case Xdr.TwoCellAnchor twoCell:
+                xlChart.Anchor = XLDrawingAnchor.MoveAndSizeWithCells;
+                ReadMarker(twoCell.FromMarker, xlChart.Position);
+                ReadMarker(twoCell.ToMarker, xlChart.SecondPosition);
+                break;
+
+            case Xdr.OneCellAnchor oneCell:
+                xlChart.Anchor = XLDrawingAnchor.MoveWithCells;
+                ReadMarker(oneCell.FromMarker, xlChart.Position);
+                ReadExtent(oneCell.Extent, xlChart);
+                break;
+
+            case Xdr.AbsoluteAnchor absolute:
+                xlChart.Anchor = XLDrawingAnchor.Absolute;
+                if (absolute.Position != null)
+                {
+                    xlChart.Left = ToPixels(absolute.Position.X?.Value);
+                    xlChart.Top = ToPixels(absolute.Position.Y?.Value);
+                }
+
+                ReadExtent(absolute.Extent, xlChart);
+                break;
+        }
     }
+
+    private static void ReadExtent(Xdr.Extent? extent, XLChart xlChart)
+    {
+        if (extent == null)
+            return;
+
+        xlChart.Width = ToPixels(extent.Cx?.Value);
+        xlChart.Height = ToPixels(extent.Cy?.Value);
+    }
+
+    private static int ToPixels(long? emu) =>
+        emu == null ? 0 : (int)System.Math.Round(emu.Value / EmuPerPixel);
 
     private static void ReadMarker(Xdr.MarkerType? marker, IXLDrawingPosition position)
     {

--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -911,6 +911,7 @@ internal static class ChartWriter
             AppendMarker(series, s, autoSymbol: false);
             AppendSeriesDataLabels(series, s, group.ChartType);
             AppendCatAndVal(series, s);
+            AppendSmooth(series, s, smoothByChartType: false);
             stockChart.Append(series);
         }
         AppendGroupDataLabels(stockChart, group.Chart, group.ChartType);

--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -1033,6 +1033,9 @@ internal static class ChartWriter
     private static C.SeriesText BuildSeriesText(IXLChartSeries s) =>
         new(new C.NumericValue(s.Name));
 
+    /// <summary>EMU per pixel, the unit the drawing markers and extents are stored in.</summary>
+    private const double EmuPerPixel = 9525;
+
     private static void AppendAnchor(Xdr.WorksheetDrawing worksheetDrawing, XLChart xlChart, A.GraphicData graphicData)
     {
         var nvps = worksheetDrawing.Descendants<Xdr.NonVisualDrawingProperties>();
@@ -1040,39 +1043,69 @@ internal static class ChartWriter
             ? (UInt32Value)nvps.Max(p => p.Id!.Value) + 1
             : 1U;
 
-        var fromPos = xlChart.Position;
-        var toPos = xlChart.SecondPosition;
-
-        var anchor = new Xdr.TwoCellAnchor(
-            new Xdr.FromMarker
-            {
-                ColumnId = new Xdr.ColumnId(fromPos.Column.ToString()),
-                RowId = new Xdr.RowId(fromPos.Row.ToString()),
-                ColumnOffset = new Xdr.ColumnOffset(((long)(fromPos.ColumnOffset * 9525)).ToString()),
-                RowOffset = new Xdr.RowOffset(((long)(fromPos.RowOffset * 9525)).ToString())
-            },
-            new Xdr.ToMarker
-            {
-                ColumnId = new Xdr.ColumnId(toPos.Column.ToString()),
-                RowId = new Xdr.RowId(toPos.Row.ToString()),
-                ColumnOffset = new Xdr.ColumnOffset(((long)(toPos.ColumnOffset * 9525)).ToString()),
-                RowOffset = new Xdr.RowOffset(((long)(toPos.RowOffset * 9525)).ToString())
-            },
-            new Xdr.GraphicFrame(
-                new Xdr.NonVisualGraphicFrameProperties(
-                    new Xdr.NonVisualDrawingProperties { Id = nvpId, Name = xlChart.Name },
-                    new Xdr.NonVisualGraphicFrameDrawingProperties()
-                ),
-                new Xdr.Transform(
-                    new A.Offset { X = 0, Y = 0 },
-                    new A.Extents { Cx = 0, Cy = 0 }
-                ),
-                new A.Graphic(graphicData)
+        var graphicFrame = new Xdr.GraphicFrame(
+            new Xdr.NonVisualGraphicFrameProperties(
+                new Xdr.NonVisualDrawingProperties { Id = nvpId, Name = xlChart.Name },
+                new Xdr.NonVisualGraphicFrameDrawingProperties()
             ),
-            new Xdr.ClientData()
+            new Xdr.Transform(
+                new A.Offset { X = 0, Y = 0 },
+                new A.Extents { Cx = 0, Cy = 0 }
+            ),
+            new A.Graphic(graphicData)
         );
+
+        OpenXmlCompositeElement anchor = xlChart.Anchor switch
+        {
+            XLDrawingAnchor.MoveWithCells => new Xdr.OneCellAnchor(
+                BuildFromMarker(xlChart.Position),
+                BuildExtent(xlChart),
+                graphicFrame,
+                new Xdr.ClientData()),
+
+            XLDrawingAnchor.Absolute => new Xdr.AbsoluteAnchor(
+                new Xdr.Position
+                {
+                    X = ToEmu(xlChart.Left),
+                    Y = ToEmu(xlChart.Top)
+                },
+                BuildExtent(xlChart),
+                graphicFrame,
+                new Xdr.ClientData()),
+
+            _ => new Xdr.TwoCellAnchor(
+                BuildFromMarker(xlChart.Position),
+                BuildToMarker(xlChart.SecondPosition),
+                graphicFrame,
+                new Xdr.ClientData())
+        };
+
         worksheetDrawing.Append(anchor);
     }
+
+    private static Xdr.FromMarker BuildFromMarker(IXLDrawingPosition position) => new()
+    {
+        ColumnId = new Xdr.ColumnId(position.Column.ToString()),
+        RowId = new Xdr.RowId(position.Row.ToString()),
+        ColumnOffset = new Xdr.ColumnOffset(ToEmu(position.ColumnOffset).ToString()),
+        RowOffset = new Xdr.RowOffset(ToEmu(position.RowOffset).ToString())
+    };
+
+    private static Xdr.ToMarker BuildToMarker(IXLDrawingPosition position) => new()
+    {
+        ColumnId = new Xdr.ColumnId(position.Column.ToString()),
+        RowId = new Xdr.RowId(position.Row.ToString()),
+        ColumnOffset = new Xdr.ColumnOffset(ToEmu(position.ColumnOffset).ToString()),
+        RowOffset = new Xdr.RowOffset(ToEmu(position.RowOffset).ToString())
+    };
+
+    private static Xdr.Extent BuildExtent(XLChart xlChart) => new()
+    {
+        Cx = ToEmu(xlChart.Width),
+        Cy = ToEmu(xlChart.Height)
+    };
+
+    private static long ToEmu(double pixels) => (long)(pixels * EmuPerPixel);
 
     /// <summary>
     /// Appends a TwoCellAnchor for an extended chart, wrapping the GraphicFrame in mc:AlternateContent

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -201,3 +201,13 @@ XLibur.Excel.IXLChartAxis.LogBase.set -> void
 XLibur.Excel.XLAxisOrientation
 XLibur.Excel.XLAxisOrientation.MinMax = 0 -> XLibur.Excel.XLAxisOrientation
 XLibur.Excel.XLAxisOrientation.MaxMin = 1 -> XLibur.Excel.XLAxisOrientation
+XLibur.Excel.IXLChart.Anchor.get -> XLibur.Excel.XLDrawingAnchor
+XLibur.Excel.IXLChart.Anchor.set -> void
+XLibur.Excel.IXLChart.Width.get -> int
+XLibur.Excel.IXLChart.Width.set -> void
+XLibur.Excel.IXLChart.Height.get -> int
+XLibur.Excel.IXLChart.Height.set -> void
+XLibur.Excel.IXLChart.Left.get -> int
+XLibur.Excel.IXLChart.Left.set -> void
+XLibur.Excel.IXLChart.Top.get -> int
+XLibur.Excel.IXLChart.Top.set -> void

--- a/docs-website/docs/charts.md
+++ b/docs-website/docs/charts.md
@@ -153,6 +153,30 @@ PlaceChart(revenueChart, row: 1, column: 4);
 PlaceChart(marginChart, row: 17, column: 4);
 ```
 
+### Anchoring
+
+By default a chart spans the rectangle between `Position` and `SecondPosition`, so inserting rows or
+columns moves and resizes it. `Anchor` picks a different rule:
+
+```csharp
+// Keep the size, move with the cell underneath the top-left corner
+chart.Anchor = XLDrawingAnchor.MoveWithCells;
+chart.Position.SetColumn(4).SetRow(3);
+chart.Width = 480;    // pixels
+chart.Height = 288;
+
+// Pin to a spot on the sheet, ignoring the grid
+chart.Anchor = XLDrawingAnchor.Absolute;
+chart.Left = 200;     // pixels from the left edge
+chart.Top = 120;
+chart.Width = 480;
+chart.Height = 288;
+```
+
+`SecondPosition` is only used by the default `MoveAndSizeWithCells`; `Width`/`Height` are only used
+by the other two, and `Left`/`Top` only by `Absolute`. All four are read back from a file, whichever
+anchor the chart came with.
+
 ## Combo charts
 
 Set `SecondaryChartType` and add series to `SecondarySeries`. Both types share one plot area —
@@ -477,6 +501,9 @@ foreach (var chart in ws.Charts)
     Console.WriteLine($"{chart.Title} ({chart.ChartType}), {chart.Series.Count} series");
 }
 ```
+
+Charts anchored any of the three ways are listed, as are the chart types XLibur reads but does not
+write itself: 3D pie, line, area and surface groups, and pie-of-pie / bar-of-pie.
 
 Chart type and title are settable after creation:
 

--- a/docs-website/docs/charts.md
+++ b/docs-website/docs/charts.md
@@ -414,6 +414,10 @@ workbook.Save();   // only the fill and the scale change; the trendline stays
 Chart type, title and series references are settable on charts you create, but on a loaded chart
 only the series formatting, data labels, legend and axes are written back.
 
+The two things that would need a rebuilt plot area rather than a patch throw `NotSupportedException`
+instead of quietly doing nothing: `Series.Add(...)` and moving a series with `UseSecondaryAxis`.
+Recreate the chart with `ws.Charts.Add(type)` if you need either.
+
 ## Chart types
 
 `XLChartType` covers the full Excel catalogue. Pick by data shape:

--- a/docs/specs/10-chart-formatting-depth.md
+++ b/docs/specs/10-chart-formatting-depth.md
@@ -3,7 +3,7 @@
 **Area:** Feature (flagship differentiator — upstream ClosedXML has no charts at all)
 **Effort:** L total, but splits into 4 independent PRs
 **Dependencies:** None.
-**Status:** In progress — PRs 1, 2 and 3 implemented; see [Results](#results-pr-1). PR 4 open.
+**Status:** ✅ All four PRs implemented — see [Results](#results-pr-1) per PR.
 
 ## Summary
 
@@ -183,14 +183,12 @@ reported a plain `Line` chart as `LineWithMarkers`.
 | 4 | Existing chart tests green; ChartEx unaffected | ✅ extended charts ignore series formatting and are not patched |
 | 5 | `XLibur.Examples` gains a formatted-chart sample | ✅ `FormattedChartExamples` — four sheets, validated by a test |
 
-### Notes for PR 4
+### Left for later
 
-- `ChartPlotAreaScanner` is the place to add group kinds the reader still ignores: `c:pie3DChart`,
-  `c:line3DChart`, `c:area3DChart`, `c:surface3DChart`, `c:ofPieChart`. Today a chart built from
-  those reads as zero series with a default chart type.
 - Title, chart type and series references are still write-only for new charts; editing them on a
   loaded chart does nothing. Making `chart.Title` work on a loaded chart is one more patch step on
   `ChartFormatting`.
+- Chart sheets still land in `UnsupportedSheets` (spec 09's territory).
 
 ## Results (PR 2)
 
@@ -279,3 +277,49 @@ editing the legend keeps its layout and text properties. `Legend.Visible = false
 what the writer did before this PR. Excel's own new charts do have value axis gridlines, so this is a
 plausible thing to change, but doing it silently would alter the output of every existing caller. Left
 as a deliberate decision to revisit, not an oversight.
+
+## Results (PR 4)
+
+Both reader gaps closed. 6416 tests pass on net8.0 and net10.0.
+
+### Anchors
+
+`ChartReader.LoadCharts` iterated `Elements<Xdr.TwoCellAnchor>()`, so a chart Excel had anchored with
+`xdr:oneCellAnchor` or `xdr:absoluteAnchor` never reached `ws.Charts` — invisible to the API, though
+its XML did survive a save because the writer never touches a loaded chart. It now walks every anchor
+child.
+
+Following the picture pattern the spec pointed at, the anchor kind is exposed as
+`IXLChart.Anchor` of the already-public `XLDrawingAnchor` enum, whose three values line up exactly
+with the three anchor elements, plus `Width`, `Height`, `Left` and `Top` in pixels — the same unit and
+the same 9525 EMU conversion `IXLPicture` uses. `XLPicturePlacement` would have been the closer
+analogue by name, but it lives in `XLibur.Excel.Drawings` and reads oddly on a chart;
+`XLDrawingAnchor` is in `XLibur.Excel` and was already public.
+
+The writer emits whichever anchor `Anchor` asks for. It defaults to `MoveAndSizeWithCells`, so charts
+built by existing callers are byte-identical to before.
+
+### Trendlines and error bars
+
+Preservation-only, as specified, and it needed no code: PR 1's patch approach never rewrites a series
+element wholesale. The fixture in `ChartRoundTripPreservationTests` now carries both a `c:trendline`
+and a `c:errBars`, and the test that edits the series' fill and line width asserts they are still
+there afterwards.
+
+### Also closed: the 3D and of-pie group kinds
+
+Not in the spec's PR 4 list, but the same class of bug and one line of the spec's "Current state":
+`c:pie3DChart`, `c:line3DChart`, `c:area3DChart`, `c:surface3DChart` and `c:ofPieChart` were not
+recognised by the plot-area scan, so an Excel-authored chart using one produced a chart object with no
+series and whatever `XLChartType` happens to be zero. They are now scanned like the 2D groups, their
+series and series formatting read the same way, `c:ofPieType` tells pie-of-pie from bar-of-pie, and
+`c:grouping` on `c:area3DChart` picks the stacked variants.
+
+**The writer is still asymmetric here** and this PR deliberately did not change it: XLibur writes
+`Pie3D` as a plain `c:pieChart`, `Line3D` as `c:lineChart`, `Area3D` as `c:areaChart` and every surface
+type as `c:surfaceChart`. Its own 3D charts therefore round-trip as their 2D equivalents. Fixing the
+writer would change the output of existing callers and is a separate, larger job — the 3D groups carry
+`c:view3D`, `c:floor`, `c:sideWall` and `c:backWall` on the chart, none of which is modelled. For the
+same reason `c:surfaceChart` is still read back as `Surface` rather than the `SurfaceContour` it
+strictly means: the writer emits it for `Surface`, and matching the reader to the spec's semantics
+would break XLibur's own round trip.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -19,7 +19,7 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 07 | [Formula function coverage (257→~420)](07-formula-function-coverage.md) | Feature | L | Proposed | **6 fully independent waves** |
 | 08 | [LET / LAMBDA](08-let-lambda.md) | Feature | L | Proposed | Single owner (engine core) |
 | 09 | [Threaded comments + round-trip fidelity](09-threaded-comments-roundtrip.md) | Feature · Compat | M | Proposed | Comments vs fidelity-audit split |
-| 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | 🚧 **PR 1 done** | 4 PRs, 2–3 independent |
+| 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | ✅ **Done** (PRs 1–4) | 4 PRs, 2–3 independent |
 | 11 | [Create-path allocation reduction](11-create-path-allocations.md) | Perf (write) | M | ✅ **Tasks 1–4 done** | Task 4 lands in 11; 05 rebases |
 
 Spec 11 was added after spec 03 landed: 03 halved the *save* phase and showed the rest of it is
@@ -31,17 +31,20 @@ Spec 02 delivered **−16.5% load time and −61.5% allocations** (4.750 s / 102
 correction to spec 03's number-formatting task, and a reusable `XmlReader.ReadValueChunk` technique
 for the IO layer. Both are recorded in spec 02's Results section.
 
-Spec 10's PR 1 settled the question the spec flagged as its own hard part: the chart writer never
-regenerates a chart it loaded, so unmodeled chart XML round-trips byte for byte, and edits are
-patched into the existing part instead. **PRs 2–4 should extend that patcher rather than add a second
-write path** — see spec 10's Results section. Turning the OpenXML validator on for the new chart
-tests also surfaced three long-standing schema violations in the chart writer, now fixed.
+Spec 10 landed in four PRs. Its PR 1 settled the question the spec flagged as its own hard part: the
+chart writer never regenerates a chart it loaded, so unmodeled chart XML round-trips byte for byte,
+and edits are patched into the existing part instead — PRs 2–4 extended that patcher rather than
+adding a second write path. Along the way, turning the OpenXML validator on for the new chart tests
+surfaced three long-standing schema violations in the chart writer, and the reader turned out to drop
+one-cell/absolute anchored charts and every 3D or of-pie chart group. All fixed; see spec 10's four
+Results sections. **Still open there:** the writer emits 3D pie/line/area and every surface type as
+their 2D group elements, so XLibur's own 3D charts round-trip as 2D.
 
 ## Why these ten (01–10)
 
 **Performance (specs 02, 03, 04, 05).** The write cell-loop and the sheetData parse have both had a round of tuning; what remains, in measured order: per-cell string allocations on load (`<v>` + attributes + SST DOM), the ~543 MB formatted save (number formatting, inherited-style resolution, StyleKey hashing), the full-workbook-recalc cliff when reading one dirty formula cell (can build a 176 MB dependency tree to answer one read), and O(all-ranges·log) work per single row insert. Specs 02–05 attack each with concrete targets.
 
-**Features (specs 01, 07, 08, 10).** The fork already leads upstream on charts, dynamic arrays, in-cell images, sparklines, WebP/SVG. The gaps that matter: no bounded-memory export path for huge files (01), ~250 missing formula functions with a clean registry to extend (07), no LET/LAMBDA (08 — the one function family that needs engine work), and charts that can't be styled (10 — depth on the flagship differentiator).
+**Features (specs 01, 07, 08, 10).** The fork already leads upstream on charts, dynamic arrays, in-cell images, sparklines, WebP/SVG. The gaps that matter: no bounded-memory export path for huge files (01), ~250 missing formula functions with a clean registry to extend (07), no LET/LAMBDA (08 — the one function family that needs engine work), and charts that couldn't be styled (10 — depth on the flagship differentiator, now done).
 
 **Compatibility (specs 06, 09).** Password-encrypted files can't be opened or written at all (06 — hard blocker, zero code exists). Threaded comments are read lossily and silently downgraded on save; chartsheets, form controls, and slicers are dropped on round-trip (09).
 
@@ -55,7 +58,7 @@ Wave 1 (independent, start anytime):
   11 Tasks 1–4 ✅ done (−28.8% on the write benchmark; bulk styling −86% per cell)
 Wave 2 (after 03 lands, or coordinated):
   01 streaming write (Phase 1 seam shared with 03's territory) · 06 encryption
-  10 charts PR1 ✅ done (series formatting, secondary axis, preservation groundwork) · PRs 2–4 open
+  10 charts ✅ done (PRs 1–4: series formatting, data labels, legend/axes, reader gaps)
 Wave 3 (single-owner, correctness-critical — don't parallelize internally):
   04 demand-driven eval · 05 structural edits · 08 LET/LAMBDA (08 after or alongside 04)
 ```


### PR DESCRIPTION
Restores spec 10 PR 4 and the chart follow-up fixes, which GitHub reports as merged but which never reached `main`.

## What happened

#223 and #229 were stacked: #223's base was `feat/chart-legend-axes` and #229's base was `feat/chart-anchor-reader-gaps`. Merging a PR merges it into **its own base branch**, so both squashes landed on their parent feature branches rather than on `main`:

| PR | squashed onto | commit |
|---|---|---|
| #222 | `main` ✅ | `9e03c627` |
| #223 | `feat/chart-legend-axes` ❌ | `3fe831d7` |
| #229 | `feat/chart-anchor-reader-gaps` ❌ | `2e073572` |

Each PR shows "Merged", and each is genuinely merged — just not into `main`. `main` currently ends at #222, so the anchor/reader work and every follow-up fix on top of it are absent.

## What this PR contains

The two orphaned commits replayed onto the current `main` (`rebase --onto upstream/main d817acef`), which is content-identical to what would have landed had the stack been merged bottom-up:

- **spec 10 PR 4** — one-cell and absolute anchor reading, 3D and of-pie chart groups, `IXLChart.Anchor`/`Width`/`Height`/`Left`/`Top`.
- **the follow-ups** (#229) — primary-axis binding independent of group order, `Series.Add` throwing on a loaded chart, `c:smooth` on new stock charts, chart-wide data labels reaching every group of a loaded combo chart, and the legend guard so positioning a hidden legend does not create one.

Rebasing rather than merging the branch matters here: `feat/chart-anchor-reader-gaps` forked before #224, so merging it would have reverted the benchmark cleanup. The diff against `main` touches no `XLibur.Benchmarks` file.

Solution builds warning-free; 6423 tests pass on net8.0 and net10.0.

## Afterwards

`feat/chart-legend-axes` and `feat/chart-anchor-reader-gaps` can be deleted once this lands — everything on them is either already in `main` or in this PR.
