### PR TITLE
fix: invalidate references whose rows or columns are all deleted

### DIFF
--- a/XLibur.Tests/Excel/NamedRanges/NamedRangeDeletionTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangeDeletionTests.cs
@@ -103,6 +103,103 @@ public class NamedRangeDeletionTests
     }
 
     /// <summary>
+    /// Deleting every row a named range covers invalidates it (ClosedXML/ClosedXML#880). Excel replaces the
+    /// address with #REF! and keeps the sheet prefix; previously the shifted endpoints went negative and
+    /// were clamped back to row 1, leaving the name pointing at a surviving row it never covered.
+    /// </summary>
+    [Test]
+    public async Task DeletingAllRowsOfNamedRange_BecomesRefError()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Range("A1:B2").AddToNamed("Gone", XLScope.Workbook);
+
+        ws.Rows(1, 5).Delete();
+
+        await Assert.That(RefersTo(wb, "Gone")).IsEqualTo("Sheet1!#REF!");
+        await Assert.That(wb.DefinedNames.ValidNamedRanges()).IsEmpty();
+    }
+
+    /// <summary>
+    /// The deletion need not extend past the range: deleting exactly the rows it covers also leaves #REF!.
+    /// </summary>
+    [Test]
+    public async Task DeletingExactlyTheRowsOfNamedRange_BecomesRefError()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Range("A3:A4").AddToNamed("Exact", XLScope.Workbook);
+
+        ws.Rows(3, 4).Delete();
+
+        await Assert.That(RefersTo(wb, "Exact")).IsEqualTo("Sheet1!#REF!");
+    }
+
+    /// <summary>
+    /// The same for a single cell: deleting the row it sits on leaves #REF!, not a neighbouring cell.
+    /// </summary>
+    [Test]
+    public async Task DeletingRowOfSingleCellNamedRange_BecomesRefError()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A3").AddToNamed("Cell", XLScope.Workbook);
+
+        ws.Row(3).Delete();
+
+        await Assert.That(RefersTo(wb, "Cell")).IsEqualTo("Sheet1!#REF!");
+    }
+
+    /// <summary>
+    /// A row-only reference is invalidated the same way: rows 3:4 with those rows deleted become #REF!.
+    /// </summary>
+    [Test]
+    public async Task DeletingAllRowsOfRowOnlyNamedRange_BecomesRefError()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Rows", "Sheet1!$3:$4");
+
+        ws.Rows(1, 5).Delete();
+
+        await Assert.That(RefersTo(wb, "Rows")).IsEqualTo("Sheet1!#REF!");
+    }
+
+    /// <summary>
+    /// A cell formula goes through the same shifter, so deleting every row it reads leaves #REF! rather
+    /// than silently repointing the formula at whatever moved up into those rows.
+    /// </summary>
+    [Test]
+    public async Task DeletingAllRowsReferencedByFormula_BecomesRefError()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Range("A1:A2").Value = 1;
+        ws.Cell("D10").FormulaA1 = "=SUM(A1:A2)";
+
+        ws.Rows(1, 5).Delete();
+
+        await Assert.That(ws.Cell("D5").FormulaA1).IsEqualTo("SUM(#REF!)");
+    }
+
+    /// <summary>
+    /// Column counterpart of the invalidation: deleting every column a named range covers leaves #REF!
+    /// instead of clamping the endpoints back to column A.
+    /// </summary>
+    [Test]
+    public async Task DeletingAllColumnsOfNamedRange_BecomesRefError()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Range("A1:B2").AddToNamed("GoneCols", XLScope.Workbook);
+
+        ws.Columns(1, 5).Delete();
+
+        await Assert.That(RefersTo(wb, "GoneCols")).IsEqualTo("Sheet1!#REF!");
+        await Assert.That(wb.DefinedNames.ValidNamedRanges()).IsEmpty();
+    }
+
+    /// <summary>
     /// Column counterpart of the top-row bug: deleting the left column of a named range removes it and
     /// shifts survivors left (C1:D1 -> C1:C1) rather than expanding to B1:C1.
     /// </summary>

--- a/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -317,11 +317,7 @@ public class NamedRangesTests
         }
     }
 
-    // Deleting rows doesn't invalidate the addresses of a named range (ClosedXML/ClosedXML#880).
-    // The assertions below are also self-contradictory: the last two both read ElementAt(0) but
-    // expect different values, so the second one is presumably meant to read ElementAt(1). Both
-    // need fixing before this test can be un-skipped.
-    [Test, Skip("Addresses in named ranges don't become invalid when the range is deleted (ClosedXML/ClosedXML#880).")]
+    [Test]
     public async Task NamedRangeBecomesInvalidOnRangeAndWorksheetDeleting()
     {
         using var wb = new XLWorkbook();
@@ -339,14 +335,15 @@ public class NamedRangesTests
 
         await Assert.That(wb.DefinedNames.Count()).IsEqualTo(2);
         await Assert.That(wb.DefinedNames.ValidNamedRanges().Count()).IsEqualTo(0);
-        await Assert.That(wb.DefinedNames.ElementAt(0).RefersTo).IsEqualTo("#REF!#REF!");
-        await Assert.That(wb.DefinedNames.ElementAt(0).RefersTo).IsEqualTo("#REF!#REF!,'Sheet 2'!A10:D15");
+
+        // The row deletion reduces both Sheet 1 references to 'Sheet 1'!#REF!, and deleting the sheet
+        // then drops the prefix, matching how a reference to a deleted sheet is stored elsewhere
+        // (see NamedRangesFromDeletedSheetAreSavedWithoutAddress). Sheet 2 is untouched by either.
+        await Assert.That(wb.DefinedNames.ElementAt(0).RefersTo).IsEqualTo("#REF!");
+        await Assert.That(wb.DefinedNames.ElementAt(1).RefersTo).IsEqualTo("#REF!,'Sheet 2'!$A$10:$D$15");
     }
 
-    // Same two problems as NamedRangeBecomesInvalidOnRangeAndWorksheetDeleting: the behaviour is
-    // unimplemented, and the last two assertions both read ElementAt(0) while expecting different
-    // values, so they can never both hold.
-    [Test, Skip("Addresses in named ranges don't become invalid when the range is deleted (ClosedXML/ClosedXML#880).")]
+    [Test]
     public async Task NamedRangeBecomesInvalidOnRangeDeleting()
     {
         using var wb = new XLWorkbook();
@@ -362,8 +359,9 @@ public class NamedRangesTests
 
         await Assert.That(wb.DefinedNames.Count()).IsEqualTo(2);
         await Assert.That(wb.DefinedNames.ValidNamedRanges().Count()).IsEqualTo(0);
+        // Simple is deleted outright; Compound loses C1:D2 and keeps A10:D15, shifted up five rows.
         await Assert.That(wb.DefinedNames.ElementAt(0).RefersTo).IsEqualTo("'Sheet 1'!#REF!");
-        await Assert.That(wb.DefinedNames.ElementAt(0).RefersTo).IsEqualTo("'Sheet 1'!#REF!,'Sheet 1'!A5:D10");
+        await Assert.That(wb.DefinedNames.ElementAt(1).RefersTo).IsEqualTo("'Sheet 1'!#REF!,'Sheet 1'!$A$5:$D$10");
     }
 
     [Test]

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -8,6 +8,8 @@ namespace XLibur.Excel;
 
 internal static partial class XLCellFormulaShifter
 {
+    private const string RefError = "#REF!";
+
     private static readonly Regex A1SimpleRegex = A1SimpleRegexGenerated();
 
     private static readonly Regex A1RowRegex = A1RowRegexGenerated();
@@ -86,7 +88,9 @@ internal static partial class XLCellFormulaShifter
             sb.Append('!');
         }
 
-        if (A1RowRegex.IsMatch(rangeAddress))
+        if (IsDeletedEntirelyByRowShift(shiftedRange, matchRange, rowsShifted))
+            sb.Append(RefError);
+        else if (A1RowRegex.IsMatch(rangeAddress))
             AppendShiftedRowOnlyRange(sb, rangeAddress, rowsShifted);
         else if (shiftedRange.RangeAddress.FirstAddress.RowNumber <= matchRange.RangeAddress.FirstAddress.RowNumber)
         {
@@ -97,6 +101,21 @@ internal static partial class XLCellFormulaShifter
         }
         else
             AppendPartialRowShift(sb, worksheetInAction, matchRange, rowsShifted);
+    }
+
+    /// <summary>
+    /// True when a row deletion removes every row of <paramref name="matchRange"/>. Excel replaces such
+    /// a reference with <c>#REF!</c> rather than repointing it, so deleting rows 1-5 turns <c>A1:B2</c>
+    /// into <c>#REF!</c>. Without this the shifted endpoints would be negative and
+    /// <see cref="XLHelper.TrimRowNumber"/> would clamp them back to row 1, leaving the reference
+    /// pointing at a surviving row it never covered (<c>A1:B1</c>). See ClosedXML/ClosedXML#880.
+    /// </summary>
+    private static bool IsDeletedEntirelyByRowShift(XLRange shiftedRange, IXLRange matchRange, int rowsShifted)
+    {
+        return rowsShifted < 0
+            && matchRange.RangeAddress.FirstAddress.RowNumber >= shiftedRange.RangeAddress.FirstAddress.RowNumber
+            && matchRange.RangeAddress.LastAddress.RowNumber + rowsShifted <
+               shiftedRange.RangeAddress.FirstAddress.RowNumber;
     }
 
     /// <summary>
@@ -241,7 +260,9 @@ internal static partial class XLCellFormulaShifter
             sb.Append('!');
         }
 
-        if (A1ColumnRegex.IsMatch(rangeAddress))
+        if (IsDeletedEntirelyByColumnShift(shiftedRange, matchRange, columnsShifted))
+            sb.Append(RefError);
+        else if (A1ColumnRegex.IsMatch(rangeAddress))
             AppendShiftedColumnOnlyRange(sb, rangeAddress, columnsShifted);
         else if (shiftedRange.RangeAddress.FirstAddress.ColumnNumber <= matchRange.RangeAddress.FirstAddress.ColumnNumber)
         {
@@ -252,6 +273,20 @@ internal static partial class XLCellFormulaShifter
         }
         else
             AppendPartialColumnShift(sb, worksheetInAction, matchRange, columnsShifted);
+    }
+
+    /// <summary>
+    /// Column-wise counterpart of <see cref="IsDeletedEntirelyByRowShift"/>: true when a column deletion
+    /// removes every column of <paramref name="matchRange"/>, so the reference becomes <c>#REF!</c> instead
+    /// of being clamped back to column A by <see cref="XLHelper.TrimColumnNumber"/>.
+    /// </summary>
+    private static bool IsDeletedEntirelyByColumnShift(XLRange shiftedRange, IXLRange matchRange, int columnsShifted)
+    {
+        return columnsShifted < 0
+            && matchRange.RangeAddress.FirstAddress.ColumnNumber >=
+               shiftedRange.RangeAddress.FirstAddress.ColumnNumber
+            && matchRange.RangeAddress.LastAddress.ColumnNumber + columnsShifted <
+               shiftedRange.RangeAddress.FirstAddress.ColumnNumber;
     }
 
     /// <summary>

