### PR TITLE
fix: position row-only and column-only references on deletion

### DIFF
--- a/XLibur.Tests/Excel/NamedRanges/NamedRangeDeletionTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangeDeletionTests.cs
@@ -183,6 +183,163 @@ public class NamedRangeDeletionTests
     }
 
     /// <summary>
+    /// Row-only counterpart of DeletingExactlyTheRowsOfNamedRange_BecomesRefError. A multi-row delete is
+    /// applied one row at a time, so the reference has to shrink correctly on the way down for the last
+    /// pass to see it as fully deleted.
+    /// </summary>
+    [Test]
+    public async Task DeletingExactlyTheRowsOfRowOnlyNamedRange_BecomesRefError()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Rows", "Sheet1!$3:$4");
+
+        ws.Rows(3, 4).Delete();
+
+        await Assert.That(RefersTo(wb, "Rows")).IsEqualTo("Sheet1!#REF!");
+    }
+
+    /// <summary>
+    /// Row-only counterpart of the #2866 top-boundary shrink: rows 3:5 with row 3 deleted becomes 3:4, not
+    /// 2:4. The row-only branch shifted both endpoints regardless of where the deletion started.
+    /// </summary>
+    [Test]
+    public async Task DeletingTopRowOfRowOnlyNamedRange_ShrinksAndShifts()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Rows", "Sheet1!$3:$5");
+
+        ws.Row(3).Delete();
+
+        await Assert.That(RefersTo(wb, "Rows")).IsEqualTo("Sheet1!$3:$4");
+    }
+
+    /// <summary>
+    /// Deleting a row inside a row-only reference shrinks it from within, leaving the top fixed.
+    /// </summary>
+    [Test]
+    public async Task DeletingMiddleRowOfRowOnlyNamedRange_ShrinksFromWithin()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Rows", "Sheet1!$3:$5");
+
+        ws.Row(4).Delete();
+
+        await Assert.That(RefersTo(wb, "Rows")).IsEqualTo("Sheet1!$3:$4");
+    }
+
+    /// <summary>
+    /// A deletion that starts above a row-only reference and ends inside it keeps the surviving top row
+    /// where it is: rows 2:5 with rows 3:4 deleted becomes 2:3.
+    /// </summary>
+    [Test]
+    public async Task DeletingRowsInsideRowOnlyNamedRange_KeepsSurvivingTop()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Rows", "Sheet1!$2:$5");
+
+        ws.Rows(3, 4).Delete();
+
+        await Assert.That(RefersTo(wb, "Rows")).IsEqualTo("Sheet1!$2:$3");
+    }
+
+    /// <summary>
+    /// A row-only reference entirely below the deletion shifts up whole: rows 3:4 with row 1 deleted
+    /// becomes 2:3. This case was already correct and must not regress.
+    /// </summary>
+    [Test]
+    public async Task DeletingRowAboveRowOnlyNamedRange_ShiftsWholeRangeUp()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Rows", "Sheet1!$3:$4");
+
+        ws.Row(1).Delete();
+
+        await Assert.That(RefersTo(wb, "Rows")).IsEqualTo("Sheet1!$2:$3");
+    }
+
+    /// <summary>
+    /// A deletion overshooting the top of a row-only reference leaves only what survived, moved up:
+    /// rows 3:6 with rows 1:5 deleted becomes 1:1. This case was already correct and must not regress.
+    /// </summary>
+    [Test]
+    public async Task DeletingRowsOvershootingRowOnlyNamedRange_KeepsSurvivor()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Rows", "Sheet1!$3:$6");
+
+        ws.Rows(1, 5).Delete();
+
+        await Assert.That(RefersTo(wb, "Rows")).IsEqualTo("Sheet1!$1:$1");
+    }
+
+    /// <summary>
+    /// Column-only reference, exact cover: columns C:D with those columns deleted become #REF!.
+    /// </summary>
+    [Test]
+    public async Task DeletingExactlyTheColumnsOfColumnOnlyNamedRange_BecomesRefError()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Cols", "Sheet1!$C:$D");
+
+        ws.Columns(3, 4).Delete();
+
+        await Assert.That(RefersTo(wb, "Cols")).IsEqualTo("Sheet1!#REF!");
+    }
+
+    /// <summary>
+    /// Column-only counterpart of the left-boundary shrink: columns C:E with column C deleted become C:D.
+    /// </summary>
+    [Test]
+    public async Task DeletingLeftColumnOfColumnOnlyNamedRange_ShrinksAndShifts()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Cols", "Sheet1!$C:$E");
+
+        ws.Column(3).Delete();
+
+        await Assert.That(RefersTo(wb, "Cols")).IsEqualTo("Sheet1!$C:$D");
+    }
+
+    /// <summary>
+    /// Column-only counterpart of the surviving-left case: columns B:E with columns C:D deleted become B:C.
+    /// </summary>
+    [Test]
+    public async Task DeletingColumnsInsideColumnOnlyNamedRange_KeepsSurvivingLeft()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Cols", "Sheet1!$B:$E");
+
+        ws.Columns(3, 4).Delete();
+
+        await Assert.That(RefersTo(wb, "Cols")).IsEqualTo("Sheet1!$B:$C");
+    }
+
+    /// <summary>
+    /// A column-only reference entirely to the right of the deletion shifts left whole: columns C:D with
+    /// column A deleted become B:C. This case was already correct and must not regress.
+    /// </summary>
+    [Test]
+    public async Task DeletingColumnLeftOfColumnOnlyNamedRange_ShiftsWholeRangeLeft()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Cols", "Sheet1!$C:$D");
+
+        ws.Column(1).Delete();
+
+        await Assert.That(RefersTo(wb, "Cols")).IsEqualTo("Sheet1!$B:$C");
+    }
+
+    /// <summary>
     /// Column counterpart of the invalidation: deleting every column a named range covers leaves #REF!
     /// instead of clamping the endpoints back to column A.
     /// </summary>

