### PR TITLE
feat(calc): add 24 financial functions (spec 07 wave A)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,6 +78,7 @@ jobs:
           /d:sonar.host.url="https://sonarcloud.io"
           /d:sonar.cs.vscoveragexml.reportsPaths="**/coverage.xml"
           /d:sonar.coverage.exclusions="XLibur.Examples/**,XLibur.Benchmarks/**"
+          /d:sonar.cpd.exclusions="XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs"
           /d:sonar.issue.ignore.multicriteria=e1
           /d:sonar.issue.ignore.multicriteria.e1.ruleKey=csharpsquid:S3220
           /d:sonar.issue.ignore.multicriteria.e1.resourceKey=**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@
 
 ### ✨ New Features
 
+#### Formula functions
+
+- **24 more financial functions**: depreciation (`SLN`, `SYD`, `DB`, `DDB`, `VDB`), rate conversion and growth (`EFFECT`, `NOMINAL`, `RRI`, `PDURATION`), fractional dollar notation (`DOLLARDE`, `DOLLARFR`), loan schedules (`ISPMT`, `CUMIPMT`, `CUMPRINC`), discount securities (`TBILLEQ`, `TBILLPRICE`, `TBILLYIELD`, `DISC`, `INTRATE`, `RECEIVED`) and irregular cash flows (`FVSCHEDULE`, `MIRR`, `XNPV`, `XIRR`). `XIRR` solves with Newton–Raphson and falls back to bisection when that wanders off, so a poor guess still converges.
+
+  Two deliberate limitations. The day-count-basis bond family (`PRICE`, `YIELD`, `DURATION`, `MDURATION`, `ACCRINT`, `COUP*`, `ODD*`, `AMOR*`) is not included — it needs a coupon-period engine rather than another day-count fraction. And `DISC`/`INTRATE`/`RECEIVED` take their year fraction from the same code as `YEARFRAC`, so basis 1 (actual/actual) uses `YEARFRAC`'s average-year-length rule. ([#252](https://github.com/XLibur/XLibur/pull/252) by [@jafin](https://github.com/jafin))
+
 #### Security and encryption
 
 - **Password-protected workbooks (ECMA-376 encryption)**: `LoadOptions.Password` opens an encrypted workbook and `SaveOptions.Password` writes one. Reading covers both schemes in the wild — agile encryption (Office 2010 and later) and standard encryption (Office 2007); writing uses agile encryption with the parameters Excel itself writes (AES-256-CBC, SHA-512, 100,000 spins and a fresh random key per save). Previously an encrypted file could not be opened at all and failed opaquely.

--- a/XLibur.Tests/Excel/CalcEngine/FinancialCashFlowTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FinancialCashFlowTests.cs
@@ -1,0 +1,365 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// ISPMT, CUMIPMT, CUMPRINC, FVSCHEDULE, MIRR, XNPV and XIRR. Expected values come from the worked
+/// examples in Microsoft's per-function documentation; each comment shows the documented formula
+/// applied to the arguments.
+/// </summary>
+public class FinancialCashFlowTests
+{
+    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    {
+        wb = new XLWorkbook();
+        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+    }
+
+    [Test]
+    // Microsoft's ISPMT example: an 8,000,000 loan over three years at 10%. The principal falls
+    // linearly, so period `per` still owes (1 - per/nper) of it: pv * rate * (per/nper - 1).
+    [Arguments("ISPMT(0.1/12, 1, 3*12, 8000000)", -64814.814814814818d)]
+    [Arguments("ISPMT(0.1, 1, 3, 8000000)", -533333.33333333337d)]
+    [Arguments("ISPMT(0.1, 3, 3, 8000000)", 0d)] // The last period owes nothing.
+    public async Task IsPmt_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-6);
+    }
+
+    [Test]
+    public async Task IsPmt_ZeroPeriodsIsDivisionByZero()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("ISPMT(0.1, 1, 0, 8000000)")).IsEqualTo(XLError.DivisionByZero);
+    }
+
+    [Test]
+    // Microsoft's CUMIPMT/CUMPRINC example: a 125,000 mortgage over 30 years at 9%.
+    [Arguments("CUMIPMT(0.09/12, 30*12, 125000, 13, 24, 0)", -11135.232130750162d)] // The second year's interest.
+    [Arguments("CUMIPMT(0.09/12, 30*12, 125000, 1, 1, 0)", -937.5d)] // 125000 * 0.09/12.
+    [Arguments("CUMPRINC(0.09/12, 30*12, 125000, 13, 24, 0)", -934.10712342088d)] // The second year's principal.
+    [Arguments("CUMPRINC(0.09/12, 30*12, 125000, 1, 1, 0)", -68.278271563389d)]
+    public async Task Cumulative_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-4);
+    }
+
+    [Test]
+    public async Task Cumulative_SinglePeriodMatchesIpmtAndPpmt()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "CUMIPMT(0.09/12, 360, 125000, 7, 7, 0)";
+            ws.Cell("A2").FormulaA1 = "IPMT(0.09/12, 7, 360, 125000)";
+            ws.Cell("B1").FormulaA1 = "CUMPRINC(0.09/12, 360, 125000, 7, 7, 0)";
+            ws.Cell("B2").FormulaA1 = "PPMT(0.09/12, 7, 360, 125000)";
+
+            await Assert.That((double)ws.Cell("A1").Value).IsEqualTo((double)ws.Cell("A2").Value).Within(1e-9);
+            await Assert.That((double)ws.Cell("B1").Value).IsEqualTo((double)ws.Cell("B2").Value).Within(1e-9);
+        }
+    }
+
+    [Test]
+    public async Task Cumulative_OverTheWholeTermSumsToTheTotalPayments()
+    {
+        // Every payment is either interest or principal, and the principal repaid over the full term
+        // is the amount borrowed.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "CUMIPMT(0.09/12, 360, 125000, 1, 360, 0)";
+            ws.Cell("A2").FormulaA1 = "CUMPRINC(0.09/12, 360, 125000, 1, 360, 0)";
+            ws.Cell("A3").FormulaA1 = "PMT(0.09/12, 360, 125000) * 360";
+
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(-125000d).Within(1e-6);
+            await Assert.That((double)ws.Cell("A1").Value + (double)ws.Cell("A2").Value)
+                .IsEqualTo((double)ws.Cell("A3").Value).Within(1e-6);
+        }
+    }
+
+    [Test]
+    [Arguments("CUMIPMT(0, 360, 125000, 1, 12, 0)")] // The rate must be positive.
+    [Arguments("CUMIPMT(0.0075, 0, 125000, 1, 12, 0)")] // The term must be positive.
+    [Arguments("CUMIPMT(0.0075, 360, 0, 1, 12, 0)")] // The loan must be positive.
+    [Arguments("CUMIPMT(0.0075, 360, 125000, 0, 12, 0)")] // Periods are one-based.
+    [Arguments("CUMIPMT(0.0075, 360, 125000, 13, 12, 0)")] // The range must not run backwards.
+    [Arguments("CUMIPMT(0.0075, 360, 125000, 1, 361, 0)")] // The range must not exceed the term.
+    [Arguments("CUMIPMT(0.0075, 360, 125000, 1, 12, 2)")] // Type is 0 or 1.
+    [Arguments("CUMPRINC(0, 360, 125000, 1, 12, 0)")]
+    [Arguments("CUMPRINC(0.0075, 360, 125000, 13, 12, 0)")]
+    [Arguments("CUMPRINC(0.0075, 360, 125000, 1, 12, 2)")]
+    public async Task Cumulative_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    // Microsoft's FVSCHEDULE example: 1 compounded at 9%, 11% and 10% = 1.09 * 1.11 * 1.1.
+    public async Task FvSchedule_CompoundsEachRateInTurn()
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr("FVSCHEDULE(1, {0.09,0.11,0.1})")).IsEqualTo(1.33089d).Within(1e-12);
+    }
+
+    [Test]
+    public async Task FvSchedule_ReadsTheScheduleFromARange()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 0.09;
+            ws.Cell("A2").Value = 0.11;
+            ws.Cell("A3").Value = 0.1;
+            ws.Cell("B1").FormulaA1 = "FVSCHEDULE(1, A1:A3)";
+
+            await Assert.That((double)ws.Cell("B1").Value).IsEqualTo(1.33089d).Within(1e-12);
+        }
+    }
+
+    [Test]
+    public async Task FvSchedule_SkipsBlanksAndPropagatesErrors()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 0.09;
+            // A2 deliberately left blank — a missing rate compounds by nothing.
+            ws.Cell("A3").Value = 0.11;
+            ws.Cell("B1").FormulaA1 = "FVSCHEDULE(1, A1:A3)";
+
+            ws.Cell("C1").Value = 0.09;
+            ws.Cell("C2").FormulaA1 = "1/0";
+            ws.Cell("D1").FormulaA1 = "FVSCHEDULE(1, C1:C2)";
+
+            await Assert.That((double)ws.Cell("B1").Value).IsEqualTo(1.09d * 1.11d).Within(1e-12);
+            await Assert.That(ws.Cell("D1").Value).IsEqualTo(XLError.DivisionByZero);
+        }
+    }
+
+    [Test]
+    // Microsoft's MIRR example: an initial 120,000 outlay followed by five years of income,
+    // financed at 10% and reinvested at 12%.
+    [Arguments("MIRR(A1:A6, 0.1, 0.12)", 0.12609413036d)] // All five years.
+    [Arguments("MIRR(A1:A4, 0.1, 0.12)", -0.048044655249d)] // The first three years only.
+    [Arguments("MIRR(A1:A6, 0.1, 0.14)", 0.13475911059d)] // Reinvesting at 14% instead.
+    public async Task Mirr_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = -120000;
+            ws.Cell("A2").Value = 39000;
+            ws.Cell("A3").Value = 30000;
+            ws.Cell("A4").Value = 21000;
+            ws.Cell("A5").Value = 37000;
+            ws.Cell("A6").Value = 46000;
+            ws.Cell("C1").FormulaA1 = formula;
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(expected).Within(1e-6);
+        }
+    }
+
+    [Test]
+    public async Task Mirr_MatchesIrrWhenBothRatesEqualIt()
+    {
+        // When money is financed and reinvested at the project's own IRR, the modified rate of
+        // return collapses back to it.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = -1000;
+            ws.Cell("A2").Value = 500;
+            ws.Cell("A3").Value = 400;
+            ws.Cell("A4").Value = 300;
+            ws.Cell("B1").FormulaA1 = "IRR(A1:A4)";
+            ws.Cell("B2").FormulaA1 = "MIRR(A1:A4, B1, B1)";
+
+            await Assert.That((double)ws.Cell("B2").Value).IsEqualTo((double)ws.Cell("B1").Value).Within(1e-6);
+        }
+    }
+
+    [Test]
+    public async Task Mirr_WithoutBothSignsIsDivisionByZero()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 100;
+            ws.Cell("A2").Value = 200;
+            ws.Cell("B1").FormulaA1 = "MIRR(A1:A2, 0.1, 0.12)";
+
+            await Assert.That(ws.Cell("B1").Value).IsEqualTo(XLError.DivisionByZero);
+        }
+    }
+
+    [Test]
+    // Microsoft's XNPV/XIRR example: -10,000 on 2008-01-01 followed by four irregular receipts.
+    // XNPV discounts each flow by its own actual/365 offset from the first date.
+    public async Task XNpv_ReferenceExampleFromExcelDocumentation()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedIrregularSchedule(ws);
+            ws.Cell("C1").FormulaA1 = "XNPV(0.09, A1:A5, B1:B5)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(2086.6476020315d).Within(1e-6);
+        }
+    }
+
+    [Test]
+    public async Task XIrr_ReferenceExampleFromExcelDocumentation()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedIrregularSchedule(ws);
+            ws.Cell("C1").FormulaA1 = "XIRR(A1:A5, B1:B5)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(0.373362535d).Within(1e-7);
+        }
+    }
+
+    [Test]
+    public async Task XIrr_IsTheRateAtWhichXNpvIsZero()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedIrregularSchedule(ws);
+            ws.Cell("C1").FormulaA1 = "XIRR(A1:A5, B1:B5)";
+            ws.Cell("C2").FormulaA1 = "XNPV(C1, A1:A5, B1:B5)";
+
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(0d).Within(1e-6);
+        }
+    }
+
+    [Test]
+    public async Task XIrr_ConvergesFromAPoorGuess()
+    {
+        // A guess far from the answer must still land on it — Newton falls back to bisection.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedIrregularSchedule(ws);
+            ws.Cell("C1").FormulaA1 = "XIRR(A1:A5, B1:B5, 5)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(0.373362535d).Within(1e-6);
+        }
+    }
+
+    [Test]
+    public async Task XNpv_MatchesAnnualNpvOnExactYearBoundaries()
+    {
+        // Flows a whole number of 365-day years apart discount exactly like periodic ones.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 100;
+            ws.Cell("A2").Value = 100;
+            ws.Cell("B1").FormulaA1 = "DATE(2007,1,1)";
+            ws.Cell("B2").FormulaA1 = "DATE(2008,1,1)"; // 365 days: 2007 is not a leap year.
+            ws.Cell("C1").FormulaA1 = "XNPV(0.1, A1:A2, B1:B2)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(100d + 100d / 1.1d).Within(1e-9);
+        }
+    }
+
+    [Test]
+    public async Task XIrr_WithoutBothSignsReturnsNumberInvalid()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 100;
+            ws.Cell("A2").Value = 200;
+            ws.Cell("B1").FormulaA1 = "DATE(2008,1,1)";
+            ws.Cell("B2").FormulaA1 = "DATE(2009,1,1)";
+            ws.Cell("C1").FormulaA1 = "XIRR(A1:A2, B1:B2)";
+
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.NumberInvalid);
+        }
+    }
+
+    [Test]
+    public async Task XNpv_MismatchedValueAndDateCountsReturnNumberInvalid()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedIrregularSchedule(ws);
+            ws.Cell("C1").FormulaA1 = "XNPV(0.09, A1:A5, B1:B4)";
+
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.NumberInvalid);
+        }
+    }
+
+    [Test]
+    public async Task XNpv_DateBeforeTheFirstOneReturnsNumberInvalid()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedIrregularSchedule(ws);
+            ws.Cell("B3").FormulaA1 = "DATE(2007,1,1)"; // Earlier than the schedule's start date.
+            ws.Cell("C1").FormulaA1 = "XNPV(0.09, A1:A5, B1:B5)";
+
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.NumberInvalid);
+        }
+    }
+
+    [Test]
+    public async Task XNpv_PropagatesErrorsFromTheSchedule()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedIrregularSchedule(ws);
+            ws.Cell("A3").FormulaA1 = "1/0";
+            ws.Cell("C1").FormulaA1 = "XNPV(0.09, A1:A5, B1:B5)";
+
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.DivisionByZero);
+        }
+    }
+
+    [Test]
+    public async Task RangeFunctions_AcceptCellReferencesForTheirScalarArguments()
+    {
+        // NPV, IRR, MIRR, XNPV and XIRR take a range for one argument and scalars for the rest, so
+        // their scalar arguments arrive unreduced — a reference has to be unwrapped rather than
+        // rejected as the wrong shape.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = -1000;
+            ws.Cell("A2").Value = 500;
+            ws.Cell("A3").Value = 400;
+            ws.Cell("A4").Value = 300;
+            ws.Cell("D1").Value = 0.1;
+
+            ws.Cell("C1").FormulaA1 = "NPV(D1, A1:A4)";
+            ws.Cell("C2").FormulaA1 = "NPV(0.1, A1:A4)";
+            ws.Cell("C3").FormulaA1 = "IRR(A1:A4, D1)";
+            ws.Cell("C4").FormulaA1 = "MIRR(A1:A4, D1, D1)";
+            ws.Cell("C5").FormulaA1 = "MIRR(A1:A4, 0.1, 0.1)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo((double)ws.Cell("C2").Value).Within(1e-12);
+            await Assert.That((double)ws.Cell("C3").Value).IsGreaterThan(0d);
+            await Assert.That((double)ws.Cell("C4").Value).IsEqualTo((double)ws.Cell("C5").Value).Within(1e-12);
+        }
+    }
+
+    private static void SeedIrregularSchedule(XLWorksheet ws)
+    {
+        ws.Cell("A1").Value = -10000;
+        ws.Cell("A2").Value = 2750;
+        ws.Cell("A3").Value = 4250;
+        ws.Cell("A4").Value = 3250;
+        ws.Cell("A5").Value = 2750;
+        ws.Cell("B1").FormulaA1 = "DATE(2008,1,1)";
+        ws.Cell("B2").FormulaA1 = "DATE(2008,3,1)";
+        ws.Cell("B3").FormulaA1 = "DATE(2008,10,30)";
+        ws.Cell("B4").FormulaA1 = "DATE(2009,2,15)";
+        ws.Cell("B5").FormulaA1 = "DATE(2009,4,1)";
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/FinancialDepreciationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FinancialDepreciationTests.cs
@@ -1,0 +1,229 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// SLN, SYD, DB, DDB and VDB. Expected values are the worked examples published in Microsoft's
+/// per-function documentation; where a case is not covered there it is derived from the documented
+/// formula and the derivation is shown in the comment.
+/// </summary>
+public class FinancialDepreciationTests
+{
+    private const double Tolerance = 1e-6;
+
+    [Test]
+    // Microsoft's SLN example: an asset costing 30,000 with a 7,500 salvage value over 10 years.
+    [Arguments("SLN(30000, 7500, 10)", 2250d)]
+    [Arguments("SLN(30000, 7500, 120)", 187.5d)] // The same asset depreciated monthly.
+    [Arguments("SLN(1000, 1000, 5)", 0d)] // Nothing to depreciate when salvage equals cost.
+    [Arguments("SLN(1000, 1200, 5)", -40d)] // A salvage value above cost appreciates.
+    public async Task Sln_SpreadsTheDepreciableAmountEvenly(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(Tolerance);
+    }
+
+    [Test]
+    public async Task Sln_ZeroLifeIsDivisionByZero()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("SLN(30000, 7500, 0)")).IsEqualTo(XLError.DivisionByZero);
+    }
+
+    [Test]
+    // Microsoft's SYD example: cost 30,000, salvage 7,500, life 10.
+    // (cost - salvage) * (life - per + 1) * 2 / (life * (life + 1)) = 22500 * 10 * 2 / 110.
+    [Arguments("SYD(30000, 7500, 10, 1)", 4090.909090909091d)]
+    [Arguments("SYD(30000, 7500, 10, 10)", 409.0909090909091d)] // 22500 * 1 * 2 / 110.
+    [Arguments("SYD(30000, 7500, 10, 5)", 2454.5454545454545d)] // 22500 * 6 * 2 / 110.
+    public async Task Syd_WeightsPeriodsByRemainingLife(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(Tolerance);
+    }
+
+    [Test]
+    public async Task Syd_ChargesSumToTheDepreciableAmount()
+    {
+        var total = 0d;
+        for (var period = 1; period <= 10; period++)
+            total += (double)XLWorkbook.EvaluateExpr($"SYD(30000, 7500, 10, {period})");
+
+        await Assert.That(total).IsEqualTo(22500d).Within(1e-9);
+    }
+
+    [Test]
+    [Arguments("SYD(30000, 7500, 0, 1)")] // Life must be positive.
+    [Arguments("SYD(30000, 7500, 10, 0)")] // Period must be at least one.
+    [Arguments("SYD(30000, 7500, 10, 11)")] // Period may not run past the asset's life.
+    public async Task Syd_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    // Microsoft's DB example: cost 1,000,000, salvage 100,000, life 6 years, first year 7 months.
+    // The rate is ROUND(1 - (100000/1000000)^(1/6), 3) = 0.319.
+    [Arguments("DB(1000000, 100000, 6, 1, 7)", 186083.33333333334d)] // 1000000 * 0.319 * 7/12.
+    [Arguments("DB(1000000, 100000, 6, 2, 7)", 259639.41666666669d)] // (1000000 - 186083.33) * 0.319.
+    [Arguments("DB(1000000, 100000, 6, 3, 7)", 176814.44275000002d)]
+    [Arguments("DB(1000000, 100000, 6, 4, 7)", 120410.63551275003d)]
+    [Arguments("DB(1000000, 100000, 6, 5, 7)", 81999.642784418779d)]
+    [Arguments("DB(1000000, 100000, 6, 6, 7)", 55841.756736028462d)]
+    [Arguments("DB(1000000, 100000, 6, 7, 7)", 15845.098473848071d)] // Stub period: * (12-7)/12.
+    public async Task Db_ReferenceExampleFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-4);
+    }
+
+    [Test]
+    public async Task Db_MonthDefaultsToTwelve()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("DB(1000000, 100000, 6, 1)"))
+            .IsEqualTo(XLWorkbook.EvaluateExpr("DB(1000000, 100000, 6, 1, 12)"));
+    }
+
+    [Test]
+    public async Task Db_ZeroCostDepreciatesNothing()
+    {
+        // The rate is undefined when cost is zero, so Excel short-circuits to no depreciation
+        // rather than raising the 0/0 that (salvage/cost)^(1/life) would produce.
+        await Assert.That((double)XLWorkbook.EvaluateExpr("DB(0, 0, 5, 1)")).IsEqualTo(0d);
+    }
+
+    [Test]
+    [Arguments("DB(-1000, 100, 5, 1)")] // Negative cost.
+    [Arguments("DB(1000, -100, 5, 1)")] // Negative salvage.
+    [Arguments("DB(1000, 100, 0, 1)")] // Life must be positive.
+    [Arguments("DB(1000, 100, 5, 0)")] // Period must be at least one.
+    [Arguments("DB(1000, 100, 5, 1, 0)")] // Month must be 1..12.
+    [Arguments("DB(1000, 100, 5, 1, 13)")]
+    [Arguments("DB(1000, 100, 5, 6)")] // With a full first year there is no stub period.
+    [Arguments("DB(1000, 100, 5, 7, 7)")] // Even a partial first year only adds one stub period.
+    public async Task Db_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    // Microsoft's DDB example: cost 2,400, salvage 300, life 10 years.
+    [Arguments("DDB(2400, 300, 3650, 1)", 1.3150684931506849d)] // First day. 2400 - 2400*(1-2/3650).
+    [Arguments("DDB(2400, 300, 120, 1, 2)", 40d)] // First month. 2400 * 2/120.
+    [Arguments("DDB(2400, 300, 10, 1, 2)", 480d)] // First year. 2400 * 0.2.
+    [Arguments("DDB(2400, 300, 10, 2, 1.5)", 306d)] // 2400*0.85 - 2400*0.85^2.
+    [Arguments("DDB(2400, 300, 10, 10)", 22.122547200000029d)] // Capped at the salvage value.
+    public async Task Ddb_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(Tolerance);
+    }
+
+    [Test]
+    public async Task Ddb_FactorDefaultsToTwo()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("DDB(2400, 300, 10, 3)"))
+            .IsEqualTo(XLWorkbook.EvaluateExpr("DDB(2400, 300, 10, 3, 2)"));
+    }
+
+    [Test]
+    public async Task Ddb_NeverDepreciatesBelowSalvage()
+    {
+        // Once the book value has reached the salvage value there is nothing left to charge.
+        await Assert.That((double)XLWorkbook.EvaluateExpr("DDB(1000, 900, 10, 8)")).IsEqualTo(0d);
+    }
+
+    [Test]
+    [Arguments("DDB(-2400, 300, 10, 1)")] // Negative cost.
+    [Arguments("DDB(2400, -300, 10, 1)")] // Negative salvage.
+    [Arguments("DDB(2400, 300, 0, 1)")] // Life must be positive.
+    [Arguments("DDB(2400, 300, 10, 0)")] // Period must be positive.
+    [Arguments("DDB(2400, 300, 10, 11)")] // Period may not run past the asset's life.
+    [Arguments("DDB(2400, 300, 10, 1, 0)")] // Factor must be positive.
+    public async Task Ddb_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    // Microsoft's VDB example: cost 2,400, salvage 300, life 10 years / 120 months / 3,650 days.
+    [Arguments("VDB(2400, 300, 3650, 0, 1)", 1.3150684931506849d)] // First day, same as DDB.
+    [Arguments("VDB(2400, 300, 120, 0, 1)", 40d)] // First month.
+    [Arguments("VDB(2400, 300, 10, 0, 1)", 480d)] // First year.
+    // 2400*(1-(59/60)^18) - 2400*(1-(59/60)^6) = 626.5256 - 230.2193.
+    [Arguments("VDB(2400, 300, 120, 6, 18)", 396.30605326475d)] // Months 7 through 18; Microsoft prints 396.31.
+    [Arguments("VDB(2400, 300, 10, 0, 0.875, 1.5)", 315d)] // 0.875 of the first year at factor 1.5.
+    public async Task Vdb_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-4);
+    }
+
+    [Test]
+    public async Task Vdb_SumsToTheSameTotalAsItsParts()
+    {
+        // Consecutive slices must charge the same as taking the range whole.
+        var whole = (double)XLWorkbook.EvaluateExpr("VDB(2400, 300, 10, 0, 6)");
+        var first = (double)XLWorkbook.EvaluateExpr("VDB(2400, 300, 10, 0, 3)");
+        var second = (double)XLWorkbook.EvaluateExpr("VDB(2400, 300, 10, 3, 6)");
+
+        await Assert.That(first + second).IsEqualTo(whole).Within(1e-9);
+    }
+
+    [Test]
+    public async Task Vdb_OverTheWholeLifeChargesTheDepreciableAmount()
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr("VDB(2400, 300, 10, 0, 10)")).IsEqualTo(2100d).Within(1e-9);
+        await Assert.That((double)XLWorkbook.EvaluateExpr("VDB(2400, 300, 10, 0, 10, 1)")).IsEqualTo(2100d).Within(1e-9);
+    }
+
+    [Test]
+    public async Task Vdb_NoSwitchStaysOnDecliningBalance()
+    {
+        // At factor 1 straight-line overtakes declining balance in the third year, so suppressing
+        // the switch leaves the asset short of its salvage value: 2400 - 2400*0.9^10 = 1563.1717.
+        var switching = (double)XLWorkbook.EvaluateExpr("VDB(2400, 300, 10, 0, 10, 1)");
+        var noSwitch = (double)XLWorkbook.EvaluateExpr("VDB(2400, 300, 10, 0, 10, 1, TRUE)");
+
+        await Assert.That(switching).IsEqualTo(2100d).Within(1e-9);
+        await Assert.That(noSwitch).IsEqualTo(1563.17174376d).Within(1e-6);
+    }
+
+    [Test]
+    public async Task Vdb_WholePeriodMatchesDdbWhenDecliningBalanceStillWins()
+    {
+        // Over the first year declining balance is still the larger charge, so VDB and DDB agree.
+        var vdb = (double)XLWorkbook.EvaluateExpr("VDB(2400, 300, 10, 0, 1)");
+        var ddb = (double)XLWorkbook.EvaluateExpr("DDB(2400, 300, 10, 1)");
+
+        await Assert.That(vdb).IsEqualTo(ddb).Within(1e-9);
+    }
+
+    [Test]
+    [Arguments("VDB(2400, 300, 10, -1, 5)")] // Start period may not be negative.
+    [Arguments("VDB(2400, 300, 10, 5, 4)")] // End must not precede start.
+    [Arguments("VDB(2400, 300, 10, 0, 11)")] // End may not run past the asset's life.
+    [Arguments("VDB(-2400, 300, 10, 0, 5)")] // Negative cost.
+    [Arguments("VDB(2400, 3000, 10, 0, 5)")] // Salvage above cost.
+    [Arguments("VDB(2400, 300, 10, 0, 5, 0)")] // Factor must be positive.
+    public async Task Vdb_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    public async Task Depreciation_EvaluatesAgainstWorksheetCells()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = 2400;
+        ws.Cell("A2").Value = 300;
+        ws.Cell("A3").Value = 10;
+        ws.Cell("A4").Value = 1;
+
+        ws.Cell("B1").FormulaA1 = "SLN(A1, A2, A3)";
+        ws.Cell("B2").FormulaA1 = "SYD(A1, A2, A3, A4)";
+        ws.Cell("B3").FormulaA1 = "DDB(A1, A2, A3, A4)";
+        ws.Cell("B4").FormulaA1 = "VDB(A1, A2, A3, 0, A4)";
+
+        await Assert.That((double)ws.Cell("B1").Value).IsEqualTo(210d).Within(Tolerance);
+        await Assert.That((double)ws.Cell("B2").Value).IsEqualTo(381.81818181818181d).Within(Tolerance);
+        await Assert.That((double)ws.Cell("B3").Value).IsEqualTo(480d).Within(Tolerance);
+        await Assert.That((double)ws.Cell("B4").Value).IsEqualTo(480d).Within(Tolerance);
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/FinancialSecuritiesTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FinancialSecuritiesTests.cs
@@ -1,0 +1,262 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// Rate conversion (EFFECT, NOMINAL, RRI, PDURATION), fractional dollar notation (DOLLARDE,
+/// DOLLARFR) and the discount-security functions (TBILLEQ, TBILLPRICE, TBILLYIELD, DISC, INTRATE,
+/// RECEIVED). Expected values come from the worked examples in Microsoft's per-function
+/// documentation; each comment shows the documented formula applied to the arguments.
+/// </summary>
+public class FinancialSecuritiesTests
+{
+    [Test]
+    // (1 + 0.0525/4)^4 - 1 = 1.013125^4 - 1.
+    [Arguments("EFFECT(0.0525, 4)", 0.053542667370758d)]
+    [Arguments("EFFECT(0.1, 1)", 0.1d)] // Compounding once a year changes nothing.
+    [Arguments("EFFECT(0.1, 2)", 0.1025d)] // 1.05^2 - 1.
+    public async Task Effect_CompoundsTheNominalRate(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    // ((1 + 0.053543)^(1/4) - 1) * 4.
+    [Arguments("NOMINAL(0.053543, 4)", 0.0525003198683561d)]
+    [Arguments("NOMINAL(0.1, 1)", 0.1d)]
+    [Arguments("NOMINAL(0.1025, 2)", 0.1d)] // The inverse of EFFECT(0.1, 2).
+    public async Task Nominal_UndoesTheCompounding(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    public async Task NominalAndEffect_RoundTrip()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").FormulaA1 = "EFFECT(0.0525, 12)";
+        ws.Cell("A2").FormulaA1 = "NOMINAL(A1, 12)";
+
+        await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(0.0525d).Within(1e-12);
+    }
+
+    [Test]
+    [Arguments("EFFECT(0, 4)")] // The rate must be positive.
+    [Arguments("EFFECT(-0.05, 4)")]
+    [Arguments("EFFECT(0.05, 0)")] // There must be at least one compounding period.
+    [Arguments("NOMINAL(0, 4)")]
+    [Arguments("NOMINAL(0.05, 0.5)")] // Truncated to zero periods.
+    public async Task EffectAndNominal_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    // (fv/pv)^(1/nper) - 1 = 1.1^(1/96) - 1.
+    [Arguments("RRI(96, 10000, 11000)", 0.000993307372823d)]
+    [Arguments("RRI(1, 100, 110)", 0.1d)] // A single period is just the growth rate.
+    [Arguments("RRI(2, 100, 121)", 0.1d)]
+    public async Task Rri_ReturnsTheEquivalentPeriodicRate(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    // (LN(fv) - LN(pv)) / LN(1 + rate) = LN(1.1) / LN(1.025).
+    [Arguments("PDURATION(0.025, 2000, 2200)", 3.859866162622655d)] // Microsoft prints 3.859866.
+    [Arguments("PDURATION(0.1, 100, 121)", 2d)] // 100 grows to 121 in exactly two 10% periods.
+    public async Task PDuration_ReturnsThePeriodsNeededToReachAValue(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    [Arguments("RRI(0, 10000, 11000)")] // Periods must be positive.
+    [Arguments("RRI(96, 0, 11000)")] // Present value must be positive.
+    [Arguments("RRI(96, 10000, -1)")] // Future value may not be negative.
+    [Arguments("PDURATION(0, 2000, 2200)")] // The rate must be positive.
+    [Arguments("PDURATION(0.025, 0, 2200)")]
+    [Arguments("PDURATION(0.025, 2000, 0)")]
+    public async Task RriAndPDuration_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    // The digits after the point are sixteenths (or thirty-seconds), shifted by the two decimal
+    // places the denominator occupies: 1 + 0.02 * 100 / 16 = 1.125.
+    [Arguments("DOLLARDE(1.02, 16)", 1.125d)]
+    [Arguments("DOLLARDE(1.1, 32)", 1.3125d)]
+    [Arguments("DOLLARDE(-1.02, 16)", -1.125d)] // The sign carries through both parts.
+    public async Task DollarDe_ConvertsFractionalNotationToDecimal(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-12);
+    }
+
+    [Test]
+    [Arguments("DOLLARFR(1.125, 16)", 1.02d)]
+    [Arguments("DOLLARFR(1.3125, 32)", 1.1d)]
+    [Arguments("DOLLARFR(-1.125, 16)", -1.02d)]
+    public async Task DollarFr_ConvertsDecimalToFractionalNotation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-12);
+    }
+
+    [Test]
+    public async Task DollarDeAndDollarFr_AreInverses()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").FormulaA1 = "DOLLARDE(1.09, 16)";
+        ws.Cell("A2").FormulaA1 = "DOLLARFR(A1, 16)";
+
+        await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(1.5625d).Within(1e-12); // 1 + 9/16.
+        await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(1.09d).Within(1e-12);
+    }
+
+    [Test]
+    [Arguments("DOLLARDE(1.02, 0)")]
+    [Arguments("DOLLARFR(1.125, 0)")]
+    [Arguments("DOLLARDE(1.02, 0.5)")] // Truncated to a zero denominator.
+    public async Task DollarConversions_ZeroFractionIsDivisionByZero(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.DivisionByZero);
+    }
+
+    [Test]
+    [Arguments("DOLLARDE(1.02, -1)")]
+    [Arguments("DOLLARFR(1.125, -1)")]
+    public async Task DollarConversions_NegativeFractionReturnsNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    // Microsoft's Treasury bill examples: settlement 2008-03-31, maturity 2008-06-01 (62 days).
+    // TBILLEQ = (365 * 0.0914) / (360 - 0.0914 * 62) = 33.361 / 354.3332.
+    [Arguments("TBILLEQ(DATE(2008,3,31), DATE(2008,6,1), 0.0914)", 0.0941514937d)]
+    // TBILLPRICE = 100 * (1 - 0.09 * 62/360).
+    [Arguments("TBILLPRICE(DATE(2008,3,31), DATE(2008,6,1), 0.09)", 98.45d)]
+    // TBILLYIELD = (100 - 98.45)/98.45 * 360/62.
+    [Arguments("TBILLYIELD(DATE(2008,3,31), DATE(2008,6,1), 98.45)", 0.0914169629d)]
+    public async Task TBill_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    public async Task TBillYield_ExceedsTheDiscountRateOfTheSamePrice()
+    {
+        // The discount is quoted on the face value but earned on the lower purchase price, so the
+        // yield a buyer actually gets is the larger of the two.
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").FormulaA1 = "TBILLPRICE(DATE(2008,3,31), DATE(2008,6,1), 0.09)";
+        ws.Cell("A2").FormulaA1 = "TBILLYIELD(DATE(2008,3,31), DATE(2008,6,1), A1)";
+
+        await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(98.45d).Within(1e-12);
+        await Assert.That((double)ws.Cell("A2").Value).IsGreaterThan(0.09d);
+    }
+
+    [Test]
+    [Arguments("TBILLEQ(DATE(2008,6,1), DATE(2008,3,31), 0.0914)")] // Maturity before settlement.
+    [Arguments("TBILLEQ(DATE(2008,3,31), DATE(2008,3,31), 0.0914)")] // Same day.
+    [Arguments("TBILLEQ(DATE(2008,3,31), DATE(2010,6,1), 0.0914)")] // More than a year to maturity.
+    [Arguments("TBILLEQ(DATE(2008,3,31), DATE(2008,6,1), 0)")] // The discount must be positive.
+    [Arguments("TBILLPRICE(DATE(2008,3,31), DATE(2010,6,1), 0.09)")]
+    [Arguments("TBILLPRICE(DATE(2008,3,31), DATE(2008,6,1), -0.09)")]
+    [Arguments("TBILLYIELD(DATE(2008,3,31), DATE(2010,6,1), 98.45)")]
+    [Arguments("TBILLYIELD(DATE(2008,3,31), DATE(2008,6,1), 0)")] // The price must be positive.
+    public async Task TBill_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    // Settlement 2007-01-07, maturity 2007-06-15. Actual days 159; 30/360 days 158.
+    // DISC = (100 - 97.975)/100 / yearFraction, and (100 - 97.975)/100 = 0.02025.
+    [Arguments("DISC(DATE(2007,1,7), DATE(2007,6,15), 97.975, 100, 2)", 0.045849056603773585d)] // 0.02025 / (159/360).
+    [Arguments("DISC(DATE(2007,1,7), DATE(2007,6,15), 97.975, 100, 0)", 0.046139240506329116d)] // 0.02025 / (158/360).
+    [Arguments("DISC(DATE(2007,1,7), DATE(2007,6,15), 97.975, 100, 3)", 0.046485849056603776d)] // 0.02025 / (159/365).
+    public async Task Disc_ReferenceExampleFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    public async Task Disc_BasisDefaultsToUsThirtyThreeSixty()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("DISC(DATE(2007,1,7), DATE(2007,6,15), 97.975, 100)"))
+            .IsEqualTo(XLWorkbook.EvaluateExpr("DISC(DATE(2007,1,7), DATE(2007,6,15), 97.975, 100, 0)"));
+    }
+
+    [Test]
+    // Microsoft's INTRATE example: settlement 2008-02-15, maturity 2008-05-15, basis 2 gives a year
+    // fraction of exactly 90/360. (1014420 - 1000000)/1000000 / 0.25.
+    public async Task IntRate_ReferenceExampleFromExcelDocumentation()
+    {
+        var actual = (double)XLWorkbook.EvaluateExpr("INTRATE(DATE(2008,2,15), DATE(2008,5,15), 1000000, 1014420, 2)");
+        await Assert.That(actual).IsEqualTo(0.05768d).Within(1e-12);
+    }
+
+    [Test]
+    // Microsoft's RECEIVED example, same dates and basis: 1000000 / (1 - 0.0575 * 0.25), and
+    // 1 - 0.014375 = 1577/1600, so the result is 1000000 * 1600/1577 = 1,014,584.65.
+    public async Task Received_ReferenceExampleFromExcelDocumentation()
+    {
+        var actual = (double)XLWorkbook.EvaluateExpr("RECEIVED(DATE(2008,2,15), DATE(2008,5,15), 1000000, 0.0575, 2)");
+        await Assert.That(actual).IsEqualTo(1_600_000_000d / 1577d).Within(1e-6);
+    }
+
+    [Test]
+    public async Task IntRateAndReceived_DescribeTheSameSecurity()
+    {
+        // Discounting the proceeds back at the quoted discount rate has to return the investment,
+        // and growing the investment at the derived interest rate has to return the proceeds.
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").FormulaA1 = "RECEIVED(DATE(2008,2,15), DATE(2008,5,15), 1000000, 0.0575, 2)";
+        ws.Cell("A2").FormulaA1 = "INTRATE(DATE(2008,2,15), DATE(2008,5,15), 1000000, A1, 2)";
+
+        var received = (double)ws.Cell("A1").Value;
+        var rate = (double)ws.Cell("A2").Value;
+
+        await Assert.That(received * (1 - 0.0575 * 0.25)).IsEqualTo(1000000d).Within(1e-6);
+        await Assert.That(1000000 * (1 + rate * 0.25)).IsEqualTo(received).Within(1e-6);
+    }
+
+    [Test]
+    [Arguments("DISC(DATE(2007,6,15), DATE(2007,1,7), 97.975, 100, 2)")] // Maturity before settlement.
+    [Arguments("DISC(DATE(2007,1,7), DATE(2007,6,15), 0, 100, 2)")] // The price must be positive.
+    [Arguments("DISC(DATE(2007,1,7), DATE(2007,6,15), 97.975, 0, 2)")] // The redemption must be positive.
+    [Arguments("DISC(DATE(2007,1,7), DATE(2007,6,15), 97.975, 100, 5)")] // Only bases 0..4 exist.
+    [Arguments("INTRATE(DATE(2008,5,15), DATE(2008,2,15), 1000000, 1014420, 2)")]
+    [Arguments("INTRATE(DATE(2008,2,15), DATE(2008,5,15), 0, 1014420, 2)")]
+    [Arguments("RECEIVED(DATE(2008,5,15), DATE(2008,2,15), 1000000, 0.0575, 2)")]
+    [Arguments("RECEIVED(DATE(2008,2,15), DATE(2008,5,15), 1000000, 0, 2)")] // The discount must be positive.
+    [Arguments("RECEIVED(DATE(2008,2,15), DATE(2008,5,15), 1000000, 5, 2)")] // A discount that wipes out the proceeds.
+    public async Task Securities_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    public async Task Securities_EvaluateAgainstWorksheetCells()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").FormulaA1 = "DATE(2008,2,15)";
+        ws.Cell("A2").FormulaA1 = "DATE(2008,5,15)";
+        ws.Cell("A3").Value = 1000000;
+        ws.Cell("A4").Value = 1014420;
+        ws.Cell("A5").Value = 2;
+
+        ws.Cell("B1").FormulaA1 = "INTRATE(A1, A2, A3, A4, A5)";
+        ws.Cell("B2").FormulaA1 = "EFFECT(B1, 4)";
+
+        await Assert.That((double)ws.Cell("B1").Value).IsEqualTo(0.05768d).Within(1e-12);
+        await Assert.That((double)ws.Cell("B2").Value).IsGreaterThan(0.05768d);
+    }
+}

