### PR TITLE
chore: use XLChartSeries in ChartWriter private helpers (CA1859)

### DIFF
--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -955,7 +955,7 @@ internal static class ChartWriter
         chartElement.Append(new C.AxisId { Val = group.ValAxisIdOfGroup });
     }
 
-    private static void AppendCatAndVal(OpenXmlCompositeElement series, IXLChartSeries s)
+    private static void AppendCatAndVal(OpenXmlCompositeElement series, XLChartSeries s)
     {
         if (!string.IsNullOrWhiteSpace(s.CategoryReferences))
         {
@@ -968,7 +968,7 @@ internal static class ChartWriter
         ));
     }
 
-    private static void AppendXAndY(OpenXmlCompositeElement series, IXLChartSeries s)
+    private static void AppendXAndY(OpenXmlCompositeElement series, XLChartSeries s)
     {
         if (!string.IsNullOrWhiteSpace(s.CategoryReferences))
         {
@@ -1031,7 +1031,7 @@ internal static class ChartWriter
     /// <c>c:strRef</c>, is for names that come from a cell and requires a <c>c:f</c> formula, which
     /// a literal name does not have.
     /// </summary>
-    private static C.SeriesText BuildSeriesText(IXLChartSeries s) =>
+    private static C.SeriesText BuildSeriesText(XLChartSeries s) =>
         new(new C.NumericValue(s.Name));
 
     /// <summary>EMU per pixel, the unit the drawing markers and extents are stored in.</summary>


### PR DESCRIPTION
## Summary

- Change three private `ChartWriter` helpers from `IXLChartSeries` to `XLChartSeries` so they match their call sites and clear SonarCloud/Roslyn CA1859.
- Callers already pass concrete `XLChartSeries` from `SeriesInternal.Items` / `group.Series`; nearby helpers (`AppendShapeProperties`, `AppendMarker`, …) already use the concrete type.

## Changes

- `AppendCatAndVal(…, XLChartSeries s)`
- `AppendXAndY(…, XLChartSeries s)`
- `BuildSeriesText(XLChartSeries s)`

## Related Issues

- https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-cMR8yZiQzo-vEaiC7 (`AppendCatAndVal`, L958)
- https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-cMR8yZiQzo-vEaiC5 (`AppendXAndY`, L971)
- Same CA1859 finding on `BuildSeriesText` (L1034)

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually (describe below if applicable)

Signature-only change on private helpers; no behavior change.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch