### PR TITLE
chore: ignore Sonar S3220 for OpenXML params constructor noise

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,6 +66,10 @@ jobs:
         if: env.SONAR_TOKEN != ''
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        # S3220: OpenXmlElement has both params[] and IEnumerable ctors, and implements
+        # IEnumerable, so Sonar flags every one-child construction. The C# compiler binds
+        # to params correctly (dotnet/Open-XML-SDK#1136). Ignoring the rule avoids a large
+        # amount of noise for no practical safety gain.
         run: >
           dotnet sonarscanner begin
           /k:"XLibur_XLibur"
@@ -74,6 +78,9 @@ jobs:
           /d:sonar.host.url="https://sonarcloud.io"
           /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
           /d:sonar.coverage.exclusions="XLibur.Examples/**,XLibur.Benchmarks/**"
+          /d:sonar.issue.ignore.multicriteria=e1
+          /d:sonar.issue.ignore.multicriteria.e1.ruleKey=csharpsquid:S3220
+          /d:sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
 
       - name: Build
         run: dotnet build XLibur.slnx --configuration Release --no-restore


### PR DESCRIPTION
## Summary

- Ignore Sonar rule `csharpsquid:S3220` in the SonarCloud scanner begin step.
- Nearly all of our S3220 hits come from DocumentFormat.OpenXml element constructors (`Workbook`, `Sheets`, `Font`, `Fill`, …), which expose both `params OpenXmlElement[]` and `IEnumerable<OpenXmlElement>` overloads while `OpenXmlElement` itself implements `IEnumerable`.
- The C# compiler already binds these one-child constructions to the `params` overload correctly; there is no runtime ambiguity. See [dotnet/Open-XML-SDK#1136](https://github.com/dotnet/Open-XML-SDK/issues/1136).

## Why ignore instead of “fixing”

A typical call today:

```csharp
workbookPart.Workbook = new Workbook(
    new Sheets(new Sheet { Name = Data, SheetId = 1, Id = relId }));
```

The Sonar-satisfying rewrite forces the `params` overload with explicit arrays:

```csharp
workbookPart.Workbook = new Workbook(
    new OpenXmlElement[]
    {
        new Sheets(
            new OpenXmlElement[]
            {
                new Sheet { Name = Data, SheetId = 1, Id = relId }
            })
    });
```

That clears S3220 but makes nested OpenXML construction much harder to read, and we would need the same ceremony at dozens (likely hundreds) of call sites across writers, tests, and benchmarks. We get almost no safety value from the rule in this codebase — only noise.

## Changes

- `.github/workflows/build-and-test.yml`: add `sonar.issue.ignore.multicriteria` for `csharpsquid:S3220` on `**/*`, with an inline comment pointing at Open-XML-SDK#1136.

## Related Issues

- https://github.com/dotnet/Open-XML-SDK/issues/1136
- Example Sonar finding: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ0ECRxpoApNP_XKBsz-

## Testing

- [ ] Added or updated unit tests
- [ ] All existing tests pass
- [ ] Tested manually (describe below if applicable)

Workflow/YAML-only change. After merge, the next SonarCloud analysis on `main` should stop reporting S3220.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch