### PR TITLE
refactor: extract LoadArrayFormulaXml to reduce SetCellFormulaXml complexity (S3776)

### DIFF
--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -469,22 +469,7 @@ internal static class WorksheetSheetDataReader
         }
         else if (formulaType == CellFormulaValues.Array && refAttr is not null)
         {
-            // Child cells of an array may have an array type but no ref (reserved for the master cell).
-            var arrayArea = XLSheetRange.Parse(refAttr);
-            var isDynamicArray = cellMetaIndex is { } cm &&
-                                 dynamicArrayCmIndexes is not null &&
-                                 dynamicArrayCmIndexes.Contains(cm);
-            if (isDynamicArray)
-            {
-                formula = XLCellFormula.DynamicArrayA1(formulaText);
-                formula.Range = arrayArea;
-                formulaSlice.SetDuringLoad(cellAddress, formula);
-            }
-            else
-            {
-                formula = XLCellFormula.Array(formulaText, arrayArea, aca);
-                formulaSlice.SetArray(arrayArea, formula);
-            }
+            formula = LoadArrayFormulaXml(formulaText, refAttr, aca, cellAddress, cellMetaIndex, dynamicArrayCmIndexes, formulaSlice);
         }
         else if (formulaType == CellFormulaValues.Shared && sharedIndex is { } si)
         {
@@ -496,6 +481,28 @@ internal static class WorksheetSheetDataReader
         }
 
         return formula;
+    }
+
+    private static XLCellFormula LoadArrayFormulaXml(string formulaText, string refAttr, bool aca,
+        XLSheetPoint cellAddress, uint? cellMetaIndex, HashSet<uint>? dynamicArrayCmIndexes,
+        FormulaSlice formulaSlice)
+    {
+        // Child cells of an array may have an array type but no ref (reserved for the master cell).
+        var arrayArea = XLSheetRange.Parse(refAttr);
+        var isDynamicArray = cellMetaIndex is { } cm &&
+                             dynamicArrayCmIndexes is not null &&
+                             dynamicArrayCmIndexes.Contains(cm);
+        if (isDynamicArray)
+        {
+            var formula = XLCellFormula.DynamicArrayA1(formulaText);
+            formula.Range = arrayArea;
+            formulaSlice.SetDuringLoad(cellAddress, formula);
+            return formula;
+        }
+
+        var arrayFormula = XLCellFormula.Array(formulaText, arrayArea, aca);
+        formulaSlice.SetArray(arrayArea, arrayFormula);
+        return arrayFormula;
     }
 
     private static XLCellFormula LoadDataTableFormulaXml(string refAttr, string? r1Attr, string? r2Attr,

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -483,11 +483,15 @@ internal static class WorksheetSheetDataReader
         return formula;
     }
 
+    /// <summary>
+    /// Loads a classic or dynamic array formula from a master <c>&lt;f t="array"&gt;</c> cell.
+    /// Child cells of an array may have an array type but no <c>ref</c> (reserved for the master cell);
+    /// callers only invoke this when <c>ref</c> is present.
+    /// </summary>
     private static XLCellFormula LoadArrayFormulaXml(string formulaText, string refAttr, bool aca,
         XLSheetPoint cellAddress, uint? cellMetaIndex, HashSet<uint>? dynamicArrayCmIndexes,
         FormulaSlice formulaSlice)
     {
-        // Child cells of an array may have an array type but no ref (reserved for the master cell).
         var arrayArea = XLSheetRange.Parse(refAttr);
         var isDynamicArray = cellMetaIndex is { } cm &&
                              dynamicArrayCmIndexes is not null &&


### PR DESCRIPTION
## Summary

- Extract array / dynamic-array formula loading from `SetCellFormulaXml` into `LoadArrayFormulaXml`, matching the existing `LoadSharedFormula` / `LoadDataTableFormulaXml` helpers.
- Clears SonarCloud [S3776](https://sonarcloud.io/project/issues?impactSeverities=HIGH&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-SS8zGaG0jWV9Gpqg7) (cognitive complexity 21 → ≤15) on the sheet-data formula hot path.

## Changes

- `WorksheetSheetDataReader.SetCellFormulaXml` delegates array formulas to `LoadArrayFormulaXml`
- New `LoadArrayFormulaXml` owns the dynamic-array vs classic array branch

## Related Issues

- SonarCloud: https://sonarcloud.io/project/issues?impactSeverities=HIGH&issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-SS8zGaG0jWV9Gpqg7

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually (describe below if applicable)

Behavior unchanged; extraction only. Existing formula load coverage continues to exercise this path.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch