### PR TITLE
chore: disable CodeRabbit automatic PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,8 +7,9 @@ reviews:
   poem: false
   review_status: true
   sequence_diagrams: true
+  # Reviews are triggered manually by commenting `@coderabbitai review` on a PR.
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
   path_filters:
     - '!**/*.trx'


### PR DESCRIPTION
## Summary

CodeRabbit no longer reviews pull requests automatically on open/push. Reviews are now opt-in per PR.

## Changes

- `.coderabbit.yaml`: `reviews.auto_review.enabled` → `false`, with a comment noting the manual trigger.

## How to run a review

Comment on the PR:

- `@coderabbitai review` — incremental review of new changes
- `@coderabbitai full review` — review the whole PR from scratch

`chat.auto_reply` is left enabled so those comments are picked up.
