### PR TITLE
docs: encryption guide, and a restructured changelog for the work since v0.106.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,137 @@
 # Changelog
 
+## Contents
+
+- [Unreleased](#unreleased)
+- [v0.106.0](#v01060---2026-07-25)
+
 ## Unreleased
 
-### Added
+### ⚠️ Breaking Changes
 
-- **Chart series formatting**: `IXLChartSeries` gained `FillColor`, `LineColor`, `LineWidthPt`, `MarkerStyle` (new `XLMarkerStyle` enum), `MarkerSize`, `MarkerFillColor` and `Smooth`, so a generated chart can be styled instead of relying on Excel's automatic theme colours. Leaving a property `null` omits its element, which keeps the automatic colour — nothing is ever written as an explicit black.
+#### Colours and styles
 
-- **Secondary value axis per series**: `IXLChartSeries.UseSecondaryAxis` plots a series against a value axis on the right, so a percentage can share a chart with values in the thousands. It applies to series of the primary chart type as well as to a combo chart's `SecondarySeries`.
+- **`XLColorType` members are renumbered.** `Automatic` takes ordinal 0, so `Color` moves 0 → 1, `Theme` 1 → 2 and `Indexed` 2 → 3. This is source compatible but binary breaking, and breaks anything that persists the numeric value — stored settings or serialised styles written by an earlier version need remapping. ([#232](https://github.com/XLibur/XLibur/pull/232) by [@jafin](https://github.com/jafin))
 
-- **Chart data labels**: `IXLDataLabels` on both `IXLChart.DataLabels` (chart-wide) and `IXLChartSeries.DataLabels` (per series, overriding the chart's), with `ShowValue`, `ShowCategoryName`, `ShowSeriesName`, `ShowPercentage`, `NumberFormat` and `Position`. `Position` is validated against the chart type — Excel refuses to open a file that uses a position it does not offer for that type, so the setter throws with the allowed values listed rather than producing a workbook Excel has to repair.
+- **`XLColor.NoColor.Color` (and `.Indexed`/`.ThemeColor`) now throw** instead of returning a meaningless all-zero ARGB. Test with `IsAutomatic` before reading a colour component. ([#232](https://github.com/XLibur/XLibur/pull/232) by [@jafin](https://github.com/jafin))
 
-- **Chart legend**: `IXLChart.Legend` with `Visible`, `Position` (right, bottom, left, top, top-right) and `Overlay`. Charts XLibur creates still have no legend unless one is asked for; setting `Visible = false` on a chart read from a file removes the legend it came with.
+  ```csharp
+  // Before — returned Color.FromArgb(0, 0, 0, 0) for an automatic colour
+  var rgb = cell.Style.Font.FontColor.Color;
 
-- **Chart axes**: `IXLChart.CategoryAxis`, `ValueAxis` and `SecondaryValueAxis`, each with `Title`, `NumberFormat`, `Min`, `Max`, `MajorUnit`, `MinorUnit`, `Visible`, `MajorGridlines`, `Orientation` (reversed axes) and `LogScale`/`LogBase`. The unit and log-scale properties belong to a value axis in the file format and are skipped on a category axis — except on scatter and bubble charts, whose horizontal axis holds numbers.
+  // After
+  var colour = cell.Style.Font.FontColor;
+  var rgb = colour.IsAutomatic ? defaultRgb : colour.Color;
+  ```
 
-- **Charts loaded from a file can be restyled**: setting the series formatting, data labels, legend or axes on a loaded chart now writes back on save. Only the properties actually assigned are patched into the existing chart part, so trendlines, error bars, gradient fills, per-point colours and label overrides, label and axis fonts, tick marks and the chart's style/colour parts are all preserved — and a chart nobody edited is left byte for byte as it was.
+  There is no ARGB that means "automatic", which is why the property now throws rather than
+  inventing one — decide what your code should render for a colour Excel resolves at display time.
 
-- **Chart anchoring**: `IXLChart.Anchor` (`MoveAndSizeWithCells`, `MoveWithCells`, `Absolute`) with `Width`, `Height`, `Left` and `Top` in pixels, so a chart can keep its size as rows are inserted or be pinned to a spot on the sheet. Two-cell anchoring via `Position`/`SecondPosition` remains the default.
+### ✨ New Features
 
-### Fixed
+#### Security and encryption
 
-- **Charts anchored with a one-cell or absolute anchor are no longer dropped on load.** The reader only looked at `xdr:twoCellAnchor`, so a chart Excel had anchored either of the other two ways was missing from `IXLWorksheet.Charts` entirely (its XML survived a round trip, but the chart was invisible to the API).
+- **Password-protected workbooks (ECMA-376 encryption)**: `LoadOptions.Password` opens an encrypted workbook and `SaveOptions.Password` writes one. Reading covers both schemes in the wild — agile encryption (Office 2010 and later) and standard encryption (Office 2007); writing uses agile encryption with the parameters Excel itself writes (AES-256-CBC, SHA-512, 100,000 spins and a fresh random key per save). Previously an encrypted file could not be opened at all and failed opaquely.
 
-- **3D and of-pie chart groups are read.** `c:pie3DChart`, `c:line3DChart`, `c:area3DChart`, `c:surface3DChart` and `c:ofPieChart` were not recognised, so an Excel-authored chart using one loaded with no series and the wrong chart type. Their series and series formatting now read the same as the 2D groups', and pie-of-pie and bar-of-pie are told apart.
+  A wrong or missing password throws `XLInvalidPasswordException`, which is what a caller re-prompts on; an altered package whose HMAC fails throws `XLEncryptionException`, because there the password was right. A legacy `.xls` is detected and named rather than mistaken for an encrypted workbook. The password is never carried from load to save — a plain `SaveAs` cannot silently produce a file the caller can no longer open. ([#245](https://github.com/XLibur/XLibur/pull/245) by [@jafin](https://github.com/jafin))
 
-- **Chart XML now passes OpenXML schema validation.** Three long-standing violations in the chart writer are fixed: series names were written as a `c:strRef` with no required `c:f` (a literal name now uses `<c:tx><c:v>`, and both forms are read back), `c:doughnutChart` omitted the required `c:holeSize`, and `c:marker` was written after `c:cat`/`c:val` instead of before. Excel tolerated all three, but stricter readers and `SaveOptions.ValidatePackage` did not.
+#### Charts
 
-- **A `Line` chart whose markers are switched off no longer reads back as `LineWithMarkers`.** The reader treated the presence of a `c:marker` element as "has markers", even when it held `<c:symbol val="none"/>`.
+- **Chart series formatting**: `IXLChartSeries` gained `FillColor`, `LineColor`, `LineWidthPt`, `MarkerStyle` (new `XLMarkerStyle` enum), `MarkerSize`, `MarkerFillColor` and `Smooth`, so a generated chart can be styled instead of relying on Excel's automatic theme colours. Leaving a property `null` omits its element, which keeps the automatic colour — nothing is ever written as an explicit black. ([#220](https://github.com/XLibur/XLibur/pull/220) by [@jafin](https://github.com/jafin))
 
-- **Charts with more than one plot group of the same type now read all of their series.** The reader took only the first `c:barChart` (or `c:lineChart`, …) of a plot area, so the series of a second group — which is how Excel stores a secondary axis — were dropped.
+- **Secondary value axis per series**: `IXLChartSeries.UseSecondaryAxis` plots a series against a value axis on the right, so a percentage can share a chart with values in the thousands. It applies to series of the primary chart type as well as to a combo chart's `SecondarySeries`. ([#220](https://github.com/XLibur/XLibur/pull/220) by [@jafin](https://github.com/jafin))
 
-- **Which of those groups is on the secondary axis no longer depends on the order they appear in the file.** The primary axis pair was taken from whichever group came first, so a file that wrote its secondary group ahead of the primary one read back with `UseSecondaryAxis` inverted on every series and the two axis models swapped. The group whose value axis crosses at the maximum — how a secondary axis comes to be drawn on the right — is now passed over instead.
+- **Chart data labels**: `IXLDataLabels` on both `IXLChart.DataLabels` (chart-wide) and `IXLChartSeries.DataLabels` (per series, overriding the chart's), with `ShowValue`, `ShowCategoryName`, `ShowSeriesName`, `ShowPercentage`, `NumberFormat` and `Position`. `Position` is validated against the chart type — Excel refuses to open a file that uses a position it does not offer for that type, so the setter throws with the allowed values listed rather than producing a workbook Excel has to repair. ([#221](https://github.com/XLibur/XLibur/pull/221) by [@jafin](https://github.com/jafin))
 
-- **`Smooth` is honoured on a new stock chart.** A stock chart's series are `CT_LineSer` and take `c:smooth`, but the writer never emitted it, so the property worked on a stock chart read from a file and was silently dropped on one XLibur created.
+- **Chart legend**: `IXLChart.Legend` with `Visible`, `Position` (right, bottom, left, top, top-right) and `Overlay`. Charts XLibur creates still have no legend unless one is asked for; setting `Visible = false` on a chart read from a file removes the legend it came with. ([#222](https://github.com/XLibur/XLibur/pull/222) by [@jafin](https://github.com/jafin))
 
-- **Positioning a legend that is not there no longer creates one.** `IXLChartLegend.Position` and `Overlay` are documented as ignored while `Visible` is `false`, and a new chart gets no legend from them — but assigning one of them on a *loaded* chart that had no legend added one.
+- **Chart axes**: `IXLChart.CategoryAxis`, `ValueAxis` and `SecondaryValueAxis`, each with `Title`, `NumberFormat`, `Min`, `Max`, `MajorUnit`, `MinorUnit`, `Visible`, `MajorGridlines`, `Orientation` (reversed axes) and `LogScale`/`LogBase`. The unit and log-scale properties belong to a value axis in the file format and are skipped on a category axis — except on scatter and bubble charts, whose horizontal axis holds numbers. ([#222](https://github.com/XLibur/XLibur/pull/222) by [@jafin](https://github.com/jafin))
 
-- **Chart-wide data labels reach every group of a loaded combo chart.** `IXLChart.DataLabels` applies to the whole chart, and a new combo chart gets them on both of its plot groups, but a loaded one was patched on the primary group only — so turning labels on left the secondary series unlabelled.
+- **Charts loaded from a file can be restyled**: setting the series formatting, data labels, legend or axes on a loaded chart now writes back on save. Only the properties actually assigned are patched into the existing chart part, so trendlines, error bars, gradient fills, per-point colours and label overrides, label and axis fonts, tick marks and the chart's style/colour parts are all preserved — and a chart nobody edited is left byte for byte as it was. ([#220](https://github.com/XLibur/XLibur/pull/220), [#221](https://github.com/XLibur/XLibur/pull/221), [#222](https://github.com/XLibur/XLibur/pull/222) by [@jafin](https://github.com/jafin))
 
-- **`Series.Add(...)` on a chart loaded from a file throws instead of being discarded on save.** A loaded chart is patched, not regenerated, so a new series had nowhere to be written and vanished without a word. It now throws `NotSupportedException`, as `UseSecondaryAxis` already did.
+- **Chart anchoring**: `IXLChart.Anchor` (`MoveAndSizeWithCells`, `MoveWithCells`, `Absolute`) with `Width`, `Height`, `Left` and `Top` in pixels, so a chart can keep its size as rows are inserted or be pinned to a spot on the sheet. Two-cell anchoring via `Position`/`SecondPosition` remains the default. ([#230](https://github.com/XLibur/XLibur/pull/230) by [@jafin](https://github.com/jafin))
+
+#### Colours and styles
+
+- **`XLColorType.Automatic`**, with `XLColor.Automatic` and `XLColor.IsAutomatic`. OOXML has four kinds of colour and XLibur modelled three; the automatic colour (ECMA-376 `CT_Color/@auto`, what Excel's font colour picker labels "Automatic") was disguised as a fully transparent black. `auto="1"` is now read and written explicitly. ([#232](https://github.com/XLibur/XLibur/pull/232) by [@jafin](https://github.com/jafin))
+
+### ⚡ Performance
+
+#### Workbook creation
+
+- **40% fewer allocations building a workbook** (create phase of the 50K x 10 benchmark, 305.5 → 183.6 MB; whole benchmark 423.4 → 301.3 MB). Every `cell.Value = x` ran a merged-range membership test that allocated ~250 bytes even on a sheet with no merged ranges at all, boxing the address and building a LINQ iterator chain over an empty list. That test is now skipped outright when the sheet has no merges, and made allocation-free when it does — a merged title row is a common layout and used to cost *more* than no merge at all, because the predicate then actually ran. A cell write drops 375.5 → 103.6 bytes on both paths. ([#185](https://github.com/XLibur/XLibur/pull/185) by [@jafin](https://github.com/jafin))
+
+- **Repeated access to the same cell is cheaper**: `ws.Cell(r, c)` minted a fresh `XLCell` every call, so the per-object style cache never hit and a `.Style` access threw away an 80-byte `XLStyle` one statement later. A small direct-mapped cache now hands back the same wrapper for the same address. ([#185](https://github.com/XLibur/XLibur/pull/185) by [@jafin](https://github.com/jafin))
+
+#### Styling
+
+- **86% fewer allocations styling a range, row or column in bulk** (~234 → ~33 bytes per cell): setting a style on a container collected every child cell into a `HashSet` of wrappers before writing anything. Containers that can enumerate exactly those cells now walk the addresses and write the style slice directly. ([#185](https://github.com/XLibur/XLibur/pull/185) by [@jafin](https://github.com/jafin))
+
+#### Saving
+
+- **50% fewer allocations on save** (237.1 → 117.9 MB for the same benchmark), with wall time improving from 1187–1290 ms to 1051–1167 ms. Four save helpers materialised a cell wrapper for every used cell just to read one property and now read the underlying storage directly; `int`/`uint` cell values are formatted into a span instead of allocating a string each; style-key hashes are memoised, cutting `StyleKey.GetHashCode` by 95% over 100K styles. Saved output is byte-identical to before. ([#179](https://github.com/XLibur/XLibur/pull/179) by [@jafin](https://github.com/jafin))
+
+### 🐛 Bug Fixes
+
+#### Formulas and references
+
+- **A reference whose rows or columns are all deleted becomes `#REF!`** ([ClosedXML #880](https://github.com/ClosedXML/ClosedXML/issues/880)): endpoints were shifted by the deleted height and clamped to row 1, so deleting rows 1–5 turned `Sheet1!$A$1:$B$2` into `Sheet1!$A$1:$B$1` — a phantom one-row range over whatever data had moved up into it. The same shifter serves cell formulas, so `=SUM(A1:A2)` with those rows deleted now reads `SUM(#REF!)` rather than quietly summing the wrong cells. Deleting the sheet afterwards drops the stale sheet prefix instead of leaving a defined name pointing at a sheet that no longer exists. ([#243](https://github.com/XLibur/XLibur/pull/243) by [@jafin](https://github.com/jafin))
+
+- **Row-only and column-only references are positioned correctly when rows or columns are inserted or deleted**: `3:5` with row 4 deleted became `2:4` — a reference that had walked onto row 2, which it never covered, while losing row 5, which survived. Because a multi-row delete is applied one row at a time, the reference kept drifting up instead of shrinking and never became small enough for the `#REF!` check to fire. Insertions had the mirror problem: inserting two rows at row 4 moved `3:5` to `5:7` rather than expanding it to `3:7`. Both axes now follow the same boundary rules as an equivalent cell range. ([#244](https://github.com/XLibur/XLibur/pull/244) by [@jafin](https://github.com/jafin))
+
+- **Copying a worksheet repoints the copy's self-references at the copy** ([ClosedXML #836](https://github.com/ClosedXML/ClosedXML/issues/836)): copying a sheet named `Original` holding `Original!A1 * 3` produced a sheet whose formula still pointed back at the original. References to *other* sheets are left alone, as they should be. ([#241](https://github.com/XLibur/XLibur/pull/241) by [@jafin](https://github.com/jafin))
+
+#### Text and number parsing
+
+- **Text-to-number and text-to-date coercion matches Excel much more closely.** The date-time patterns had no seconds component, so `8/22/2008 3:30:45 PM` failed to coerce at all. Beyond that: time components that overflow their range now carry into the date (`11/30/2022 24:59` is one minute to one in the morning of December 1st); parenthesised, spaced and sign-separated numbers such as `(100%)`, `(   1,000.54  )` and `- 100 %` are read as negative; a month is matched by any prefix from three letters up, as Excel does; a shortened or dot-suffixed AM/PM designator is accepted. In the other direction, group-separator and currency placement are now enforced the way Excel enforces them — `1,00`, `1,00,000` and `1$` are rejected under en-US where the underlying BCL parse accepted them. ([#241](https://github.com/XLibur/XLibur/pull/241) by [@jafin](https://github.com/jafin))
+
+#### Rich text and shared strings
+
+- **Rich-text runs keep their automatic or absent colour through a round-trip**: a plain load → `SaveAs` wrote every colour-less run back with an explicit `<color rgb="FF000000"/>`, and promoted a plain string carrying a phonetic guide (`<t>` + `<rPh>`, common in Japanese workbooks) into a synthetic run that inherited the same injection. An explicit black cannot be overridden by a theme colour change or by conditional formatting, where the automatic colour it replaced can. A run that was read with no `<rPr>` is now written back without one, so inheritance stays inheritance; splitting such a run keeps that property rather than materialising the cell font as explicit formatting. ([#225](https://github.com/XLibur/XLibur/pull/225), [#227](https://github.com/XLibur/XLibur/pull/227) by [@jafin](https://github.com/jafin))
+
+- **Saving a plain shared string that carries a phonetic guide no longer throws.** Its text is decoded on the way in, so a decoded `_xHHHH_` escape is a literal control character — not valid XML content — and the writer emitted it raw, failing with an `ArgumentException` naming the invalid character. ([#225](https://github.com/XLibur/XLibur/pull/225), [#227](https://github.com/XLibur/XLibur/pull/227) by [@jafin](https://github.com/jafin))
+
+#### Colours and conditional formatting
+
+- **An automatic colour is no longer written as an explicit `rgb="00000000"`.** Colour writers switch on the colour type, and the automatic colour fell into the RGB arm — pinning down a colour the source deliberately left for the application to resolve. The three conditional-format colour converters gained explicit automatic arms too, where they would otherwise have dropped the colour silently. ([#232](https://github.com/XLibur/XLibur/pull/232) by [@jafin](https://github.com/jafin))
+
+#### Charts
+
+- **Charts anchored with a one-cell or absolute anchor are no longer dropped on load.** The reader only looked at `xdr:twoCellAnchor`, so a chart Excel had anchored either of the other two ways was missing from `IXLWorksheet.Charts` entirely (its XML survived a round trip, but the chart was invisible to the API). ([#230](https://github.com/XLibur/XLibur/pull/230) by [@jafin](https://github.com/jafin))
+
+- **3D and of-pie chart groups are read.** `c:pie3DChart`, `c:line3DChart`, `c:area3DChart`, `c:surface3DChart` and `c:ofPieChart` were not recognised, so an Excel-authored chart using one loaded with no series and the wrong chart type. Their series and series formatting now read the same as the 2D groups', and pie-of-pie and bar-of-pie are told apart. ([#230](https://github.com/XLibur/XLibur/pull/230) by [@jafin](https://github.com/jafin))
+
+- **Chart XML now passes OpenXML schema validation.** Three long-standing violations in the chart writer are fixed: series names were written as a `c:strRef` with no required `c:f` (a literal name now uses `<c:tx><c:v>`, and both forms are read back), `c:doughnutChart` omitted the required `c:holeSize`, and `c:marker` was written after `c:cat`/`c:val` instead of before. Excel tolerated all three, but stricter readers and `SaveOptions.ValidatePackage` did not. ([#220](https://github.com/XLibur/XLibur/pull/220) by [@jafin](https://github.com/jafin))
+
+- **A `Line` chart whose markers are switched off no longer reads back as `LineWithMarkers`.** The reader treated the presence of a `c:marker` element as "has markers", even when it held `<c:symbol val="none"/>`. ([#220](https://github.com/XLibur/XLibur/pull/220) by [@jafin](https://github.com/jafin))
+
+- **Charts with more than one plot group of the same type now read all of their series.** The reader took only the first `c:barChart` (or `c:lineChart`, …) of a plot area, so the series of a second group — which is how Excel stores a secondary axis — were dropped. ([#220](https://github.com/XLibur/XLibur/pull/220) by [@jafin](https://github.com/jafin))
+
+- **Which of those groups is on the secondary axis no longer depends on the order they appear in the file.** The primary axis pair was taken from whichever group came first, so a file that wrote its secondary group ahead of the primary one read back with `UseSecondaryAxis` inverted on every series and the two axis models swapped. The group whose value axis crosses at the maximum — how a secondary axis comes to be drawn on the right — is now passed over instead. ([#230](https://github.com/XLibur/XLibur/pull/230) by [@jafin](https://github.com/jafin))
+
+- **`Smooth` is honoured on a new stock chart.** A stock chart's series are `CT_LineSer` and take `c:smooth`, but the writer never emitted it, so the property worked on a stock chart read from a file and was silently dropped on one XLibur created. ([#230](https://github.com/XLibur/XLibur/pull/230) by [@jafin](https://github.com/jafin))
+
+- **Positioning a legend that is not there no longer creates one.** `IXLChartLegend.Position` and `Overlay` are documented as ignored while `Visible` is `false`, and a new chart gets no legend from them — but assigning one of them on a *loaded* chart that had no legend added one. ([#230](https://github.com/XLibur/XLibur/pull/230) by [@jafin](https://github.com/jafin))
+
+- **Chart-wide data labels reach every group of a loaded combo chart.** `IXLChart.DataLabels` applies to the whole chart, and a new combo chart gets them on both of its plot groups, but a loaded one was patched on the primary group only — so turning labels on left the secondary series unlabelled. ([#230](https://github.com/XLibur/XLibur/pull/230) by [@jafin](https://github.com/jafin))
+
+- **`Series.Add(...)` on a chart loaded from a file throws instead of being discarded on save.** A loaded chart is patched, not regenerated, so a new series had nowhere to be written and vanished without a word. It now throws `NotSupportedException`, as `UseSecondaryAxis` already did. ([#230](https://github.com/XLibur/XLibur/pull/230) by [@jafin](https://github.com/jafin))
+
+### 🗑️ Deprecations
+
+#### Colours and styles
+
+- **`XLColor.NoColor` is deprecated in favour of `XLColor.Automatic`.** Some Excel pickers (sheet tab, fill background) label the same value "No Color" — that is a GUI convention, not a different value. `NoColor` still compiles but now warns, which is an error for consumers building with `TreatWarningsAsErrors`. ([#232](https://github.com/XLibur/XLibur/pull/232) by [@jafin](https://github.com/jafin))
+
+  ```csharp
+  // Before
+  cell.Style.Font.FontColor = XLColor.NoColor;
+
+  // After
+  cell.Style.Font.FontColor = XLColor.Automatic;
+  ```
+
+  A straight rename — `NoColor` returns `Automatic`, so the two are the same value.
 
 ## v0.106.0 - 2026-07-25
 

--- a/docs-website/docs/encryption.md
+++ b/docs-website/docs/encryption.md
@@ -1,0 +1,287 @@
+---
+id: encryption
+title: Encryption and Passwords
+sidebar_label: Encryption
+description: Open and save password-protected workbooks with ECMA-376 encryption — load and save passwords, the exceptions to handle, and which encryption schemes are supported.
+---
+
+# Encryption and Passwords
+
+A password-protected workbook is encrypted on disk. Excel asks for the password before it will
+show you anything, and without it the contents cannot be recovered by any tool — the file is a
+container of ciphertext rather than a spreadsheet.
+
+XLibur reads these files and writes them, through `LoadOptions.Password` and
+`SaveOptions.Password`.
+
+:::warning Encryption is not the same as protection
+This page is about **encrypting the file**. That is different from
+[workbook and sheet protection](./workbook-settings.md#protection), which controls what a user is
+allowed to *edit* in a file that anyone can open.
+
+Protection is stored in plain text inside the `.xlsx` and any tool — including XLibur — can read
+straight past it. Encryption is the only one of the two that actually keeps a file's contents
+from being read.
+:::
+
+## Opening an encrypted workbook
+
+Set `Password` on `LoadOptions`:
+
+```csharp
+using XLibur.Excel;
+
+using var workbook = new XLWorkbook("Confidential.xlsx", new LoadOptions
+{
+    Password = "s3cret",
+});
+
+var value = workbook.Worksheet("Data").Cell("A1").GetString();
+```
+
+The same works for a stream:
+
+```csharp
+using var stream = File.OpenRead("Confidential.xlsx");
+using var workbook = new XLWorkbook(stream, new LoadOptions { Password = "s3cret" });
+```
+
+`Password` is only consulted when the file turns out to be encrypted, so setting it against a file
+that isn't is harmless. That makes it safe to pass a password for input of mixed provenance
+without sniffing each file first:
+
+```csharp
+// Fine whether or not Report.xlsx is encrypted
+using var workbook = new XLWorkbook(path, new LoadOptions { Password = suppliedPassword });
+```
+
+## Saving an encrypted workbook
+
+Set `Password` on `SaveOptions`:
+
+```csharp
+using var workbook = new XLWorkbook();
+var ws = workbook.AddWorksheet("Data");
+ws.Cell("A1").Value = "Commercially sensitive";
+
+workbook.SaveAs("Confidential.xlsx", new SaveOptions
+{
+    Password = "s3cret",
+});
+```
+
+Files are written with **agile encryption** using the parameters Excel itself writes —
+AES-256-CBC, SHA-512, a spin count of 100,000, and a freshly generated random key per save — so
+the result is indistinguishable from a file Excel produced, and opens in Excel with no complaint.
+
+Saving to a stream works the same way:
+
+```csharp
+using var ms = new MemoryStream();
+workbook.SaveAs(ms, new SaveOptions { Password = "s3cret" });
+```
+
+## The password is never carried from load to save
+
+Opening a workbook with a password does **not** cause it to be re-encrypted when you save it. To
+keep a file encrypted, supply the password again:
+
+```csharp
+using var workbook = new XLWorkbook("Confidential.xlsx", new LoadOptions { Password = "s3cret" });
+
+workbook.Worksheet("Data").Cell("A1").Value = "Updated";
+
+// Still encrypted — the password has to be given again
+workbook.SaveAs("Confidential.xlsx", new SaveOptions { Password = "s3cret" });
+```
+
+This is deliberate. If the password carried over implicitly, a plain `SaveAs` would silently
+produce a file the caller could not open without a password they never mentioned. The flip side
+is that forgetting it decrypts the file, so make the save password explicit wherever a file is
+meant to stay protected.
+
+Removing the protection is therefore just a save without a password:
+
+```csharp
+using var workbook = new XLWorkbook("Confidential.xlsx", new LoadOptions { Password = "s3cret" });
+workbook.SaveAs("Public.xlsx");                    // plain, unencrypted
+```
+
+And changing it is a save with a different one:
+
+```csharp
+workbook.SaveAs("Confidential.xlsx", new SaveOptions { Password = "n3wsecret" });
+```
+
+:::warning `Save()` does not update an encrypted file in place
+A workbook opened from an encrypted file is backed by the decrypted copy held in memory, because
+the file on disk is a compound file rather than a package the save path can patch. `Save()` writes
+to that in-memory copy and leaves the file on disk untouched — your changes go nowhere.
+
+Always use `SaveAs` for a workbook that was loaded encrypted:
+
+```csharp
+// Wrong — the file on disk is not updated
+workbook.Save();
+
+// Right
+workbook.SaveAs("Confidential.xlsx", new SaveOptions { Password = "s3cret" });
+```
+:::
+
+## Handling a wrong password
+
+Two exceptions, distinguished by whether the password is the problem:
+
+| Exception | Means | What to do |
+|---|---|---|
+| `XLInvalidPasswordException` | The password is wrong, or none was supplied for an encrypted file | Re-prompt the user |
+| `XLEncryptionException` | The password was right but the file is malformed, tampered with, or uses an unsupported scheme | Report the file as unreadable — do not re-prompt |
+
+Both derive from `XLiburException`.
+
+The distinction matters at the point where you would ask the user to type the password again. A
+failed integrity check means the bytes were altered after they were written; sending the user off
+to re-enter a password that was never the problem wastes their time and hides the real fault.
+
+```csharp
+using XLibur.Excel;
+using XLibur.Excel.Exceptions;
+
+static XLWorkbook OpenWithPrompt(string path, Func<string> promptForPassword)
+{
+    for (var attempt = 0; attempt < 3; attempt++)
+    {
+        try
+        {
+            return new XLWorkbook(path, new LoadOptions { Password = promptForPassword() });
+        }
+        catch (XLInvalidPasswordException)
+        {
+            // Wrong password — worth another try
+        }
+    }
+
+    throw new InvalidOperationException($"Could not open {path} after three attempts.");
+}
+```
+
+`XLEncryptionException` is deliberately not caught there: it will propagate, which is what you
+want for a corrupt file.
+
+Each exception carries a message naming the specific problem — an unexpected cipher, chaining
+mode, hash or key length is rejected by name rather than approximated into something that
+half-works.
+
+## What is supported
+
+| Scheme | Read | Write |
+|---|---|---|
+| Agile encryption (Office 2010 and later) | Yes | Yes |
+| Standard encryption (Office 2007) | Yes | No — re-saved as agile |
+| RC4 encryption (Office 97–2003) | No | No |
+| Legacy `.xls` workbooks | No | No |
+
+Reading covers both schemes in current use. Writing is agile only, which is what Excel has
+produced for well over a decade — so a standard-encrypted file you open and save comes back out
+as agile, which Excel opens with the same password.
+
+An RC4-encrypted file reports that re-saving from Excel will upgrade it. A legacy `.xls` is a
+compound file too, so it would otherwise look like an encrypted workbook; it is detected and named
+rather than reported as a mysterious decryption failure.
+
+The specification permits far more cipher and hash combinations than Excel emits. Anything outside
+that profile is rejected with a message saying what the file asked for, rather than being decrypted
+into plausible-looking garbage.
+
+## Streams must be seekable
+
+Encryption is detected by sniffing the compound-file signature at the start of the file, which
+requires seeking. A non-seekable stream is passed straight through as an ordinary package:
+
+```csharp
+// Works — MemoryStream and FileStream are seekable
+using var workbook = new XLWorkbook(seekableStream, new LoadOptions { Password = "s3cret" });
+```
+
+If you are reading from something non-seekable — a network or compressed stream — copy it into a
+`MemoryStream` first, or the encrypted file will fail as a corrupt archive rather than asking for
+the password:
+
+```csharp
+using var buffer = new MemoryStream();
+await responseStream.CopyToAsync(buffer);
+buffer.Position = 0;
+
+using var workbook = new XLWorkbook(buffer, new LoadOptions { Password = "s3cret" });
+```
+
+## Practical notes
+
+- **There is no recovery path.** A lost password means lost data; XLibur has no backdoor and
+  neither does Excel. Whatever stores your passwords needs to be as durable as the files.
+- **Encryption is deliberately slow.** The spin count of 100,000 iterations exists to make
+  brute-forcing expensive, and it applies on every open and every save. Budget for it when
+  encrypting files in bulk, and do not put an encrypted save inside a tight loop.
+- **Derived keys are zeroed** after use with `CryptographicOperations.ZeroMemory`. Passwords are
+  ordinary strings, matching the rest of the API, so they live in memory until the GC reclaims
+  them — if that matters in your threat model, keep their lifetime short.
+- **The whole file is encrypted**, not individual sheets. Excel offers no way to encrypt part of a
+  workbook, so neither does XLibur. Split the data across files if different audiences need
+  different access.
+
+## A worked example
+
+Generating a confidential report, then reading it back:
+
+```csharp
+using XLibur.Excel;
+using XLibur.Excel.Exceptions;
+
+const string Password = "correct horse battery staple";
+
+// Write
+using (var workbook = new XLWorkbook())
+{
+    var ws = workbook.AddWorksheet("Salaries");
+    ws.Cell("A1").Value = "Employee";
+    ws.Cell("B1").Value = "Salary";
+    ws.Range("A1:B1").Style.Font.Bold = true;
+
+    ws.Cell("A2").Value = "A. Example";
+    ws.Cell("B2").Value = 62_000;
+    ws.Cell("B2").Style.NumberFormat.Format = "#,##0";
+
+    // Protection stops casual edits; encryption stops the file being read at all.
+    workbook.Protect(Password, XLProtectionAlgorithm.Algorithm.SHA512);
+
+    workbook.SaveAs("Salaries.xlsx", new SaveOptions
+    {
+        Password = Password,
+        EvaluateFormulasBeforeSaving = true,
+    });
+}
+
+// Read
+try
+{
+    using var workbook = new XLWorkbook("Salaries.xlsx", new LoadOptions { Password = Password });
+    var salary = workbook.Worksheet("Salaries").Cell("B2").GetDouble();
+    Console.WriteLine($"Salary: {salary:N0}");
+}
+catch (XLInvalidPasswordException)
+{
+    Console.Error.WriteLine("Wrong password.");
+}
+catch (XLEncryptionException ex)
+{
+    Console.Error.WriteLine($"The file could not be decrypted: {ex.Message}");
+}
+```
+
+## Where to next
+
+- [Workbook Settings](./workbook-settings.md#protection) — workbook and sheet protection, and the
+  load and save options encryption sits alongside
+- [Worksheets](./worksheets.md#protecting-a-sheet) — protecting the contents of a single sheet
+- [Importing and Exporting](./importing-exporting.md) — the other ways data gets in and out

--- a/docs-website/docs/workbook-settings.md
+++ b/docs-website/docs/workbook-settings.md
@@ -184,8 +184,8 @@ workbook.Protect("s3cret", XLProtectionAlgorithm.Algorithm.SHA512);
 :::warning
 Neither workbook nor sheet protection encrypts anything. The data is stored in plain text
 inside the `.xlsx` and any tool — including XLibur — can read it without the password. Treat it
-as a guard against accidental edits, not as security. To genuinely protect contents, encrypt
-the file at rest or restrict access to it.
+as a guard against accidental edits, not as security. To genuinely protect contents, see
+[Encryption](./encryption.md) — or restrict access to the file.
 :::
 
 ### Read-only recommendation
@@ -219,6 +219,7 @@ using var fresh = new XLWorkbook(options);
 | `Dpi` | Resolution assumed for text measurement and images; default 96×96 |
 | `FontEngine` | Per-workbook font engine — see [Fonts](./fonts.md) |
 | `GraphicEngine` | Per-workbook image handling engine |
+| `Password` | Decrypts a password-protected workbook — see [Encryption](./encryption.md) |
 
 Two static members set global defaults for every workbook that does not specify its own:
 
@@ -253,6 +254,7 @@ workbook.SaveAs("Report.xlsx", options);
 | `ConsolidateDataValidationRanges` | `true` | Same, for data validation |
 | `GenerateCalculationChain` | `true` | Write the calc chain part Excel uses to order recalculation |
 | `FilterPrivacy` | `null` | Set the privacy flag; `null` leaves it unchanged |
+| `Password` | `null` | Encrypt the saved file — see [Encryption](./encryption.md) |
 
 The shorthand overloads cover the two common cases:
 

--- a/docs-website/sidebars.ts
+++ b/docs-website/sidebars.ts
@@ -15,6 +15,7 @@ const sidebars: SidebarsConfig = {
         'defined-names',
         'importing-exporting',
         'workbook-settings',
+        'encryption',
       ],
     },
     {


### PR DESCRIPTION
Two documentation changes, one commit each.

## Encryption guide

Password-protected workbooks landed in #245 with no documentation beyond the XML comments on `LoadOptions.Password` and `SaveOptions.Password`. Adds `docs-website/docs/encryption.md`, under **Working with workbooks** after Workbook Settings.

It leads with the distinction that matters most — encryption is not workbook protection. The Workbook Settings page already warned that protection encrypts nothing and told the reader to "encrypt the file at rest" without saying how; that warning now links to the new page, and the `LoadOptions`/`SaveOptions` tables gain their `Password` rows.

Two behaviours are documented that aren't obvious from the API and weren't in the PR description. Both came from reading the load and save paths:

- **`Save()` does not update an encrypted file in place.** Loading one sets `_loadSource = Stream` and never assigns `_originalFile`, so `Save()` writes into the decrypted `MemoryStream` and the file on disk is untouched — the changes are silently lost. This gets a warning admonition and a wrong/right pair. **Worth a maintainer opinion: is this intended, or a bug to fix?** If it's a bug the page should say so instead.
- **Stream loads must be seekable.** Detection sniffs the compound-file signature and only runs when `stream.CanSeek`, so an encrypted workbook arriving on a non-seekable stream fails as a corrupt archive rather than prompting for a password. Includes the buffer-into-a-`MemoryStream` workaround.

Also covers the read/write matrix (agile read+write, standard read-only, RC4 and legacy `.xls` unsupported), that the password is never carried from load to save, that the 100,000-iteration spin count costs real time on every open and save, and that there is no recovery path for a lost password.

## Changelog

The `Unreleased` section held the spec 10 chart work and nothing else, so everything else merged since the release was undocumented. Adds the missing entries — #245, #232, #243, #244, #241, #225, #227, #185, #179 — and restructures the section along two axes: change type first as emoji headings, feature area second within each. Sixteen bug fixes in a flat list is not a changelog.

Every entry now carries its PR and author. Links point at `XLibur/XLibur` rather than the `origin` fork, and authors come from the PRs rather than the git author, which a squash merge rewrites. Entries needing a code change carry a before/after example (`XLColor.NoColor` → `XLColor.Automatic`, and the `IsAutomatic` guard). A `Contents` table links each version including `Unreleased`.

The `v0.106.0` section is deliberately untouched — it's released, and attributing its entries means mapping the whole v0.105..v0.106 range, which is its own job. Happy to do that as a follow-up if wanted.

## Excluded

Sonar/style commits, the NUnit→TUnit migration (#238), the internal coordinate renames (#248 — internal types, absent from `PublicAPI.Shipped.txt`), CI config, the benchmark-only EPPlus bump, and README/docs-site infrastructure. Documentation-only work (#186, #188, #237) is also left out of the changelog; say the word and I'll add a section for it.

## Verification

`pnpm build` in `docs-website` succeeds. `onBrokenLinks` is `throw`, so every cross-link and anchor in the new page resolves. No library code is touched.
