### PR TITLE
chore: remove unused ParseRowIndex wrapper

### DIFF
--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -1347,17 +1347,9 @@ internal static class WorksheetSheetDataReader
 
     /// <summary>
     /// Fast-path parser for non-negative integer strings as found in OOXML shared string
-    /// indices. Only accepts pure ASCII digit sequences with no whitespace or signs.
+    /// indices and similar attributes. Only accepts pure ASCII digit sequences with no
+    /// whitespace or signs.
     /// </summary>
-    /// <summary>
-    /// Parse a row index attribute value. Row indices in OOXML are always positive integers.
-    /// </summary>
-    private static int ParseRowIndex(ReadOnlySpan<char> s)
-    {
-        TryParseOoxmlNonNegativeInt(s, out var result);
-        return result;
-    }
-
     private static bool TryParseOoxmlNonNegativeInt(ReadOnlySpan<char> s, out int result)
     {
         result = 0;


### PR DESCRIPTION
## Summary

- Remove unused `ParseRowIndex` from `WorksheetSheetDataReader` — it only forwarded to `TryParseOoxmlNonNegativeInt` and had no callers.
- Move the orphaned fast-path parser docs onto `TryParseOoxmlNonNegativeInt`, where they belong.

## Changes

- Delete `ParseRowIndex`
- Attach the OOXML non-negative int parser summary to `TryParseOoxmlNonNegativeInt`

## Related Issues

- Split out from the S3776 work on #231 so that PR stays extraction-only

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually (describe below if applicable)

No behavior change; dead private helper only.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch