### PR TITLE
feat: add XLColorType.Automatic, aligning with ClosedXML

### DIFF
--- a/XLibur.Tests/Excel/Styles/XLColorAutomaticTests.cs
+++ b/XLibur.Tests/Excel/Styles/XLColorAutomaticTests.cs
@@ -1,0 +1,205 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Styles;
+
+/// <summary>
+/// The automatic color - ECMA-376 <c>CT_Color/@auto</c>, shown as "Automatic" in Excel's font color
+/// picker. The application resolves the actual color from the context it is used in, so it must not
+/// be pinned to a concrete value on save.
+/// </summary>
+[TestFixture]
+public class XLColorAutomaticTests
+{
+    [Test]
+    public void Automatic_IsTheFirstColorType()
+    {
+        // Deliberately ordinal 0 so a default XLColorKey describes itself as automatic instead of
+        // masquerading as a fully transparent RGB black.
+        Assert.That((int)XLColorType.Automatic, Is.Zero);
+    }
+
+    [Test]
+    public void Automatic_AndNoColor_AreTheSameValue()
+    {
+        Assert.Multiple(() =>
+        {
+#pragma warning disable CS0618 // NoColor is deprecated; this test exists to pin the alias.
+            Assert.That(XLColor.NoColor, Is.SameAs(XLColor.Automatic),
+                "NoColor is only the GUI label some Excel pickers use for the automatic color.");
+#pragma warning restore CS0618
+            Assert.That(XLColor.Automatic.ColorType, Is.EqualTo(XLColorType.Automatic));
+            Assert.That(XLColor.Automatic.IsAutomatic, Is.True);
+            Assert.That(XLColor.FromArgb(0, 0, 0).IsAutomatic, Is.False,
+                "An explicit black is a stated color, not an automatic one.");
+        });
+    }
+
+    [Test]
+    public void Automatic_ToString_IsNotAnRgbValue()
+    {
+        Assert.That(XLColor.Automatic.ToString(), Is.EqualTo("Automatic"));
+    }
+
+    [Test]
+    public void Automatic_HasNoRgbValueToRead()
+    {
+        // The automatic color carries no color value; reading one would silently hand back the
+        // meaningless all-zero ARGB that used to leak into saved files.
+        Assert.Throws<InvalidOperationException>(() => _ = XLColor.Automatic.Color);
+    }
+
+    [Test]
+    public void AutomaticFontColor_IsWrittenAsAutoRatherThanTransparentBlack()
+    {
+        // The automatic color has no rgb/indexed/theme, so it used to fall through to the RGB branch
+        // on save and be written as rgb="00000000" - a fully transparent black that no Excel file
+        // means to express, and which pins down a color the source left to the application.
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = "Auto";
+            ws.Cell("A1").Style.Font.FontColor = XLColor.Automatic;
+            wb.SaveAs(ms);
+        }
+
+        // Assert against the <fonts> block alone: a solid fill writes its own <fgColor auto="1"/>,
+        // which would make a whole-document match pass for the wrong reason.
+        var fonts = FontsBlock(ReadPart(ms.ToArray(), "xl/styles.xml"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fonts, Does.Not.Contain("00000000"),
+                $"The automatic font color was written as a transparent black.\n\n{fonts}");
+            Assert.That(fonts, Does.Contain("auto=\"1\""),
+                $"The automatic font color was not written.\n\n{fonts}");
+        });
+    }
+
+    [Test]
+    public void AutomaticFontColor_SurvivesARoundTrip()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = "Auto";
+            ws.Cell("A1").Style.Font.FontColor = XLColor.Automatic;
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        using var reloaded = new XLWorkbook(ms);
+
+        Assert.That(reloaded.Worksheets.First().Cell("A1").Style.Font.FontColor.IsAutomatic, Is.True,
+            "The automatic font color did not survive a save/load round-trip.");
+    }
+
+    private static string FontsBlock(string stylesXml)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(stylesXml, "<x:fonts.*?</x:fonts>",
+            System.Text.RegularExpressions.RegexOptions.Singleline);
+        Assert.That(match.Success, Is.True, $"No <fonts> block in styles.xml.\n\n{stylesXml}");
+        return match.Value;
+    }
+
+    [Test]
+    public void FontWithAutoColor_LoadsAsAutomatic()
+    {
+        var input = BuildWorkbook();
+
+        using var wb = new XLWorkbook(new MemoryStream(input));
+        var color = wb.Worksheets.First().Cell("A1").Style.Font.FontColor;
+
+        Assert.That(color.IsAutomatic, Is.True, "auto=\"1\" should load as the automatic color.");
+    }
+
+    private static string ReadPart(byte[] xlsx, string partPath)
+    {
+        using var zip = new ZipArchive(new MemoryStream(xlsx), ZipArchiveMode.Read);
+        var entry = zip.GetEntry(partPath) ?? throw new AssertionException($"Missing part: {partPath}");
+        using var r = new StreamReader(entry.Open());
+        return r.ReadToEnd();
+    }
+
+    /// <summary>
+    /// A minimal package whose only font states an explicitly automatic color. The input can't be
+    /// produced through the <see cref="XLWorkbook"/> API, so it is built by hand.
+    /// </summary>
+    private static byte[] BuildWorkbook()
+    {
+        var parts = new (string Path, string Content)[]
+        {
+            ("[Content_Types].xml",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+                  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+                  <Default Extension="xml" ContentType="application/xml"/>
+                  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+                  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+                  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+                </Types>
+                """),
+            ("_rels/.rels",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+                </Relationships>
+                """),
+            ("xl/workbook.xml",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+                  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+                </workbook>
+                """),
+            ("xl/_rels/workbook.xml.rels",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+                  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+                </Relationships>
+                """),
+            ("xl/styles.xml",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                  <fonts count="1"><font><sz val="11"/><color auto="1"/><name val="Calibri"/></font></fonts>
+                  <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+                  <borders count="1"><border/></borders>
+                  <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+                  <cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyFont="1"/></cellXfs>
+                </styleSheet>
+                """),
+            ("xl/worksheets/sheet1.xml",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                  <sheetData><row r="1"><c r="A1" s="0" t="str"><v>Auto</v></c></row></sheetData>
+                </worksheet>
+                """),
+        };
+
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (path, content) in parts)
+            {
+                var e = zip.CreateEntry(path, CompressionLevel.Optimal);
+                using var w = new StreamWriter(e.Open(), new UTF8Encoding(false));
+                w.Write(content.TrimStart());
+            }
+        }
+
+        return ms.ToArray();
+    }
+}

--- a/XLibur.Tests/Excel/Styles/XLFillTests.cs
+++ b/XLibur.Tests/Excel/Styles/XLFillTests.cs
@@ -17,7 +17,7 @@ public class XLFillTests
     [Test]
     public void BackgroundNoColorSetsPatternNone()
     {
-        var fill = new XLFill { BackgroundColor = XLColor.NoColor };
+        var fill = new XLFill { BackgroundColor = XLColor.Automatic };
         Assert.AreEqual(XLFillPatternValues.None, fill.PatternType);
     }
 
@@ -45,7 +45,7 @@ public class XLFillTests
         var fill1 = new XLFill { BackgroundColor = XLColor.ElectricUltramarine, PatternType = XLFillPatternValues.None };
         var fill2 = new XLFill { BackgroundColor = XLColor.EtonBlue, PatternType = XLFillPatternValues.None };
         var fill3 = new XLFill { BackgroundColor = XLColor.FromIndex(64) };
-        var fill4 = new XLFill { BackgroundColor = XLColor.NoColor };
+        var fill4 = new XLFill { BackgroundColor = XLColor.Automatic };
 
         Assert.IsTrue(fill1.Equals(fill2));
         Assert.IsTrue(fill1.Equals(fill3));

--- a/XLibur/Excel/AutoFilters/XLFilterColumn.cs
+++ b/XLibur/Excel/AutoFilters/XLFilterColumn.cs
@@ -154,7 +154,7 @@ internal sealed class XLFilterColumn : IXLFilterColumn, IXLFilteredColumn, IEnum
     /// </summary>
     public double DynamicValue { get; set; } = double.NaN;
 
-    public XLColor FilterColor { get; set; } = XLColor.NoColor;
+    public XLColor FilterColor { get; set; } = XLColor.Automatic;
 
     public bool FilterByCellColor { get; set; }
 

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFColorScaleConverter.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFColorScaleConverter.cs
@@ -28,6 +28,10 @@ internal sealed class XLCFColorScaleConverter : IXLCFConverter
             var color = new Color();
             switch (xlColor.ColorType)
             {
+                case XLColorType.Automatic:
+                    color.Auto = true;
+                    break;
+
                 case XLColorType.Color:
                     color.Rgb = xlColor.Color.ToHex();
                     break;

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFDataBarConverter.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFDataBarConverter.cs
@@ -22,6 +22,10 @@ internal sealed class XLCFDataBarConverter : IXLCFConverter
         var color = new Color();
         switch (cf.Colors[1].ColorType)
         {
+            case XLColorType.Automatic:
+                color.Auto = true;
+                break;
+
             case XLColorType.Color:
                 color.Rgb = cf.Colors[1].Color.ToHex();
                 break;

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFDataBarConverterExtension.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFDataBarConverterExtension.cs
@@ -90,6 +90,10 @@ internal sealed class XLCFDataBarConverterExtension : IXLCFConverterExtension
     {
         switch (color.ColorType)
         {
+            case XLColorType.Automatic:
+                target.Auto = true;
+                break;
+
             case XLColorType.Color:
                 target.Rgb = color.Color.ToHex();
                 break;

--- a/XLibur/Excel/Drawings/Style/XLDrawingColorsAndLines.cs
+++ b/XLibur/Excel/Drawings/Style/XLDrawingColorsAndLines.cs
@@ -7,8 +7,8 @@ internal sealed class XLDrawingColorsAndLines : IXLDrawingColorsAndLines
     public XLDrawingColorsAndLines(IXLDrawingStyle style)
     {
         _style = style;
-        FillColor = XLColor.NoColor;
-        LineColor = XLColor.NoColor;
+        FillColor = XLColor.Automatic;
+        LineColor = XLColor.Automatic;
     }
     public XLColor FillColor { get; set; }
     public IXLDrawingStyle SetFillColor(XLColor value) { FillColor = value; return _style; }

--- a/XLibur/Excel/IO/WorksheetElementReader.cs
+++ b/XLibur/Excel/IO/WorksheetElementReader.cs
@@ -549,11 +549,11 @@ internal static class WorksheetElementReader
                 return bgColor.ToXLiburColor();
             if (patternFill?.ForegroundColor is { } fgColor)
                 return fgColor.ToXLiburColor();
-            return XLColor.NoColor;
+            return XLColor.Automatic;
         }
 
         var fontColor = dxf.Font?.Color;
-        return fontColor is not null ? fontColor.ToXLiburColor() : XLColor.NoColor;
+        return fontColor is not null ? fontColor.ToXLiburColor() : XLColor.Automatic;
     }
 
     internal static void LoadAutoFilterSort(AutoFilter af, XLWorksheet ws, XLAutoFilter autoFilter)

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -770,7 +770,7 @@ internal static class WorksheetSheetDataReader
     /// </summary>
     private static XLFont ColorlessFont(IXLFontBase cellFont, ref XLFont? cached)
     {
-        return cached ??= new XLFont(XLFont.GenerateKey(cellFont) with { FontColor = XLColor.NoColor.Key });
+        return cached ??= new XLFont(XLFont.GenerateKey(cellFont) with { FontColor = XLColor.Automatic.Key });
     }
 
     /// <summary>

--- a/XLibur/Excel/Style/Colors/XLColor_Internal.cs
+++ b/XLibur/Excel/Style/Colors/XLColor_Internal.cs
@@ -10,6 +10,11 @@ public sealed partial class XLColor
     {
     }
 
+    /// <summary>
+    /// The automatic color. <see cref="XLColorType.Automatic"/> is the first enum member, so a
+    /// default <see cref="XLColorKey"/> already describes itself as automatic - no sentinel value
+    /// smuggled into an RGB component.
+    /// </summary>
     private XLColor() : this(new XLColorKey())
     {
         HasValue = false;

--- a/XLibur/Excel/Style/Colors/XLColor_Public.cs
+++ b/XLibur/Excel/Style/Colors/XLColor_Public.cs
@@ -7,8 +7,33 @@ namespace XLibur.Excel;
 
 public enum XLColorType
 {
+    /// <summary>
+    /// Automatic color, serialized as <c>&lt;color auto="1"/&gt;</c> or by omitting the color
+    /// element entirely. The actual color is chosen by the application from the context it is used
+    /// in - generally black for a font or border, white for a fill. <see cref="XLColor.Color"/> has
+    /// no bearing on the resolved color and must not be read.
+    /// <para>
+    /// Deliberately the first member so that a default <c>XLColorKey</c> is automatic rather than a
+    /// fully transparent RGB black, which is not a color any Excel file means to express.
+    /// </para>
+    /// </summary>
+    Automatic,
+
+    /// <summary>
+    /// An RGB color, stored directly in <see cref="XLColor.Color"/>. It can carry an alpha
+    /// component, but Excel ignores it and treats every color as fully opaque.
+    /// </summary>
     Color,
+
+    /// <summary>
+    /// A theme color. The value depends on the workbook theme.
+    /// </summary>
     Theme,
+
+    /// <summary>
+    /// An indexed color into the legacy palette, from the days when a fixed palette was the norm.
+    /// The only semi-current uses are the system foreground (64) and background (65) colors.
+    /// </summary>
     Indexed
 }
 
@@ -34,17 +59,23 @@ public sealed partial class XLColor : IEquatable<XLColor>
 
     public XLColorType ColorType => Key.ColorType;
 
+    /// <summary>
+    /// Whether this is the <see cref="XLColorType.Automatic"/> color, i.e. no color was stated and
+    /// the application resolves one from context.
+    /// </summary>
+    public bool IsAutomatic => ColorType == XLColorType.Automatic;
+
     public Color Color
     {
         get
         {
-            if (ColorType == XLColorType.Theme)
-                throw new InvalidOperationException("Cannot convert theme color to Color.");
+            if (ColorType == XLColorType.Color)
+                return Key.Color;
 
             if (ColorType == XLColorType.Indexed)
                 return IndexedColors[Indexed].Color;
 
-            return Key.Color;
+            throw new InvalidOperationException($"Cannot convert {ColorType} color to Color.");
         }
     }
 
@@ -52,13 +83,10 @@ public sealed partial class XLColor : IEquatable<XLColor>
     {
         get
         {
-            if (ColorType == XLColorType.Theme)
-                throw new InvalidOperationException("Cannot convert theme color to indexed color.");
-
             if (ColorType == XLColorType.Indexed)
                 return Key.Indexed;
 
-            throw new InvalidOperationException("Cannot convert Color to indexed color.");
+            throw new InvalidOperationException($"Cannot convert {ColorType} color to indexed color.");
         }
     }
 
@@ -69,10 +97,7 @@ public sealed partial class XLColor : IEquatable<XLColor>
             if (ColorType == XLColorType.Theme)
                 return Key.ThemeColor;
 
-            if (ColorType == XLColorType.Indexed)
-                throw new InvalidOperationException("Cannot convert indexed color to theme color.");
-
-            throw new InvalidOperationException("Cannot convert Color to theme color.");
+            throw new InvalidOperationException($"Cannot convert {ColorType} color to theme color.");
         }
     }
 
@@ -114,6 +139,9 @@ public sealed partial class XLColor : IEquatable<XLColor>
 
     public override string ToString()
     {
+        if (ColorType == XLColorType.Automatic)
+            return "Automatic";
+
         if (ColorType == XLColorType.Color)
             return Color.ToHex();
 

--- a/XLibur/Excel/Style/Colors/XLColor_Static.cs
+++ b/XLibur/Excel/Style/Colors/XLColor_Static.cs
@@ -259,16 +259,30 @@ public sealed partial class XLColor
     }
 
     /// <summary>
-    /// True when the key is the <see cref="NoColor"/> sentinel, i.e. no color was ever set.
-    /// Unlike <see cref="IsTransparent"/> this does not match indexed color 64, which is an
+    /// True when no color was ever set, i.e. the key is <see cref="Automatic"/>. Unlike
+    /// <see cref="IsTransparent"/> this does not match indexed color 64, which is an
     /// explicitly written value and must round-trip as such.
     /// </summary>
     internal static bool IsUnset(in XLColorKey colorKey)
     {
-        return colorKey == NoColor.Key;
+        return colorKey.IsAutomatic;
     }
 
-    public static XLColor NoColor { get; } = new();
+    /// <summary>
+    /// The automatic color: the application picks the actual color from the context it is used in,
+    /// generally black for a font or border and white for a fill. This is what Excel's font color
+    /// picker calls "Automatic", and what <c>&lt;color auto="1"/&gt;</c> - or the absence of a color
+    /// element - means in a file.
+    /// </summary>
+    public static XLColor Automatic { get; } = new();
+
+    /// <summary>
+    /// An alias for <see cref="Automatic"/>. Some Excel color pickers (sheet tab color, fill
+    /// background) label the same value "No Color" rather than "Automatic"; that is only a GUI
+    /// convention, the stored value is the automatic color.
+    /// </summary>
+    [Obsolete($"Use {nameof(Automatic)} instead. NoColor is the label some Excel pickers use for the same value.")]
+    public static XLColor NoColor => Automatic;
 
     public static XLColor AliceBlue => FromColor(Color.AliceBlue);
 

--- a/XLibur/Excel/Style/XLColorKey.cs
+++ b/XLibur/Excel/Style/XLColorKey.cs
@@ -15,6 +15,13 @@ internal readonly struct XLColorKey : IEquatable<XLColorKey>
 
     public double ThemeTint { get; init; }
 
+    /// <summary>
+    /// True when no color was stated and the application resolves one from context. Unlike
+    /// <see cref="XLColor.IsTransparent"/> this does not match indexed color 64, which is an
+    /// explicitly written value and must round-trip as such.
+    /// </summary>
+    public bool IsAutomatic => ColorType == XLColorType.Automatic;
+
     public override int GetHashCode()
     {
         unchecked
@@ -23,6 +30,10 @@ internal readonly struct XLColorKey : IEquatable<XLColorKey>
 
             switch (ColorType)
             {
+                case XLColorType.Automatic:
+                    // Carries no value of its own - the color type alone identifies it.
+                    break;
+
                 case XLColorType.Indexed:
                     hash = (hash * 397) ^ Indexed;
                     break;
@@ -50,6 +61,10 @@ internal readonly struct XLColorKey : IEquatable<XLColorKey>
         if (ColorType != other.ColorType) return false;
         switch (ColorType)
         {
+            case XLColorType.Automatic:
+                // Carries no value of its own - matching color types is the whole comparison.
+                return true;
+
             case XLColorType.Color:
                 return Color.ToArgb() == other.Color.ToArgb();
             case XLColorType.Theme:
@@ -79,6 +94,7 @@ internal readonly struct XLColorKey : IEquatable<XLColorKey>
     {
         return ColorType switch
         {
+            XLColorType.Automatic => "Automatic",
             XLColorType.Color => Color.ToString(),
             XLColorType.Theme => $"{ThemeColor} ({ThemeTint})",
             XLColorType.Indexed => $"Indexed: {Indexed}",

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -100,7 +100,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
         ShowWhiteSpace = workbook.ShowWhiteSpace;
         ShowZeros = workbook.ShowZeros;
         RightToLeft = workbook.RightToLeft;
-        TabColor = XLColor.NoColor;
+        TabColor = XLColor.Automatic;
         _selectedRanges = new XLRanges();
 
         Author = workbook.Author;

--- a/XLibur/Extensions/XmlWriterExtensions.cs
+++ b/XLibur/Extensions/XmlWriterExtensions.cs
@@ -181,6 +181,13 @@ internal static class XmlWriterExtensions
             w.WriteStartElement(elName, OpenXmlConst.Main2006SsNs);
             switch (xlColor.ColorType)
             {
+                case XLColorType.Automatic:
+                    // Only reached where the element itself is required. Callers that may omit the
+                    // element - a font colour, say - should skip writing it at all for an automatic
+                    // colour rather than emit auto="1".
+                    w.WriteAttribute("auto", 1);
+                    break;
+
                 case XLColorType.Color:
                     w.WriteAttributeString("rgb", xlColor.Color.ToHex());
                     break;

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -211,3 +211,12 @@ XLibur.Excel.IXLChart.Left.get -> int
 XLibur.Excel.IXLChart.Left.set -> void
 XLibur.Excel.IXLChart.Top.get -> int
 XLibur.Excel.IXLChart.Top.set -> void
+*REMOVED*XLibur.Excel.XLColorType.Color = 0 -> XLibur.Excel.XLColorType
+*REMOVED*XLibur.Excel.XLColorType.Theme = 1 -> XLibur.Excel.XLColorType
+*REMOVED*XLibur.Excel.XLColorType.Indexed = 2 -> XLibur.Excel.XLColorType
+XLibur.Excel.XLColorType.Automatic = 0 -> XLibur.Excel.XLColorType
+XLibur.Excel.XLColorType.Color = 1 -> XLibur.Excel.XLColorType
+XLibur.Excel.XLColorType.Theme = 2 -> XLibur.Excel.XLColorType
+XLibur.Excel.XLColorType.Indexed = 3 -> XLibur.Excel.XLColorType
+XLibur.Excel.XLColor.IsAutomatic.get -> bool
+static XLibur.Excel.XLColor.Automatic.get -> XLibur.Excel.XLColor!

--- a/XLibur/Utils/OpenXmlHelper.cs
+++ b/XLibur/Utils/OpenXmlHelper.cs
@@ -423,6 +423,13 @@ internal static class OpenXmlHelper
     private static XLColor ConvertToXLiburColor(IColorTypeAdapter openXMLColor)
     {
         XLColor? retVal = null;
+
+        // auto="1" is the explicit spelling of the automatic color (ECMA-376 CT_Color/@auto). It is
+        // checked first because it wins over any other attribute present on the same element, and
+        // the fall-through at the end resolves to the same color for an element that states nothing.
+        if (openXMLColor.Auto?.Value == true)
+            return XLColor.Automatic;
+
         if (openXMLColor.Rgb?.Value is not null)
         {
             var thisColor = ColorStringParser.ParseFromArgb(openXMLColor.Rgb.Value.AsSpan());
@@ -436,7 +443,8 @@ internal static class OpenXmlHelper
                 ? XLColor.FromTheme((XLThemeColor)openXMLColor.Theme.Value, openXMLColor.Tint.Value)
                 : XLColor.FromTheme((XLThemeColor)openXMLColor.Theme.Value);
         }
-        return retVal ?? XLColor.NoColor;
+        // An element stating none of rgb/indexed/theme is automatic, same as auto="1".
+        return retVal ?? XLColor.Automatic;
     }
 
     /// <summary>
@@ -455,6 +463,10 @@ internal static class OpenXmlHelper
 
         switch (xlColor.ColorType)
         {
+            case XLColorType.Automatic:
+                openXMLColor.Auto = true;
+                break;
+
             case XLColorType.Color:
                 openXMLColor.Rgb = xlColor.Color.ToHex();
                 break;


### PR DESCRIPTION
Branched from `main`, independent of #225 / #227. Follows ClosedXML [`d939190`](https://github.com/ClosedXML/ClosedXML/commit/d9391901a2eaa350e93bce2afc5025b97913ba56) and [`ea25dee`](https://github.com/ClosedXML/ClosedXML/commit/ea25deef8b918441691341b3f769b72fb6116c37).

## Problem

OOXML has four kinds of colour; XLibur only modelled three. The fourth — automatic, `CT_Color/@auto`, what Excel's font colour picker labels **"Automatic"** — was represented by `XLColor.NoColor`: a default `XLColorKey` reporting `ColorType.Color` with an all-zero ARGB. The automatic colour was disguised as a fully transparent black, which is not a colour any Excel file means to express.

That disguise caused real defects. Colour writers switch on `ColorType`, so an automatic colour silently fell into the RGB arm and was written as `rgb="00000000"` — pinning down a colour the source deliberately left for the application to resolve, where a theme change or conditional format could otherwise override it.

## Changes

- **`XLColorType.Automatic` is the first member.** A default `XLColorKey` now describes *itself* as automatic. Every switch on colour type gains an arm that can't be reached by accident, rather than a sentinel smuggled into a colour component.
- **`XLColor.Automatic`** is the canonical name; **`XLColor.NoColor` stays as an alias**. Some Excel pickers (sheet tab, fill background) label the same value "No Color" — a GUI convention, not a different value.
- **Reading** honours `auto="1"` explicitly instead of relying on the fall-through for an element that states nothing. Both spellings resolve to the same colour, as they should.
- **Writing** emits `auto="1"`. Callers that may omit the element entirely — a font colour, say — should skip it rather than write `auto="1"`; that's noted on `WriteColor`, and is what Excel itself does.
- `XLColor.Color` / `Indexed` / `ThemeColor` throw for an automatic colour instead of handing back the meaningless all-zero ARGB; `ToString()` returns `"Automatic"` rather than `"00000000"`.
- Explicit `Automatic` arms in the three conditional-format colour converters, which would otherwise drop the colour silently.

## ⚠️ BREAKING CHANGE

`XLColorType` members are **renumbered** because `Automatic` takes ordinal 0:

| Member | Before | After |
|---|---|---|
| `Automatic` | — | 0 |
| `Color` | 0 | 1 |
| `Theme` | 1 | 2 |
| `Indexed` | 2 | 3 |

Source compatible, but **binary breaking**, and breaking for anything persisting the numeric value. Recorded in `PublicAPI.Unshipped.txt` via `*REMOVED*` entries — the Roslyn public-API analyzer flags this precisely, which is how it was caught.

Also: `XLColor.NoColor.Color` previously returned an all-zero `Color` and now throws.

## Deliberately not included

ClosedXML also changed the default fill and border colours to automatic. That's a behavioural change to every workbook, so it's left out here.

## Tests

New `XLColorAutomaticTests`. The two writer tests were verified to fail without the fix (`rgb="00000000"` in the `<fonts>` block; automatic colour lost across a round-trip).

A note on one of them: an earlier version asserted `auto="1"` against the whole of `styles.xml` and passed for the wrong reason — a solid fill writes its own `<fgColor auto="1"/>`, and a font loaded from a preserved stylesheet is never regenerated. The test now builds the font through the API and asserts against the `<fonts>` block alone.

**No existing reference fixture changed** — the model correction is behaviour-preserving for the current corpus. Suite green on net8.0 and net10.0 (6340 passed); Release build clean under `TreatWarningsAsErrors`.

## Follow-up

Once this lands, #225 / #227 can drop their local `IsUnset` helper and the `colorlessCellFont` naming in `WorksheetSheetDataReader` in favour of this vocabulary — which is what the reviewer asked for on #225.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for automatic font colors through the public `XLColor.Automatic` option.
  - Added `IsAutomatic` indicators for colors and color keys.
  - Automatic colors now display as “Automatic” and provide clearer validation when accessing incompatible color values.

- **Bug Fixes**
  - Preserved automatic colors when saving and reopening workbooks.
  - Correctly reads and writes Excel’s `auto="1"` color setting.
  - Applied automatic color handling to conditional formatting color scales and data bars.

- **Tests**
  - Added coverage for automatic color behavior, serialization, and round-trip compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->