### PR TITLE
chore: replace OpenXml namespace URI literals with OpenXmlConst (S1075)

### DIFF
--- a/XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs
@@ -8,6 +8,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using SpreadsheetFonts = DocumentFormat.OpenXml.Spreadsheet.Fonts;
+using XLibur.Excel.IO;
 
 namespace XLibur.Benchmarks;
 
@@ -24,7 +25,7 @@ namespace XLibur.Benchmarks;
 public class OpenXmlWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
-    private const string Ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    private const string Ns = OpenXmlConst.Main2006SsNs;
 
     private string[] _strings = null;
     private double[] _numbers = null;

--- a/XLibur.Tests/Excel/PageSetup/HeaderFooterImageTests.cs
+++ b/XLibur.Tests/Excel/PageSetup/HeaderFooterImageTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 using XLibur.Excel;
+using XLibur.Excel.IO;
 using System.Threading.Tasks;
 
 namespace XLibur.Tests.Excel.PageSetup;
@@ -271,7 +272,7 @@ public class HeaderFooterImageTests
         var sheetEntry = archive.Entries.First(e => e.FullName.Contains("worksheets/sheet"));
         using var sheetStream = sheetEntry.Open();
         var sheetXml = XDocument.Load(sheetStream);
-        var ssNs = XNamespace.Get("http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+        var ssNs = XNamespace.Get(OpenXmlConst.Main2006SsNs);
         var legacyDrawingHF = sheetXml.Root!.Element(ssNs + "legacyDrawingHF");
         await Assert.That(legacyDrawingHF).IsNotNull().Because("Sheet should contain <legacyDrawingHF> element");
     }
@@ -327,7 +328,7 @@ public class HeaderFooterImageTests
         var sheetEntry = archive.Entries.First(e => e.FullName.Contains("worksheets/sheet"));
         using var sheetStream = sheetEntry.Open();
         var sheetXml = XDocument.Load(sheetStream);
-        var ssNs = XNamespace.Get("http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+        var ssNs = XNamespace.Get(OpenXmlConst.Main2006SsNs);
         var legacyDrawingHF = sheetXml.Root!.Element(ssNs + "legacyDrawingHF");
         await Assert.That(legacyDrawingHF).IsNull().Because("Sheet should NOT contain <legacyDrawingHF> when no images");
     }
@@ -355,7 +356,7 @@ public class HeaderFooterImageTests
         var sheetEntry = archive.Entries.First(e => e.FullName.Contains("worksheets/sheet"));
         using var sheetStream = sheetEntry.Open();
         var sheetXml = XDocument.Load(sheetStream);
-        var ssNs = XNamespace.Get("http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+        var ssNs = XNamespace.Get(OpenXmlConst.Main2006SsNs);
 
         await Assert.That(sheetXml.Root!.Element(ssNs + "legacyDrawing")).IsNotNull();
         await Assert.That(sheetXml.Root!.Element(ssNs + "legacyDrawingHF")).IsNotNull();
@@ -402,7 +403,7 @@ public class HeaderFooterImageTests
         using (var sheetStream = sheetEntry.Open())
         {
             var sheetXml = XDocument.Load(sheetStream);
-            var ssNs = XNamespace.Get("http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+            var ssNs = XNamespace.Get(OpenXmlConst.Main2006SsNs);
             var hf = sheetXml.Root!.Element(ssNs + "headerFooter");
             headerText = hf?.Element(ssNs + "oddHeader")?.Value ?? "";
             footerText = hf?.Element(ssNs + "oddFooter")?.Value ?? "";

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -1,4 +1,5 @@
 ﻿using XLibur.Excel;
+using XLibur.Excel.IO;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -1021,7 +1022,7 @@ public class XLPivotTableTests
             CreatedVersion = 5,
             RefreshedVersion = 5,
         };
-        cacheDefinition.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+        cacheDefinition.AddNamespaceDeclaration("r", OpenXmlConst.RelationshipsNs);
 
         var cacheSource = new CacheSource { Type = SourceValues.Worksheet };
         cacheSource.Append(new WorksheetSource { Sheet = "Data", Reference = "A1:C4" });
@@ -1288,7 +1289,7 @@ public class XLPivotTableTests
             CreatedVersion = 5,
             RefreshedVersion = 5,
         };
-        cacheDefinition.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+        cacheDefinition.AddNamespaceDeclaration("r", OpenXmlConst.RelationshipsNs);
 
         var cacheSource = new CacheSource { Type = SourceValues.Worksheet };
         cacheSource.Append(new WorksheetSource { Sheet = "Data", Reference = "A1:B4" });

--- a/XLibur.Tests/Utils/StreamHelper.cs
+++ b/XLibur.Tests/Utils/StreamHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using XLibur.Excel.IO;
 
 namespace XLibur.Tests.Utils;
 
@@ -11,22 +12,22 @@ namespace XLibur.Tests.Utils;
 /// </summary>
 public static class StreamHelper
 {
-    private static readonly XName colTagName = XName.Get("col", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+    private static readonly XName colTagName = XName.Get("col", OpenXmlConst.Main2006SsNs);
     private static readonly XName widthAttrName = XName.Get("width");
 
     private static readonly IEnumerable<(string PartSubstring, XName NodeName)> ignoredNodes = new List<(string PartSubstring, XName NodeName)>
     {
         ("/docProps/core.xml", XName.Get("created", "http://purl.org/dc/terms/")),
         ("/docProps/core.xml", XName.Get("modified", "http://purl.org/dc/terms/")),
-        ("sheet", XName.Get("id", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"))
+        ("sheet", XName.Get("id", OpenXmlConst.X14Main2009SsNs))
     };
 
     private static readonly IEnumerable<(string PartSubstring, XName NodeName, XName AttrName)> ignoredAttributes = new List<(string PartSubstring, XName NodeName, XName AttrName)>
     {
-        ("sheet", XName.Get("cfRule", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"), XName.Get("id")),
+        ("sheet", XName.Get("cfRule", OpenXmlConst.X14Main2009SsNs), XName.Get("id")),
         // count and uniqueCount were removed due to streaming, but they are used by every file, for now ignore difference.
-        ("/xl/sharedStrings.xml", XName.Get("sst", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"), XName.Get("count")),
-        ("/xl/sharedStrings.xml", XName.Get("sst", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"), XName.Get("uniqueCount")),
+        ("/xl/sharedStrings.xml", XName.Get("sst", OpenXmlConst.Main2006SsNs), XName.Get("count")),
+        ("/xl/sharedStrings.xml", XName.Get("sst", OpenXmlConst.Main2006SsNs), XName.Get("uniqueCount")),
     };
 
     public static void StreamToStreamAppend(Stream streamIn, Stream streamToWrite)

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFDataBarConverter.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFDataBarConverter.cs
@@ -1,6 +1,7 @@
 ﻿using DocumentFormat.OpenXml.Office2010.Excel;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel.ConditionalFormats;
+using XLibur.Excel.IO;
 using XLibur.Extensions;
 using Color = DocumentFormat.OpenXml.Spreadsheet.Color;
 using ConditionalFormattingRule = DocumentFormat.OpenXml.Spreadsheet.ConditionalFormattingRule;
@@ -55,7 +56,7 @@ internal sealed class XLCFDataBarConverter : IXLCFConverter
     private static ConditionalFormattingRuleExtension BuildRuleExtension(IXLConditionalFormat cf)
     {
         var conditionalFormattingRuleExtension = new ConditionalFormattingRuleExtension { Uri = "{B025F937-C7B1-47D3-B67F-A62EFF666E3E}" };
-        conditionalFormattingRuleExtension.AddNamespaceDeclaration("x14", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main");
+        conditionalFormattingRuleExtension.AddNamespaceDeclaration("x14", OpenXmlConst.X14Main2009SsNs);
         var id = new Id
         {
             Text = ((XLConditionalFormat)cf).Id.WrapInBraces()

--- a/XLibur/Excel/IO/ChartReader.cs
+++ b/XLibur/Excel/IO/ChartReader.cs
@@ -75,8 +75,7 @@ internal static class ChartReader
             var unknownEl = graphicData.ChildElements.Count > 0 ? graphicData.ChildElements[0] : null;
             if (unknownEl != null)
             {
-                var attr = unknownEl.GetAttribute("id",
-                    "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+                var attr = unknownEl.GetAttribute("id", OpenXmlConst.RelationshipsNs);
                 if (!string.IsNullOrWhiteSpace(attr.Value))
                     cxRefId = attr.Value;
             }

--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -9,6 +9,7 @@ using DocumentFormat.OpenXml.Experimental;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel.ContentManagers;
+using static XLibur.Excel.IO.OpenXmlConst;
 using static XLibur.Excel.XLWorkbook;
 using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
@@ -286,7 +287,7 @@ internal static class ChartWriter
         var chartSpace = new Cx.ChartSpace();
         chartSpace.AddNamespaceDeclaration("cx", "http://schemas.microsoft.com/office/drawing/2014/chartex");
         chartSpace.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");
-        chartSpace.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+        chartSpace.AddNamespaceDeclaration("r", RelationshipsNs);
         chartSpace.AppendChild(chartData);
         chartSpace.AppendChild(cxChart);
         return chartSpace;
@@ -1157,8 +1158,7 @@ internal static class ChartWriter
         {
             var tableParts = worksheet.Elements<TableParts>().FirstOrDefault();
             var drawingRef = new Drawing { Id = worksheetPart.GetIdOfPart(drawingsPart) };
-            drawingRef.AddNamespaceDeclaration("r",
-                "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+            drawingRef.AddNamespaceDeclaration("r", RelationshipsNs);
             if (tableParts != null)
                 worksheet.InsertBefore(drawingRef, tableParts);
             else
@@ -1173,9 +1173,8 @@ internal static class ChartWriter
                 nd.Value.Equals("http://schemas.openxmlformats.org/drawingml/2006/main")))
             worksheetDrawing.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");
         if (!worksheetDrawing.NamespaceDeclarations.Any(nd =>
-                nd.Value.Equals("http://schemas.openxmlformats.org/officeDocument/2006/relationships")))
-            worksheetDrawing.AddNamespaceDeclaration("r",
-                "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+                nd.Value.Equals(RelationshipsNs)))
+            worksheetDrawing.AddNamespaceDeclaration("r", RelationshipsNs);
     }
 
     // ── Type classification ─────────────────────────────────────────────

--- a/XLibur/Excel/IO/PictureWriter.cs
+++ b/XLibur/Excel/IO/PictureWriter.cs
@@ -8,6 +8,7 @@ using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel.ContentManagers;
 using XLibur.Excel.Drawings;
 using XLibur.Extensions;
+using static XLibur.Excel.IO.OpenXmlConst;
 using static XLibur.Excel.XLWorkbook;
 using Drawing = DocumentFormat.OpenXml.Spreadsheet.Drawing;
 using Point = System.Drawing.Point;
@@ -40,8 +41,7 @@ internal static class PictureWriter
         if (xlWorksheet.Pictures.Count > 0 && !worksheet.OfType<Drawing>().Any())
         {
             var worksheetDrawing = new Drawing { Id = worksheetPart.GetIdOfPart(worksheetPart.DrawingsPart!) };
-            worksheetDrawing.AddNamespaceDeclaration("r",
-                "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+            worksheetDrawing.AddNamespaceDeclaration("r", RelationshipsNs);
             worksheet.InsertBefore(worksheetDrawing, tableParts);
             cm.SetElement(XLWorksheetContents.Drawing, worksheet.Elements<Drawing>().First());
         }
@@ -190,9 +190,8 @@ internal static class PictureWriter
             worksheetDrawing.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");
 
         if (!worksheetDrawing.NamespaceDeclarations.Any(nd =>
-                nd.Value.Equals("http://schemas.openxmlformats.org/officeDocument/2006/relationships")))
-            worksheetDrawing.AddNamespaceDeclaration("r",
-                "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+                nd.Value.Equals(RelationshipsNs)))
+            worksheetDrawing.AddNamespaceDeclaration("r", RelationshipsNs);
     }
 
     private static void AddPictureAnchor(WorksheetPart worksheetPart, IXLPicture picture, SaveContext context)

--- a/XLibur/Excel/IO/PivotTableCacheDefinitionPartWriter.cs
+++ b/XLibur/Excel/IO/PivotTableCacheDefinitionPartWriter.cs
@@ -23,7 +23,7 @@ internal static class PivotTableCacheDefinitionPartWriter
         {
             pivotCacheDefinition = new PivotCacheDefinition { Id = "rId1" };
 
-            pivotCacheDefinition.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+            pivotCacheDefinition.AddNamespaceDeclaration("r", OpenXmlConst.RelationshipsNs);
             pivotTableCacheDefinitionPart.PivotCacheDefinition = pivotCacheDefinition;
         }
 

--- a/XLibur/Excel/IO/RichDataReader.cs
+++ b/XLibur/Excel/IO/RichDataReader.cs
@@ -19,9 +19,6 @@ internal static class RichDataReader
     private const string RichValueStructureRelType = "http://schemas.microsoft.com/office/2017/06/relationships/rdRichValueStructure";
     private const string RichValueRelRelType = "http://schemas.microsoft.com/office/2017/06/relationships/richValueRel";
 
-    // XML namespaces
-    private const string RNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
-
     /// <summary>
     /// Load rich data parts from the workbook part. If successful, populates
     /// <see cref="LoadContext.RichValueImages"/> with vm-to-CellImage mapping.
@@ -139,7 +136,7 @@ internal static class RichDataReader
             if (reader.NodeType == XmlNodeType.Element && reader.LocalName == "rel")
             {
                 // The r:id attribute is in the relationships namespace
-                var id = reader.GetAttribute("id", RNs);
+                var id = reader.GetAttribute("id", OpenXmlConst.RelationshipsNs);
                 if (id is not null)
                     relIds.Add(id);
             }

--- a/XLibur/Excel/IO/RichDataWriter.cs
+++ b/XLibur/Excel/IO/RichDataWriter.cs
@@ -26,11 +26,8 @@ internal static class RichDataWriter
     private const string RichValueRelContentType = "application/vnd.ms-excel.richValueRel+xml";
     private const string RichValueTypesContentType = "application/vnd.ms-excel.rdrichvaluetypes+xml";
 
-    // XML namespaces
-    private const string RvNs = "http://schemas.microsoft.com/office/spreadsheetml/2017/richdata";
-    private const string RvsNs = "http://schemas.microsoft.com/office/spreadsheetml/2017/richdata2";
+    // XML namespaces (RvrNs has no OpenXmlConst entry yet)
     private const string RvrNs = "http://schemas.microsoft.com/office/spreadsheetml/2022/richvaluerel";
-    private const string RNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
     /// <summary>
     /// Entry for a single rich value (one per cell with in-cell image).
@@ -155,12 +152,12 @@ internal static class RichDataWriter
 
         w.WriteStartDocument(true);
         w.WriteStartElement("richValueRels", RvrNs);
-        w.WriteAttributeString("xmlns", "r", null, RNs);
+        w.WriteAttributeString("xmlns", "r", null, OpenXmlConst.RelationshipsNs);
 
         foreach (var relId in imageRelIds)
         {
             w.WriteStartElement("rel", RvrNs);
-            w.WriteAttributeString("id", RNs, relId);
+            w.WriteAttributeString("id", OpenXmlConst.RelationshipsNs, relId);
             w.WriteEndElement(); // rel
         }
 
@@ -189,7 +186,7 @@ internal static class RichDataWriter
         using var w = XmlWriter.Create(stream, XmlSettings());
 
         w.WriteStartDocument(true);
-        w.WriteStartElement("rvData", RvNs);
+        w.WriteStartElement("rvData", OpenXmlConst.RichDataNs);
         w.WriteAttributeString("count", entries.Count.ToString());
 
         for (var i = 0; i < entries.Count; i++)
@@ -197,15 +194,15 @@ internal static class RichDataWriter
             var entry = entries[i];
             var relIndex = imageIndexToRelIndex[entry.ImageStoreIndex];
 
-            w.WriteStartElement("rv", RvNs);
+            w.WriteStartElement("rv", OpenXmlConst.RichDataNs);
             w.WriteAttributeString("s", "0"); // structure index 0 = _localImage
 
             // Key 0: _rvRel:LocalImageFileUri (rel index)
-            w.WriteElementString("v", RvNs, relIndex.ToString());
+            w.WriteElementString("v", OpenXmlConst.RichDataNs, relIndex.ToString());
             // Key 1: CalcOrigin
-            w.WriteElementString("v", RvNs, "5");
+            w.WriteElementString("v", OpenXmlConst.RichDataNs, "5");
             // Key 2: text (alt text)
-            w.WriteElementString("v", RvNs, entry.AltText);
+            w.WriteElementString("v", OpenXmlConst.RichDataNs, entry.AltText);
 
             w.WriteEndElement(); // rv
         }
@@ -222,26 +219,26 @@ internal static class RichDataWriter
         using var w = XmlWriter.Create(stream, XmlSettings());
 
         w.WriteStartDocument(true);
-        w.WriteStartElement("rvStructures", RvsNs);
+        w.WriteStartElement("rvStructures", OpenXmlConst.RichData2Ns);
         w.WriteAttributeString("count", "1");
 
-        w.WriteStartElement("s", RvsNs);
+        w.WriteStartElement("s", OpenXmlConst.RichData2Ns);
         w.WriteAttributeString("t", "_localImage");
 
         // Key 0: _rvRel:LocalImageFileUri
-        w.WriteStartElement("k", RvsNs);
+        w.WriteStartElement("k", OpenXmlConst.RichData2Ns);
         w.WriteAttributeString("n", "_rvRel:LocalImageFileUri");
         w.WriteAttributeString("t", "i");
         w.WriteEndElement(); // k
 
         // Key 1: CalcOrigin
-        w.WriteStartElement("k", RvsNs);
+        w.WriteStartElement("k", OpenXmlConst.RichData2Ns);
         w.WriteAttributeString("n", "CalcOrigin");
         w.WriteAttributeString("t", "i");
         w.WriteEndElement(); // k
 
         // Key 2: text (alt text)
-        w.WriteStartElement("k", RvsNs);
+        w.WriteStartElement("k", OpenXmlConst.RichData2Ns);
         w.WriteAttributeString("n", "text");
         w.WriteAttributeString("t", "s");
         w.WriteEndElement(); // k
@@ -256,28 +253,26 @@ internal static class RichDataWriter
     /// </summary>
     private static void WriteRichValueTypesXml(OpenXmlPart part)
     {
-        const string rvTypesNs = "http://schemas.microsoft.com/office/spreadsheetml/2017/richdata2";
-
         using var stream = part.GetStream(FileMode.Create, FileAccess.Write);
         using var w = XmlWriter.Create(stream, XmlSettings());
 
         w.WriteStartDocument(true);
-        w.WriteStartElement("rvTypesInfo", rvTypesNs);
+        w.WriteStartElement("rvTypesInfo", OpenXmlConst.RichData2Ns);
 
-        w.WriteStartElement("global", rvTypesNs);
+        w.WriteStartElement("global", OpenXmlConst.RichData2Ns);
 
-        w.WriteStartElement("keyFlags", rvTypesNs);
+        w.WriteStartElement("keyFlags", OpenXmlConst.RichData2Ns);
 
         // _rvRel:LocalImageFileUri key flag
-        w.WriteStartElement("key", rvTypesNs);
+        w.WriteStartElement("key", OpenXmlConst.RichData2Ns);
         w.WriteAttributeString("name", "_rvRel:LocalImageFileUri");
 
-        w.WriteStartElement("flag", rvTypesNs);
+        w.WriteStartElement("flag", OpenXmlConst.RichData2Ns);
         w.WriteAttributeString("name", "ExcludeFromFile");
         w.WriteAttributeString("value", "1");
         w.WriteEndElement(); // flag
 
-        w.WriteStartElement("flag", rvTypesNs);
+        w.WriteStartElement("flag", OpenXmlConst.RichData2Ns);
         w.WriteAttributeString("name", "ExcludeFromCalcComparison");
         w.WriteAttributeString("value", "1");
         w.WriteEndElement(); // flag

--- a/XLibur/Excel/IO/SharedStringReader.cs
+++ b/XLibur/Excel/IO/SharedStringReader.cs
@@ -52,8 +52,6 @@ internal readonly struct SharedStringEntry
 /// </summary>
 internal static class SharedStringReader
 {
-    private const string XmlNs = "http://www.w3.org/XML/1998/namespace";
-
     internal static SharedStringEntry[] Read(SharedStringTablePart part)
     {
         using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
@@ -200,7 +198,7 @@ internal static class SharedStringReader
             if (leadingText is not null)
             {
                 writer.WriteStartElement("t", OpenXmlConst.Main2006SsNs);
-                writer.WriteAttributeString("space", XmlNs, "preserve");
+                writer.WriteAttributeString("space", OpenXmlConst.Xml1998Ns, "preserve");
                 writer.WriteString(leadingText);
                 writer.WriteEndElement();
             }

--- a/XLibur/Excel/IO/WorkbookPartWriter.cs
+++ b/XLibur/Excel/IO/WorkbookPartWriter.cs
@@ -5,6 +5,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Extensions;
 using XLibur.Utils;
+using static XLibur.Excel.IO.OpenXmlConst;
 
 namespace XLibur.Excel.IO;
 
@@ -17,10 +18,9 @@ internal static class WorkbookPartWriter
         var workbook = workbookPart.Workbook;
         if (
             !workbook.NamespaceDeclarations.Contains(new KeyValuePair<string, string>("r",
-                "http://schemas.openxmlformats.org/officeDocument/2006/relationships")))
+                RelationshipsNs)))
         {
-            workbook.AddNamespaceDeclaration("r",
-                "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+            workbook.AddNamespaceDeclaration("r", RelationshipsNs);
         }
 
         WriteWorkbookProperties(workbook, xlWorkbook, options);

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -608,7 +608,6 @@ public partial class XLWorkbook
             .FirstOrDefault(fm => fm.Name?.Value == "XLRICHVALUE");
         existingFm?.Remove();
 
-        const string xlrvNs = "http://schemas.microsoft.com/office/spreadsheetml/2017/richdata";
         var futureMetadata = new FutureMetadata { Name = "XLRICHVALUE", Count = (uint)entries.Count };
         for (var i = 0; i < entries.Count; i++)
         {
@@ -616,7 +615,7 @@ public partial class XLWorkbook
             var extList = new ExtensionList();
             var ext = new Extension { Uri = "{3e2802c4-a4d2-4d8b-9148-e3be6c30e623}" };
 
-            var rvb = new OpenXmlUnknownElement("xlrv", "rvb", xlrvNs);
+            var rvb = new OpenXmlUnknownElement("xlrv", "rvb", OpenXmlConst.RichDataNs);
             rvb.SetAttribute(new OpenXmlAttribute("", "i", "", i.ToString()));
             ext.Append(rvb);
             extList.Append(ext);


### PR DESCRIPTION
## Summary

- Replace hardcoded OpenXML **namespace** URI literals with the existing `OpenXmlConst` constants (1:1 swaps only).
- Clears SonarCloud [S1075](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZz_KycNF53k-yCo7TpC) findings for those namespace URIs already defined in `OpenXmlConst`.
- No string-interpolation of constants into XML templates; embedded fixture/XML blobs left alone.

## Changes

- Production: `ChartWriter`, `ChartReader`, `PictureWriter`, `WorkbookPartWriter`, `PivotTableCacheDefinitionPartWriter`, `RichDataWriter`/`Reader`, `SharedStringReader`, `XLWorkbook_Save`, `XLCFDataBarConverter`
- Tests/benchmarks: `StreamHelper`, `HeaderFooterImageTests`, `XLPivotTableTests`, `OpenXmlWorkbookBenchmarks`

## Related Issues

- SonarCloud S1075: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZz_KycNF53k-yCo7TpC

## Follow-ups (out of scope)

`OpenXmlConst` can grow further in later PRs if we want — e.g. shared DrawingML / DocPropsVTypes namespaces, and relationship types duplicated between `RichDataWriter` and `RichDataReader`. This PR only wires up namespace constants that already exist.

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually (describe below if applicable)

Build of library, tests, and benchmarks succeeded locally. Behavior unchanged.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch