### PR TITLE
Surface the style of a pivot table format when reading

### DIFF
--- a/XLibur.Tests/Excel/Loading/LoadingTests.cs
+++ b/XLibur.Tests/Excel/Loading/LoadingTests.cs
@@ -245,7 +245,6 @@ public class LoadingTests
     }
 
     [Test]
-    [Skip("Pivot table style formats are not implemented, so the border is not read back.")]
     public async Task CanLoadPivotTableWithBorder()
     {
         using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\PivotTableWithBorder.xlsx"));
@@ -256,6 +255,26 @@ public class LoadingTests
         await Assert.That(border.LeftBorder).IsEqualTo(XLBorderStyleValues.Thin);
         await Assert.That(border.TopBorder).IsEqualTo(XLBorderStyleValues.Thin);
         await Assert.That(border.RightBorder).IsEqualTo(XLBorderStyleValues.Thin);
+        await Assert.That(border.BottomBorder).IsEqualTo(XLBorderStyleValues.Thin);
+    }
+
+    [Test]
+    public async Task PivotTableBorderSurvivesRoundTrip()
+    {
+        using var ms = new MemoryStream();
+        using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\PivotTableWithBorder.xlsx")))
+        using (var wb = new XLWorkbook(stream))
+        {
+            wb.SaveAs(ms, true);
+        }
+
+        ms.Seek(0, SeekOrigin.Begin);
+
+        using var reloaded = new XLWorkbook(ms);
+        var pt = reloaded.Worksheet(1).PivotTables.PivotTable("PivotTable1");
+        var border = pt.RowLabels.Single().StyleFormats.DataValuesFormat.Style.Border;
+
+        await Assert.That(border.LeftBorder).IsEqualTo(XLBorderStyleValues.Thin);
         await Assert.That(border.BottomBorder).IsEqualTo(XLBorderStyleValues.Thin);
     }
 

--- a/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
@@ -292,8 +292,12 @@ internal static class WorkbookStylesPartWriter
     {
         foreach (var pt in ws.PivotTables)
         {
-            AddPivotTableStyleFormatDxfs(differentialFormats, pt, context);
+            // Formats first: a style format reads its style from the format that covers it, so both
+            // of the first two calls see the same styles and whichever runs first decides the order
+            // the differential formats are written in. Going through pt.Formats keeps that order the
+            // same as the order the formats themselves are written in.
             AddPivotTableFormatDxfs(differentialFormats, pt, context);
+            AddPivotTableStyleFormatDxfs(differentialFormats, pt, context);
             AddPivotTableConditionalFormatDxfs(differentialFormats, pt, context);
         }
     }

--- a/XLibur/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormatBase.cs
+++ b/XLibur/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormatBase.cs
@@ -18,7 +18,7 @@ internal abstract class XLPivotStyleFormatBase : IXLPivotStyleFormat, IXLStylize
     {
         PivotTable = pivotTable;
 
-        // Value is Default, because it's a differential style that can't be represented yet.
+        // Only used until a matching format exists, see the StyleValue getter.
         _styleValue = XLStyle.Default.Value;
     }
 
@@ -49,7 +49,12 @@ internal abstract class XLPivotStyleFormatBase : IXLPivotStyleFormat, IXLStylize
 
     public XLStyleValue StyleValue
     {
-        get => _styleValue;
+        // Read through to the pivot table's formats, which is where the style actually lives and
+        // where loading a file puts it. These style format objects are created fresh on every
+        // property access and the area they match can still be narrowed after construction
+        // (IXLPivotValueStyleFormat.AndWith), so nothing is cached. Unlike GetFormats, this does
+        // not create a format when none matches -- reading a style must not write one.
+        get => TryGetFormatStyleValue(out var formatStyleValue) ? formatStyleValue : _styleValue;
         set
         {
             // This sets the style of everything to the passed style, while ModifyStyle
@@ -64,6 +69,9 @@ internal abstract class XLPivotStyleFormatBase : IXLPivotStyleFormat, IXLStylize
 
     public void ModifyStyle(Func<XLStyleKey, XLStyleKey> modification)
     {
+        // Seeded from _styleValue, not StyleValue: this is the style a format gets if it has to be
+        // created, and a new format starts from Default. Formats that already exist are modified
+        // from their own value in the loop below.
         var styleKey = modification(_styleValue.Key);
         _styleValue = XLStyleValue.FromKey(ref styleKey);
 
@@ -81,6 +89,31 @@ internal abstract class XLPivotStyleFormatBase : IXLPivotStyleFormat, IXLStylize
     internal abstract XLPivotArea GetCurrentArea();
 
     internal abstract bool Filter(XLPivotArea area);
+
+    /// <summary>
+    /// Whether a format's area styles the cells this instance stands for. Defaults to
+    /// <see cref="Filter"/>, the exact area used when writing, and is loosened where a file can
+    /// legitimately hold a wider area that still styles those cells.
+    /// </summary>
+    internal virtual bool Covers(XLPivotArea area) => Filter(area);
+
+    /// <summary>
+    /// The style of the first format whose area this instance selects, if the pivot table has one.
+    /// </summary>
+    private bool TryGetFormatStyleValue(out XLStyleValue styleValue)
+    {
+        foreach (var format in PivotTable.Formats)
+        {
+            if (format.Action == XLPivotFormatAction.Formatting && Covers(format.PivotArea))
+            {
+                styleValue = format.DxfStyleValue;
+                return true;
+            }
+        }
+
+        styleValue = XLStyle.Default.Value;
+        return false;
+    }
 
     private IEnumerable<XLPivotFormat> GetFormats()
     {

--- a/XLibur/Excel/PivotTables/PivotStyleFormats/XLPivotValueStyleFormat.cs
+++ b/XLibur/Excel/PivotTables/PivotStyleFormats/XLPivotValueStyleFormat.cs
@@ -87,5 +87,17 @@ internal sealed class XLPivotValueStyleFormat : XLPivotStyleFormatBase, IXLPivot
         return XLPivotAreaComparer.Instance.Equals(area, currentArea);
     }
 
+    internal override bool Covers(XLPivotArea area)
+    {
+        // Styling a field's cells in Excel writes one area for the labels and the data together
+        // (dataOnly="0", with a fieldPosition), not the data-only area this class writes. The data
+        // cells still carry that style, so it counts when reading. An area that took in the labels
+        // alone would not.
+        if (area.LabelOnly)
+            return false;
+
+        return XLPivotAreaComparer.Instance.EqualsIgnoringScope(area, GetCurrentArea());
+    }
+
     private sealed record FieldReference(FieldIndex FieldIndex, IReadOnlyList<uint>? Items = null);
 }

--- a/XLibur/Excel/PivotTables/XLPivotAreaComparer.cs
+++ b/XLibur/Excel/PivotTables/XLPivotAreaComparer.cs
@@ -36,6 +36,34 @@ internal sealed class XLPivotAreaComparer : IEqualityComparer<XLPivotArea>
                x.FieldPosition == y.FieldPosition;
     }
 
+    /// <summary>
+    /// Whether two areas select the same region of the pivot table, ignoring how much of that region
+    /// they take in: <see cref="XLPivotArea.DataOnly"/> and <see cref="XLPivotArea.LabelOnly"/> pick
+    /// the data cells, the label cells or both, and <see cref="XLPivotArea.FieldPosition"/> is the
+    /// position Excel records next to that choice. Used when reading a style, where a format that
+    /// takes in more than the caller asked about still styles what the caller asked about. Writing a
+    /// style has to identify one exact area and uses <see cref="Equals(XLPivotArea, XLPivotArea)"/>.
+    /// </summary>
+    public bool EqualsIgnoringScope(XLPivotArea? x, XLPivotArea? y)
+    {
+        if (ReferenceEquals(x, y))
+            return true;
+
+        if (x is null || y is null)
+            return false;
+
+        return x.References.SequenceEqual(y.References, _referenceComparer) &&
+               Nullable.Equals(x.Field, y.Field) &&
+               x.Type == y.Type &&
+               x.GrandRow == y.GrandRow &&
+               x.GrandCol == y.GrandCol &&
+               x.CacheIndex == y.CacheIndex &&
+               x.Outline == y.Outline &&
+               Nullable.Equals(x.Offset, y.Offset) &&
+               x.CollapsedLevelsAreSubtotals == y.CollapsedLevelsAreSubtotals &&
+               x.Axis == y.Axis;
+    }
+
     public int GetHashCode(XLPivotArea obj)
     {
         var hashCode = new HashCode();


### PR DESCRIPTION
Stacked on `test/review-skipped-tests` — review that one first, this PR is the single commit on top.

Unskips `CanLoadPivotTableWithBorder`. **Skipped: 6 → 5**, green on net8.0 and net10.0.

## Two defects, the first wider than the test implies

**No pivot style was ever readable.** `XLPivotStyleFormatBase` initialised its style value to `Default` and the getter returned that field. The loader populates `XLPivotFormat.DxfStyleValue` correctly — borders included — so every loaded pivot style went into the object model and was then unreachable from the API. Nothing border-specific about it: the getter never consulted `PivotTable.Formats` at all.

The getter now reads through to the formats. Nothing is cached — these style format objects are created fresh on every property access, and the area one matches can still be narrowed after construction via `IXLPivotValueStyleFormat.AndWith`. Unlike `GetFormats`, the read does not create a format when none matches, because reading a style must not write one.

**The area match was too strict for reading.** Styling a field in Excel writes one area covering the labels and the data together, rather than the data-only area `XLPivotValueStyleFormat` writes:

```xml
<pivotArea dataOnly="0" fieldPosition="0">
  <references count="1"><reference field="0" count="0"/></references>
</pivotArea>
```

Exact area equality can never match that. Those data cells do carry the style, so a value style format now counts any area that reaches them, excluding one that took in the labels alone. **Writing still uses the strict comparison** — it has to identify one exact area — so the write path and round-trips are unchanged.

## A dead code path woke up

Fixing the getter broke `Add_grand_row_total_styles` and `Add_grand_column_total_styles`.

`AddPivotTableStyleFormatDxfs` iterates style formats reading `.Style`, which was always `Default`, so it had always added nothing. A live getter made it start registering differential formats — correctly, but *first*, which renumbered `dxfId`s in saved files.

The generated output was semantically identical to the expected resource, only the `dxf` array order differed. Rather than regenerate two binary test resources to encode a cosmetic change, the two calls are swapped so `pt.Formats` registers first and the written order is unchanged.

## Tests

`PivotTableBorderSurvivesRoundTrip` is added because the live getter now feeds the save path as well, so load → save → load is worth pinning rather than assuming.

## Scope

This makes styles that are already loaded readable. It does **not** implement pivot table style formats as a feature — the API the old `PivotTableStyleFormatsTest` used (`XLPivotValueStyleFormat.FieldReferences`, `PivotLabelFieldReference`, `PivotValueFieldReference`) no longer exists and is not restored here.