--- a/XLibur/Excel/DefinedNames/XLDefinedName.cs
+++ b/XLibur/Excel/DefinedNames/XLDefinedName.cs
@@ -12,6 +12,8 @@ namespace XLibur.Excel;
 [DebuggerDisplay("{_name}:{_formula}")]
 internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
 {
+    private const string RefError = "#REF!";
+
     private readonly XLDefinedNames _container;
     private string _name;
     private string _formula = null!;
@@ -184,6 +186,24 @@ internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
     internal void OnWorksheetDeleted(string worksheetName)
     {
         RenameFormulaSheet(worksheetName, null);
+        DropSheetPrefixOfRefError(worksheetName);
+    }
+
+    /// <summary>
+    /// A reference that a row or column deletion has already reduced to <c>#REF!</c> keeps its sheet
+    /// prefix (<c>'Sheet 1'!#REF!</c>), which is what Excel does while the sheet still exists. The
+    /// parser reports that prefix as part of an error node rather than as a sheet reference, so
+    /// <see cref="RenameFormulaSheet"/> never sees it and the prefix would outlive the sheet it names.
+    /// Excel treats a defined name pointing at an absent sheet as a broken file, so drop the prefix and
+    /// leave the bare <c>#REF!</c> that the rest of the deleted-sheet handling produces.
+    /// </summary>
+    private void DropSheetPrefixOfRefError(string worksheetName)
+    {
+        var prefixedRefError = worksheetName.EscapeSheetName() + "!" + RefError;
+        if (!_formula.Contains(prefixedRefError, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        RefersTo = _formula.Replace(prefixedRefError, RefError, StringComparison.OrdinalIgnoreCase);
     }
 
     private void RenameFormulaSheet(string oldSheetName, string? newSheetName)


### PR DESCRIPTION
## Summary

Follow-up to #241. Deleting every row a reference covers left it pointing at a row it never covered, and the two `NamedRangeBecomesInvalid*` tests that documented this were still skipped. Fixing the shifter lets both be unskipped.

`XLCellFormulaShifter` moves each endpoint by the deleted height and passes the result through `XLHelper.TrimRowNumber`, which clamps to row 1. So `'Sheet 1'!$A$1:$B$2` with rows 1-5 deleted became `'Sheet 1'!$A$1:$B$1` — a phantom one-row range sitting over whatever data had moved up into it. Excel writes `#REF!`.

## Changes

**The shifter** (`XLibur/Excel/Cells/XLCellFormulaShifter.cs`)

- Detect the wiped-out case before the endpoints are shifted: the range starts at or after the deletion and its last row lands above the deletion start. Emit `#REF!` there, keeping the sheet prefix, which is what Excel writes while the sheet still exists.
- The column path had the same clamp via `TrimColumnNumber`, so it gets the mirrored treatment rather than being left inconsistent with rows.
- Only the fully-deleted case changes. A range straddling the deletion still shrinks and shifts through `IsTopBoundaryDeletion` (#2866), and a range entirely below the deletion still shifts by the full height.
- The same shifter serves cell formulas, so `=SUM(A1:A2)` with those rows deleted now reads `SUM(#REF!)` rather than summing whatever moved up.

**Deleting the sheet afterwards** (`XLibur/Excel/DefinedNames/XLDefinedName.cs`)

- Once a row deletion produces `'Sheet 1'!#REF!`, the parser reports that sheet prefix as part of an error node rather than as a sheet reference — routing it through `RenameRefModVisitor` mangles it to `'''Sheet 1'''!#REF!`. So `RenameFormulaSheet` never sees it, and the prefix would outlive the sheet it names, writing a workbook whose defined name points at an absent sheet. Excel treats that as broken.
- `OnWorksheetDeleted` now drops the prefix, leaving the bare `#REF!` the deleted-sheet path already produces and that `NamedRangesFromDeletedSheetAreSavedWithoutAddress` pins down.

**The two skipped tests** (`XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs`)

Both are unskipped. Their assertions needed correcting first — each read `ElementAt(0)` twice with different expected values, so neither could ever have passed:

- `NamedRangeBecomesInvalidOnRangeDeleting`: second assertion now reads `ElementAt(1)`, and the expectations carry the `$` that references have had since they are stored fixed (`'Sheet 1'!$A$5:$D$10`, not `A5:D10`).
- `NamedRangeBecomesInvalidOnRangeAndWorksheetDeleting`: same fix, plus the expectations said `#REF!#REF!`, which contradicts the bare `#REF!` that `NamedRangesFromDeletedSheetAreSavedWithoutAddress` documents as the form Excel accepts.

## Related Issues

Closes the row and column deletion half of ClosedXML/ClosedXML#880.

Known adjacent gap, deliberately left alone: a *row-only* reference (`Sheet1!$3:$4`) whose rows are removed by an exact-cover multi-row delete still lands on `Sheet1!$1:$2`. `IXLRows.Delete()` applies the deletion row by row, and that branch never received the #2866 top-boundary handling the cell-range branch has, so the range drifts upward out from under the invalidation check. Separate defect, separate change.

## Testing

- [x] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually

Six cases added to `NamedRangeDeletionTests`, alongside the existing #2866 shrink-and-shift cases they must not disturb: exact-cover and overshooting row deletions, a single cell, a row-only reference, a cell formula, and the column counterpart.

Full suite on net8.0 and net10.0: 6494 total, 6490 passed, 0 failed, 4 skipped (was 6488/6482/6 before this branch).

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