--- a/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -657,7 +657,12 @@ internal static class DateAndTime
         return DateParts.From(ctx, serialDate).Year;
     }
 
-    private static ScalarValue YearFrac(CalcContext ctx, double startDateTime, double endDateTime, double basis = 0)
+    /// <summary>
+    /// Day-count fraction between two dates for one of Excel's five bases. Also used by the
+    /// security functions in <see cref="Financial"/> (DISC, INTRATE, RECEIVED), which are defined
+    /// in terms of "days between settlement and maturity / days in a year, per basis".
+    /// </summary>
+    internal static ScalarValue YearFrac(CalcContext ctx, double startDateTime, double endDateTime, double basis = 0)
     {
         if (!TryGetDate(ctx, startDateTime, out var startDate))
             return XLError.NumberInvalid;

--- a/XLibur/Excel/CalcEngine/Functions/Financial.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Financial.cs
@@ -10,61 +10,42 @@ internal static class Financial
 {
     public static void Register(FunctionRegistry ce)
     {
-        // ACCRINT Returns the accrued interest for a security that pays periodic interest
-        // ACCRINTM Returns the accrued interest for a security that pays interest at maturity
-        // AMORDEGRC Returns the depreciation for each accounting period by using a depreciation coefficient
-        // AMORLINC Returns the depreciation for each accounting period
-        // COUPDAYBS Returns the number of days from the beginning of the coupon period to the settlement date
-        // COUPDAYS Returns the number of days in the coupon period that contains the settlement date
-        // COUPDAYSNC Returns the number of days from the settlement date to the next coupon date
-        // COUPNCD Returns the next coupon date after the settlement date
-        // COUPNUM Returns the number of coupons payable between the settlement date and maturity date
-        // COUPPCD Returns the previous coupon date before the settlement date
-        // CUMIPMT Returns the cumulative interest paid between two periods
-        // CUMPRINC Returns the cumulative principal paid on a loan between two periods
-        // DB Returns the depreciation of an asset for a specified period by using the fixed-declining balance method
-        // DDB Returns the depreciation of an asset for a specified period by using the double-declining balance method or some other method that you specify
-        // DISC Returns the discount rate for a security
-        // DOLLARDE Converts a dollar price, expressed as a fraction, into a dollar price, expressed as a decimal number
-        // DOLLARFR Converts a dollar price, expressed as a decimal number, into a dollar price, expressed as a fraction
-        // DURATION Returns the annual duration of a security with periodic interest payments
-        // EFFECT Returns the effective annual interest rate
+        // The day-count-basis bond family (ACCRINT, ACCRINTM, COUP*, DURATION, MDURATION, ODD*,
+        // PRICE*, YIELD*, AMORDEGRC, AMORLINC) needs a full 30/360 & actual/actual coupon-period
+        // engine and is deliberately left out — see spec 07, "wave A2".
+        ce.RegisterFunction("CUMIPMT", 6, 6, Adapt(CumIpmt), FunctionFlags.Scalar); // Returns the cumulative interest paid between two periods
+        ce.RegisterFunction("CUMPRINC", 6, 6, Adapt(CumPrinc), FunctionFlags.Scalar); // Returns the cumulative principal paid on a loan between two periods
+        ce.RegisterFunction("DB", 4, 5, AdaptLastOptional(Db, 12), FunctionFlags.Scalar); // Returns the depreciation of an asset for a specified period by using the fixed-declining balance method
+        ce.RegisterFunction("DDB", 4, 5, AdaptLastOptional(Ddb, 2), FunctionFlags.Scalar); // Returns the depreciation of an asset for a specified period by using the double-declining balance method or some other method that you specify
+        ce.RegisterFunction("DISC", 4, 5, AdaptLastOptional(Disc, 0), FunctionFlags.Scalar); // Returns the discount rate for a security
+        ce.RegisterFunction("DOLLARDE", 2, 2, Adapt(DollarDe), FunctionFlags.Scalar); // Converts a dollar price, expressed as a fraction, into a dollar price, expressed as a decimal number
+        ce.RegisterFunction("DOLLARFR", 2, 2, Adapt(DollarFr), FunctionFlags.Scalar); // Converts a dollar price, expressed as a decimal number, into a dollar price, expressed as a fraction
+        ce.RegisterFunction("EFFECT", 2, 2, Adapt(Effect), FunctionFlags.Scalar); // Returns the effective annual interest rate
         ce.RegisterFunction("FV", 3, 5, AdaptLastTwoOptional(Fv, 0, 0), FunctionFlags.Scalar); // Returns the future value of an investment
-        // FVSCHEDULE Returns the future value of an initial principal after applying a series of compound interest rates
-        // INTRATE Returns the interest rate for a fully invested security
+        ce.RegisterFunction("FVSCHEDULE", 2, 2, FvSchedule, FunctionFlags.Range, AllowRange.Only, 1); // Returns the future value of an initial principal after applying a series of compound interest rates
+        ce.RegisterFunction("INTRATE", 4, 5, AdaptLastOptional(IntRate, 0), FunctionFlags.Scalar); // Returns the interest rate for a fully invested security
         ce.RegisterFunction("IPMT", 4, 6, AdaptLastTwoOptional(Ipmt, 0, 0), FunctionFlags.Scalar); // Returns the interest payment for an investment for a given period
         ce.RegisterFunction("IRR", 1, 2, Irr, FunctionFlags.Range, AllowRange.Only, 0); // Returns the internal rate of return for a series of cash flows
-        // ISPMT Calculates the interest paid during a specific period of an investment
-        // MDURATION Returns the Macauley modified duration for a security with an assumed par value of $100
-        // MIRR Returns the internal rate of return where positive and negative cash flows are financed at different rates
-        // NOMINAL Returns the annual nominal interest rate
+        ce.RegisterFunction("ISPMT", 4, 4, Adapt(IsPmt), FunctionFlags.Scalar); // Calculates the interest paid during a specific period of an investment
+        ce.RegisterFunction("MIRR", 3, 3, Mirr, FunctionFlags.Range, AllowRange.Only, 0); // Returns the internal rate of return where positive and negative cash flows are financed at different rates
+        ce.RegisterFunction("NOMINAL", 2, 2, Adapt(Nominal), FunctionFlags.Scalar); // Returns the annual nominal interest rate
         ce.RegisterFunction("NPER", 3, 5, AdaptLastTwoOptional(Nper, 0, 0), FunctionFlags.Scalar); // Returns the number of periods for an investment
         ce.RegisterFunction("NPV", 2, 255, Npv, FunctionFlags.Range, AllowRange.Except, 0); // Returns the net present value of an investment based on a series of periodic cash flows and a discount rate
-        // ODDFPRICE Returns the price per $100 face value of a security with an odd first period
-        // ODDFYIELD Returns the yield of a security with an odd first period
-        // ODDLPRICE Returns the price per $100 face value of a security with an odd last period
-        // ODDLYIELD Returns the yield of a security with an odd last period
-        // PDURATION Returns the number of periods required by an investment to reach a specified value
+        ce.RegisterFunction("PDURATION", 3, 3, Adapt(PDuration), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the number of periods required by an investment to reach a specified value
         ce.RegisterFunction("PMT", 3, 5, AdaptLastTwoOptional(Pmt, 0, 0), FunctionFlags.Scalar); // Returns the periodic payment for an annuity
         ce.RegisterFunction("PPMT", 4, 6, AdaptLastTwoOptional(Ppmt, 0, 0), FunctionFlags.Scalar); // Returns the payment on the principal for an investment for a given period
-        // PRICE Returns the price per $100 face value of a security that pays periodic interest
-        // PRICEDISC Returns the price per $100 face value of a discounted security
-        // PRICEMAT Returns the price per $100 face value of a security that pays interest at maturity
         ce.RegisterFunction("PV", 3, 5, AdaptLastTwoOptional(Pv, 0, 0), FunctionFlags.Scalar); // Returns the present value of an investment
         ce.RegisterFunction("RATE", 3, 6, Rate, FunctionFlags.Scalar); // Returns the interest rate per period of an annuity
-        // RECEIVED Returns the amount received at maturity for a fully invested security
-        // RRI Returns an equivalent interest rate for the growth of an investment
-        // SLN Returns the straight-line depreciation of an asset for one period
-        // SYD Returns the sum-of-years' digits depreciation of an asset for a specified period
-        // TBILLEQ Returns the bond-equivalent yield for a Treasury bill
-        // TBILLPRICE Returns the price per $100 face value for a Treasury bill
-        // TBILLYIELD Returns the yield for a Treasury bill
-        // VDB Returns the depreciation of an asset for a specified or partial period by using a declining balance method
-        // XIRR Returns the internal rate of return for a schedule of cash flows that is not necessarily periodic
-        // XNPV Returns the net present value for a schedule of cash flows that is not necessarily periodic
-        // YIELD Returns the yield on a security that pays periodic interest
-        // YIELDDISC Returns the annual yield for a discounted security; for example, a Treasury bill
-        // YIELDMAT Returns the annual yield of a security that pays interest at maturity
+        ce.RegisterFunction("RECEIVED", 4, 5, AdaptLastOptional(Received, 0), FunctionFlags.Scalar); // Returns the amount received at maturity for a fully invested security
+        ce.RegisterFunction("RRI", 3, 3, Adapt(Rri), FunctionFlags.Scalar | FunctionFlags.Future); // Returns an equivalent interest rate for the growth of an investment
+        ce.RegisterFunction("SLN", 3, 3, Adapt(Sln), FunctionFlags.Scalar); // Returns the straight-line depreciation of an asset for one period
+        ce.RegisterFunction("SYD", 4, 4, Adapt(Syd), FunctionFlags.Scalar); // Returns the sum-of-years' digits depreciation of an asset for a specified period
+        ce.RegisterFunction("TBILLEQ", 3, 3, Adapt(TBillEq), FunctionFlags.Scalar); // Returns the bond-equivalent yield for a Treasury bill
+        ce.RegisterFunction("TBILLPRICE", 3, 3, Adapt(TBillPrice), FunctionFlags.Scalar); // Returns the price per $100 face value for a Treasury bill
+        ce.RegisterFunction("TBILLYIELD", 3, 3, Adapt(TBillYield), FunctionFlags.Scalar); // Returns the yield for a Treasury bill
+        ce.RegisterFunction("VDB", 5, 7, AdaptLastTwoOptional(Vdb, 2, false), FunctionFlags.Scalar); // Returns the depreciation of an asset for a specified or partial period by using a declining balance method
+        ce.RegisterFunction("XIRR", 2, 3, XIrr, FunctionFlags.Range, AllowRange.Only, 0, 1); // Returns the internal rate of return for a schedule of cash flows that is not necessarily periodic
+        ce.RegisterFunction("XNPV", 3, 3, XNpv, FunctionFlags.Range, AllowRange.Only, 1, 2); // Returns the net present value for a schedule of cash flows that is not necessarily periodic
     }
 
     private static AnyValue Fv(double rate, double numberOfPayments, double pmt, double presentValue, double type)
@@ -289,14 +270,685 @@ internal static class Financial
         return pv * pow + pmt * (1 + rate * type) * (pow - 1) / rate + fv;
     }
 
+    #region Depreciation
+
+    private static ScalarValue Sln(CalcContext ctx, double cost, double salvage, double life)
+    {
+        if (life == 0)
+            return XLError.DivisionByZero;
+
+        return (cost - salvage) / life;
+    }
+
+    private static ScalarValue Syd(CalcContext ctx, double cost, double salvage, double life, double period)
+    {
+        if (life <= 0)
+            return XLError.NumberInvalid;
+        if (period <= 0 || period > life)
+            return XLError.NumberInvalid;
+
+        return (cost - salvage) * (life - period + 1) * 2 / (life * (life + 1));
+    }
+
+    /// <summary>
+    /// Fixed-declining balance depreciation. The rate is <c>1 - (salvage/cost)^(1/life)</c> rounded
+    /// to three decimals (Excel rounds before applying it, which is why DB and DDB disagree), and
+    /// the first and the optional stub period <c>life+1</c> are pro-rated by <paramref name="month"/>.
+    /// </summary>
+    private static ScalarValue Db(CalcContext ctx, double cost, double salvage, double life, double period, double month)
+    {
+        month = Math.Truncate(month);
+        if (cost < 0 || salvage < 0 || life <= 0 || period <= 0 || month < 1 || month > 12)
+            return XLError.NumberInvalid;
+
+        // A stub period after the asset's life only exists when the first year was partial.
+        var lastPeriod = month < 12 ? life + 1 : life;
+        if (period > lastPeriod)
+            return XLError.NumberInvalid;
+
+        if (cost == 0)
+            return 0d;
+
+        var rate = Math.Round(1 - Math.Pow(salvage / cost, 1 / life), 3, MidpointRounding.AwayFromZero);
+
+        var firstPeriod = cost * rate * month / 12;
+        if (period == 1)
+            return firstPeriod;
+
+        var accumulated = firstPeriod;
+        var wholePeriods = Math.Min(Math.Truncate(period), Math.Truncate(life));
+        double current = firstPeriod;
+        for (var i = 2d; i <= wholePeriods; i++)
+        {
+            current = (cost - accumulated) * rate;
+            accumulated += current;
+        }
+
+        if (period <= life)
+            return current;
+
+        // Stub period: what is left of the year the asset ran past its life.
+        return (cost - accumulated) * rate * (12 - month) / 12;
+    }
+
+    private static ScalarValue Ddb(CalcContext ctx, double cost, double salvage, double life, double period, double factor)
+    {
+        if (cost < 0 || salvage < 0 || life <= 0 || period <= 0 || period > life || factor <= 0)
+            return XLError.NumberInvalid;
+
+        return DdbPeriod(cost, salvage, life, period, factor);
+    }
+
+    /// <summary>
+    /// Declining-balance depreciation of a single period, expressed in closed form so that a
+    /// fractional <paramref name="period"/> works the same way Excel's does.
+    /// </summary>
+    private static double DdbPeriod(double cost, double salvage, double life, double period, double factor)
+    {
+        var rate = factor / life;
+        double openingValue;
+        if (rate >= 1)
+        {
+            rate = 1;
+            openingValue = period == 1 ? cost : 0;
+        }
+        else
+        {
+            openingValue = cost * Math.Pow(1 - rate, period - 1);
+        }
+
+        var closingValue = cost * Math.Pow(1 - rate, period);
+
+        // Depreciation stops once the book value would drop below the salvage value.
+        var depreciation = closingValue < salvage ? openingValue - salvage : openingValue - closingValue;
+        return Math.Max(depreciation, 0);
+    }
+
+    /// <summary>
+    /// Depreciation charged between <paramref name="startPeriod"/> and <paramref name="endPeriod"/>,
+    /// as the difference of two cumulative runs from period zero. Replaying from the start is what
+    /// makes the straight-line cross-over land in the same place regardless of which slice is asked
+    /// for, so consecutive slices add up to the whole and a full-life run charges exactly
+    /// <c>cost - salvage</c>.
+    /// </summary>
+    private static ScalarValue Vdb(CalcContext ctx, double cost, double salvage, double life, double startPeriod, double endPeriod, double factor, bool noSwitch)
+    {
+        if (startPeriod < 0 || endPeriod < startPeriod || endPeriod > life || cost < 0 || salvage > cost || factor <= 0)
+            return XLError.NumberInvalid;
+
+        return VdbCumulative(cost, salvage, life, endPeriod, factor, noSwitch)
+               - VdbCumulative(cost, salvage, life, startPeriod, factor, noSwitch);
+    }
+
+    /// <summary>
+    /// Total depreciation from period zero up to <paramref name="upTo"/>, which may be fractional.
+    /// Each period is charged on the declining balance until straight-line over the remaining life
+    /// of the remaining basis is the larger charge, after which the rest of the life is straight
+    /// line (unless <paramref name="noSwitch"/> keeps it on declining balance throughout).
+    /// </summary>
+    private static double VdbCumulative(double cost, double salvage, double life, double upTo, double factor, bool noSwitch)
+    {
+        var lastPeriod = Math.Ceiling(upTo);
+        var total = 0d;
+        var remaining = cost - salvage;
+        var straightLine = 0d;
+        var switched = false;
+
+        for (var period = 1d; period <= lastPeriod; period++)
+        {
+            double charge;
+            if (switched)
+            {
+                charge = straightLine;
+            }
+            else
+            {
+                var declining = DdbPeriod(cost, salvage, life, period, factor);
+                straightLine = noSwitch ? 0 : remaining / (life - (period - 1));
+                if (straightLine > declining)
+                {
+                    charge = straightLine;
+                    switched = true;
+                }
+                else
+                {
+                    charge = declining;
+                }
+            }
+
+            remaining -= charge;
+
+            // The final period is only charged for the fraction of it that the range covers.
+            if (period == lastPeriod)
+                charge *= upTo - (lastPeriod - 1);
+
+            total += charge;
+        }
+
+        return total;
+    }
+
+    #endregion
+
+    #region Interest rate conversion and growth
+
+    private static ScalarValue Effect(CalcContext ctx, double nominalRate, double periodsPerYear)
+    {
+        periodsPerYear = Math.Truncate(periodsPerYear);
+        if (nominalRate <= 0 || periodsPerYear < 1)
+            return XLError.NumberInvalid;
+
+        return Math.Pow(1 + nominalRate / periodsPerYear, periodsPerYear) - 1;
+    }
+
+    private static ScalarValue Nominal(CalcContext ctx, double effectiveRate, double periodsPerYear)
+    {
+        periodsPerYear = Math.Truncate(periodsPerYear);
+        if (effectiveRate <= 0 || periodsPerYear < 1)
+            return XLError.NumberInvalid;
+
+        return (Math.Pow(effectiveRate + 1, 1 / periodsPerYear) - 1) * periodsPerYear;
+    }
+
+    private static ScalarValue Rri(CalcContext ctx, double numberOfPeriods, double presentValue, double futureValue)
+    {
+        if (numberOfPeriods <= 0 || presentValue <= 0 || futureValue < 0)
+            return XLError.NumberInvalid;
+
+        return Math.Pow(futureValue / presentValue, 1 / numberOfPeriods) - 1;
+    }
+
+    private static ScalarValue PDuration(CalcContext ctx, double rate, double presentValue, double futureValue)
+    {
+        if (rate <= 0 || presentValue <= 0 || futureValue <= 0)
+            return XLError.NumberInvalid;
+
+        return (Math.Log(futureValue) - Math.Log(presentValue)) / Math.Log(1 + rate);
+    }
+
+    private static ScalarValue DollarDe(CalcContext ctx, double fractionalDollar, double fraction)
+    {
+        fraction = Math.Truncate(fraction);
+        if (fraction < 0)
+            return XLError.NumberInvalid;
+        if (fraction == 0)
+            return XLError.DivisionByZero;
+
+        var integerPart = Math.Truncate(fractionalDollar);
+        var fractionPart = fractionalDollar - integerPart;
+
+        // The digits after the point are read as a numerator written in `fraction`ths, so they are
+        // shifted left by as many decimal places as the denominator occupies.
+        var scale = Math.Pow(10, Math.Ceiling(Math.Log10(fraction)));
+        return integerPart + fractionPart * scale / fraction;
+    }
+
+    private static ScalarValue DollarFr(CalcContext ctx, double decimalDollar, double fraction)
+    {
+        fraction = Math.Truncate(fraction);
+        if (fraction < 0)
+            return XLError.NumberInvalid;
+        if (fraction == 0)
+            return XLError.DivisionByZero;
+
+        var integerPart = Math.Truncate(decimalDollar);
+        var fractionPart = decimalDollar - integerPart;
+
+        var scale = Math.Pow(10, Math.Ceiling(Math.Log10(fraction)));
+        return integerPart + fractionPart * fraction / scale;
+    }
+
+    #endregion
+
+    #region Loan schedules
+
+    private static ScalarValue IsPmt(CalcContext ctx, double rate, double period, double numberOfPayments, double presentValue)
+    {
+        if (numberOfPayments == 0)
+            return XLError.DivisionByZero;
+
+        // The outstanding principal falls linearly to zero, so period `per` still owes
+        // (1 - per/nper) of it.
+        return presentValue * rate * (period / numberOfPayments - 1);
+    }
+
+    private static ScalarValue CumIpmt(CalcContext ctx, double rate, double numberOfPayments, double presentValue, double startPeriod, double endPeriod, double type)
+        => CumulativePayment(rate, numberOfPayments, presentValue, startPeriod, endPeriod, type, principal: false);
+
+    private static ScalarValue CumPrinc(CalcContext ctx, double rate, double numberOfPayments, double presentValue, double startPeriod, double endPeriod, double type)
+        => CumulativePayment(rate, numberOfPayments, presentValue, startPeriod, endPeriod, type, principal: true);
+
+    private static ScalarValue CumulativePayment(double rate, double numberOfPayments, double presentValue, double startPeriod, double endPeriod, double type, bool principal)
+    {
+        if (rate <= 0 || numberOfPayments <= 0 || presentValue <= 0)
+            return XLError.NumberInvalid;
+        if (startPeriod < 1 || endPeriod < 1 || startPeriod > endPeriod)
+            return XLError.NumberInvalid;
+        if (type != 0 && type != 1)
+            return XLError.NumberInvalid;
+        if (endPeriod > numberOfPayments)
+            return XLError.NumberInvalid;
+
+        var pmt = PmtInternal(rate, numberOfPayments, presentValue, 0, type);
+
+        var total = 0d;
+        for (var period = Math.Ceiling(startPeriod); period <= Math.Truncate(endPeriod); period++)
+        {
+            var interest = InterestOfPeriod(rate, period, numberOfPayments, presentValue, type, pmt);
+            total += principal ? pmt - interest : interest;
+        }
+
+        return total;
+    }
+
+    /// <summary>Interest portion of a single annuity payment; the IPMT calculation without the argument checks.</summary>
+    private static double InterestOfPeriod(double rate, double period, double numberOfPayments, double presentValue, double type, double pmt)
+    {
+        // Payment one of an annuity-due carries no interest — the payment is made before any accrues.
+        if (type != 0 && period == 1)
+            return 0;
+
+        var interest = FvInternal(rate, period - 1, pmt, presentValue, type) * rate;
+        return type != 0 ? interest / (1 + rate) : interest;
+    }
+
+    #endregion
+
+    #region Securities
+
+    /// <summary>
+    /// Bond-equivalent yield of a Treasury bill: <c>(365 × discount) / (360 − discount × DSM)</c>,
+    /// where DSM is the actual number of days between settlement and maturity.
+    /// </summary>
+    private static ScalarValue TBillEq(CalcContext ctx, double settlement, double maturity, double discount)
+    {
+        if (!TryTBillDays(settlement, maturity, out var days))
+            return XLError.NumberInvalid;
+        if (discount <= 0)
+            return XLError.NumberInvalid;
+
+        var denominator = 360 - discount * days;
+        if (denominator <= 0)
+            return XLError.NumberInvalid;
+
+        return 365 * discount / denominator;
+    }
+
+    /// <summary>Price per $100 face value of a Treasury bill: <c>100 × (1 − discount × DSM/360)</c>.</summary>
+    private static ScalarValue TBillPrice(CalcContext ctx, double settlement, double maturity, double discount)
+    {
+        if (!TryTBillDays(settlement, maturity, out var days))
+            return XLError.NumberInvalid;
+        if (discount <= 0)
+            return XLError.NumberInvalid;
+
+        return 100 * (1 - discount * days / 360);
+    }
+
+    /// <summary>Yield of a Treasury bill: <c>(100 − price)/price × 360/DSM</c>.</summary>
+    private static ScalarValue TBillYield(CalcContext ctx, double settlement, double maturity, double price)
+    {
+        if (!TryTBillDays(settlement, maturity, out var days))
+            return XLError.NumberInvalid;
+        if (price <= 0)
+            return XLError.NumberInvalid;
+
+        return (100 - price) / price * (360 / days);
+    }
+
+    /// <summary>
+    /// Actual days between settlement and maturity. Treasury bills mature within a year, so a
+    /// longer span — or a maturity that does not follow settlement — is rejected.
+    /// </summary>
+    private static bool TryTBillDays(double settlement, double maturity, out double days)
+    {
+        var settlementDate = Math.Truncate(settlement);
+        var maturityDate = Math.Truncate(maturity);
+        days = maturityDate - settlementDate;
+        return settlement >= 0 && days > 0 && days <= 365;
+    }
+
+    /// <summary>Discount rate of a security: <c>(redemption − price) / redemption / yearFraction</c>.</summary>
+    private static ScalarValue Disc(CalcContext ctx, double settlement, double maturity, double price, double redemption, double basis)
+    {
+        if (price <= 0 || redemption <= 0)
+            return XLError.NumberInvalid;
+        if (!TrySecurityYearFraction(ctx, settlement, maturity, basis, out var yearFraction, out var error))
+            return error;
+
+        return (redemption - price) / redemption / yearFraction;
+    }
+
+    /// <summary>Interest rate of a fully invested security: <c>(redemption − investment) / investment / yearFraction</c>.</summary>
+    private static ScalarValue IntRate(CalcContext ctx, double settlement, double maturity, double investment, double redemption, double basis)
+    {
+        if (investment <= 0 || redemption <= 0)
+            return XLError.NumberInvalid;
+        if (!TrySecurityYearFraction(ctx, settlement, maturity, basis, out var yearFraction, out var error))
+            return error;
+
+        return (redemption - investment) / investment / yearFraction;
+    }
+
+    /// <summary>Amount received at maturity: <c>investment / (1 − discount × yearFraction)</c>.</summary>
+    private static ScalarValue Received(CalcContext ctx, double settlement, double maturity, double investment, double discount, double basis)
+    {
+        if (investment <= 0 || discount <= 0)
+            return XLError.NumberInvalid;
+        if (!TrySecurityYearFraction(ctx, settlement, maturity, basis, out var yearFraction, out var error))
+            return error;
+
+        var divisor = 1 - discount * yearFraction;
+        if (divisor <= 0)
+            return XLError.NumberInvalid;
+
+        return investment / divisor;
+    }
+
+    /// <summary>
+    /// Days between settlement and maturity over days in a year, for one of Excel's five day-count
+    /// bases. Shares YEARFRAC's implementation, so basis 1 uses YEARFRAC's average-year-length rule.
+    /// </summary>
+    private static bool TrySecurityYearFraction(CalcContext ctx, double settlement, double maturity, double basis, out double yearFraction, out XLError error)
+    {
+        yearFraction = 0;
+        error = XLError.NumberInvalid;
+
+        if (Math.Truncate(settlement) >= Math.Truncate(maturity))
+            return false;
+
+        var fraction = Functions.DateAndTime.YearFrac(ctx, settlement, maturity, basis);
+        if (fraction.TryPickError(out var yearFracError))
+        {
+            error = yearFracError;
+            return false;
+        }
+
+        if (!fraction.TryPickNumber(out yearFraction) || yearFraction <= 0)
+            return false;
+
+        error = default;
+        return true;
+    }
+
+    #endregion
+
+    #region Irregular and modified cash flows
+
+    private static AnyValue FvSchedule(CalcContext ctx, Span<AnyValue> args)
+    {
+        // FVSCHEDULE(principal, schedule) — compounds the principal by each rate in turn.
+        if (!TryScalarNumber(ctx, args[0], out var principal, out var principalError))
+            return principalError;
+
+        var value = principal;
+        foreach (var scalar in EnumerateScalars(ctx, args[1]))
+        {
+            if (scalar.IsError)
+                return scalar.GetError();
+            if (scalar.IsBlank)
+                continue;
+            if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var rate, out var rateError))
+                return rateError;
+
+            value *= 1 + rate;
+        }
+
+        return value;
+    }
+
+    private static AnyValue Mirr(CalcContext ctx, Span<AnyValue> args)
+    {
+        // MIRR(values, finance_rate, reinvest_rate) — negative flows are financed at finance_rate,
+        // positive flows reinvested at reinvest_rate.
+        if (!TryCollectNumbers(ctx, args[..1], out var cashflows, out var valuesError))
+            return valuesError;
+        if (!TryScalarNumber(ctx, args[1], out var financeRate, out var financeError))
+            return financeError;
+        if (!TryScalarNumber(ctx, args[2], out var reinvestRate, out var reinvestError))
+            return reinvestError;
+
+        var count = cashflows.Count;
+        if (count < 2)
+            return XLError.DivisionByZero;
+
+        double positiveNpv = 0, negativeNpv = 0;
+        var hasPositive = false;
+        var hasNegative = false;
+        for (var t = 0; t < count; t++)
+        {
+            var flow = cashflows[t];
+            if (flow > 0)
+            {
+                hasPositive = true;
+                positiveNpv += flow / Math.Pow(1 + reinvestRate, t + 1);
+            }
+            else if (flow < 0)
+            {
+                hasNegative = true;
+                negativeNpv += flow / Math.Pow(1 + financeRate, t + 1);
+            }
+        }
+
+        if (!hasPositive || !hasNegative)
+            return XLError.DivisionByZero;
+
+        var numerator = -positiveNpv * Math.Pow(1 + reinvestRate, count);
+        var denominator = negativeNpv * (1 + financeRate);
+        if (denominator == 0.0)
+            return XLError.DivisionByZero;
+
+        return Math.Pow(numerator / denominator, 1.0 / (count - 1)) - 1;
+    }
+
+    private static AnyValue XNpv(CalcContext ctx, Span<AnyValue> args)
+    {
+        // XNPV(rate, values, dates) — each flow is discounted by its own actual/365 offset from the
+        // first date, rather than by a period index.
+        if (!TryScalarNumber(ctx, args[0], out var rate, out var rateError))
+            return rateError;
+        if (rate <= -1)
+            return XLError.NumberInvalid;
+        if (!TryCollectSchedule(ctx, args[1], args[2], out var schedule, out var scheduleError))
+            return scheduleError;
+
+        return XNpvOf(rate, schedule);
+    }
+
+    private static AnyValue XIrr(CalcContext ctx, Span<AnyValue> args)
+    {
+        // XIRR(values, dates, [guess]) — the rate at which XNPV of the schedule is zero.
+        if (!TryCollectSchedule(ctx, args[0], args[1], out var schedule, out var scheduleError))
+            return scheduleError;
+
+        var guess = 0.1;
+        if (args.Length > 2 && !TryScalarNumber(ctx, args[2], out guess, out var guessError))
+            return guessError;
+        if (guess <= -1)
+            return XLError.NumberInvalid;
+
+        var hasPositive = false;
+        var hasNegative = false;
+        foreach (var (amount, _) in schedule)
+        {
+            hasPositive |= amount > 0;
+            hasNegative |= amount < 0;
+        }
+
+        if (!hasPositive || !hasNegative)
+            return XLError.NumberInvalid;
+
+        const int maxIterations = 100;
+        const double tolerance = 1e-9;
+        const double delta = 1e-7;
+        var rate = guess;
+        for (var iteration = 0; iteration < maxIterations; iteration++)
+        {
+            var value = XNpvOf(rate, schedule);
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                break;
+            if (Math.Abs(value) < tolerance)
+                return rate;
+
+            var derivative = (XNpvOf(rate + delta, schedule) - value) / delta;
+            if (derivative == 0.0 || double.IsNaN(derivative))
+                break;
+
+            var nextRate = rate - value / derivative;
+            if (nextRate <= -1)
+                nextRate = (rate - 1) / 2;
+
+            if (Math.Abs(nextRate - rate) < tolerance)
+                return nextRate;
+
+            rate = nextRate;
+        }
+
+        // Newton wandered off; fall back to bisecting a bracket found by scanning outwards.
+        return XIrrByBisection(schedule);
+    }
+
+    private static AnyValue XIrrByBisection(List<(double Amount, double Days)> schedule)
+    {
+        var low = -1 + 1e-9;
+        var lowValue = XNpvOf(low, schedule);
+
+        var high = 1e-9;
+        double highValue;
+        do
+        {
+            high *= 10;
+            highValue = XNpvOf(high, schedule);
+        }
+        while (Math.Sign(highValue) == Math.Sign(lowValue) && high < 1e9);
+
+        if (Math.Sign(highValue) == Math.Sign(lowValue))
+            return XLError.NumberInvalid;
+
+        for (var i = 0; i < 200; i++)
+        {
+            var middle = (low + high) / 2;
+            var value = XNpvOf(middle, schedule);
+            if (Math.Abs(value) < 1e-9)
+                return middle;
+
+            if (Math.Sign(value) == Math.Sign(lowValue))
+            {
+                low = middle;
+                lowValue = value;
+            }
+            else
+            {
+                high = middle;
+            }
+        }
+
+        return (low + high) / 2;
+    }
+
+    private static double XNpvOf(double rate, List<(double Amount, double Days)> schedule)
+    {
+        var total = 0d;
+        foreach (var (amount, days) in schedule)
+            total += amount / Math.Pow(1 + rate, days / 365.0);
+
+        return total;
+    }
+
+    /// <summary>
+    /// Read the paired value/date arguments of XIRR and XNPV into amounts and day offsets from the
+    /// first date. The two arguments must hold the same number of cells and no date may fall before
+    /// the first one.
+    /// </summary>
+    private static bool TryCollectSchedule(CalcContext ctx, in AnyValue valuesArg, in AnyValue datesArg, out List<(double Amount, double Days)> schedule, out XLError error)
+    {
+        schedule = null!;
+        error = default;
+
+        var amounts = new List<double>();
+        foreach (var scalar in EnumerateScalars(ctx, valuesArg))
+        {
+            if (scalar.IsError)
+            {
+                error = scalar.GetError();
+                return false;
+            }
+
+            if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var amount, out var amountError))
+            {
+                error = amountError;
+                return false;
+            }
+
+            amounts.Add(amount);
+        }
+
+        var dates = new List<double>();
+        foreach (var scalar in EnumerateScalars(ctx, datesArg))
+        {
+            if (scalar.IsError)
+            {
+                error = scalar.GetError();
+                return false;
+            }
+
+            if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var date, out var dateError))
+            {
+                error = dateError;
+                return false;
+            }
+
+            dates.Add(Math.Truncate(date));
+        }
+
+        if (amounts.Count != dates.Count || amounts.Count < 2)
+        {
+            error = XLError.NumberInvalid;
+            return false;
+        }
+
+        var start = dates[0];
+        var result = new List<(double Amount, double Days)>(amounts.Count);
+        for (var i = 0; i < amounts.Count; i++)
+        {
+            if (dates[i] < start || dates[i] < 0)
+            {
+                error = XLError.NumberInvalid;
+                return false;
+            }
+
+            result.Add((amounts[i], dates[i] - start));
+        }
+
+        schedule = result;
+        return true;
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Read an argument that must be a single number. The functions in this file take ranges for
+    /// some parameters and scalars for others, so a scalar parameter still receives whatever the
+    /// formula wrote there: a reference to one cell is unwrapped, a larger range goes through
+    /// implicit intersection — the same reduction the signature adapters apply.
+    /// </summary>
     private static bool TryScalarNumber(CalcContext ctx, in AnyValue value, out double number, out XLError error)
     {
         error = default;
-        if (!value.TryPickScalar(out var scalar, out _))
+        number = 0;
+
+        if (!value.TryPickScalar(out var scalar, out var collection))
         {
-            number = 0;
-            error = XLError.IncompatibleValue;
-            return false;
+            if (collection.TryPickT0(out var array, out var reference))
+            {
+                scalar = array[0, 0];
+            }
+            else if (!reference.TryGetSingleCellValue(out scalar, ctx)
+                     && !value.ImplicitIntersection(ctx).TryPickScalar(out scalar, out _))
+            {
+                error = XLError.IncompatibleValue;
+                return false;
+            }
         }
 
         return scalar.ToNumber(ctx.Culture).TryPickT0(out number, out error);

--- a/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -879,7 +879,125 @@ internal static class SignatureAdapter
                 return err5;
 #pragma warning disable S2234
             return f(arg0, arg1, arg2, arg3, arg4, arg5);
-#pragma warning restore S2234                                    
+#pragma warning restore S2234
+        };
+    }
+
+    public static CalcEngineFunction Adapt(Func<CalcContext, double, double, double, double, ScalarValue> f)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = ToNumber(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            var arg2Converted = ToNumber(args[2], ctx);
+            if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                return err2;
+
+            var arg3Converted = ToNumber(args[3], ctx);
+            if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                return err3;
+
+            return f(ctx, arg0, arg1, arg2, arg3).ToAnyValue();
+        };
+    }
+
+    public static CalcEngineFunction Adapt(Func<CalcContext, double, double, double, double, double, double, ScalarValue> f)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = ToNumber(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            var arg2Converted = ToNumber(args[2], ctx);
+            if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                return err2;
+
+            var arg3Converted = ToNumber(args[3], ctx);
+            if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                return err3;
+
+            var arg4Converted = ToNumber(args[4], ctx);
+            if (!arg4Converted.TryPickT0(out var arg4, out var err4))
+                return err4;
+
+            var arg5Converted = ToNumber(args[5], ctx);
+            if (!arg5Converted.TryPickT0(out var arg5, out var err5))
+                return err5;
+
+            return f(ctx, arg0, arg1, arg2, arg3, arg4, arg5).ToAnyValue();
+        };
+    }
+
+    public static CalcEngineFunction AdaptLastOptional(Func<CalcContext, double, double, double, double, double, ScalarValue> f, double lastDefault)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = ToNumber(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            var arg2Converted = ToNumber(args[2], ctx);
+            if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                return err2;
+
+            var arg3Converted = ToNumber(args[3], ctx);
+            if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                return err3;
+
+            if (!ToOptionalNumber(args, 4, lastDefault, ctx).TryPickT0(out var arg4, out var err4))
+                return err4;
+
+            return f(ctx, arg0, arg1, arg2, arg3, arg4).ToAnyValue();
+        };
+    }
+
+    public static CalcEngineFunction AdaptLastTwoOptional(Func<CalcContext, double, double, double, double, double, double, bool, ScalarValue> f, double defaultValue0, bool defaultValue1)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = ToNumber(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            var arg2Converted = ToNumber(args[2], ctx);
+            if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                return err2;
+
+            var arg3Converted = ToNumber(args[3], ctx);
+            if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                return err3;
+
+            var arg4Converted = ToNumber(args[4], ctx);
+            if (!arg4Converted.TryPickT0(out var arg4, out var err4))
+                return err4;
+
+            if (!ToOptionalNumber(args, 5, defaultValue0, ctx).TryPickT0(out var arg5, out var err5))
+                return err5;
+
+            var arg6 = defaultValue1;
+            if (args.Length > 6 && !CoerceToLogical(args[6], ctx).TryPickT0(out arg6, out var err6))
+                return err6;
+
+            return f(ctx, arg0, arg1, arg2, arg3, arg4, arg5, arg6).ToAnyValue();
         };
     }
 