--- a/XLibur.Tests/Excel/NamedRanges/NamedRangeInsertionTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangeInsertionTests.cs
@@ -7,6 +7,11 @@ namespace XLibur.Tests.Excel.NamedRanges;
 
 public class NamedRangeInsertionTests
 {
+    private static string RefersTo(XLWorkbook wb, string name)
+    {
+        return wb.DefinedNames.First(dn => dn.Name == name).RefersTo;
+    }
+
     /// <summary>
     /// When rows are inserted inside a named range by shifting cells down,
     /// the named range should expand to include the new rows,
@@ -150,6 +155,68 @@ public class NamedRangeInsertionTests
             var range = ranges.First();
             await Assert.That(range.RangeAddress.ToString()).IsEqualTo("$A$1:$B$14");
         }
+    }
+
+    /// <summary>
+    /// A row-only reference expands the same way a cell range does: rows 3:5 with two rows inserted at
+    /// row 4 becomes 3:7. The row-only branch used to shift both endpoints regardless of where the insert
+    /// landed, giving 5:7 -- a reference that had moved off the rows it covered.
+    /// </summary>
+    [Test]
+    public async Task InsertingRowsInsideRowOnlyNamedRange_ExpandsRange()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Rows", "Sheet1!$3:$5");
+
+        ws.Row(4).InsertRowsAbove(2);
+
+        await Assert.That(RefersTo(wb, "Rows")).IsEqualTo("Sheet1!$3:$7");
+    }
+
+    /// <summary>
+    /// Inserting above a row-only reference shifts it down without expanding, as for a cell range.
+    /// </summary>
+    [Test]
+    public async Task InsertingRowsAboveRowOnlyNamedRange_ShiftsRangeDown()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Rows", "Sheet1!$3:$5");
+
+        ws.Row(1).InsertRowsAbove(2);
+
+        await Assert.That(RefersTo(wb, "Rows")).IsEqualTo("Sheet1!$5:$7");
+    }
+
+    /// <summary>
+    /// Column-only counterpart: columns C:E with two columns inserted before D becomes C:G.
+    /// </summary>
+    [Test]
+    public async Task InsertingColumnsInsideColumnOnlyNamedRange_ExpandsRange()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Cols", "Sheet1!$C:$E");
+
+        ws.Column(4).InsertColumnsBefore(2);
+
+        await Assert.That(RefersTo(wb, "Cols")).IsEqualTo("Sheet1!$C:$G");
+    }
+
+    /// <summary>
+    /// Inserting to the left of a column-only reference shifts it right without expanding.
+    /// </summary>
+    [Test]
+    public async Task InsertingColumnsLeftOfColumnOnlyNamedRange_ShiftsRangeRight()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        wb.DefinedNames.Add("Cols", "Sheet1!$C:$E");
+
+        ws.Column(1).InsertColumnsBefore(2);
+
+        await Assert.That(RefersTo(wb, "Cols")).IsEqualTo("Sheet1!$E:$G");
     }
 
     /// <summary>

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -91,7 +91,7 @@ internal static partial class XLCellFormulaShifter
         if (IsDeletedEntirelyByRowShift(shiftedRange, matchRange, rowsShifted))
             sb.Append(RefError);
         else if (A1RowRegex.IsMatch(rangeAddress))
-            AppendShiftedRowOnlyRange(sb, rangeAddress, rowsShifted);
+            AppendShiftedRowOnlyRange(sb, rangeAddress, shiftedRange, matchRange, rowsShifted);
         else if (shiftedRange.RangeAddress.FirstAddress.RowNumber <= matchRange.RangeAddress.FirstAddress.RowNumber)
         {
             if (IsTopBoundaryDeletion(shiftedRange, matchRange, rowsShifted))
@@ -155,20 +155,41 @@ internal static partial class XLCellFormulaShifter
             && shiftedRange.RangeAddress.LastAddress.ColumnNumber >= matchRange.RangeAddress.LastAddress.ColumnNumber;
     }
 
-    private static string ShiftRowString(string rowString, int rowsShifted)
+    /// <summary>
+    /// A row-only reference (<c>3:5</c>) obeys the same rules as a cell range but renders as bare row
+    /// numbers. Both boundaries are decided here rather than shifted blindly: the top only moves when the
+    /// deletion starts at or above it, and a deletion that removes the top boundary leaves the top pinned
+    /// at the deletion start. Shifting both endpoints regardless (as this did) walked the reference onto
+    /// rows it never covered -- 3:5 with row 4 deleted became 2:4 -- and kept it from ever shrinking to
+    /// nothing, so <see cref="IsDeletedEntirelyByRowShift"/> never saw the fully deleted case.
+    /// </summary>
+    private static void AppendShiftedRowOnlyRange(StringBuilder sb, string rangeAddress, XLRange shiftedRange,
+        IXLRange matchRange, int rowsShifted)
     {
-        if (rowString[0] == '$')
-            return "$" + XLHelper.TrimRowNumber(int.Parse(rowString.Substring(1)) + rowsShifted).ToInvariantString();
+        var firstRow = matchRange.RangeAddress.FirstAddress.RowNumber;
+        var lastRow = matchRange.RangeAddress.LastAddress.RowNumber;
+        var deletionStart = shiftedRange.RangeAddress.FirstAddress.RowNumber;
 
-        return XLHelper.TrimRowNumber(int.Parse(rowString) + rowsShifted).ToInvariantString();
+        var newFirstRow = firstRow;
+        if (deletionStart <= firstRow)
+        {
+            newFirstRow = IsTopBoundaryDeletion(shiftedRange, matchRange, rowsShifted)
+                ? deletionStart
+                : firstRow + rowsShifted;
+        }
+
+        var rows = rangeAddress.Split(':');
+        AppendRowBoundary(sb, rows[0], newFirstRow);
+        sb.Append(':');
+        AppendRowBoundary(sb, rows[1], lastRow + rowsShifted);
     }
 
