### PR TITLE
Cover the encryption paths a workbook round trip cannot reach

### DIFF
--- a/XLibur.Tests/Excel/Encryption/AgileCryptoTests.cs
+++ b/XLibur.Tests/Excel/Encryption/AgileCryptoTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using XLibur.Excel.Exceptions;
+using XLibur.Excel.IO.Encryption;
+using XLibur.Excel.IO.Encryption.Agile;
+
+namespace XLibur.Tests.Excel.Encryption;
+
+/// <summary>
+/// The agile cipher below the workbook API: algorithm agility, segment handling and the integrity
+/// check.
+/// </summary>
+/// <remarks>
+/// XLibur writes one profile, AES-256 with SHA-512, so saving and reloading a workbook only ever
+/// exercises that one. It has to <em>read</em> whatever the specification allows, and other
+/// producers do pick differently, so the combinations are driven directly here rather than through
+/// a saved file that could never contain them.
+/// </remarks>
+// Internal because the test cases are parameterised by OfficeHashAlgorithm, which is internal.
+internal class AgileCryptoTests
+{
+    private const string Password = "a password";
+
+    // A low spin count: these tests exercise algorithm selection, not the cost of the spin, and
+    // 100,000 iterations per combination would dominate the suite's runtime for no added signal.
+    private const int SpinCount = 64;
+
+    private static AgileCipherParameters Parameters(OfficeHashAlgorithm hash, int keyBits)
+    {
+        var salt = new byte[16];
+        RandomNumberGenerator.Fill(salt);
+
+        return new AgileCipherParameters
+        {
+            SaltSize = 16,
+            BlockSize = 16,
+            KeyBits = keyBits,
+            HashSize = hash.GetHashSize(),
+            ChainingMode = CipherMode.CBC,
+            HashAlgorithm = hash,
+            SaltValue = salt,
+        };
+    }
+
+    /// <summary>
+    /// Encrypts a payload under the given profile and returns the descriptor describing it.
+    /// </summary>
+    private static (AgileEncryptionDescriptor Descriptor, byte[] EncryptedPackage) Encrypt(
+        byte[] payload, OfficeHashAlgorithm hash, int keyBits)
+    {
+        var keyData = Parameters(hash, keyBits);
+        var keyEncryptor = Parameters(hash, keyBits);
+
+        var packageKey = new byte[keyBits / 8];
+        RandomNumberGenerator.Fill(packageKey);
+
+        var (verifierInput, verifierValue, encryptedKeyValue) =
+            AgileCrypto.CreateVerifier(keyEncryptor, SpinCount, Password, packageKey);
+
+        var withoutIntegrity = new AgileEncryptionDescriptor
+        {
+            KeyData = keyData,
+            PasswordKeyEncryptor = new AgilePasswordKeyEncryptor
+            {
+                Parameters = keyEncryptor,
+                SpinCount = SpinCount,
+                EncryptedVerifierHashInput = verifierInput,
+                EncryptedVerifierHashValue = verifierValue,
+                EncryptedKeyValue = encryptedKeyValue,
+            },
+        };
+
+        var encryptedPackage = AgileCrypto.EncryptPackage(withoutIntegrity, packageKey, payload);
+        var (hmacKey, hmacValue) = AgileCrypto.CreateIntegrity(keyData, packageKey, encryptedPackage);
+
+        var descriptor = new AgileEncryptionDescriptor
+        {
+            KeyData = keyData,
+            PasswordKeyEncryptor = withoutIntegrity.PasswordKeyEncryptor,
+            EncryptedHmacKey = hmacKey,
+            EncryptedHmacValue = hmacValue,
+        };
+
+        return (descriptor, encryptedPackage);
+    }
+
+    [Test]
+    [Arguments(OfficeHashAlgorithm.Sha1, 128)]
+    [Arguments(OfficeHashAlgorithm.Sha1, 256)]
+    [Arguments(OfficeHashAlgorithm.Sha256, 128)]
+    [Arguments(OfficeHashAlgorithm.Sha256, 192)]
+    [Arguments(OfficeHashAlgorithm.Sha256, 256)]
+    [Arguments(OfficeHashAlgorithm.Sha384, 256)]
+    [Arguments(OfficeHashAlgorithm.Sha512, 128)]
+    [Arguments(OfficeHashAlgorithm.Sha512, 256)]
+    public async Task Every_supported_hash_and_key_length_round_trips(OfficeHashAlgorithm hash, int keyBits)
+    {
+        // SHA-1 with a 256 bit key is the interesting corner: the hash is 20 bytes and the key needs
+        // 32, so the derived material has to be padded rather than truncated.
+        var payload = new byte[5000];
+        RandomNumberGenerator.Fill(payload);
+
+        var (descriptor, encryptedPackage) = Encrypt(payload, hash, keyBits);
+
+        var packageKey = AgileCrypto.DecryptPackageKey(descriptor, Password);
+        AgileCrypto.VerifyIntegrity(descriptor, packageKey, encryptedPackage);
+        var decrypted = AgileCrypto.DecryptPackage(descriptor, packageKey, encryptedPackage);
+
+        await Assert.That(decrypted).IsEquivalentTo(payload);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(15)]
+    [Arguments(16)]
+    [Arguments(4095)]
+    [Arguments(4096)]
+    [Arguments(4097)]
+    [Arguments(8192)]
+    [Arguments(12289)]
+    public async Task Payloads_around_the_segment_and_block_boundaries_round_trip(int length)
+    {
+        // The package is encrypted in 4096 byte segments, each with its own IV, and a trailing
+        // segment is padded to a whole cipher block. Lengths either side of both boundaries are
+        // where an off-by-one in that loop shows up; an ordinary workbook is far too big to land on
+        // one by accident.
+        var payload = new byte[length];
+        RandomNumberGenerator.Fill(payload);
+
+        var (descriptor, encryptedPackage) = Encrypt(payload, OfficeHashAlgorithm.Sha512, 256);
+
+        var packageKey = AgileCrypto.DecryptPackageKey(descriptor, Password);
+        var decrypted = AgileCrypto.DecryptPackage(descriptor, packageKey, encryptedPackage);
+
+        await Assert.That(decrypted.Length).IsEqualTo(length);
+        await Assert.That(decrypted).IsEquivalentTo(payload);
+    }
+
+    [Test]
+    public async Task The_length_prefix_is_what_decides_the_plaintext_length()
+    {
+        // Ciphertext is padded to whole blocks, so the prefix is the only thing that says where the
+        // content stops. A payload that is not a multiple of the block size proves the padding is
+        // not being handed back as content.
+        var payload = new byte[100];
+        RandomNumberGenerator.Fill(payload);
+
+        var (descriptor, encryptedPackage) = Encrypt(payload, OfficeHashAlgorithm.Sha512, 256);
+
+        // 8 byte prefix plus 112 bytes of ciphertext, being 100 padded up to seven 16 byte blocks.
+        await Assert.That(encryptedPackage.Length).IsEqualTo(8 + 112);
+
+        var packageKey = AgileCrypto.DecryptPackageKey(descriptor, Password);
+        await Assert.That(AgileCrypto.DecryptPackage(descriptor, packageKey, encryptedPackage).Length).IsEqualTo(100);
+    }
+
+    [Test]
+    public async Task A_wrong_password_is_refused_before_anything_is_decrypted()
+    {
+        var (descriptor, _) = Encrypt([1, 2, 3], OfficeHashAlgorithm.Sha512, 256);
+
+        await Assert.That(() => AgileCrypto.DecryptPackageKey(descriptor, "the wrong password"))
+            .Throws<XLInvalidPasswordException>();
+    }
+
+    [Test]
+    public async Task A_package_shorter_than_its_length_prefix_is_rejected()
+    {
+        var (descriptor, _) = Encrypt([1, 2, 3], OfficeHashAlgorithm.Sha512, 256);
+        var packageKey = AgileCrypto.DecryptPackageKey(descriptor, Password);
+
+        await Assert.That(() => AgileCrypto.DecryptPackage(descriptor, packageKey, new byte[4]))
+            .Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task A_package_claiming_more_content_than_it_carries_is_rejected()
+    {
+        var (descriptor, encryptedPackage) = Encrypt([1, 2, 3], OfficeHashAlgorithm.Sha512, 256);
+        var packageKey = AgileCrypto.DecryptPackageKey(descriptor, Password);
+
+        // Truncation is the shape a partial download or a cut-off copy takes. The declared length
+        // then exceeds what is there, and inventing the difference would hand back invented data.
+        var truncated = new byte[encryptedPackage.Length];
+        encryptedPackage.CopyTo(truncated, 0);
+        BitConverter.TryWriteBytes(truncated.AsSpan(0, 8), (long)100_000);
+
+        await Assert.That(() => AgileCrypto.DecryptPackage(descriptor, packageKey, truncated))
+            .Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task A_descriptor_without_data_integrity_skips_the_check_rather_than_failing_it()
+    {
+        var payload = new byte[64];
+        RandomNumberGenerator.Fill(payload);
+
+        var (descriptor, encryptedPackage) = Encrypt(payload, OfficeHashAlgorithm.Sha512, 256);
+        var withoutIntegrity = new AgileEncryptionDescriptor
+        {
+            KeyData = descriptor.KeyData,
+            PasswordKeyEncryptor = descriptor.PasswordKeyEncryptor,
+        };
+
+        var packageKey = AgileCrypto.DecryptPackageKey(withoutIntegrity, Password);
+
+        await Assert.That(() => AgileCrypto.VerifyIntegrity(withoutIntegrity, packageKey, encryptedPackage))
+            .ThrowsNothing();
+    }
+
+    [Test]
+    public async Task The_integrity_check_notices_a_single_flipped_bit()
+    {
+        var payload = new byte[4096];
+        RandomNumberGenerator.Fill(payload);
+
+        var (descriptor, encryptedPackage) = Encrypt(payload, OfficeHashAlgorithm.Sha512, 256);
+        var packageKey = AgileCrypto.DecryptPackageKey(descriptor, Password);
+
+        encryptedPackage[encryptedPackage.Length / 2] ^= 0x01;
+
+        await Assert.That(() => AgileCrypto.VerifyIntegrity(descriptor, packageKey, encryptedPackage))
+            .Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task Each_save_uses_fresh_random_material()
+    {
+        // Salts and the package key are generated per save. If any of them were fixed, two saves of
+        // the same content under the same password would produce identical ciphertext, which leaks
+        // that the content is unchanged.
+        var payload = new byte[256];
+        RandomNumberGenerator.Fill(payload);
+
+        var (first, firstPackage) = Encrypt(payload, OfficeHashAlgorithm.Sha512, 256);
+        var (second, secondPackage) = Encrypt(payload, OfficeHashAlgorithm.Sha512, 256);
+
+        await Assert.That(first.KeyData.SaltValue).IsNotEquivalentTo(second.KeyData.SaltValue);
+        await Assert.That(firstPackage).IsNotEquivalentTo(secondPackage);
+    }
+}

--- a/XLibur.Tests/Excel/Encryption/AgileDescriptorTests.cs
+++ b/XLibur.Tests/Excel/Encryption/AgileDescriptorTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using XLibur.Excel.Exceptions;
+using XLibur.Excel.IO.Encryption;
+using XLibur.Excel.IO.Encryption.Agile;
+
+namespace XLibur.Tests.Excel.Encryption;
+
+/// <summary>
+/// The agile encryption descriptor: what XLibur emits, what it accepts, and what it refuses.
+/// </summary>
+/// <remarks>
+/// The specification allows far more combinations than Excel writes, and the design deliberately
+/// rejects anything outside that profile by name instead of approximating it. Approximating would
+/// turn an unusual file into plausible-looking garbage rather than an error, so the refusals are
+/// part of the contract and are asserted here rather than assumed.
+/// </remarks>
+// Internal because some cases are parameterised by OfficeHashAlgorithm, which is internal.
+internal class AgileDescriptorTests
+{
+    /// <summary>
+    /// Wraps descriptor XML in the 8 byte EncryptionInfo header so it can go through the real parser.
+    /// </summary>
+    private static byte[] EncryptionInfo(string xml)
+    {
+        var body = Encoding.UTF8.GetBytes(xml);
+        var stream = new byte[8 + body.Length];
+        BitConverter.TryWriteBytes(stream.AsSpan(0), (ushort)4);
+        BitConverter.TryWriteBytes(stream.AsSpan(2), (ushort)4);
+        BitConverter.TryWriteBytes(stream.AsSpan(4), 0x40u);
+        body.CopyTo(stream.AsSpan(8));
+        return stream;
+    }
+
+    private static string Descriptor(
+        string keyDataAttributes =
+            "saltSize=\"16\" blockSize=\"16\" keyBits=\"256\" hashSize=\"64\" cipherAlgorithm=\"AES\" cipherChaining=\"ChainingModeCBC\" hashAlgorithm=\"SHA512\" saltValue=\"AAAAAAAAAAAAAAAAAAAAAA==\"",
+        string encryptedKeyAttributes =
+            "spinCount=\"100000\" saltSize=\"16\" blockSize=\"16\" keyBits=\"256\" hashSize=\"64\" cipherAlgorithm=\"AES\" cipherChaining=\"ChainingModeCBC\" hashAlgorithm=\"SHA512\" saltValue=\"AAAAAAAAAAAAAAAAAAAAAA==\" encryptedVerifierHashInput=\"AAAAAAAAAAAAAAAAAAAAAA==\" encryptedVerifierHashValue=\"AAAAAAAAAAAAAAAAAAAAAA==\" encryptedKeyValue=\"AAAAAAAAAAAAAAAAAAAAAA==\"",
+        string keyEncryptorUri = "http://schemas.microsoft.com/office/2006/keyEncryptor/password")
+    {
+        return $"""
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <encryption xmlns="http://schemas.microsoft.com/office/2006/encryption"
+                            xmlns:p="http://schemas.microsoft.com/office/2006/keyEncryptor/password">
+                  <keyData {keyDataAttributes}/>
+                  <keyEncryptors>
+                    <keyEncryptor uri="{keyEncryptorUri}">
+                      <p:encryptedKey {encryptedKeyAttributes}/>
+                    </keyEncryptor>
+                  </keyEncryptors>
+                </encryption>
+                """;
+    }
+
+    [Test]
+    [Arguments(OfficeHashAlgorithm.Sha1, 128)]
+    [Arguments(OfficeHashAlgorithm.Sha256, 192)]
+    [Arguments(OfficeHashAlgorithm.Sha384, 256)]
+    [Arguments(OfficeHashAlgorithm.Sha512, 256)]
+    public async Task What_XLibur_emits_is_what_XLibur_accepts(OfficeHashAlgorithm hash, int keyBits)
+    {
+        // The writer and the reader are separate bodies of code over the same XML. This is the test
+        // that fails if one drifts from the other, which no round trip through a saved workbook
+        // would localise as clearly.
+        //
+        // Driven across every supported algorithm even though XLibur only ever writes SHA-512:
+        // the name each algorithm is written under has to be the name the parser reads back, and a
+        // mismatch in the rarely used ones would otherwise sit undetected until a file needed them.
+        var salt = new byte[16];
+        RandomNumberGenerator.Fill(salt);
+
+        var parameters = new AgileCipherParameters
+        {
+            SaltSize = 16,
+            BlockSize = 16,
+            KeyBits = keyBits,
+            HashSize = hash.GetHashSize(),
+            ChainingMode = CipherMode.CBC,
+            HashAlgorithm = hash,
+            SaltValue = salt,
+        };
+
+        var original = new AgileEncryptionDescriptor
+        {
+            KeyData = parameters,
+            PasswordKeyEncryptor = new AgilePasswordKeyEncryptor
+            {
+                Parameters = parameters,
+                SpinCount = 100_000,
+                EncryptedVerifierHashInput = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                EncryptedVerifierHashValue = [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+                EncryptedKeyValue = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+            },
+            EncryptedHmacKey = [9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9],
+            EncryptedHmacValue = [8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+        };
+
+        var parsed = AgileEncryptionDescriptor.Parse(original.ToEncryptionInfo());
+
+        await Assert.That(parsed.KeyData.SaltValue).IsEquivalentTo(salt);
+        await Assert.That(parsed.KeyData.KeyBits).IsEqualTo(keyBits);
+        await Assert.That(parsed.KeyData.HashAlgorithm).IsEqualTo(hash);
+        await Assert.That(parsed.KeyData.HashSize).IsEqualTo(hash.GetHashSize());
+        await Assert.That(parsed.KeyData.ChainingMode).IsEqualTo(CipherMode.CBC);
+        await Assert.That(parsed.PasswordKeyEncryptor.SpinCount).IsEqualTo(100_000);
+        await Assert.That(parsed.PasswordKeyEncryptor.EncryptedVerifierHashInput)
+            .IsEquivalentTo(original.PasswordKeyEncryptor.EncryptedVerifierHashInput);
+        await Assert.That(parsed.PasswordKeyEncryptor.EncryptedVerifierHashValue)
+            .IsEquivalentTo(original.PasswordKeyEncryptor.EncryptedVerifierHashValue);
+        await Assert.That(parsed.PasswordKeyEncryptor.EncryptedKeyValue)
+            .IsEquivalentTo(original.PasswordKeyEncryptor.EncryptedKeyValue);
+        await Assert.That(parsed.EncryptedHmacKey).IsEquivalentTo(original.EncryptedHmacKey);
+        await Assert.That(parsed.EncryptedHmacValue).IsEquivalentTo(original.EncryptedHmacValue);
+    }
+
+    [Test]
+    public async Task A_descriptor_without_data_integrity_is_accepted()
+    {
+        // dataIntegrity is optional. A file without it simply has no HMAC to check, which is not the
+        // same as a file whose HMAC fails.
+        var descriptor = AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor()));
+
+        await Assert.That(descriptor.EncryptedHmacKey).IsNull();
+        await Assert.That(descriptor.EncryptedHmacValue).IsNull();
+    }
+
+    [Test]
+    [Arguments("cipherAlgorithm=\"RC4\"", "RC4")]
+    [Arguments("cipherAlgorithm=\"DES\"", "DES")]
+    public async Task An_unsupported_cipher_is_named_in_the_error(string cipherAttribute, string expectedInMessage)
+    {
+        var keyData = "saltSize=\"16\" blockSize=\"16\" keyBits=\"256\" hashSize=\"64\" " + cipherAttribute +
+                      " cipherChaining=\"ChainingModeCBC\" hashAlgorithm=\"SHA512\" saltValue=\"AAAAAAAAAAAAAAAAAAAAAA==\"";
+
+        var exception = await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor(keyData))))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains(expectedInMessage);
+    }
+
+    [Test]
+    public async Task The_unsupported_cfb_chaining_mode_is_called_out_by_name()
+    {
+        // CFB is the one alternative the specification defines, so it is worth a message of its own
+        // rather than falling into the generic "unsupported" branch.
+        var keyData = "saltSize=\"16\" blockSize=\"16\" keyBits=\"256\" hashSize=\"64\" cipherAlgorithm=\"AES\" " +
+                      "cipherChaining=\"ChainingModeCFB\" hashAlgorithm=\"SHA512\" saltValue=\"AAAAAAAAAAAAAAAAAAAAAA==\"";
+
+        var exception = await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor(keyData))))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("ChainingModeCFB");
+    }
+
+    [Test]
+    public async Task An_unsupported_hash_algorithm_is_named_in_the_error()
+    {
+        var keyData = "saltSize=\"16\" blockSize=\"16\" keyBits=\"256\" hashSize=\"64\" cipherAlgorithm=\"AES\" " +
+                      "cipherChaining=\"ChainingModeCBC\" hashAlgorithm=\"MD5\" saltValue=\"AAAAAAAAAAAAAAAAAAAAAA==\"";
+
+        var exception = await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor(keyData))))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("MD5");
+    }
+
+    [Test]
+    public async Task An_impossible_key_length_is_rejected()
+    {
+        var keyData = "saltSize=\"16\" blockSize=\"16\" keyBits=\"64\" hashSize=\"64\" cipherAlgorithm=\"AES\" " +
+                      "cipherChaining=\"ChainingModeCBC\" hashAlgorithm=\"SHA512\" saltValue=\"AAAAAAAAAAAAAAAAAAAAAA==\"";
+
+        var exception = await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor(keyData))))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("64");
+    }
+
+    [Test]
+    public async Task A_salt_whose_length_contradicts_its_declared_size_is_rejected()
+    {
+        // Declares 32 bytes of salt but carries 16. Trusting either number over the other would
+        // silently derive the wrong key.
+        var keyData = "saltSize=\"32\" blockSize=\"16\" keyBits=\"256\" hashSize=\"64\" cipherAlgorithm=\"AES\" " +
+                      "cipherChaining=\"ChainingModeCBC\" hashAlgorithm=\"SHA512\" saltValue=\"AAAAAAAAAAAAAAAAAAAAAA==\"";
+
+        await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor(keyData))))
+            .Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task A_hash_size_that_contradicts_the_hash_algorithm_is_rejected()
+    {
+        // SHA-512 produces 64 bytes; a descriptor claiming 32 disagrees with itself.
+        var keyData = "saltSize=\"16\" blockSize=\"16\" keyBits=\"256\" hashSize=\"32\" cipherAlgorithm=\"AES\" " +
+                      "cipherChaining=\"ChainingModeCBC\" hashAlgorithm=\"SHA512\" saltValue=\"AAAAAAAAAAAAAAAAAAAAAA==\"";
+
+        await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor(keyData))))
+            .Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task A_missing_attribute_names_the_attribute()
+    {
+        var keyData = "blockSize=\"16\" keyBits=\"256\" hashSize=\"64\" cipherAlgorithm=\"AES\" " +
+                      "cipherChaining=\"ChainingModeCBC\" hashAlgorithm=\"SHA512\" saltValue=\"AAAAAAAAAAAAAAAAAAAAAA==\"";
+
+        var exception = await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor(keyData))))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("saltSize");
+    }
+
+    [Test]
+    public async Task A_non_numeric_attribute_names_the_attribute_and_the_value()
+    {
+        var keyData = "saltSize=\"sixteen\" blockSize=\"16\" keyBits=\"256\" hashSize=\"64\" cipherAlgorithm=\"AES\" " +
+                      "cipherChaining=\"ChainingModeCBC\" hashAlgorithm=\"SHA512\" saltValue=\"AAAAAAAAAAAAAAAAAAAAAA==\"";
+
+        var exception = await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor(keyData))))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("saltSize");
+        await Assert.That(exception.Message).Contains("sixteen");
+    }
+
+    [Test]
+    public async Task Malformed_base64_names_the_attribute()
+    {
+        var keyData = "saltSize=\"16\" blockSize=\"16\" keyBits=\"256\" hashSize=\"64\" cipherAlgorithm=\"AES\" " +
+                      "cipherChaining=\"ChainingModeCBC\" hashAlgorithm=\"SHA512\" saltValue=\"not base64 at all!\"";
+
+        var exception = await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor(keyData))))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("saltValue");
+    }
+
+    [Test]
+    public async Task Malformed_xml_is_reported_as_such()
+    {
+        await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo("<encryption><unclosed>")))
+            .Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task A_descriptor_with_no_key_data_is_rejected()
+    {
+        const string xml = """
+                           <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                           <encryption xmlns="http://schemas.microsoft.com/office/2006/encryption"/>
+                           """;
+
+        var exception = await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(xml)))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("keyData");
+    }
+
+    [Test]
+    public async Task A_descriptor_with_no_key_encryptors_is_rejected()
+    {
+        const string xml = """
+                           <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                           <encryption xmlns="http://schemas.microsoft.com/office/2006/encryption">
+                             <keyData saltSize="16" blockSize="16" keyBits="256" hashSize="64" cipherAlgorithm="AES"
+                                      cipherChaining="ChainingModeCBC" hashAlgorithm="SHA512" saltValue="AAAAAAAAAAAAAAAAAAAAAA=="/>
+                           </encryption>
+                           """;
+
+        var exception = await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(xml)))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("keyEncryptors");
+    }
+
+    [Test]
+    public async Task A_workbook_encrypted_to_a_certificate_says_so_rather_than_blaming_the_password()
+    {
+        // A certificate key encryptor is a well-formed file that no password can open. Reporting it
+        // as a bad password would send the caller round a loop they can never get out of.
+        var exception = await Assert.That(() => AgileEncryptionDescriptor.Parse(EncryptionInfo(Descriptor(
+                keyEncryptorUri: "http://schemas.microsoft.com/office/2006/keyEncryptor/certificate"))))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("password");
+    }
+
+    [Test]
+    public async Task An_encryption_info_too_short_to_hold_xml_is_rejected()
+    {
+        await Assert.That(() => AgileEncryptionDescriptor.Parse(new byte[4]))
+            .Throws<XLEncryptionException>();
+    }
+}

--- a/XLibur.Tests/Excel/Encryption/EncryptedContainerTests.cs
+++ b/XLibur.Tests/Excel/Encryption/EncryptedContainerTests.cs
@@ -1,0 +1,236 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using OpenMcdf;
+using XLibur.Excel.Exceptions;
+using XLibur.Excel.IO.Encryption;
+
+namespace XLibur.Tests.Excel.Encryption;
+
+/// <summary>
+/// The compound file wrapper and the choice of scheme made from the EncryptionInfo version.
+/// </summary>
+internal class EncryptedContainerTests
+{
+    /// <summary>A compound file carrying the two streams an encrypted workbook needs.</summary>
+    private static MemoryStream Container(byte[] encryptionInfo, byte[] encryptedPackage)
+    {
+        var ms = new MemoryStream();
+        EncryptedPackageContainer.WriteStreams(ms, encryptionInfo, encryptedPackage);
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static byte[] VersionedEncryptionInfo(ushort major, ushort minor)
+    {
+        var info = new byte[64];
+        BitConverter.TryWriteBytes(info.AsSpan(0), major);
+        BitConverter.TryWriteBytes(info.AsSpan(2), minor);
+        return info;
+    }
+
+    [Test]
+    public async Task An_ordinary_package_is_not_mistaken_for_a_compound_file()
+    {
+        // An .xlsx is a zip and opens "PK". The two formats are told apart by their first bytes,
+        // never by the file extension, which is the same for both.
+        using var zipLike = new MemoryStream([0x50, 0x4B, 0x03, 0x04, 0, 0, 0, 0, 0, 0]);
+
+        await Assert.That(EncryptedPackageContainer.IsCompoundFile(zipLike)).IsFalse();
+    }
+
+    [Test]
+    public async Task Detection_leaves_the_stream_where_it_found_it()
+    {
+        // The caller reads the same stream afterwards whichever answer comes back, so a sniff that
+        // consumed bytes would corrupt the ordinary path rather than the encrypted one.
+        using var stream = new MemoryStream([0x50, 0x4B, 0x03, 0x04, 0, 0, 0, 0, 0, 0]);
+        stream.Position = 2;
+
+        _ = EncryptedPackageContainer.IsCompoundFile(stream);
+
+        await Assert.That(stream.Position).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task A_stream_too_short_to_hold_a_signature_is_not_a_compound_file()
+    {
+        using var tiny = new MemoryStream([0xD0, 0xCF]);
+
+        await Assert.That(EncryptedPackageContainer.IsCompoundFile(tiny)).IsFalse();
+    }
+
+    [Test]
+    public async Task Detection_requires_a_seekable_stream()
+    {
+        // Sniffing means reading and rewinding. A forward-only stream cannot be rewound, so this is
+        // refused with an explanation rather than silently consuming the first eight bytes.
+        using var forwardOnly = new ForwardOnlyStream([0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+
+        await Assert.That(() => EncryptedPackageContainer.IsCompoundFile(forwardOnly))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Bytes_that_start_like_a_compound_file_but_are_not_one_are_reported_clearly()
+    {
+        var garbage = new byte[512];
+        garbage[0] = 0xD0;
+        garbage[1] = 0xCF;
+        garbage[2] = 0x11;
+        garbage[3] = 0xE0;
+        garbage[4] = 0xA1;
+        garbage[5] = 0xB1;
+        garbage[6] = 0x1A;
+        garbage[7] = 0xE1;
+
+        using var stream = new MemoryStream(garbage);
+
+        await Assert.That(() => EncryptedPackageContainer.ReadStreams(stream))
+            .Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task A_compound_file_missing_the_encrypted_package_is_reported_clearly()
+    {
+        using var ms = new MemoryStream();
+        using (var storage = RootStorage.Create(ms, OpenMcdf.Version.V4, StorageModeFlags.LeaveOpen))
+        {
+            using var info = storage.CreateStream("EncryptionInfo");
+            info.Write([1, 2, 3, 4], 0, 4);
+        }
+
+        ms.Position = 0;
+
+        var exception = await Assert.That(() => EncryptedPackageContainer.ReadStreams(ms))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("EncryptedPackage");
+    }
+
+    [Test]
+    public async Task The_two_streams_survive_a_write_and_read_of_the_container()
+    {
+        var encryptionInfo = new byte[100];
+        var encryptedPackage = new byte[10_000];
+        Random.Shared.NextBytes(encryptionInfo);
+        Random.Shared.NextBytes(encryptedPackage);
+
+        // 10,000 bytes is deliberately over the 4096 byte cutoff below which a compound file keeps
+        // content in the mini stream, so this covers the ordinary sector path as well.
+        using var container = Container(encryptionInfo, encryptedPackage);
+        var (readInfo, readPackage) = EncryptedPackageContainer.ReadStreams(container);
+
+        await Assert.That(readInfo).IsEquivalentTo(encryptionInfo);
+        await Assert.That(readPackage).IsEquivalentTo(encryptedPackage);
+    }
+
+    [Test]
+    public async Task A_tiny_package_below_the_mini_stream_cutoff_also_survives()
+    {
+        var encryptionInfo = new byte[16];
+        var encryptedPackage = new byte[64];
+        Random.Shared.NextBytes(encryptionInfo);
+        Random.Shared.NextBytes(encryptedPackage);
+
+        using var container = Container(encryptionInfo, encryptedPackage);
+        var (readInfo, readPackage) = EncryptedPackageContainer.ReadStreams(container);
+
+        await Assert.That(readInfo).IsEquivalentTo(encryptionInfo);
+        await Assert.That(readPackage).IsEquivalentTo(encryptedPackage);
+    }
+
+    [Test]
+    public async Task An_rc4_encrypted_workbook_says_what_it_is_and_what_to_do()
+    {
+        using var container = Container(VersionedEncryptionInfo(2, 2), new byte[64]);
+
+        var exception = await Assert.That(() => WorkbookEncryption.Decrypt(container, "password"))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("RC4");
+    }
+
+    [Test]
+    [Arguments((ushort)5, (ushort)5)]
+    [Arguments((ushort)1, (ushort)1)]
+    [Arguments((ushort)4, (ushort)3)]
+    public async Task An_unknown_encryption_version_is_named_in_the_error(ushort major, ushort minor)
+    {
+        using var container = Container(VersionedEncryptionInfo(major, minor), new byte[64]);
+
+        var exception = await Assert.That(() => WorkbookEncryption.Decrypt(container, "password"))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains($"{major}.{minor}");
+    }
+
+    [Test]
+    public async Task An_encryption_info_too_short_to_hold_a_version_is_rejected()
+    {
+        using var container = Container(new byte[2], new byte[64]);
+
+        await Assert.That(() => WorkbookEncryption.Decrypt(container, "password"))
+            .Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task Decrypting_without_a_password_says_where_to_put_one()
+    {
+        using var container = Container(VersionedEncryptionInfo(4, 4), new byte[64]);
+
+        var exception = await Assert.That(() => WorkbookEncryption.Decrypt(container, null))
+            .Throws<XLInvalidPasswordException>();
+
+        await Assert.That(exception!.Message).Contains("LoadOptions.Password");
+    }
+
+    [Test]
+    public async Task Encrypting_without_a_password_is_a_programming_error_not_a_file_error()
+    {
+        // Nothing about a file is wrong here: the caller asked to encrypt and supplied nothing to
+        // encrypt with, which is an argument problem rather than an encryption one.
+        using var destination = new MemoryStream();
+
+        await Assert.That(() => WorkbookEncryption.Encrypt(destination, [1, 2, 3], string.Empty))
+            .Throws<ArgumentException>();
+    }
+
+    /// <summary>A stream that cannot seek, for exercising the forward-only path.</summary>
+    private sealed class ForwardOnlyStream(byte[] data) : Stream
+    {
+        private readonly MemoryStream _inner = new(data);
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner.Dispose();
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/XLibur.Tests/Excel/Encryption/StandardCryptoTests.cs
+++ b/XLibur.Tests/Excel/Encryption/StandardCryptoTests.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using XLibur.Excel.Exceptions;
+using XLibur.Excel.IO.Encryption;
+using XLibur.Excel.IO.Encryption.Standard;
+
+namespace XLibur.Tests.Excel.Encryption;
+
+/// <summary>
+/// Standard encryption, the Office 2007 scheme. XLibur reads it and never writes it, so no round
+/// trip through the workbook API reaches this code and no file in the corpus covers it either.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The descriptors here are built by hand from [MS-OFFCRYPTO] 2.3.4.5 through 2.3.4.9, which is
+/// worth being clear about: the malformed-descriptor tests are worth exactly what they look like,
+/// but the round trip is a second implementation by the same author and so shows internal
+/// consistency and freedom from regression rather than conformance to the specification. Only a
+/// workbook encrypted by Office 2007 can show that, and the corpus README asks for one.
+/// </para>
+/// </remarks>
+internal class StandardCryptoTests
+{
+    private const string Password = "a password";
+
+    private const uint AlgIdAes128 = 0x660E;
+    private const uint AlgIdAes256 = 0x6610;
+    private const uint AlgIdHashSha1 = 0x8004;
+
+    /// <summary>
+    /// Derives the key the way [MS-OFFCRYPTO] 2.3.4.7 describes: a spin of SHA-1 over the password,
+    /// then an ipad/opad pair that resembles HMAC without being it.
+    /// </summary>
+    private static byte[] DeriveKey(string password, byte[] salt, int keyBytes)
+    {
+        var passwordBytes = Encoding.Unicode.GetBytes(password);
+        var seed = new byte[salt.Length + passwordBytes.Length];
+        salt.CopyTo(seed, 0);
+        passwordBytes.CopyTo(seed, salt.Length);
+
+        var current = SHA1.HashData(seed);
+        for (var i = 0; i < 50000; i++)
+        {
+            var buffer = new byte[4 + current.Length];
+            BitConverter.TryWriteBytes(buffer.AsSpan(0, 4), i);
+            current.CopyTo(buffer, 4);
+            current = SHA1.HashData(buffer);
+        }
+
+        var block = new byte[current.Length + 4];
+        current.CopyTo(block, 0);
+        var hFinal = SHA1.HashData(block);
+
+        var x1 = SHA1.HashData(XorWithPad(hFinal, 0x36));
+        var x2 = SHA1.HashData(XorWithPad(hFinal, 0x5C));
+
+        var x3 = new byte[x1.Length + x2.Length];
+        x1.CopyTo(x3, 0);
+        x2.CopyTo(x3, x1.Length);
+
+        return x3.AsSpan(0, keyBytes).ToArray();
+    }
+
+    private static byte[] XorWithPad(byte[] hash, byte pad)
+    {
+        var buffer = new byte[64];
+        buffer.AsSpan().Fill(pad);
+        for (var i = 0; i < hash.Length; i++)
+            buffer[i] ^= hash[i];
+
+        return buffer;
+    }
+
+    private static byte[] Ecb(byte[] key, byte[] data, bool encrypting)
+    {
+        using var aes = Aes.Create();
+        aes.KeySize = key.Length * 8;
+        aes.Key = key;
+        aes.Mode = CipherMode.ECB;
+        aes.Padding = PaddingMode.None;
+
+        using var transform = encrypting ? aes.CreateEncryptor() : aes.CreateDecryptor();
+        return transform.TransformFinalBlock(data, 0, data.Length);
+    }
+
+    private static byte[] Pad(byte[] value, int blockSize)
+    {
+        if (value.Length % blockSize == 0)
+            return value;
+
+        var padded = new byte[value.Length + (blockSize - value.Length % blockSize)];
+        value.CopyTo(padded, 0);
+        return padded;
+    }
+
+    /// <summary>
+    /// Builds an EncryptionInfo stream. The pieces are separately overridable so a test can make one
+    /// of them invalid without hand-assembling the whole thing.
+    /// </summary>
+    private static byte[] EncryptionInfo(
+        byte[] salt,
+        byte[] encryptedVerifier,
+        byte[] encryptedVerifierHash,
+        uint algId = AlgIdAes256,
+        uint algIdHash = AlgIdHashSha1,
+        int keyBits = 256,
+        int? saltSizeOverride = null,
+        int? headerSizeOverride = null,
+        ushort majorVersion = 4)
+    {
+        var header = new byte[32];
+        BitConverter.TryWriteBytes(header.AsSpan(8), algId);
+        BitConverter.TryWriteBytes(header.AsSpan(12), algIdHash);
+        BitConverter.TryWriteBytes(header.AsSpan(16), keyBits);
+
+        var verifier = new byte[4 + salt.Length + encryptedVerifier.Length + 4 + encryptedVerifierHash.Length];
+        var offset = 0;
+        BitConverter.TryWriteBytes(verifier.AsSpan(offset), saltSizeOverride ?? salt.Length);
+        offset += 4;
+        salt.CopyTo(verifier.AsSpan(offset));
+        offset += salt.Length;
+        encryptedVerifier.CopyTo(verifier.AsSpan(offset));
+        offset += encryptedVerifier.Length;
+        BitConverter.TryWriteBytes(verifier.AsSpan(offset), 20);
+        offset += 4;
+        encryptedVerifierHash.CopyTo(verifier.AsSpan(offset));
+
+        var stream = new byte[12 + header.Length + verifier.Length];
+        BitConverter.TryWriteBytes(stream.AsSpan(0), majorVersion);
+        BitConverter.TryWriteBytes(stream.AsSpan(2), (ushort)2);
+        BitConverter.TryWriteBytes(stream.AsSpan(4), 0x24u);
+        BitConverter.TryWriteBytes(stream.AsSpan(8), headerSizeOverride ?? header.Length);
+        header.CopyTo(stream.AsSpan(12));
+        verifier.CopyTo(stream.AsSpan(12 + header.Length));
+        return stream;
+    }
+
+    /// <summary>Builds a valid descriptor and the matching encrypted package.</summary>
+    private static (byte[] EncryptionInfo, byte[] EncryptedPackage) Encrypt(
+        byte[] payload, string password, int keyBits = 256, ushort majorVersion = 4)
+    {
+        var salt = new byte[16];
+        RandomNumberGenerator.Fill(salt);
+
+        var key = DeriveKey(password, salt, keyBits / 8);
+
+        var verifier = new byte[16];
+        RandomNumberGenerator.Fill(verifier);
+
+        var encryptedVerifier = Ecb(key, verifier, encrypting: true);
+        var encryptedVerifierHash = Ecb(key, Pad(SHA1.HashData(verifier), 16), encrypting: true);
+
+        var package = new byte[8 + Pad(payload, 16).Length];
+        BitConverter.TryWriteBytes(package.AsSpan(0, 8), (long)payload.Length);
+        Ecb(key, Pad(payload, 16), encrypting: true).CopyTo(package.AsSpan(8));
+
+        return (
+            EncryptionInfo(salt, encryptedVerifier, encryptedVerifierHash, keyBits: keyBits, majorVersion: majorVersion),
+            package);
+    }
+
+    [Test]
+    [Arguments(128)]
+    [Arguments(256)]
+    public async Task A_standard_encrypted_package_round_trips(int keyBits)
+    {
+        var payload = new byte[3000];
+        RandomNumberGenerator.Fill(payload);
+
+        var (encryptionInfo, encryptedPackage) = Encrypt(payload, Password, keyBits);
+
+        var descriptor = StandardEncryptionDescriptor.Parse(encryptionInfo);
+        var key = descriptor.DeriveAndVerifyKey(Password);
+        var decrypted = StandardEncryptionDescriptor.DecryptPackage(key, encryptedPackage);
+
+        await Assert.That(descriptor.KeyBytes).IsEqualTo(keyBits / 8);
+        await Assert.That(decrypted).IsEquivalentTo(payload);
+    }
+
+    [Test]
+    [Arguments((ushort)3)]
+    [Arguments((ushort)4)]
+    public async Task A_standard_container_decrypts_through_the_workbook_entry_point(ushort majorVersion)
+    {
+        // Both 3.2 and 4.2 mean standard encryption, and the entry point has to route either of them
+        // away from the agile reader. Driving the descriptor directly, as the tests above do, would
+        // never exercise that choice.
+        var payload = new byte[1000];
+        RandomNumberGenerator.Fill(payload);
+
+        var (encryptionInfo, encryptedPackage) = Encrypt(payload, Password, majorVersion: majorVersion);
+
+        using var container = new MemoryStream();
+        EncryptedPackageContainer.WriteStreams(container, encryptionInfo, encryptedPackage);
+        container.Position = 0;
+
+        using var decrypted = WorkbookEncryption.Decrypt(container, Password);
+
+        await Assert.That(decrypted.ToArray()).IsEquivalentTo(payload);
+    }
+
+    [Test]
+    public async Task A_wrong_password_on_a_standard_container_reaches_the_caller_as_a_password_error()
+    {
+        var (encryptionInfo, encryptedPackage) = Encrypt([1, 2, 3, 4], Password);
+
+        using var container = new MemoryStream();
+        EncryptedPackageContainer.WriteStreams(container, encryptionInfo, encryptedPackage);
+        container.Position = 0;
+
+        await Assert.That(() => WorkbookEncryption.Decrypt(container, "the wrong password"))
+            .Throws<XLInvalidPasswordException>();
+    }
+
+    [Test]
+    public async Task A_wrong_password_is_refused_by_the_verifier()
+    {
+        var (encryptionInfo, _) = Encrypt([1, 2, 3, 4], Password);
+        var descriptor = StandardEncryptionDescriptor.Parse(encryptionInfo);
+
+        await Assert.That(() => descriptor.DeriveAndVerifyKey("the wrong password"))
+            .Throws<XLInvalidPasswordException>();
+    }
+
+    [Test]
+    public async Task The_length_prefix_trims_the_block_padding()
+    {
+        // 100 bytes pad up to 112. Without the prefix being honoured the caller would receive 12
+        // trailing zero bytes as though they were content.
+        var payload = new byte[100];
+        RandomNumberGenerator.Fill(payload);
+
+        var (encryptionInfo, encryptedPackage) = Encrypt(payload, Password);
+        var descriptor = StandardEncryptionDescriptor.Parse(encryptionInfo);
+        var key = descriptor.DeriveAndVerifyKey(Password);
+
+        await Assert.That(StandardEncryptionDescriptor.DecryptPackage(key, encryptedPackage).Length).IsEqualTo(100);
+    }
+
+    [Test]
+    public async Task An_unsupported_cipher_names_the_identifier()
+    {
+        // 0x6801 is RC4, which the standard scheme allows and XLibur does not read.
+        var info = EncryptionInfo(new byte[16], new byte[16], new byte[32], algId: 0x6801);
+
+        var exception = await Assert.That(() => StandardEncryptionDescriptor.Parse(info))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("6801");
+    }
+
+    [Test]
+    public async Task An_unsupported_hash_names_the_identifier()
+    {
+        var info = EncryptionInfo(new byte[16], new byte[16], new byte[32], algIdHash: 0x800C);
+
+        var exception = await Assert.That(() => StandardEncryptionDescriptor.Parse(info))
+            .Throws<XLEncryptionException>();
+
+        await Assert.That(exception!.Message).Contains("800C");
+    }
+
+    [Test]
+    public async Task A_zero_hash_identifier_is_read_as_the_provider_default()
+    {
+        // Zero means "whatever this provider uses", which for standard encryption is SHA-1. Treating
+        // it as an unknown algorithm would reject files that are perfectly ordinary.
+        var info = EncryptionInfo(new byte[16], new byte[16], new byte[32], algIdHash: 0);
+
+        await Assert.That(() => StandardEncryptionDescriptor.Parse(info)).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task The_key_length_in_the_header_wins_over_the_one_implied_by_the_cipher()
+    {
+        // AlgID is allowed to be the generic AES identifier, so the header's own key size decides.
+        var info = EncryptionInfo(new byte[16], new byte[16], new byte[32], algId: AlgIdAes128, keyBits: 256);
+        var descriptor = StandardEncryptionDescriptor.Parse(info);
+
+        await Assert.That(descriptor.KeyBytes).IsEqualTo(32);
+    }
+
+    [Test]
+    public async Task An_impossible_key_length_is_rejected()
+    {
+        var info = EncryptionInfo(new byte[16], new byte[16], new byte[32], keyBits: 64);
+
+        await Assert.That(() => StandardEncryptionDescriptor.Parse(info)).Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task An_encryption_info_too_short_to_hold_a_header_is_rejected()
+    {
+        await Assert.That(() => StandardEncryptionDescriptor.Parse(new byte[8]))
+            .Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    [Arguments(8)]
+    [Arguments(100_000)]
+    public async Task A_header_size_that_does_not_fit_the_stream_is_rejected(int headerSize)
+    {
+        // Too small to hold the fields the header must have, or larger than the stream itself.
+        var info = EncryptionInfo(new byte[16], new byte[16], new byte[32], headerSizeOverride: headerSize);
+
+        await Assert.That(() => StandardEncryptionDescriptor.Parse(info)).Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task A_salt_of_the_wrong_size_is_rejected()
+    {
+        // The scheme fixes the salt at 16 bytes, so a descriptor saying otherwise is malformed
+        // rather than merely unusual.
+        var info = EncryptionInfo(new byte[16], new byte[16], new byte[32], saltSizeOverride: 8);
+
+        await Assert.That(() => StandardEncryptionDescriptor.Parse(info)).Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task A_package_shorter_than_its_length_prefix_is_rejected()
+    {
+        var (encryptionInfo, _) = Encrypt([1, 2, 3, 4], Password);
+        var descriptor = StandardEncryptionDescriptor.Parse(encryptionInfo);
+        var key = descriptor.DeriveAndVerifyKey(Password);
+
+        await Assert.That(() => StandardEncryptionDescriptor.DecryptPackage(key, new byte[4]))
+            .Throws<XLEncryptionException>();
+    }
+
+    [Test]
+    public async Task A_package_claiming_more_content_than_it_carries_is_rejected()
+    {
+        var (encryptionInfo, encryptedPackage) = Encrypt([1, 2, 3, 4], Password);
+        var descriptor = StandardEncryptionDescriptor.Parse(encryptionInfo);
+        var key = descriptor.DeriveAndVerifyKey(Password);
+
+        BitConverter.TryWriteBytes(encryptedPackage.AsSpan(0, 8), (long)100_000);
+
+        await Assert.That(() => StandardEncryptionDescriptor.DecryptPackage(key, encryptedPackage))
+            .Throws<XLEncryptionException>();
+    }
+}

--- a/XLibur/Excel/IO/Encryption/OfficeCryptoAlgorithms.cs
+++ b/XLibur/Excel/IO/Encryption/OfficeCryptoAlgorithms.cs
@@ -50,25 +50,6 @@ internal static class OfficeCryptoAlgorithms
         _ => throw new XLEncryptionException($"Unsupported hash algorithm '{algorithm}'."),
     };
 
-    /// <summary>
-    /// Computes an HMAC over a stream without materialising it, for the data integrity check over an
-    /// encrypted package that may be far larger than a comfortable byte array.
-    /// </summary>
-    public static byte[] HmacStream(this OfficeHashAlgorithm algorithm, byte[] key, System.IO.Stream stream)
-    {
-        using var hmac = CreateHmac(algorithm, key);
-        return hmac.ComputeHash(stream);
-    }
-
-    private static HMAC CreateHmac(OfficeHashAlgorithm algorithm, byte[] key) => algorithm switch
-    {
-        OfficeHashAlgorithm.Sha1 => new HMACSHA1(key),
-        OfficeHashAlgorithm.Sha256 => new HMACSHA256(key),
-        OfficeHashAlgorithm.Sha384 => new HMACSHA384(key),
-        OfficeHashAlgorithm.Sha512 => new HMACSHA512(key),
-        _ => throw new XLEncryptionException($"Unsupported hash algorithm '{algorithm}'."),
-    };
-
     public static OfficeHashAlgorithm ParseHashAlgorithm(string? name) => name switch
     {
         "SHA1" or "SHA-1" => OfficeHashAlgorithm.Sha1,


### PR DESCRIPTION
Follow-up to #245, which merged with thin coverage. Encryption namespace block coverage goes **62.9% → 94.0%** (+77 tests, 6606 total, 0 failures on net8.0 and net10.0).

I measured before writing anything, and the measurement changed what I wrote. The gaps below were picked for what they protect, not for the number.

## Why a round trip proved so little

Saving and reloading a workbook only ever exercises **one profile** — AES-256 with SHA-512 — over a package of whatever size the workbook happens to be. Everything else the reader is required to accept was untested.

- **Algorithm agility.** The cipher is now driven across every supported hash and key length. The interesting corner is SHA-1 with a 256-bit key: the hash is *shorter* than the key, so derived material has to be padded rather than truncated. That branch had never executed.
- **Segment boundaries.** Payloads at 4095/4096/4097 and 15/16/17 bytes, either side of the 4096-byte segment boundary and the 16-byte block boundary. A real workbook never lands on one by accident.
- **The length prefix.** Ciphertext is padded to whole blocks, so the prefix is the only thing saying where content stops. A 100-byte payload now proves padding is not handed back as content.

## Standard encryption had 204 unreachable blocks

XLibur reads that scheme and never writes it, so no round trip touches it, and the corpus has no Office 2007 file. Descriptors are now built by hand from [MS-OFFCRYPTO] 2.3.4.5–2.3.4.9.

**Being precise about what this proves:** the malformed-descriptor tests are worth exactly what they look like. The round trip is a second implementation by the same author, so it shows internal consistency and freedom from regression — **not** conformance to the specification. The test file says so in its remarks rather than letting a green tick imply otherwise. Only a workbook encrypted by Office 2007 can show conformance, and `Resource/Encrypted/README.md` still asks for one.

Both version pairs meaning standard encryption, 3.2 and 4.2, are driven through `WorkbookEncryption.Decrypt`, because that routing is precisely what a descriptor-level test misses — `DecryptStandard` sat at 0% until those cases were added.

## The "reject rather than guess" contract was entirely untested

#245 deliberately refuses anything outside the profile Excel writes, by name, on the grounds that approximating turns an unusual file into plausible-looking garbage instead of an error. That is a stated design goal and it had **no tests at all**.

Fifteen now assert the offending value appears in the message: unknown ciphers, chaining modes and hashes; key lengths no cipher has; a salt whose length contradicts its declared size; a hash size contradicting its algorithm; missing and non-numeric attributes; malformed base64 and XML; and a workbook encrypted to a certificate, which is refused as *"not with a password"* rather than as a bad password — otherwise the caller re-prompts forever for a password that was never the problem.

Also added: `What_XLibur_emits_is_what_XLibur_accepts`, which parses the descriptor the writer produced. The writer and reader are separate bodies of code over the same XML; this is the test that fails when one drifts.

## One deletion instead of a test

`HmacStream` and `CreateHmac` are removed. They were written for a streaming integrity check and never called once the byte-array overload was used instead — 21 of the uncovered blocks. Deleting dead code is the honest way to stop it being uncovered.

## What is deliberately still uncovered

The remaining 67 blocks are mostly the `_ => throw` arm of switches over an enum whose every value is handled, plus guards for stream states the public API cannot produce. Reaching them would mean contorting tests around unreachable code, which buys a number and no safety. Flagging it here so the 94% is not mistaken for "someone gave up at 94".