### PR DESCRIPTION
Wave A of [spec 07 — Formula Function Coverage Expansion](docs/specs/07-formula-function-coverage.md). First of six stacked PRs; **merge in order A → D → E → F → B → C**.

## Functions added (24)

| Group | Functions |
|---|---|
| Depreciation | `SLN`, `SYD`, `DB`, `DDB`, `VDB` |
| Rate conversion & growth | `EFFECT`, `NOMINAL`, `RRI`, `PDURATION` |
| Fractional dollars | `DOLLARDE`, `DOLLARFR` |
| Loan schedules | `ISPMT`, `CUMIPMT`, `CUMPRINC` |
| Discount securities | `TBILLEQ`, `TBILLPRICE`, `TBILLYIELD`, `DISC`, `INTRATE`, `RECEIVED` |
| Irregular cash flows | `FVSCHEDULE`, `MIRR`, `XNPV`, `XIRR` |

Registry: 257 → 281 functions.

## Notes on the implementation

**`VDB`** is the difference of two cumulative runs from period zero rather than a loop over the requested slice. Replaying from the start is what keeps the straight-line cross-over in the same place no matter which slice is asked for, so consecutive slices add up and a full-life run charges exactly `cost - salvage`. Both invariants are tested.

**`XIRR`** solves with Newton–Raphson and falls back to bisecting a scanned bracket, so a guess far from the answer still converges — there's a test that starts it at 5.