-    private static void AppendShiftedRowOnlyRange(StringBuilder sb, string rangeAddress, int rowsShifted)
+    private static void AppendRowBoundary(StringBuilder sb, string rowToken, int rowNumber)
     {
-        var rows = rangeAddress.Split(':');
-        sb.Append(ShiftRowString(rows[0], rowsShifted));
-        sb.Append(':');
-        sb.Append(ShiftRowString(rows[1], rowsShifted));
+        if (rowToken[0] == '$')
+            sb.Append('$');
+
+        sb.Append(XLHelper.TrimRowNumber(rowNumber).ToInvariantString());
     }
 
     private static void AppendShiftedRowCellRange(StringBuilder sb, XLWorksheet ws, IXLRange matchRange,
@@ -263,7 +284,7 @@ internal static partial class XLCellFormulaShifter
         if (IsDeletedEntirelyByColumnShift(shiftedRange, matchRange, columnsShifted))
             sb.Append(RefError);
         else if (A1ColumnRegex.IsMatch(rangeAddress))
-            AppendShiftedColumnOnlyRange(sb, rangeAddress, columnsShifted);
+            AppendShiftedColumnOnlyRange(sb, rangeAddress, shiftedRange, matchRange, columnsShifted);
         else if (shiftedRange.RangeAddress.FirstAddress.ColumnNumber <= matchRange.RangeAddress.FirstAddress.ColumnNumber)
         {
             if (IsLeftBoundaryDeletion(shiftedRange, matchRange, columnsShifted))
@@ -325,22 +346,38 @@ internal static partial class XLCellFormulaShifter
             && shiftedRange.RangeAddress.LastAddress.RowNumber >= matchRange.RangeAddress.LastAddress.RowNumber;
     }
 
-    private static string ShiftColumnString(string columnString, int columnsShifted)
+    /// <summary>
+    /// Column-wise counterpart of <see cref="AppendShiftedRowOnlyRange"/>: a column-only reference
+    /// (<c>C:E</c>) keeps its left boundary unless the deletion starts at or to the left of it, and pins
+    /// that boundary at the deletion start when the deletion removes it.
+    /// </summary>
+    private static void AppendShiftedColumnOnlyRange(StringBuilder sb, string rangeAddress, XLRange shiftedRange,
+        IXLRange matchRange, int columnsShifted)
     {
-        if (columnString[0] == '$')
-            return "$" + XLHelper.GetColumnLetterFromNumber(
-                XLHelper.GetColumnNumberFromLetter(columnString.Substring(1)) + columnsShifted, true);
+        var firstColumn = matchRange.RangeAddress.FirstAddress.ColumnNumber;
+        var lastColumn = matchRange.RangeAddress.LastAddress.ColumnNumber;
+        var deletionStart = shiftedRange.RangeAddress.FirstAddress.ColumnNumber;
 
-        return XLHelper.GetColumnLetterFromNumber(
-            XLHelper.GetColumnNumberFromLetter(columnString) + columnsShifted, true);
+        var newFirstColumn = firstColumn;
+        if (deletionStart <= firstColumn)
+        {
+            newFirstColumn = IsLeftBoundaryDeletion(shiftedRange, matchRange, columnsShifted)
+                ? deletionStart
+                : firstColumn + columnsShifted;
+        }
+
+        var columns = rangeAddress.Split(':');
+        AppendColumnBoundary(sb, columns[0], newFirstColumn);
+        sb.Append(':');
+        AppendColumnBoundary(sb, columns[1], lastColumn + columnsShifted);
     }
 
-    private static void AppendShiftedColumnOnlyRange(StringBuilder sb, string rangeAddress, int columnsShifted)
+    private static void AppendColumnBoundary(StringBuilder sb, string columnToken, int columnNumber)
     {
-        var columns = rangeAddress.Split(':');
-        sb.Append(ShiftColumnString(columns[0], columnsShifted));
-        sb.Append(':');
-        sb.Append(ShiftColumnString(columns[1], columnsShifted));
+        if (columnToken[0] == '$')
+            sb.Append('$');
+
+        sb.Append(XLHelper.GetColumnLetterFromNumber(columnNumber, true));
     }
 
     private static void AppendShiftedColumnCellRange(StringBuilder sb, XLWorksheet ws, IXLRange matchRange,

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -158,23 +158,27 @@ internal static partial class XLCellFormulaShifter
     /// <summary>
     /// A row-only reference (<c>3:5</c>) obeys the same rules as a cell range but renders as bare row
     /// numbers. Both boundaries are decided here rather than shifted blindly: the top only moves when the
-    /// deletion starts at or above it, and a deletion that removes the top boundary leaves the top pinned
-    /// at the deletion start. Shifting both endpoints regardless (as this did) walked the reference onto
-    /// rows it never covered -- 3:5 with row 4 deleted became 2:4 -- and kept it from ever shrinking to
-    /// nothing, so <see cref="IsDeletedEntirelyByRowShift"/> never saw the fully deleted case.
+    /// shift starts at or above it, and a deletion that removes the top boundary leaves the top pinned at
+    /// the deletion start; the bottom always shifts.
+    /// <para>
+    /// Shifting both endpoints regardless (as this did) walked the reference onto rows it never covered.
+    /// Deleting row 4 turned 3:5 into 2:4, and it kept the reference from ever shrinking to nothing, so
+    /// <see cref="IsDeletedEntirelyByRowShift"/> never saw the fully deleted case. The same applied to
+    /// insertions: inserting two rows at row 4 turned 3:5 into 5:7 instead of expanding it to 3:7.
+    /// </para>
     /// </summary>
     private static void AppendShiftedRowOnlyRange(StringBuilder sb, string rangeAddress, XLRange shiftedRange,
         IXLRange matchRange, int rowsShifted)
     {
         var firstRow = matchRange.RangeAddress.FirstAddress.RowNumber;
         var lastRow = matchRange.RangeAddress.LastAddress.RowNumber;
-        var deletionStart = shiftedRange.RangeAddress.FirstAddress.RowNumber;
+        var shiftStart = shiftedRange.RangeAddress.FirstAddress.RowNumber;
 
         var newFirstRow = firstRow;
-        if (deletionStart <= firstRow)
+        if (shiftStart <= firstRow)
         {
             newFirstRow = IsTopBoundaryDeletion(shiftedRange, matchRange, rowsShifted)
-                ? deletionStart
+                ? shiftStart
                 : firstRow + rowsShifted;
         }
 
@@ -348,21 +352,21 @@ internal static partial class XLCellFormulaShifter
 
     /// <summary>
     /// Column-wise counterpart of <see cref="AppendShiftedRowOnlyRange"/>: a column-only reference
-    /// (<c>C:E</c>) keeps its left boundary unless the deletion starts at or to the left of it, and pins
-    /// that boundary at the deletion start when the deletion removes it.
+    /// (<c>C:E</c>) keeps its left boundary unless the shift starts at or to the left of it, and pins that
+    /// boundary at the deletion start when a deletion removes it.
     /// </summary>
     private static void AppendShiftedColumnOnlyRange(StringBuilder sb, string rangeAddress, XLRange shiftedRange,
         IXLRange matchRange, int columnsShifted)
     {
         var firstColumn = matchRange.RangeAddress.FirstAddress.ColumnNumber;
         var lastColumn = matchRange.RangeAddress.LastAddress.ColumnNumber;
-        var deletionStart = shiftedRange.RangeAddress.FirstAddress.ColumnNumber;
+        var shiftStart = shiftedRange.RangeAddress.FirstAddress.ColumnNumber;
 
         var newFirstColumn = firstColumn;
-        if (deletionStart <= firstColumn)
+        if (shiftStart <= firstColumn)
         {
             newFirstColumn = IsLeftBoundaryDeletion(shiftedRange, matchRange, columnsShifted)
-                ? deletionStart
+                ? shiftStart
                 : firstColumn + columnsShifted;
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #243, now merged; this targets `main` and contains one commit.

#243 noted a gap it deliberately left alone: a row-only reference (`Sheet1!$3:$4`) whose rows are removed by an exact-cover delete landed on `Sheet1!$1:$2` instead of `#REF!`. Looking properly, that symptom was the least of it — the row-only branch shifted both endpoints and clamped, without ever consulting where the deletion started. The cell-range branch received the top-boundary rules in #2866 and the `#REF!` invalidation in #243; this branch received neither.

Three distinct cases were wrong, on both axes:

| reference | deletion | before | correct |
| --- | --- | --- | --- |
| `$3:$5` | row 4 (inside) | `$2:$4` | `$3:$4` |
| `$3:$5` | row 3 (top boundary) | `$2:$4` | `$3:$4` |
| `$3:$4` | rows 3:4 (exact cover) | `$1:$2` | `#REF!` |
| `$C:$E` | column C | `$B:$D` | `$C:$D` |
| `$B:$E` | columns C:D | `$A:$C` | `$B:$C` |
| `$C:$D` | columns C:D | `$A:$B` | `#REF!` |

The first two are silent data corruption: the reference walks onto rows it never covered and drops rows that survived.

Insertion was wrong for the same reason, since it runs through the same branch:

| reference | insertion | before | correct |
| --- | --- | --- | --- |
| `$3:$5` | 2 rows at row 4 | `$5:$7` | `$3:$7` |
| `$C:$E` | 2 columns before D | `$E:$G` | `$C:$G` |

The equivalent cell ranges (`$A$3:$A$5` → `$A$3:$A$7`) have always expanded correctly; only the row-only and column-only forms moved off the rows they covered.

The exact-cover case is a consequence of the other two. `IXLRows.Delete()` applies a multi-row delete one row at a time, so a reference that drifts upward instead of shrinking never gets small enough for #243's invalidation check to fire.

## Changes

`XLibur/Excel/Cells/XLCellFormulaShifter.cs`

- `AppendShiftedRowOnlyRange` now decides both boundaries the way the cell-range branch does: the top only moves when the deletion starts at or above it, and stays pinned at the deletion start when the deletion removes it (`IsTopBoundaryDeletion`, shared with the cell-range path); the bottom always shifts. Rendering stays row-only and preserves whatever `$` the reference carried.
- `AppendShiftedColumnOnlyRange` had the identical three defects and gets the same treatment, sharing `IsLeftBoundaryDeletion`.
- `ShiftRowString` / `ShiftColumnString` are replaced by `AppendRowBoundary` / `AppendColumnBoundary`, which render one already-decided boundary rather than folding the shift arithmetic into the string handling.
- Both helpers name the boundary `shiftStart`, not `deletionStart`: insertions reach the same code.

## Related Issues

Completes the row and column deletion half of ClosedXML/ClosedXML#880, and extends the ClosedXML/ClosedXML#2866 top-boundary rules to the row-only and column-only references they missed.

## Testing

- [x] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually

Ten cases added to `NamedRangeDeletionTests`. For each axis: the exact cover, the boundary-removing delete, and the delete inside — plus the two cases that were already correct (a deletion entirely before the reference, and one overshooting its top, which reached the right answer only because clamping happened to cancel the drift) so the new positioning cannot regress them. All ten fail without this change and pass with it.

Four more in `NamedRangeInsertionTests`, alongside the cell-range cases they mirror: inserting inside and inserting before, for both axes.

Full suite on net8.0 and net10.0: 6508 total, 6504 passed, 0 failed, 4 skipped.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