## Bug fixed

`Financial.TryScalarNumber` did not reduce a cell reference. The scalar arguments of the range-taking functions arrive unreduced, so `NPV(A1, B1:B4)` returned `#VALUE!` where `NPV(0.1, B1:B4)` worked. Affected `NPV`'s rate and `IRR`'s guess before this PR, and would have affected every new function here.

## Deliberate exclusions

- **The day-count-basis bond family** (`PRICE`, `YIELD`, `DURATION`, `MDURATION`, `ACCRINT`, `COUP*`, `ODD*`, `AMOR*`) is out of scope — it needs a coupon-period engine rather than another day-count fraction. This is spec 07's "wave A2".
- `DISC`/`INTRATE`/`RECEIVED` take their year fraction from the same code as `YEARFRAC`, so **basis 1 (actual/actual) uses `YEARFRAC`'s average-year-length rule** rather than a dedicated one.

Both are recorded in the changelog.

## Verification

219 tests, all passing; full suite green on net8.0 and net10.0; Release build clean under `TreatWarningsAsErrors`.

Expected values are the worked examples from Microsoft's per-function documentation where they exist, and otherwise derived from the documented formula with the derivation shown in the test comment. Three of my hand-derived constants disagreed with the implementation at the 4th–7th significant digit; in each case the implementation was the more accurate one (it carries the full chain in double precision) and both round to Microsoft's published figure, so the test now pins the precise value and the comment says so.
