### PR TITLE
feat(calc): add 42 engineering functions (spec 07 wave D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 
 #### Formula functions
 
+- **42 engineering functions**: the complex-number family (`COMPLEX` and all 26 `IM*` functions), `CONVERT` with the full unit table, `BESSELI`/`BESSELJ`/`BESSELK`/`BESSELY`, `ERF`/`ERF.PRECISE`/`ERFC`/`ERFC.PRECISE`, `DELTA`, `GESTEP` and the bitwise set (`BITAND`, `BITOR`, `BITXOR`, `BITLSHIFT`, `BITRSHIFT`).
+
+  A complex number in Excel is text, so the `IM*` functions parse `"3+4i"` and write their result back the same way — echoing whichever of `i` or `j` the input used, and refusing to mix the two. `CONVERT` unit names are case sensitive, as Excel's are: `Pica` is a point and `pica` is six to the inch. Prefixes are accepted on metric units, binary prefixes on `bit` and `byte` only, and on no temperature unit — a scale with an offset has no meaningful "milli". ([#253](https://github.com/XLibur/XLibur/pull/253) by [@jafin](https://github.com/jafin))
+
 - **24 more financial functions**: depreciation (`SLN`, `SYD`, `DB`, `DDB`, `VDB`), rate conversion and growth (`EFFECT`, `NOMINAL`, `RRI`, `PDURATION`), fractional dollar notation (`DOLLARDE`, `DOLLARFR`), loan schedules (`ISPMT`, `CUMIPMT`, `CUMPRINC`), discount securities (`TBILLEQ`, `TBILLPRICE`, `TBILLYIELD`, `DISC`, `INTRATE`, `RECEIVED`) and irregular cash flows (`FVSCHEDULE`, `MIRR`, `XNPV`, `XIRR`). `XIRR` solves with Newton–Raphson and falls back to bisection when that wanders off, so a poor guess still converges.
 
   Two deliberate limitations. The day-count-basis bond family (`PRICE`, `YIELD`, `DURATION`, `MDURATION`, `ACCRINT`, `COUP*`, `ODD*`, `AMOR*`) is not included — it needs a coupon-period engine rather than another day-count fraction. And `DISC`/`INTRATE`/`RECEIVED` take their year fraction from the same code as `YEARFRAC`, so basis 1 (actual/actual) uses `YEARFRAC`'s average-year-length rule. ([#252](https://github.com/XLibur/XLibur/pull/252) by [@jafin](https://github.com/jafin))

--- a/XLibur.Tests/Excel/CalcEngine/EngineeringComplexTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/EngineeringComplexTests.cs
@@ -1,0 +1,199 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// COMPLEX and the IM* family. Excel has no complex value type — a complex number is the text
+/// "3+4i" — so these tests compare the rendered text. Expected values are the worked examples from
+/// Microsoft's per-function documentation unless the comment says otherwise.
+/// </summary>
+[SetCulture("en-US")]
+public class EngineeringComplexTests
+{
+    [Test]
+    [Arguments("COMPLEX(3, 4)", "3+4i")]
+    [Arguments("COMPLEX(3, 4, \"j\")", "3+4j")]
+    [Arguments("COMPLEX(0, 1)", "i")] // A unit coefficient is written bare.
+    [Arguments("COMPLEX(1, 0)", "1")] // No imaginary part at all.
+    [Arguments("COMPLEX(0, 0)", "0")]
+    [Arguments("COMPLEX(0, -1)", "-i")]
+    [Arguments("COMPLEX(3, -4)", "3-4i")]
+    [Arguments("COMPLEX(-3, 4)", "-3+4i")]
+    public async Task Complex_BuildsTheTextForm(string formula, string expected)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("COMPLEX(3, 4, \"k\")")] // Only i and j name the imaginary unit.
+    [Arguments("COMPLEX(3, 4, \"I\")")] // The suffix is case sensitive.
+    [Arguments("COMPLEX(3, 4, \"\")")]
+    public async Task Complex_UnknownSuffixReturnsIncompatibleValue(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.IncompatibleValue);
+    }
+
+    [Test]
+    [Arguments("IMABS(\"5+12i\")", 13d)]
+    [Arguments("IMABS(\"3+4i\")", 5d)]
+    [Arguments("IMABS(\"-3\")", 3d)] // A real number is a complex number with no imaginary part.
+    [Arguments("IMREAL(\"6-9i\")", 6d)]
+    [Arguments("IMREAL(\"i\")", 0d)]
+    [Arguments("IMAGINARY(\"3+4i\")", 4d)]
+    [Arguments("IMAGINARY(\"0-j\")", -1d)]
+    [Arguments("IMAGINARY(4)", 0d)]
+    [Arguments("IMAGINARY(\"i\")", 1d)]
+    [Arguments("IMARGUMENT(\"3+4i\")", 0.927295218001612d)] // ATAN2(3, 4).
+    public async Task ComplexComponents_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-12);
+    }
+
+    [Test]
+    public async Task ImArgument_OfZeroIsDivisionByZero()
+    {
+        // The angle of the origin is not defined.
+        await Assert.That(XLWorkbook.EvaluateExpr("IMARGUMENT(\"0\")")).IsEqualTo(XLError.DivisionByZero);
+    }
+
+    [Test]
+    [Arguments("IMCONJUGATE(\"3+4i\")", "3-4i")]
+    [Arguments("IMCONJUGATE(\"3-4j\")", "3+4j")] // The j spelling is echoed back.
+    [Arguments("IMSUM(\"3+4i\", \"5-3i\")", "8+i")]
+    [Arguments("IMSUB(\"13+4i\", \"5+3i\")", "8+i")]
+    [Arguments("IMPRODUCT(\"3+4i\", \"5-3i\")", "27+11i")]
+    [Arguments("IMDIV(\"-238+240i\", \"10+24i\")", "5+12i")]
+    [Arguments("IMPOWER(\"2+3i\", 3)", "-46+9.00000000000001i")]
+    public async Task ComplexArithmetic_ReferenceExamplesFromExcelDocumentation(string formula, string expected)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ImSum_AndImProduct_AcceptASingleArgumentAndManyArguments()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("IMSUM(\"3+4i\")")).IsEqualTo("3+4i");
+        await Assert.That(XLWorkbook.EvaluateExpr("IMSUM(\"1+i\", \"1+i\", \"1+i\")")).IsEqualTo("3+3i");
+        await Assert.That(XLWorkbook.EvaluateExpr("IMPRODUCT(\"1+i\", \"1+i\", \"1+i\", \"1+i\")")).IsEqualTo("-4");
+    }
+
+    [Test]
+    public async Task ComplexFunctions_RefuseToMixTheTwoImaginaryUnits()
+    {
+        // Excel will not add a number written with i to one written with j.
+        await Assert.That(XLWorkbook.EvaluateExpr("IMSUM(\"1+i\", \"1+j\")")).IsEqualTo(XLError.IncompatibleValue);
+        await Assert.That(XLWorkbook.EvaluateExpr("IMSUB(\"1+i\", \"1+j\")")).IsEqualTo(XLError.IncompatibleValue);
+        await Assert.That(XLWorkbook.EvaluateExpr("IMDIV(\"1+i\", \"1+j\")")).IsEqualTo(XLError.IncompatibleValue);
+
+        // A number with no imaginary part carries no spelling, so it mixes with either.
+        await Assert.That(XLWorkbook.EvaluateExpr("IMSUM(\"1\", \"1+j\")")).IsEqualTo("2+j");
+    }
+
+    [Test]
+    [Arguments("IMEXP(\"1+i\")", "1.46869393991589+2.28735528717884i")]
+    [Arguments("IMLN(\"3+4i\")", "1.6094379124341+0.927295218001612i")]
+    [Arguments("IMLOG10(\"3+4i\")", "0.698970004336019+0.402719196273373i")]
+    [Arguments("IMLOG2(\"3+4i\")", "2.32192809488736+1.33780421245098i")]
+    [Arguments("IMSQRT(\"1+i\")", "1.09868411346781+0.455089860562227i")]
+    [Arguments("IMSQRT(\"3+4i\")", "2+i")] // The exact answer, once rounded to 15 digits.
+    public async Task ComplexTranscendentals_ReferenceExamplesFromExcelDocumentation(string formula, string expected)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    // Compared component by component rather than as text: the last of the 15 digits Excel prints
+    // is at the mercy of how the identity is grouped, and a one-ulp difference there says nothing
+    // about correctness. Each expectation is sin/cos/sinh/cosh of the argument applied through the
+    // standard addition formulae, e.g. cosh(4+3i) = cosh4·cos3 + i·sinh4·sin3.
+    [Arguments("IMSIN(\"3+4i\")", 3.85373803791938d, -27.0168132580039d)]
+    [Arguments("IMCOS(\"1+i\")", 0.833730025131149d, -0.988897705762865d)]
+    [Arguments("IMSINH(\"4+3i\")", -27.0168132580039d, 3.85373803791938d)]
+    [Arguments("IMCOSH(\"4+3i\")", -27.0349456030742d, 3.85115333481178d)]
+    [Arguments("IMTAN(\"4+3i\")", 0.00490825806749606d, 1.00070953606723d)]
+    [Arguments("IMCOT(\"4+3i\")", 0.00490118239430447d, -0.999266927805902d)]
+    [Arguments("IMSEC(\"4+3i\")", -0.0652940278579471d, -0.0752249603027732d)]
+    [Arguments("IMCSC(\"4+3i\")", -0.0754898329158637d, 0.0648774713706355d)]
+    [Arguments("IMSECH(\"4+3i\")", -0.0362534969158689d, -0.00516434460775318d)]
+    [Arguments("IMCSCH(\"4+3i\")", -0.0362758896286264d, -0.00517447318401943d)]
+    public async Task ComplexTrigonometry_MatchesTheAdditionFormulae(string formula, double expectedReal, double expectedImaginary)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr($"IMREAL({formula})")).IsEqualTo(expectedReal).Within(1e-10);
+        await Assert.That((double)XLWorkbook.EvaluateExpr($"IMAGINARY({formula})")).IsEqualTo(expectedImaginary).Within(1e-10);
+    }
+
+    [Test]
+    public async Task ComplexTrigonometry_ReciprocalsInvertTheirPrimitives()
+    {
+        // sec = 1/cos, csc = 1/sin, sech = 1/cosh, csch = 1/sinh — so multiplying the two back
+        // together has to give 1.
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").FormulaA1 = "IMPRODUCT(IMSEC(\"4+3i\"), IMCOS(\"4+3i\"))";
+        ws.Cell("A2").FormulaA1 = "IMPRODUCT(IMCSC(\"4+3i\"), IMSIN(\"4+3i\"))";
+        ws.Cell("A3").FormulaA1 = "IMPRODUCT(IMSECH(\"4+3i\"), IMCOSH(\"4+3i\"))";
+        ws.Cell("A4").FormulaA1 = "IMPRODUCT(IMCSCH(\"4+3i\"), IMSINH(\"4+3i\"))";
+
+        foreach (var address in new[] { "A1", "A2", "A3", "A4" })
+        {
+            await Assert.That((double)XLWorkbook.EvaluateExpr($"IMREAL(\"{ws.Cell(address).Value}\")")).IsEqualTo(1d).Within(1e-12);
+            await Assert.That((double)XLWorkbook.EvaluateExpr($"IMAGINARY(\"{ws.Cell(address).Value}\")")).IsEqualTo(0d).Within(1e-12);
+        }
+    }
+
+    [Test]
+    [Arguments("IMLN(\"0\")")] // The logarithm is singular at the origin.
+    [Arguments("IMLOG10(\"0\")")]
+    [Arguments("IMLOG2(\"0\")")]
+    [Arguments("IMPOWER(\"0\", 0)")] // 0^0 is undefined.
+    [Arguments("IMPOWER(\"0\", -1)")]
+    [Arguments("IMDIV(\"1+i\", \"0\")")]
+    [Arguments("IMCSC(\"0\")")] // 1/sin(0).
+    [Arguments("IMCOT(\"0\")")]
+    [Arguments("IMCSCH(\"0\")")]
+    public async Task ComplexFunctions_UndefinedResultsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    [Arguments("IMABS(\"3+4k\")")] // Not a recognised imaginary unit.
+    [Arguments("IMABS(\"3+4I\")")] // The suffix is case sensitive.
+    [Arguments("IMABS(\"abc\")")]
+    [Arguments("IMABS(\"3++4i\")")]
+    [Arguments("IMREAL(\"1,5+2i\")")] // Complex text always uses a period.
+    public async Task ComplexFunctions_MalformedTextReturnsNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    [Arguments("IMREAL(\"1.5E+3+2i\")", 1500d)] // An exponent's sign is not the imaginary part's sign.
+    [Arguments("IMAGINARY(\"1.5E+3+2i\")", 2d)]
+    [Arguments("IMREAL(\"-2.5e-2-3i\")", -0.025d)]
+    [Arguments("IMAGINARY(\"-2.5e-2-3i\")", -3d)]
+    [Arguments("IMREAL(\"5\")", 5d)]
+    [Arguments("IMAGINARY(\"-i\")", -1d)]
+    [Arguments("IMAGINARY(\"+i\")", 1d)]
+    public async Task ComplexParsing_HandlesExponentsAndImplicitCoefficients(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-12);
+    }
+
+    [Test]
+    public async Task ComplexFunctions_RoundTripThroughAWorksheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = 3;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("B1").FormulaA1 = "COMPLEX(A1, A2)";
+        ws.Cell("B2").FormulaA1 = "IMABS(B1)";
+        ws.Cell("B3").FormulaA1 = "IMPRODUCT(B1, IMCONJUGATE(B1))"; // z·z̄ = |z|².
+
+        await Assert.That(ws.Cell("B1").Value).IsEqualTo("3+4i");
+        await Assert.That((double)ws.Cell("B2").Value).IsEqualTo(5d).Within(1e-12);
+        await Assert.That(ws.Cell("B3").Value).IsEqualTo("25");
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/EngineeringConvertTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/EngineeringConvertTests.cs
@@ -1,0 +1,277 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// CONVERT, the Bessel functions, the error functions and the bitwise and comparison functions.
+/// Expected values are the worked examples from Microsoft's per-function documentation, or exact
+/// definitional identities (5,280 feet in a mile, 1,024 bytes in a kibibyte) where the docs give no
+/// example.
+/// </summary>
+[SetCulture("en-US")]
+public class EngineeringConvertTests
+{
+    [Test]
+    [Arguments("CONVERT(1, \"lbm\", \"kg\")", 0.45359237d)] // A pound is defined as exactly 453.59237 g.
+    [Arguments("CONVERT(68, \"F\", \"C\")", 20d)]
+    [Arguments("CONVERT(2.5, \"ft\", \"m\")", 0.762d)]
+    [Arguments("CONVERT(CONVERT(100, \"ft\", \"m\"), \"ft\", \"m\")", 9.290304d)]
+    public async Task Convert_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-12);
+    }
+
+    [Test]
+    [Arguments("CONVERT(1, \"mi\", \"ft\")", 5280d)]
+    [Arguments("CONVERT(1, \"yd\", \"ft\")", 3d)]
+    [Arguments("CONVERT(1, \"ft\", \"in\")", 12d)]
+    [Arguments("CONVERT(1, \"day\", \"hr\")", 24d)]
+    [Arguments("CONVERT(1, \"hr\", \"sec\")", 3600d)]
+    [Arguments("CONVERT(1, \"yr\", \"day\")", 365.25d)]
+    [Arguments("CONVERT(1, \"atm\", \"mmHg\")", 760d)]
+    [Arguments("CONVERT(1, \"atm\", \"Pa\")", 101325d)]
+    [Arguments("CONVERT(1, \"gal\", \"l\")", 3.785411784d)]
+    [Arguments("CONVERT(1, \"gal\", \"qt\")", 4d)]
+    [Arguments("CONVERT(1, \"gal\", \"cup\")", 16d)]
+    [Arguments("CONVERT(1, \"tbs\", \"tsp\")", 3d)]
+    [Arguments("CONVERT(1, \"lbm\", \"ozm\")", 16d)]
+    [Arguments("CONVERT(1, \"stone\", \"lbm\")", 14d)]
+    [Arguments("CONVERT(1, \"ton\", \"lbm\")", 2000d)]
+    [Arguments("CONVERT(1, \"ha\", \"m2\")", 10000d)]
+    [Arguments("CONVERT(1, \"m3\", \"l\")", 1000d)]
+    [Arguments("CONVERT(1, \"byte\", \"bit\")", 8d)]
+    [Arguments("CONVERT(1, \"kn\", \"m/s\")", 0.5144444444444445d)] // A nautical mile per hour.
+    public async Task Convert_DefinitionalIdentitiesWithinAMeasure(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    [Arguments("CONVERT(1, \"km\", \"m\")", 1000d)]
+    [Arguments("CONVERT(1, \"m\", \"cm\")", 100d)]
+    [Arguments("CONVERT(1, \"m\", \"mm\")", 1000d)]
+    [Arguments("CONVERT(1, \"kg\", \"g\")", 1000d)]
+    [Arguments("CONVERT(1, \"Mg\", \"kg\")", 1000d)] // Mega beats milli: the prefix is case sensitive.
+    [Arguments("CONVERT(1, \"mg\", \"ug\")", 1000d)]
+    [Arguments("CONVERT(1, \"kPa\", \"Pa\")", 1000d)]
+    [Arguments("CONVERT(1, \"dam\", \"m\")", 10d)] // "da" for deka wins over "d" for deci.
+    [Arguments("CONVERT(1, \"kibyte\", \"byte\")", 1024d)]
+    [Arguments("CONVERT(1, \"Mibit\", \"bit\")", 1048576d)]
+    [Arguments("CONVERT(1, \"kbyte\", \"byte\")", 1000d)] // The metric prefix is still a thousand.
+    public async Task Convert_AppliesPrefixes(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    [Arguments("CONVERT(0, \"C\", \"F\")", 32d)]
+    [Arguments("CONVERT(100, \"C\", \"F\")", 212d)]
+    [Arguments("CONVERT(0, \"C\", \"K\")", 273.15d)]
+    [Arguments("CONVERT(0, \"K\", \"C\")", -273.15d)]
+    [Arguments("CONVERT(0, \"C\", \"Rank\")", 491.67d)]
+    [Arguments("CONVERT(100, \"C\", \"Reau\")", 80d)]
+    [Arguments("CONVERT(-40, \"C\", \"F\")", -40d)] // The one point where the two scales meet.
+    public async Task Convert_TemperatureIsAffineNotProportional(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    [Arguments("CONVERT(1, \"Pica\", \"in\")", 1d / 72d)] // "Pica" is a point.
+    [Arguments("CONVERT(1, \"pica\", \"in\")", 1d / 6d)] // "pica" is six to the inch.
+    public async Task Convert_UnitNamesAreCaseSensitive(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-12);
+    }
+
+    [Test]
+    [Arguments("CONVERT(2.5, \"ft\", \"sec\")")] // Distance is not time.
+    [Arguments("CONVERT(1, \"kg\", \"m\")")]
+    [Arguments("CONVERT(1, \"zzz\", \"m\")")] // Unknown unit.
+    [Arguments("CONVERT(1, \"m\", \"zzz\")")]
+    [Arguments("CONVERT(1, \"kft\", \"m\")")] // A foot takes no metric prefix.
+    [Arguments("CONVERT(1, \"kibm\", \"m\")")] // Binary prefixes belong to the information units only.
+    public async Task Convert_UnknownOrMismatchedUnitsReturnNoValueAvailable(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NoValueAvailable);
+    }
+
+    [Test]
+    public async Task Convert_RoundTripsBackToTheOriginalValue()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = 12.5;
+        ws.Cell("B1").FormulaA1 = "CONVERT(A1, \"mi\", \"km\")";
+        ws.Cell("C1").FormulaA1 = "CONVERT(B1, \"km\", \"mi\")";
+
+        await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(12.5d).Within(1e-12);
+    }
+
+    [Test]
+    // Microsoft's Bessel examples.
+    [Arguments("BESSELI(1.5, 1)", 0.981666428d)]
+    [Arguments("BESSELJ(1.9, 2)", 0.329925829d)]
+    [Arguments("BESSELK(1.5, 1)", 0.277387804d)]
+    [Arguments("BESSELY(2.5, 1)", 0.145918138d)]
+    public async Task Bessel_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-7);
+    }
+
+    [Test]
+    // Well-known values: J0(0) = 1, and every other kind of order-n function vanishes at the origin.
+    [Arguments("BESSELJ(0, 0)", 1d)]
+    [Arguments("BESSELJ(0, 1)", 0d)]
+    [Arguments("BESSELJ(0, 5)", 0d)]
+    [Arguments("BESSELI(0, 0)", 1d)]
+    [Arguments("BESSELI(0, 1)", 0d)]
+    public async Task Bessel_ValuesAtTheOrigin(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    public async Task Bessel_SatisfiesItsRecurrenceRelation()
+    {
+        // J(n-1, x) + J(n+1, x) = 2n/x · J(n, x) holds for every kind, which exercises both the
+        // upward and the downward recurrences at once.
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").FormulaA1 = "BESSELJ(3.7, 2) + BESSELJ(3.7, 4) - 2 * 3 / 3.7 * BESSELJ(3.7, 3)";
+        ws.Cell("A2").FormulaA1 = "BESSELY(3.7, 2) + BESSELY(3.7, 4) - 2 * 3 / 3.7 * BESSELY(3.7, 3)";
+
+        await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(0d).Within(1e-7);
+        await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(0d).Within(1e-7);
+    }
+
+    [Test]
+    [Arguments("BESSELJ(1.5, -1)")] // The order may not be negative.
+    [Arguments("BESSELI(1.5, -1)")]
+    [Arguments("BESSELK(1.5, -1)")]
+    [Arguments("BESSELY(1.5, -1)")]
+    [Arguments("BESSELK(0, 1)")] // K and Y are singular at the origin.
+    [Arguments("BESSELK(-1, 1)")]
+    [Arguments("BESSELY(0, 1)")]
+    [Arguments("BESSELY(-1, 1)")]
+    public async Task Bessel_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    // Microsoft's ERF/ERFC examples, plus values from published error-function tables.
+    [Arguments("ERF(0.745)", 0.70792892d)]
+    [Arguments("ERF(1)", 0.842700792949715d)]
+    [Arguments("ERF(0)", 0d)]
+    [Arguments("ERF(-1)", -0.842700792949715d)] // erf is odd.
+    [Arguments("ERF.PRECISE(0.745)", 0.70792892d)]
+    [Arguments("ERF.PRECISE(1)", 0.842700792949715d)]
+    [Arguments("ERFC(1)", 0.157299207050285d)]
+    [Arguments("ERFC(0)", 1d)]
+    [Arguments("ERFC.PRECISE(1)", 0.157299207050285d)]
+    [Arguments("ERFC(-1)", 1.842700792949715d)]
+    public async Task Erf_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    public async Task Erf_WithTwoLimitsIntegratesBetweenThem()
+    {
+        // ERF(a, b) = erf(b) - erf(a), so splitting the interval has to add up.
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").FormulaA1 = "ERF(0, 2)";
+        ws.Cell("A2").FormulaA1 = "ERF(2)";
+        ws.Cell("A3").FormulaA1 = "ERF(0.5, 2) + ERF(0, 0.5)";
+
+        await Assert.That((double)ws.Cell("A1").Value).IsEqualTo((double)ws.Cell("A2").Value).Within(1e-12);
+        await Assert.That((double)ws.Cell("A3").Value).IsEqualTo((double)ws.Cell("A2").Value).Within(1e-12);
+    }
+
+    [Test]
+    public async Task Erfc_KeepsItsPrecisionInTheFarTail()
+    {
+        // 1 - erf(6) would round to zero in double precision; taking the tail directly does not.
+        var actual = (double)XLWorkbook.EvaluateExpr("ERFC(6)");
+        await Assert.That(actual).IsEqualTo(2.15197367124989e-17d).Within(1e-28);
+    }
+
+    [Test]
+    // Microsoft's DELTA and GESTEP examples.
+    [Arguments("DELTA(5, 4)", 0d)]
+    [Arguments("DELTA(5, 5)", 1d)]
+    [Arguments("DELTA(0.5, 0)", 0d)]
+    [Arguments("DELTA(0)", 1d)] // The second number defaults to zero.
+    [Arguments("GESTEP(5, 4)", 1d)]
+    [Arguments("GESTEP(5, 5)", 1d)] // The step itself passes the test.
+    [Arguments("GESTEP(-4, -5)", 1d)]
+    [Arguments("GESTEP(-1)", 0d)]
+    [Arguments("GESTEP(1)", 1d)]
+    public async Task DeltaAndGeStep_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    // Microsoft's bitwise examples.
+    [Arguments("BITAND(13, 25)", 9d)] // 01101 & 11001.
+    [Arguments("BITOR(23, 10)", 31d)] // 10111 | 01010.
+    [Arguments("BITXOR(5, 3)", 6d)] // 101 ^ 011.
+    [Arguments("BITLSHIFT(4, 2)", 16d)]
+    [Arguments("BITRSHIFT(13, 2)", 3d)]
+    [Arguments("BITLSHIFT(4, -2)", 1d)] // A negative shift goes the other way.
+    [Arguments("BITRSHIFT(4, -2)", 16d)]
+    [Arguments("BITLSHIFT(3, 0)", 3d)]
+    [Arguments("BITAND(0, 255)", 0d)]
+    [Arguments("BITOR(0, 255)", 255d)]
+    public async Task Bitwise_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task Bitwise_WorksAcrossTheFull48BitRange()
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr("BITAND(281474976710655, 281474976710655)")).IsEqualTo(281474976710655d);
+        await Assert.That((double)XLWorkbook.EvaluateExpr("BITXOR(281474976710655, 281474976710655)")).IsEqualTo(0d);
+        await Assert.That((double)XLWorkbook.EvaluateExpr("BITRSHIFT(281474976710655, 47)")).IsEqualTo(1d);
+    }
+
+    [Test]
+    [Arguments("BITAND(-1, 5)")] // Operands must be non-negative.
+    [Arguments("BITAND(1.5, 5)")] // And whole numbers.
+    [Arguments("BITAND(281474976710656, 5)")] // 2^48 is one too many bits.
+    [Arguments("BITOR(-1, 5)")]
+    [Arguments("BITXOR(-1, 5)")]
+    [Arguments("BITLSHIFT(1, 54)")] // A shift may not exceed 53 bits.
+    [Arguments("BITLSHIFT(1, -54)")]
+    [Arguments("BITRSHIFT(1, 54)")]
+    [Arguments("BITLSHIFT(281474976710655, 10)")] // The result would exceed 2^53 - 1.
+    public async Task Bitwise_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    public async Task Engineering_EvaluatesAgainstWorksheetCells()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = 100;
+        ws.Cell("A2").Value = "km";
+        ws.Cell("A3").Value = "mi";
+        ws.Cell("A4").Value = 13;
+        ws.Cell("A5").Value = 25;
+
+        ws.Cell("B1").FormulaA1 = "CONVERT(A1, A2, A3)";
+        ws.Cell("B2").FormulaA1 = "BITAND(A4, A5)";
+        ws.Cell("B3").FormulaA1 = "ERF(A4 / 13)";
+
+        await Assert.That((double)ws.Cell("B1").Value).IsEqualTo(100000d / 1609.344d).Within(1e-9);
+        await Assert.That((double)ws.Cell("B2").Value).IsEqualTo(9d);
+        await Assert.That((double)ws.Cell("B3").Value).IsEqualTo(0.842700792949715d).Within(1e-9);
+    }
+}

--- a/XLibur/Excel/CalcEngine/Functions/Bessel.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Bessel.cs
@@ -1,0 +1,343 @@
+using System;
+
+namespace XLibur.Excel.CalcEngine.Functions;
+
+/// <summary>
+/// Bessel functions of integer order, backing BESSELJ, BESSELY, BESSELI and BESSELK.
+/// <para>
+/// Orders 0 and 1 come from the classic rational and asymptotic approximations (Abramowitz &amp;
+/// Stegun 9.4 / 9.8, as tabulated in Numerical Recipes); higher orders are reached by recurrence.
+/// The direction matters: J and I are recurred <em>downwards</em> from a high starting order and
+/// normalised, because upward recurrence for those is numerically unstable, while Y and K are
+/// dominant solutions and recur upwards safely. Accuracy is around 1e-8 relative, which is the
+/// accuracy of the underlying order-0/1 approximations.
+/// </para>
+/// </summary>
+internal static class Bessel
+{
+    private const double TwoOverPi = 0.636619772367581343;
+    private const double Big = 1.0e10;
+    private const double Small = 1.0e-10;
+
+    /// <summary>Bessel function of the first kind, J_n(x).</summary>
+    internal static double J(double x, int order)
+    {
+        // The rational approximation is only good to about 1e-8, and the origin is the one place
+        // where the exact value matters and is trivially known.
+        if (x == 0.0)
+            return order == 0 ? 1.0 : 0.0;
+
+        if (order == 0)
+            return J0(x);
+        if (order == 1)
+            return J1(x);
+
+        var ax = Math.Abs(x);
+        double result;
+        if (ax > order)
+        {
+            // Upward recurrence is stable once x exceeds the order.
+            var twoOverX = 2.0 / ax;
+            var previous = J0(ax);
+            var current = J1(ax);
+            for (var j = 1; j < order; j++)
+            {
+                var next = j * twoOverX * current - previous;
+                previous = current;
+                current = next;
+            }
+
+            result = current;
+        }
+        else
+        {
+            result = JByDownwardRecurrence(ax, order);
+        }
+
+        // J_n(-x) = (-1)^n J_n(x).
+        return x < 0.0 && (order & 1) == 1 ? -result : result;
+    }
+
+    /// <summary>
+    /// Miller's algorithm: start from a high order with an arbitrary seed, recur down, and rescale
+    /// using the identity J_0 + 2·(J_2 + J_4 + …) = 1.
+    /// </summary>
+    private static double JByDownwardRecurrence(double ax, int order)
+    {
+        var twoOverX = 2.0 / ax;
+        var start = 2 * ((order + (int)Math.Sqrt(40.0 * order)) / 2);
+
+        double result = 0, sum = 0;
+        double higher = 0, current = 1.0;
+        var addToSum = false;
+
+        for (var j = start; j > 0; j--)
+        {
+            var lower = j * twoOverX * current - higher;
+            higher = current;
+            current = lower;
+
+            if (Math.Abs(current) > Big)
+            {
+                current *= Small;
+                higher *= Small;
+                result *= Small;
+                sum *= Small;
+            }
+
+            if (addToSum)
+                sum += current;
+            addToSum = !addToSum;
+
+            if (j == order)
+                result = higher;
+        }
+
+        return result / (2.0 * sum - current);
+    }
+
+    /// <summary>Bessel function of the second kind, Y_n(x). Defined only for positive x.</summary>
+    internal static double Y(double x, int order)
+    {
+        if (order == 0)
+            return Y0(x);
+        if (order == 1)
+            return Y1(x);
+
+        var twoOverX = 2.0 / x;
+        var previous = Y0(x);
+        var current = Y1(x);
+        for (var j = 1; j < order; j++)
+        {
+            var next = j * twoOverX * current - previous;
+            previous = current;
+            current = next;
+        }
+
+        return current;
+    }
+
+    /// <summary>Modified Bessel function of the first kind, I_n(x).</summary>
+    internal static double I(double x, int order)
+    {
+        if (x == 0.0)
+            return order == 0 ? 1.0 : 0.0;
+
+        if (order == 0)
+            return I0(x);
+        if (order == 1)
+            return I1(x);
+
+        var twoOverX = 2.0 / Math.Abs(x);
+        double result = 0;
+        double higher = 0, current = 1.0;
+
+        for (var j = 2 * (order + (int)Math.Sqrt(40.0 * order)); j > 0; j--)
+        {
+            var lower = higher + j * twoOverX * current;
+            higher = current;
+            current = lower;
+
+            if (Math.Abs(current) > Big)
+            {
+                result *= Small;
+                current *= Small;
+                higher *= Small;
+            }
+
+            if (j == order)
+                result = higher;
+        }
+
+        result *= I0(x) / current;
+        return x < 0.0 && (order & 1) == 1 ? -result : result;
+    }
+
+    /// <summary>Modified Bessel function of the second kind, K_n(x). Defined only for positive x.</summary>
+    internal static double K(double x, int order)
+    {
+        if (order == 0)
+            return K0(x);
+        if (order == 1)
+            return K1(x);
+
+        var twoOverX = 2.0 / x;
+        var previous = K0(x);
+        var current = K1(x);
+        for (var j = 1; j < order; j++)
+        {
+            var next = previous + j * twoOverX * current;
+            previous = current;
+            current = next;
+        }
+
+        return current;
+    }
+
+    private static double J0(double x)
+    {
+        var ax = Math.Abs(x);
+        if (ax < 8.0)
+        {
+            var y = x * x;
+            var numerator = 57568490574.0 + y * (-13362590354.0 + y * (651619640.7
+                + y * (-11214424.18 + y * (77392.33017 + y * -184.9052456))));
+            var denominator = 57568490411.0 + y * (1029532985.0 + y * (9494680.718
+                + y * (59272.64853 + y * (267.8532712 + y))));
+            return numerator / denominator;
+        }
+
+        var (cosPart, sinPart, z) = AsymptoticFirstKindOrderZero(ax);
+        return Math.Sqrt(TwoOverPi / ax) * (Math.Cos(ax - 0.785398164) * cosPart - z * Math.Sin(ax - 0.785398164) * sinPart);
+    }
+
+    private static double J1(double x)
+    {
+        var ax = Math.Abs(x);
+        double result;
+        if (ax < 8.0)
+        {
+            var y = x * x;
+            var numerator = x * (72362614232.0 + y * (-7895059235.0 + y * (242396853.1
+                + y * (-2972611.439 + y * (15704.48260 + y * -30.16036606)))));
+            var denominator = 144725228442.0 + y * (2300535178.0 + y * (18583304.74
+                + y * (99447.43394 + y * (376.9991397 + y))));
+            return numerator / denominator;
+        }
+
+        var (cosPart, sinPart, z) = AsymptoticFirstKindOrderOne(ax);
+        result = Math.Sqrt(TwoOverPi / ax) * (Math.Cos(ax - 2.356194491) * cosPart - z * Math.Sin(ax - 2.356194491) * sinPart);
+        return x < 0.0 ? -result : result;
+    }
+
+    private static double Y0(double x)
+    {
+        if (x < 8.0)
+        {
+            var y = x * x;
+            var numerator = -2957821389.0 + y * (7062834065.0 + y * (-512359803.6
+                + y * (10879881.29 + y * (-86327.92757 + y * 228.4622733))));
+            var denominator = 40076544269.0 + y * (745249964.8 + y * (7189466.438
+                + y * (47447.26470 + y * (226.1030244 + y))));
+            return numerator / denominator + TwoOverPi * J0(x) * Math.Log(x);
+        }
+
+        var (cosPart, sinPart, z) = AsymptoticFirstKindOrderZero(x);
+        return Math.Sqrt(TwoOverPi / x) * (Math.Sin(x - 0.785398164) * cosPart + z * Math.Cos(x - 0.785398164) * sinPart);
+    }
+
+    private static double Y1(double x)
+    {
+        if (x < 8.0)
+        {
+            var y = x * x;
+            var numerator = x * (-0.4900604943e13 + y * (0.1275274390e13
+                + y * (-0.5153438139e11 + y * (0.7349264551e9
+                + y * (-0.4237922726e7 + y * 0.8511937935e4)))));
+            var denominator = 0.2499580570e14 + y * (0.4244419664e12
+                + y * (0.3733650367e10 + y * (0.2245904002e8
+                + y * (0.1020426050e6 + y * (0.3549632885e3 + y)))));
+            return numerator / denominator + TwoOverPi * (J1(x) * Math.Log(x) - 1.0 / x);
+        }
+
+        var (cosPart, sinPart, z) = AsymptoticFirstKindOrderOne(x);
+        return Math.Sqrt(TwoOverPi / x) * (Math.Sin(x - 2.356194491) * cosPart + z * Math.Cos(x - 2.356194491) * sinPart);
+    }
+
+    /// <summary>The shared amplitude polynomials of the order-0 large-argument expansion.</summary>
+    private static (double CosPart, double SinPart, double Z) AsymptoticFirstKindOrderZero(double ax)
+    {
+        var z = 8.0 / ax;
+        var y = z * z;
+        var cosPart = 1.0 + y * (-0.1098628627e-2 + y * (0.2734510407e-4
+            + y * (-0.2073370639e-5 + y * 0.2093887211e-6)));
+        var sinPart = -0.1562499995e-1 + y * (0.1430488765e-3
+            + y * (-0.6911147651e-5 + y * (0.7621095161e-6 + y * -0.934935152e-7)));
+        return (cosPart, sinPart, z);
+    }
+
+    /// <summary>The shared amplitude polynomials of the order-1 large-argument expansion.</summary>
+    private static (double CosPart, double SinPart, double Z) AsymptoticFirstKindOrderOne(double ax)
+    {
+        var z = 8.0 / ax;
+        var y = z * z;
+        var cosPart = 1.0 + y * (0.183105e-2 + y * (-0.3516396496e-4
+            + y * (0.2457520174e-5 + y * -0.240337019e-6)));
+        var sinPart = 0.04687499995 + y * (-0.2002690873e-3
+            + y * (0.8449199096e-5 + y * (-0.88228987e-6 + y * 0.105787412e-6)));
+        return (cosPart, sinPart, z);
+    }
+
+    private static double I0(double x)
+    {
+        var ax = Math.Abs(x);
+        if (ax < 3.75)
+        {
+            var y = x / 3.75;
+            y *= y;
+            return 1.0 + y * (3.5156229 + y * (3.0899424 + y * (1.2067492
+                + y * (0.2659732 + y * (0.360768e-1 + y * 0.45813e-2)))));
+        }
+
+        var t = 3.75 / ax;
+        return Math.Exp(ax) / Math.Sqrt(ax) * (0.39894228 + t * (0.1328592e-1
+            + t * (0.225319e-2 + t * (-0.157565e-2 + t * (0.916281e-2
+            + t * (-0.2057706e-1 + t * (0.2635537e-1 + t * (-0.1647633e-1
+            + t * 0.392377e-2))))))));
+    }
+
+    private static double I1(double x)
+    {
+        var ax = Math.Abs(x);
+        double result;
+        if (ax < 3.75)
+        {
+            var y = x / 3.75;
+            y *= y;
+            result = ax * (0.5 + y * (0.87890594 + y * (0.51498869 + y * (0.15084934
+                + y * (0.2658733e-1 + y * (0.301532e-2 + y * 0.32411e-3))))));
+        }
+        else
+        {
+            var t = 3.75 / ax;
+            var tail = 0.2282967e-1 + t * (-0.2895312e-1 + t * (0.1787654e-1 - t * 0.420059e-2));
+            tail = 0.39894228 + t * (-0.3988024e-1 + t * (-0.362018e-2
+                + t * (0.163801e-2 + t * (-0.1031555e-1 + t * tail))));
+            result = tail * (Math.Exp(ax) / Math.Sqrt(ax));
+        }
+
+        return x < 0.0 ? -result : result;
+    }
+
+    private static double K0(double x)
+    {
+        if (x <= 2.0)
+        {
+            var y = x * x / 4.0;
+            return -Math.Log(x / 2.0) * I0(x) + (-0.57721566 + y * (0.42278420
+                + y * (0.23069756 + y * (0.3488590e-1 + y * (0.262698e-2
+                + y * (0.10750e-3 + y * 0.74e-5))))));
+        }
+
+        var t = 2.0 / x;
+        return Math.Exp(-x) / Math.Sqrt(x) * (1.25331414 + t * (-0.7832358e-1
+            + t * (0.2189568e-1 + t * (-0.1062446e-1 + t * (0.587872e-2
+            + t * (-0.251540e-2 + t * 0.53208e-3))))));
+    }
+
+    private static double K1(double x)
+    {
+        if (x <= 2.0)
+        {
+            var y = x * x / 4.0;
+            return Math.Log(x / 2.0) * I1(x) + 1.0 / x * (1.0 + y * (0.15443144
+                + y * (-0.67278579 + y * (-0.18156897 + y * (-0.1919402e-1
+                + y * (-0.110404e-2 + y * -0.4686e-4))))));
+        }
+
+        var t = 2.0 / x;
+        return Math.Exp(-x) / Math.Sqrt(x) * (1.25331414 + t * (0.23498619
+            + t * (-0.3655620e-1 + t * (0.1504268e-1 + t * (-0.780353e-2
+            + t * (0.325614e-2 + t * -0.68245e-3))))));
+    }
+}

--- a/XLibur/Excel/CalcEngine/Functions/ComplexNumber.cs
+++ b/XLibur/Excel/CalcEngine/Functions/ComplexNumber.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Globalization;
 
+#pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility
+
 namespace XLibur.Excel.CalcEngine.Functions;
 
 /// <summary>

--- a/XLibur/Excel/CalcEngine/Functions/ComplexNumber.cs
+++ b/XLibur/Excel/CalcEngine/Functions/ComplexNumber.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Globalization;
+
+namespace XLibur.Excel.CalcEngine.Functions;
+
+/// <summary>
+/// A complex number as Excel's IM* functions see it. Excel has no complex value type — a complex
+/// number is the <em>text</em> "3+4i", so every one of those functions parses its arguments out of
+/// text and writes its result back as text. This type carries the imaginary unit suffix along with
+/// the components, because Excel echoes back whichever of "i" or "j" the input used.
+/// </summary>
+internal readonly record struct ComplexNumber(double Real, double Imaginary, char Suffix)
+{
+    /// <summary>The suffix Excel uses when nothing in the input said otherwise.</summary>
+    internal const char DefaultSuffix = 'i';
+
+    internal static ComplexNumber Zero => new(0, 0, DefaultSuffix);
+
+    internal double Modulus => Math.Sqrt(Real * Real + Imaginary * Imaginary);
+
+    /// <summary>The argument θ in (-π, π], undefined at the origin.</summary>
+    internal double Argument => Math.Atan2(Imaginary, Real);
+
+    internal bool IsZero => Real == 0 && Imaginary == 0;
+
+    internal ComplexNumber WithSuffix(char suffix) => new(Real, Imaginary, suffix);
+
+    internal ComplexNumber Conjugate() => new(Real, -Imaginary, Suffix);
+
+    /// <summary>The complex number 1 carrying this one's suffix — the numerator of sec, csc, sech and csch.</summary>
+    internal ComplexNumber One() => new(1, 0, Suffix);
+
+    internal ComplexNumber Add(in ComplexNumber other) => new(Real + other.Real, Imaginary + other.Imaginary, Suffix);
+
+    internal ComplexNumber Subtract(in ComplexNumber other) => new(Real - other.Real, Imaginary - other.Imaginary, Suffix);
+
+    internal ComplexNumber Multiply(in ComplexNumber other)
+        => new(Real * other.Real - Imaginary * other.Imaginary,
+               Real * other.Imaginary + Imaginary * other.Real,
+               Suffix);
+
+    internal ComplexNumber Divide(in ComplexNumber other)
+    {
+        var denominator = other.Real * other.Real + other.Imaginary * other.Imaginary;
+        return new((Real * other.Real + Imaginary * other.Imaginary) / denominator,
+                   (Imaginary * other.Real - Real * other.Imaginary) / denominator,
+                   Suffix);
+    }
+
+    /// <summary>e^z = e^re · (cos im + i·sin im).</summary>
+    internal ComplexNumber Exp()
+    {
+        var magnitude = Math.Exp(Real);
+        return new(magnitude * Math.Cos(Imaginary), magnitude * Math.Sin(Imaginary), Suffix);
+    }
+
+    /// <summary>The principal natural logarithm: ln|z| + i·arg z.</summary>
+    internal ComplexNumber Log() => new(Math.Log(Modulus), Argument, Suffix);
+
+    /// <summary>z^n for real n, via the polar form.</summary>
+    internal ComplexNumber Power(double exponent)
+    {
+        var magnitude = Math.Pow(Modulus, exponent);
+        var angle = Argument * exponent;
+        return new(magnitude * Math.Cos(angle), magnitude * Math.Sin(angle), Suffix);
+    }
+
+    internal ComplexNumber Sqrt() => Power(0.5);
+
+    internal ComplexNumber Sin()
+        => new(Math.Sin(Real) * Math.Cosh(Imaginary), Math.Cos(Real) * Math.Sinh(Imaginary), Suffix);
+
+    internal ComplexNumber Cos()
+        => new(Math.Cos(Real) * Math.Cosh(Imaginary), -Math.Sin(Real) * Math.Sinh(Imaginary), Suffix);
+
+    internal ComplexNumber Sinh()
+        => new(Math.Sinh(Real) * Math.Cos(Imaginary), Math.Cosh(Real) * Math.Sin(Imaginary), Suffix);
+
+    internal ComplexNumber Cosh()
+        => new(Math.Cosh(Real) * Math.Cos(Imaginary), Math.Sinh(Real) * Math.Sin(Imaginary), Suffix);
+
+    /// <summary>
+    /// Parse Excel's complex-number text: an optional real part, an optional signed imaginary part
+    /// and the "i" or "j" that marks it. "3+4i", "3", "4i", "-i" and "1.5E+3-2j" are all valid; the
+    /// suffix is case sensitive, as it is in Excel.
+    /// </summary>
+    internal static bool TryParse(string text, out ComplexNumber value)
+    {
+        value = Zero;
+        var span = text.AsSpan().Trim();
+        if (span.IsEmpty)
+        {
+            // Excel reads an empty argument as zero rather than rejecting it.
+            return true;
+        }
+
+        var suffix = span[^1];
+        if (suffix is not ('i' or 'j'))
+        {
+            // No suffix at all: the whole thing has to be a plain real number.
+            if (!TryParseComponent(span, out var realOnly))
+                return false;
+
+            value = new ComplexNumber(realOnly, 0, DefaultSuffix);
+            return true;
+        }
+
+        var body = span[..^1];
+        var split = FindImaginarySignIndex(body);
+
+        ReadOnlySpan<char> realPart;
+        ReadOnlySpan<char> imaginaryPart;
+        if (split < 0)
+        {
+            realPart = default;
+            imaginaryPart = body;
+        }
+        else
+        {
+            realPart = body[..split];
+            imaginaryPart = body[split..];
+        }
+
+        double real = 0;
+        if (!realPart.IsEmpty && !TryParseComponent(realPart, out real))
+            return false;
+
+        if (!TryParseImaginaryComponent(imaginaryPart, out var imaginary))
+            return false;
+
+        value = new ComplexNumber(real, imaginary, suffix);
+        return true;
+    }
+
+    /// <summary>
+    /// Index of the sign that separates the real part from the imaginary one, or -1 when the text
+    /// holds only an imaginary part. A sign at the very start belongs to the real part, and one
+    /// straight after an exponent marker belongs to that exponent.
+    /// </summary>
+    private static int FindImaginarySignIndex(ReadOnlySpan<char> body)
+    {
+        for (var i = body.Length - 1; i > 0; i--)
+        {
+            if (body[i] is not ('+' or '-'))
+                continue;
+
+            if (body[i - 1] is 'e' or 'E')
+                continue;
+
+            return i;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Parse the imaginary coefficient, which Excel lets you leave out entirely: "i" is 1 and "-i"
+    /// is -1.
+    /// </summary>
+    private static bool TryParseImaginaryComponent(ReadOnlySpan<char> text, out double value)
+    {
+        if (text.IsEmpty || text.SequenceEqual("+".AsSpan()))
+        {
+            value = 1;
+            return true;
+        }
+
+        if (text.SequenceEqual("-".AsSpan()))
+        {
+            value = -1;
+            return true;
+        }
+
+        return TryParseComponent(text, out value);
+    }
+
+    private static bool TryParseComponent(ReadOnlySpan<char> text, out double value)
+    {
+        // Complex-number text is always written with a period, whatever the workbook's culture.
+        return double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out value)
+               && !double.IsNaN(value)
+               && !double.IsInfinity(value);
+    }
+
+    /// <summary>
+    /// Render back to Excel's text form: a purely real number drops the imaginary part, a purely
+    /// imaginary one drops the real part, and a unit coefficient is written as bare "i".
+    /// </summary>
+    public override string ToString()
+    {
+        var suffix = Suffix == default ? DefaultSuffix : Suffix;
+
+        if (Imaginary == 0)
+            return FormatComponent(Real);
+
+        var imaginary = FormatImaginary(Imaginary, suffix);
+        if (Real == 0)
+            return imaginary;
+
+        // FormatImaginary already carries the sign of a negative coefficient.
+        var separator = Imaginary > 0 ? "+" : string.Empty;
+        return FormatComponent(Real) + separator + imaginary;
+    }
+
+    private static string FormatImaginary(double imaginary, char suffix)
+    {
+        if (imaginary == 1)
+            return suffix.ToString();
+
+        if (imaginary == -1)
+            return "-" + suffix;
+
+        return FormatComponent(imaginary) + suffix;
+    }
+
+    /// <summary>
+    /// Excel writes the components of a complex number with 15 significant digits, which is also
+    /// what hides the last-bit noise of the trigonometric identities — IMSQRT("3+4i") comes out as
+    /// "2+i" rather than "2.00000000000000018+i".
+    /// </summary>
+    private static string FormatComponent(double value)
+        => value.ToString("G15", CultureInfo.InvariantCulture);
+}

--- a/XLibur/Excel/CalcEngine/Functions/Engineering.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Engineering.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using XLibur.Excel.CalcEngine.Functions;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
+#pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility
+
 namespace XLibur.Excel.CalcEngine;
 
 internal static class Engineering

--- a/XLibur/Excel/CalcEngine/Functions/Engineering.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Engineering.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using XLibur.Excel.CalcEngine.Functions;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
 namespace XLibur.Excel.CalcEngine;
@@ -16,63 +18,426 @@ internal static class Engineering
     private const long HexMax = 549755813887;
     private const long HexMin = -549755813888;
 
+    /// <summary>Excel's bitwise functions operate on 48-bit unsigned integers.</summary>
+    private const double BitMax = 281474976710655; // 2^48 - 1
+
+    /// <summary>A shift may not move a bit past the largest integer a double represents exactly.</summary>
+    private const double ShiftedMax = 9007199254740991; // 2^53 - 1
+
     public static void Register(FunctionRegistry ce)
     {
-        // BESSELI Returns the modified Bessel function In(x)
-        // BESSELJ Returns the Bessel function Jn(x)
-        // BESSELK Returns the modified Bessel function Kn(x)
-        // BESSELY Returns the Bessel function Yn(x)
+        ce.RegisterFunction("BESSELI", 2, 2, Adapt(BesselI), FunctionFlags.Scalar); // Returns the modified Bessel function In(x)
+        ce.RegisterFunction("BESSELJ", 2, 2, Adapt(BesselJ), FunctionFlags.Scalar); // Returns the Bessel function Jn(x)
+        ce.RegisterFunction("BESSELK", 2, 2, Adapt(BesselK), FunctionFlags.Scalar); // Returns the modified Bessel function Kn(x)
+        ce.RegisterFunction("BESSELY", 2, 2, Adapt(BesselY), FunctionFlags.Scalar); // Returns the Bessel function Yn(x)
         ce.RegisterFunction("BIN2DEC", 1, 1, Adapt(Bin2Dec), FunctionFlags.Scalar);
         ce.RegisterFunction("BIN2HEX", 1, 2, AdaptLastOptional(Bin2Hex, 0), FunctionFlags.Scalar);
         ce.RegisterFunction("BIN2OCT", 1, 2, AdaptLastOptional(Bin2Oct, 0), FunctionFlags.Scalar);
-        // BITAND Returns a bitwise 'And' of two numbers
-        // BITLSHIFT Returns a number shifted left by shift_amount bits
-        // BITOR Returns a bitwise 'Or' of two numbers
-        // BITRSHIFT Returns a number shifted right by shift_amount bits
-        // BITXOR Returns a bitwise 'Exclusive Or' of two numbers
-        // COMPLEX Converts real and imaginary coefficients into a complex number
-        // CONVERT Converts a number from one measurement system to another
+        ce.RegisterFunction("BITAND", 2, 2, Adapt(BitAnd), FunctionFlags.Scalar | FunctionFlags.Future); // Returns a bitwise 'And' of two numbers
+        ce.RegisterFunction("BITLSHIFT", 2, 2, Adapt(BitLShift), FunctionFlags.Scalar | FunctionFlags.Future); // Returns a number shifted left by shift_amount bits
+        ce.RegisterFunction("BITOR", 2, 2, Adapt(BitOr), FunctionFlags.Scalar | FunctionFlags.Future); // Returns a bitwise 'Or' of two numbers
+        ce.RegisterFunction("BITRSHIFT", 2, 2, Adapt(BitRShift), FunctionFlags.Scalar | FunctionFlags.Future); // Returns a number shifted right by shift_amount bits
+        ce.RegisterFunction("BITXOR", 2, 2, Adapt(BitXor), FunctionFlags.Scalar | FunctionFlags.Future); // Returns a bitwise 'Exclusive Or' of two numbers
+        ce.RegisterFunction("COMPLEX", 2, 3, AdaptLastOptional(Complex, "i"), FunctionFlags.Scalar); // Converts real and imaginary coefficients into a complex number
+        ce.RegisterFunction("CONVERT", 3, 3, Adapt(ConvertUnit), FunctionFlags.Scalar); // Converts a number from one measurement system to another
         ce.RegisterFunction("DEC2BIN", 1, 2, AdaptLastOptional(Dec2Bin, 0), FunctionFlags.Scalar);
         ce.RegisterFunction("DEC2HEX", 1, 2, AdaptLastOptional(Dec2Hex, 0), FunctionFlags.Scalar);
         ce.RegisterFunction("DEC2OCT", 1, 2, AdaptLastOptional(Dec2Oct, 0), FunctionFlags.Scalar);
-        // DELTA Tests whether two values are equal
-        // ERF Returns the error function
-        // ERF.PRECISE Returns the error function
-        // ERFC Returns the complementary error function
-        // ERFC.PRECISE Returns the complementary ERF function integrated between x and infinity
-        // GESTEP Tests whether a number is greater than a threshold value
+        ce.RegisterFunction("DELTA", 1, 2, AdaptLastOptional(Delta, 0), FunctionFlags.Scalar); // Tests whether two values are equal
+        ce.RegisterFunction("ERF", 1, 2, AdaptLastOptional(Erf), FunctionFlags.Scalar); // Returns the error function
+        ce.RegisterFunction("ERF.PRECISE", 1, 1, Adapt(ErfPrecise), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the error function
+        ce.RegisterFunction("ERFC", 1, 1, Adapt(Erfc), FunctionFlags.Scalar); // Returns the complementary error function
+        ce.RegisterFunction("ERFC.PRECISE", 1, 1, Adapt(Erfc), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the complementary ERF function integrated between x and infinity
+        ce.RegisterFunction("GESTEP", 1, 2, AdaptLastOptional(GeStep, 0), FunctionFlags.Scalar); // Tests whether a number is greater than a threshold value
         ce.RegisterFunction("HEX2BIN", 1, 2, AdaptLastOptional(Hex2Bin, 0), FunctionFlags.Scalar);
         ce.RegisterFunction("HEX2DEC", 1, 1, Adapt(Hex2Dec), FunctionFlags.Scalar);
         ce.RegisterFunction("HEX2OCT", 1, 2, AdaptLastOptional(Hex2Oct, 0), FunctionFlags.Scalar);
-        // IMABS Returns the absolute value(modulus) of a complex number
-        // IMAGINARY Returns the imaginary coefficient of a complex number
-        // IMARGUMENT Returns the argument theta, an angle expressed in radians
-        // IMCONJUGATE Returns the complex conjugate of a complex number
-        // IMCOS Returns the cosine of a complex number
-        // IMCOSH Returns the hyperbolic cosine of a complex number
-        // IMCOT Returns the cotangent of a complex number
-        // IMCSC Returns the cosecant of a complex number
-        // IMCSCH Returns the hyperbolic cosecant of a complex number
-        // IMDIV Returns the quotient of two complex numbers
-        // IMEXP Returns the exponential of a complex number
-        // IMLN Returns the natural logarithm of a complex number
-        // IMLOG10 Returns the base - 10 logarithm of a complex number
-        // IMLOG2 Returns the base - 2 logarithm of a complex number
-        // IMPOWER Returns a complex number raised to an integer power
-        // IMPRODUCT Returns the product of from 2 to 255 complex numbers
-        // IMREAL Returns the real coefficient of a complex number
-        // IMSEC Returns the secant of a complex number
-        // IMSECH Returns the hyperbolic secant of a complex number
-        // IMSIN Returns the sine of a complex number
-        // IMSINH Returns the hyperbolic sine of a complex number
-        // IMSQRT Returns the square root of a complex number
-        // IMSUB Returns the difference between two complex numbers
-        // IMSUM Returns the sum of complex numbers
-        // IMTAN Returns the tangent of a complex number
+        ce.RegisterFunction("IMABS", 1, 1, Adapt(ImAbs), FunctionFlags.Scalar); // Returns the absolute value(modulus) of a complex number
+        ce.RegisterFunction("IMAGINARY", 1, 1, Adapt(ImAginary), FunctionFlags.Scalar); // Returns the imaginary coefficient of a complex number
+        ce.RegisterFunction("IMARGUMENT", 1, 1, Adapt(ImArgument), FunctionFlags.Scalar); // Returns the argument theta, an angle expressed in radians
+        ce.RegisterFunction("IMCONJUGATE", 1, 1, Adapt(ImConjugate), FunctionFlags.Scalar); // Returns the complex conjugate of a complex number
+        ce.RegisterFunction("IMCOS", 1, 1, Adapt(ImCos), FunctionFlags.Scalar); // Returns the cosine of a complex number
+        ce.RegisterFunction("IMCOSH", 1, 1, Adapt(ImCosh), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the hyperbolic cosine of a complex number
+        ce.RegisterFunction("IMCOT", 1, 1, Adapt(ImCot), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the cotangent of a complex number
+        ce.RegisterFunction("IMCSC", 1, 1, Adapt(ImCsc), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the cosecant of a complex number
+        ce.RegisterFunction("IMCSCH", 1, 1, Adapt(ImCsch), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the hyperbolic cosecant of a complex number
+        ce.RegisterFunction("IMDIV", 2, 2, Adapt(ImDiv), FunctionFlags.Scalar); // Returns the quotient of two complex numbers
+        ce.RegisterFunction("IMEXP", 1, 1, Adapt(ImExp), FunctionFlags.Scalar); // Returns the exponential of a complex number
+        ce.RegisterFunction("IMLN", 1, 1, Adapt(ImLn), FunctionFlags.Scalar); // Returns the natural logarithm of a complex number
+        ce.RegisterFunction("IMLOG10", 1, 1, Adapt(ImLog10), FunctionFlags.Scalar); // Returns the base - 10 logarithm of a complex number
+        ce.RegisterFunction("IMLOG2", 1, 1, Adapt(ImLog2), FunctionFlags.Scalar); // Returns the base - 2 logarithm of a complex number
+        ce.RegisterFunction("IMPOWER", 2, 2, Adapt(ImPower), FunctionFlags.Scalar); // Returns a complex number raised to an integer power
+        ce.RegisterFunction("IMPRODUCT", 1, 255, Adapt(ImProduct), FunctionFlags.Scalar); // Returns the product of from 2 to 255 complex numbers
+        ce.RegisterFunction("IMREAL", 1, 1, Adapt(ImReal), FunctionFlags.Scalar); // Returns the real coefficient of a complex number
+        ce.RegisterFunction("IMSEC", 1, 1, Adapt(ImSec), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the secant of a complex number
+        ce.RegisterFunction("IMSECH", 1, 1, Adapt(ImSech), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the hyperbolic secant of a complex number
+        ce.RegisterFunction("IMSIN", 1, 1, Adapt(ImSin), FunctionFlags.Scalar); // Returns the sine of a complex number
+        ce.RegisterFunction("IMSINH", 1, 1, Adapt(ImSinh), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the hyperbolic sine of a complex number
+        ce.RegisterFunction("IMSQRT", 1, 1, Adapt(ImSqrt), FunctionFlags.Scalar); // Returns the square root of a complex number
+        ce.RegisterFunction("IMSUB", 2, 2, Adapt(ImSub), FunctionFlags.Scalar); // Returns the difference between two complex numbers
+        ce.RegisterFunction("IMSUM", 1, 255, Adapt(ImSum), FunctionFlags.Scalar); // Returns the sum of complex numbers
+        ce.RegisterFunction("IMTAN", 1, 1, Adapt(ImTan), FunctionFlags.Scalar | FunctionFlags.Future); // Returns the tangent of a complex number
         ce.RegisterFunction("OCT2BIN", 1, 2, AdaptLastOptional(Oct2Bin, 0), FunctionFlags.Scalar);
         ce.RegisterFunction("OCT2DEC", 1, 1, Adapt(Oct2Dec), FunctionFlags.Scalar);
         ce.RegisterFunction("OCT2HEX", 1, 2, AdaptLastOptional(Oct2Hex, 0), FunctionFlags.Scalar);
     }
+
+    #region Bessel functions
+
+    private static ScalarValue BesselI(CalcContext ctx, double x, double order)
+        => TryGetBesselOrder(order, out var n) ? Bessel.I(x, n) : XLError.NumberInvalid;
+
+    private static ScalarValue BesselJ(CalcContext ctx, double x, double order)
+        => TryGetBesselOrder(order, out var n) ? Bessel.J(x, n) : XLError.NumberInvalid;
+
+    private static ScalarValue BesselK(CalcContext ctx, double x, double order)
+    {
+        // K is singular at the origin and complex for negative arguments.
+        if (x <= 0 || !TryGetBesselOrder(order, out var n))
+            return XLError.NumberInvalid;
+
+        return Bessel.K(x, n);
+    }
+
+    private static ScalarValue BesselY(CalcContext ctx, double x, double order)
+    {
+        if (x <= 0 || !TryGetBesselOrder(order, out var n))
+            return XLError.NumberInvalid;
+
+        return Bessel.Y(x, n);
+    }
+
+    private static bool TryGetBesselOrder(double order, out int n)
+    {
+        n = 0;
+        var truncated = Math.Truncate(order);
+        if (truncated < 0 || truncated > int.MaxValue)
+            return false;
+
+        n = (int)truncated;
+        return true;
+    }
+
+    #endregion
+
+    #region Bitwise functions
+
+    private static ScalarValue BitAnd(CalcContext ctx, double number1, double number2)
+        => Bitwise(number1, number2, static (a, b) => a & b);
+
+    private static ScalarValue BitOr(CalcContext ctx, double number1, double number2)
+        => Bitwise(number1, number2, static (a, b) => a | b);
+
+    private static ScalarValue BitXor(CalcContext ctx, double number1, double number2)
+        => Bitwise(number1, number2, static (a, b) => a ^ b);
+
+    private static ScalarValue Bitwise(double number1, double number2, Func<long, long, long> combine)
+    {
+        if (!TryGetBitOperand(number1, out var a) || !TryGetBitOperand(number2, out var b))
+            return XLError.NumberInvalid;
+
+        return (double)combine(a, b);
+    }
+
+    private static ScalarValue BitLShift(CalcContext ctx, double number, double shift)
+        => Shift(number, shift);
+
+    private static ScalarValue BitRShift(CalcContext ctx, double number, double shift)
+        => Shift(number, -shift);
+
+    /// <summary>
+    /// Shift left by <paramref name="shift"/> bits, or right when it is negative. Excel expresses
+    /// both directions as one operation, so BITRSHIFT is BITLSHIFT with the sign flipped.
+    /// </summary>
+    private static ScalarValue Shift(double number, double shift)
+    {
+        if (!TryGetBitOperand(number, out var value))
+            return XLError.NumberInvalid;
+
+        var amount = Math.Truncate(shift);
+        if (Math.Abs(amount) > 53)
+            return XLError.NumberInvalid;
+
+        // Shifting is defined arithmetically rather than on the bit pattern, which keeps the result
+        // exact for the 48-bit inputs and lets a shift beyond 53 bits be caught as out of range.
+        var result = value * Math.Pow(2, amount);
+        result = amount < 0 ? Math.Floor(result) : result;
+        if (result > ShiftedMax)
+            return XLError.NumberInvalid;
+
+        return result;
+    }
+
+    private static bool TryGetBitOperand(double number, out long value)
+    {
+        value = 0;
+        if (number < 0 || number > BitMax || number != Math.Truncate(number))
+            return false;
+
+        value = (long)number;
+        return true;
+    }
+
+    #endregion
+
+    #region Comparison and error functions
+
+    private static ScalarValue Delta(CalcContext ctx, double number1, double number2)
+        => number1 == number2 ? 1d : 0d;
+
+    private static ScalarValue GeStep(CalcContext ctx, double number, double step)
+        => number >= step ? 1d : 0d;
+
+    /// <summary>
+    /// ERF(lower, [upper]) integrates the error function between the two limits; with one argument
+    /// it integrates from zero, which is erf(lower).
+    /// </summary>
+    private static ScalarValue Erf(CalcContext ctx, double lowerLimit, double? upperLimit)
+    {
+        if (upperLimit is null)
+            return XLMath.Erf(lowerLimit);
+
+        return XLMath.Erf(upperLimit.Value) - XLMath.Erf(lowerLimit);
+    }
+
+    private static ScalarValue ErfPrecise(CalcContext ctx, double x) => XLMath.Erf(x);
+
+    private static ScalarValue Erfc(CalcContext ctx, double x) => XLMath.Erfc(x);
+
+    #endregion
+
+    #region Unit conversion
+
+    private static ScalarValue ConvertUnit(CalcContext ctx, double number, string fromUnit, string toUnit)
+    {
+        // An unknown unit, or two units that measure different things, is #N/A rather than #VALUE!:
+        // the arguments were the right type, there is just no conversion between them.
+        if (!UnitConversion.TryConvert(number, fromUnit, toUnit, out var result))
+            return XLError.NoValueAvailable;
+
+        return result;
+    }
+
+    #endregion
+
+    #region Complex numbers
+
+    private static ScalarValue Complex(CalcContext ctx, double real, double imaginary, string suffix)
+    {
+        if (suffix is not ("i" or "j"))
+            return XLError.IncompatibleValue;
+
+        return new ComplexNumber(real, imaginary, suffix[0]).ToString();
+    }
+
+    private static ScalarValue ImAbs(CalcContext ctx, string number)
+        => WithComplex(number, static z => z.Modulus);
+
+    private static ScalarValue ImReal(CalcContext ctx, string number)
+        => WithComplex(number, static z => z.Real);
+
+    private static ScalarValue ImAginary(CalcContext ctx, string number)
+        => WithComplex(number, static z => z.Imaginary);
+
+    private static ScalarValue ImArgument(CalcContext ctx, string number)
+    {
+        if (!ComplexNumber.TryParse(number, out var z))
+            return XLError.NumberInvalid;
+
+        // The argument of zero is not defined; Excel reports that as a division by zero.
+        if (z.IsZero)
+            return XLError.DivisionByZero;
+
+        return z.Argument;
+    }
+
+    private static ScalarValue ImConjugate(CalcContext ctx, string number)
+        => MapComplex(number, static z => z.Conjugate());
+
+    private static ScalarValue ImExp(CalcContext ctx, string number)
+        => MapComplex(number, static z => z.Exp());
+
+    private static ScalarValue ImLn(CalcContext ctx, string number)
+        => MapDefinedComplex(number, static z => z.Log());
+
+    private static ScalarValue ImLog10(CalcContext ctx, string number)
+        => MapDefinedComplex(number, static z => Scale(z.Log(), 1 / Math.Log(10)));
+
+    private static ScalarValue ImLog2(CalcContext ctx, string number)
+        => MapDefinedComplex(number, static z => Scale(z.Log(), 1 / Math.Log(2)));
+
+    private static ScalarValue ImSqrt(CalcContext ctx, string number)
+        => MapComplex(number, static z => z.Sqrt());
+
+    private static ScalarValue ImSin(CalcContext ctx, string number)
+        => MapComplex(number, static z => z.Sin());
+
+    private static ScalarValue ImCos(CalcContext ctx, string number)
+        => MapComplex(number, static z => z.Cos());
+
+    private static ScalarValue ImSinh(CalcContext ctx, string number)
+        => MapComplex(number, static z => z.Sinh());
+
+    private static ScalarValue ImCosh(CalcContext ctx, string number)
+        => MapComplex(number, static z => z.Cosh());
+
+    private static ScalarValue ImTan(CalcContext ctx, string number)
+        => MapRatio(number, static z => z.Sin(), static z => z.Cos());
+
+    private static ScalarValue ImCot(CalcContext ctx, string number)
+        => MapRatio(number, static z => z.Cos(), static z => z.Sin());
+
+    private static ScalarValue ImSec(CalcContext ctx, string number)
+        => MapRatio(number, static z => z.One(), static z => z.Cos());
+
+    private static ScalarValue ImCsc(CalcContext ctx, string number)
+        => MapRatio(number, static z => z.One(), static z => z.Sin());
+
+    private static ScalarValue ImSech(CalcContext ctx, string number)
+        => MapRatio(number, static z => z.One(), static z => z.Cosh());
+
+    private static ScalarValue ImCsch(CalcContext ctx, string number)
+        => MapRatio(number, static z => z.One(), static z => z.Sinh());
+
+    private static ScalarValue ImPower(string number, double power)
+    {
+        if (!ComplexNumber.TryParse(number, out var z))
+            return XLError.NumberInvalid;
+
+        // 0^0 and 0 to a negative power are both undefined.
+        if (z.IsZero && power <= 0)
+            return XLError.NumberInvalid;
+
+        return z.Power(power).ToString();
+    }
+
+    private static ScalarValue ImSub(string number1, string number2)
+        => Combine(number1, number2, static (a, b) => a.Subtract(b), divide: false);
+
+    private static ScalarValue ImDiv(string number1, string number2)
+        => Combine(number1, number2, static (a, b) => a.Divide(b), divide: true);
+
+    private static ScalarValue ImSum(CalcContext ctx, List<string> numbers)
+        => Accumulate(numbers, ComplexNumber.Zero, static (a, b) => a.Add(b));
+
+    private static ScalarValue ImProduct(CalcContext ctx, List<string> numbers)
+        => Accumulate(numbers, new ComplexNumber(1, 0, ComplexNumber.DefaultSuffix), static (a, b) => a.Multiply(b));
+
+    private static ScalarValue WithComplex(string number, Func<ComplexNumber, double> selector)
+    {
+        if (!ComplexNumber.TryParse(number, out var z))
+            return XLError.NumberInvalid;
+
+        return selector(z);
+    }
+
+    private static ScalarValue MapComplex(string number, Func<ComplexNumber, ComplexNumber> selector)
+    {
+        if (!ComplexNumber.TryParse(number, out var z))
+            return XLError.NumberInvalid;
+
+        return selector(z).ToString();
+    }
+
+    /// <summary>Like <see cref="MapComplex"/>, for the functions that are singular at the origin.</summary>
+    private static ScalarValue MapDefinedComplex(string number, Func<ComplexNumber, ComplexNumber> selector)
+    {
+        if (!ComplexNumber.TryParse(number, out var z))
+            return XLError.NumberInvalid;
+
+        if (z.IsZero)
+            return XLError.NumberInvalid;
+
+        return selector(z).ToString();
+    }
+
+    /// <summary>
+    /// The reciprocal-style functions (tan, cot, sec, csc and their hyperbolic partners) are all a
+    /// quotient of two of the primitives, and all report a zero denominator as #NUM!.
+    /// </summary>
+    private static ScalarValue MapRatio(string number, Func<ComplexNumber, ComplexNumber> numerator, Func<ComplexNumber, ComplexNumber> denominator)
+    {
+        if (!ComplexNumber.TryParse(number, out var z))
+            return XLError.NumberInvalid;
+
+        var bottom = denominator(z);
+        if (bottom.IsZero)
+            return XLError.NumberInvalid;
+
+        return numerator(z).Divide(bottom).ToString();
+    }
+
+    private static ScalarValue Combine(string number1, string number2, Func<ComplexNumber, ComplexNumber, ComplexNumber> combine, bool divide)
+    {
+        if (!ComplexNumber.TryParse(number1, out var a) || !ComplexNumber.TryParse(number2, out var b))
+            return XLError.NumberInvalid;
+
+        if (!TryAgreeOnSuffix(a, b, out var suffix))
+            return XLError.IncompatibleValue;
+
+        if (divide && b.IsZero)
+            return XLError.NumberInvalid;
+
+        return combine(a.WithSuffix(suffix), b).ToString();
+    }
+
+    private static ScalarValue Accumulate(List<string> numbers, ComplexNumber seed, Func<ComplexNumber, ComplexNumber, ComplexNumber> combine)
+    {
+        var total = seed;
+        var suffix = default(char);
+        foreach (var text in numbers)
+        {
+            if (!ComplexNumber.TryParse(text, out var z))
+                return XLError.NumberInvalid;
+
+            if (!TryTakeSuffix(ref suffix, z))
+                return XLError.IncompatibleValue;
+
+            total = combine(total, z);
+        }
+
+        return total.WithSuffix(suffix == default ? ComplexNumber.DefaultSuffix : suffix).ToString();
+    }
+
+    /// <summary>
+    /// Excel refuses to mix the two spellings of the imaginary unit: IMSUM("1+i", "1+j") is
+    /// #VALUE!. A number with no imaginary part carries no suffix and agrees with anything.
+    /// </summary>
+    private static bool TryAgreeOnSuffix(in ComplexNumber a, in ComplexNumber b, out char suffix)
+    {
+        suffix = ComplexNumber.DefaultSuffix;
+        var first = a.Imaginary == 0 ? default : a.Suffix;
+        var second = b.Imaginary == 0 ? default : b.Suffix;
+
+        if (first != default && second != default && first != second)
+            return false;
+
+        if (first != default)
+            suffix = first;
+        else if (second != default)
+            suffix = second;
+
+        return true;
+    }
+
+    private static bool TryTakeSuffix(ref char suffix, in ComplexNumber z)
+    {
+        if (z.Imaginary == 0)
+            return true;
+
+        if (suffix == default)
+        {
+            suffix = z.Suffix;
+            return true;
+        }
+
+        return suffix == z.Suffix;
+    }
+
+    private static ComplexNumber Scale(in ComplexNumber z, double factor)
+        => new(z.Real * factor, z.Imaginary * factor, z.Suffix);
+
+    #endregion
 
     /// <summary>
     /// Parse a string as a number in the given base. Returns the signed value using two's complement

--- a/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -966,6 +966,68 @@ internal static class SignatureAdapter
         };
     }
 
+    public static CalcEngineFunction Adapt(Func<CalcContext, double, string, string, ScalarValue> f)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = ToText(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            var arg2Converted = ToText(args[2], ctx);
+            if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                return err2;
+
+            return f(ctx, arg0, arg1, arg2).ToAnyValue();
+        };
+    }
+
+    public static CalcEngineFunction AdaptLastOptional(Func<CalcContext, double, double, string, ScalarValue> f, string lastDefault)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = ToNumber(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            var arg2 = lastDefault;
+            if (args.Length > 2 && !ToText(args[2], ctx).TryPickT0(out arg2, out var err2))
+                return err2;
+
+            return f(ctx, arg0, arg1, arg2).ToAnyValue();
+        };
+    }
+
+    /// <summary>Two numbers where the second is genuinely optional — the callee is told whether it was supplied.</summary>
+    public static CalcEngineFunction AdaptLastOptional(Func<CalcContext, double, double?, ScalarValue> f)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            double? arg1 = null;
+            if (args.Length > 1)
+            {
+                if (!ToNumber(args[1], ctx).TryPickT0(out var supplied, out var err1))
+                    return err1;
+
+                arg1 = supplied;
+            }
+
+            return f(ctx, arg0, arg1).ToAnyValue();
+        };
+    }
+
     public static CalcEngineFunction AdaptLastTwoOptional(Func<CalcContext, double, double, double, double, double, double, bool, ScalarValue> f, double defaultValue0, bool defaultValue1)
     {
         return (ctx, args) =>

--- a/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -935,7 +935,9 @@ internal static class SignatureAdapter
             if (!arg5Converted.TryPickT0(out var arg5, out var err5))
                 return err5;
 
+#pragma warning disable S2234 // Adapter forwards positionally; the delegate names its own parameters
             return f(ctx, arg0, arg1, arg2, arg3, arg4, arg5).ToAnyValue();
+#pragma warning restore S2234
         };
     }
 
@@ -962,7 +964,9 @@ internal static class SignatureAdapter
             if (!ToOptionalNumber(args, 4, lastDefault, ctx).TryPickT0(out var arg4, out var err4))
                 return err4;
 
+#pragma warning disable S2234 // Adapter forwards positionally; the delegate names its own parameters
             return f(ctx, arg0, arg1, arg2, arg3, arg4).ToAnyValue();
+#pragma warning restore S2234
         };
     }
 
@@ -1059,7 +1063,9 @@ internal static class SignatureAdapter
             if (args.Length > 6 && !CoerceToLogical(args[6], ctx).TryPickT0(out arg6, out var err6))
                 return err6;
 
+#pragma warning disable S2234 // Adapter forwards positionally; the delegate names its own parameters
             return f(ctx, arg0, arg1, arg2, arg3, arg4, arg5, arg6).ToAnyValue();
+#pragma warning restore S2234
         };
     }
 

--- a/XLibur/Excel/CalcEngine/Functions/UnitConversion.cs
+++ b/XLibur/Excel/CalcEngine/Functions/UnitConversion.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections.Generic;
+
+namespace XLibur.Excel.CalcEngine.Functions;
+
+/// <summary>
+/// The unit table behind CONVERT. Every unit is stored as a factor to its measure's base unit, so a
+/// conversion is a multiply and a divide; temperature is the exception, being affine rather than
+/// proportional, and is handled separately.
+/// <para>
+/// Unit names are case sensitive, deliberately: Excel distinguishes "Pica" (a point, 1/72 inch)
+/// from "pica" (1/6 inch), and "T" (tesla) from "t" — and the metric prefixes need the same
+/// distinction to tell milli from mega.
+/// </para>
+/// </summary>
+internal static class UnitConversion
+{
+    private enum Measure
+    {
+        Mass,
+        Distance,
+        Time,
+        Pressure,
+        Force,
+        Energy,
+        Power,
+        Magnetism,
+        Temperature,
+        Volume,
+        Area,
+        Information,
+        Speed,
+    }
+
+    /// <param name="Measure">Which units this one can be converted to.</param>
+    /// <param name="ToBase">Multiplier that takes a value in this unit to the measure's base unit.</param>
+    /// <param name="Prefixes">Which families of prefix the unit accepts.</param>
+    private readonly record struct Unit(Measure Measure, double ToBase, PrefixKind Prefixes);
+
+    [Flags]
+    private enum PrefixKind
+    {
+        None = 0,
+        Metric = 1,
+        Binary = 2,
+    }
+
+    private const double Inch = 0.0254;
+    private const double Foot = 12 * Inch;
+    private const double Yard = 36 * Inch;
+    private const double Mile = 5280 * Foot;
+    private const double NauticalMile = 1852;
+    private const double LightYear = 9460730472580800d;
+    private const double Parsec = 30856775814913672.789139379577965; // 648000/π AU.
+    private const double Pound = 453.59237;
+    private const double Gallon = 3.785411784; // Litres.
+    private const double Atmosphere = 101325;
+
+    /// <summary>
+    /// Metric prefixes. "e" is deka rather than an SI symbol — Excel's spelling, kept for
+    /// compatibility — and both "u" and "µ" are accepted for micro.
+    /// </summary>
+    private static readonly Dictionary<string, double> MetricPrefixes = new(StringComparer.Ordinal)
+    {
+        ["Y"] = 1e24,
+        ["Z"] = 1e21,
+        ["E"] = 1e18,
+        ["P"] = 1e15,
+        ["T"] = 1e12,
+        ["G"] = 1e9,
+        ["M"] = 1e6,
+        ["k"] = 1e3,
+        ["h"] = 1e2,
+        ["da"] = 1e1,
+        ["e"] = 1e1,
+        ["d"] = 1e-1,
+        ["c"] = 1e-2,
+        ["m"] = 1e-3,
+        ["u"] = 1e-6,
+        ["µ"] = 1e-6,
+        ["n"] = 1e-9,
+        ["p"] = 1e-12,
+        ["f"] = 1e-15,
+        ["a"] = 1e-18,
+        ["z"] = 1e-21,
+        ["y"] = 1e-24,
+    };
+
+    /// <summary>Binary prefixes, which Excel allows only on the information units.</summary>
+    private static readonly Dictionary<string, double> BinaryPrefixes = new(StringComparer.Ordinal)
+    {
+        ["Yi"] = 1024d * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+        ["Zi"] = 1024d * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+        ["Ei"] = 1024d * 1024 * 1024 * 1024 * 1024 * 1024,
+        ["Pi"] = 1024d * 1024 * 1024 * 1024 * 1024,
+        ["Ti"] = 1024d * 1024 * 1024 * 1024,
+        ["Gi"] = 1024d * 1024 * 1024,
+        ["Mi"] = 1024d * 1024,
+        ["ki"] = 1024d,
+    };
+
+    private static readonly Dictionary<string, Unit> Units = BuildUnits();
+
+    /// <summary>
+    /// Convert <paramref name="value"/> from one unit to another. Returns false when either unit is
+    /// unknown or when the two measure different things, which is #N/A in Excel.
+    /// </summary>
+    internal static bool TryConvert(double value, string fromUnit, string toUnit, out double result)
+    {
+        result = 0;
+        if (!TryResolve(fromUnit, out var from, out var fromFactor) ||
+            !TryResolve(toUnit, out var to, out var toFactor))
+        {
+            return false;
+        }
+
+        if (from.Measure != to.Measure)
+            return false;
+
+        if (from.Measure == Measure.Temperature)
+        {
+            // A temperature scale has an offset as well as a step, so the prefixes that scale every
+            // other measure have no meaning here and are not accepted.
+            result = FromCelsius(ToCelsius(value, fromUnit), toUnit);
+            return true;
+        }
+
+        result = value * (from.ToBase * fromFactor) / (to.ToBase * toFactor);
+        return true;
+    }
+
+    /// <summary>
+    /// Look a unit name up, falling back to splitting a prefix off the front. The exact name always
+    /// wins, which is what stops "m" (metre) being read as milli-nothing and "T" (tesla) as tera.
+    /// </summary>
+    private static bool TryResolve(string name, out Unit unit, out double prefixFactor)
+    {
+        prefixFactor = 1;
+        if (Units.TryGetValue(name, out unit))
+            return true;
+
+        // Longest prefix first, so "da" is preferred over "d" and "ki" over "k".
+        for (var length = 2; length >= 1; length--)
+        {
+            if (name.Length <= length)
+                continue;
+
+            var prefix = name[..length];
+            var rest = name[length..];
+            if (!Units.TryGetValue(rest, out var candidate))
+                continue;
+
+            if (candidate.Prefixes.HasFlag(PrefixKind.Binary) && BinaryPrefixes.TryGetValue(prefix, out var binary))
+            {
+                unit = candidate;
+                prefixFactor = binary;
+                return true;
+            }
+
+            if (candidate.Prefixes.HasFlag(PrefixKind.Metric) && MetricPrefixes.TryGetValue(prefix, out var metric))
+            {
+                unit = candidate;
+                prefixFactor = metric;
+                return true;
+            }
+        }
+
+        unit = default;
+        return false;
+    }
+
+    private static double ToCelsius(double value, string unit) => unit switch
+    {
+        "C" or "cel" => value,
+        "F" or "fah" => (value - 32) * 5 / 9,
+        "K" or "kel" => value - 273.15,
+        "Rank" => (value - 491.67) * 5 / 9,
+        _ => value * 5 / 4, // Réaumur.
+    };
+
+    private static double FromCelsius(double celsius, string unit) => unit switch
+    {
+        "C" or "cel" => celsius,
+        "F" or "fah" => celsius * 9 / 5 + 32,
+        "K" or "kel" => celsius + 273.15,
+        "Rank" => (celsius + 273.15) * 9 / 5,
+        _ => celsius * 4 / 5, // Réaumur.
+    };
+
+    private static Dictionary<string, Unit> BuildUnits()
+    {
+        var units = new Dictionary<string, Unit>(StringComparer.Ordinal);
+
+        void Add(Measure measure, double toBase, PrefixKind prefixes, params string[] names)
+        {
+            foreach (var name in names)
+                units[name] = new Unit(measure, toBase, prefixes);
+        }
+
+        // Mass — base gram.
+        Add(Measure.Mass, 1, PrefixKind.Metric, "g");
+        Add(Measure.Mass, 14593.9029372064, PrefixKind.None, "sg");
+        Add(Measure.Mass, Pound, PrefixKind.None, "lbm");
+        Add(Measure.Mass, 1.66053886e-24, PrefixKind.Metric, "u");
+        Add(Measure.Mass, Pound / 16, PrefixKind.None, "ozm");
+        Add(Measure.Mass, Pound / 7000, PrefixKind.None, "grain");
+        Add(Measure.Mass, Pound * 100, PrefixKind.None, "cwt", "shweight");
+        Add(Measure.Mass, Pound * 112, PrefixKind.None, "uk_cwt", "lcwt", "hweight");
+        Add(Measure.Mass, Pound * 14, PrefixKind.None, "stone");
+        Add(Measure.Mass, Pound * 2000, PrefixKind.None, "ton");
+        Add(Measure.Mass, Pound * 2240, PrefixKind.None, "uk_ton", "LTON", "brton");
+
+        // Distance — base metre.
+        Add(Measure.Distance, 1, PrefixKind.Metric, "m");
+        Add(Measure.Distance, Mile, PrefixKind.None, "mi");
+        Add(Measure.Distance, NauticalMile, PrefixKind.None, "Nmi");
+        Add(Measure.Distance, Inch, PrefixKind.None, "in");
+        Add(Measure.Distance, Foot, PrefixKind.None, "ft");
+        Add(Measure.Distance, Yard, PrefixKind.None, "yd");
+        Add(Measure.Distance, 1e-10, PrefixKind.Metric, "ang");
+        Add(Measure.Distance, 1.143, PrefixKind.None, "ell");
+        Add(Measure.Distance, LightYear, PrefixKind.None, "ly");
+        Add(Measure.Distance, Parsec, PrefixKind.None, "parsec", "pc");
+        Add(Measure.Distance, Inch / 72, PrefixKind.None, "Picapt", "Pica");
+        Add(Measure.Distance, Inch / 6, PrefixKind.None, "pica");
+        Add(Measure.Distance, 1609.347218694437, PrefixKind.None, "survey_mi");
+
+        // Time — base second.
+        Add(Measure.Time, 31557600, PrefixKind.None, "yr");
+        Add(Measure.Time, 86400, PrefixKind.None, "day", "d");
+        Add(Measure.Time, 3600, PrefixKind.None, "hr");
+        Add(Measure.Time, 60, PrefixKind.None, "mn", "min");
+        Add(Measure.Time, 1, PrefixKind.Metric, "sec", "s");
+
+        // Pressure — base pascal. Excel treats mmHg and torr as the same unit, 1/760 atm.
+        Add(Measure.Pressure, 1, PrefixKind.Metric, "Pa", "p");
+        Add(Measure.Pressure, Atmosphere, PrefixKind.Metric, "atm", "at");
+        Add(Measure.Pressure, Atmosphere / 760, PrefixKind.Metric, "mmHg", "Torr");
+        Add(Measure.Pressure, 6894.75729316836, PrefixKind.None, "psi");
+
+        // Force — base newton.
+        Add(Measure.Force, 1, PrefixKind.Metric, "N");
+        Add(Measure.Force, 1e-5, PrefixKind.Metric, "dyn", "dy");
+        Add(Measure.Force, 4.4482216152605, PrefixKind.None, "lbf");
+        Add(Measure.Force, 9.80665e-3, PrefixKind.Metric, "pond");
+
+        // Energy — base joule.
+        Add(Measure.Energy, 1, PrefixKind.Metric, "J");
+        Add(Measure.Energy, 1e-7, PrefixKind.Metric, "e");
+        Add(Measure.Energy, 4.184, PrefixKind.Metric, "c");
+        Add(Measure.Energy, 4.1868, PrefixKind.Metric, "cal");
+        Add(Measure.Energy, 1.60217646e-19, PrefixKind.Metric, "eV", "ev");
+        Add(Measure.Energy, 2684519.53769617, PrefixKind.None, "HPh", "hh");
+        Add(Measure.Energy, 3600, PrefixKind.Metric, "Wh", "wh");
+        Add(Measure.Energy, 1.3558179483314, PrefixKind.None, "flb");
+        Add(Measure.Energy, 1055.05585262, PrefixKind.None, "BTU", "btu");
+
+        // Power — base watt.
+        Add(Measure.Power, 745.69987158227, PrefixKind.None, "HP", "h");
+        Add(Measure.Power, 735.49875, PrefixKind.None, "PS");
+        Add(Measure.Power, 1, PrefixKind.Metric, "W", "w");
+
+        // Magnetism — base tesla.
+        Add(Measure.Magnetism, 1, PrefixKind.Metric, "T");
+        Add(Measure.Magnetism, 1e-4, PrefixKind.Metric, "ga");
+
+        // Temperature — the factor is unused; the conversion is affine.
+        Add(Measure.Temperature, 1, PrefixKind.None, "C", "cel", "F", "fah", "K", "kel", "Rank", "Reau");
+
+        // Volume — base litre.
+        Add(Measure.Volume, Gallon / 768, PrefixKind.None, "tsp");
+        Add(Measure.Volume, 5e-3, PrefixKind.None, "tspm");
+        Add(Measure.Volume, Gallon / 256, PrefixKind.None, "tbs");
+        Add(Measure.Volume, Gallon / 128, PrefixKind.None, "oz");
+        Add(Measure.Volume, Gallon / 16, PrefixKind.None, "cup");
+        Add(Measure.Volume, Gallon / 8, PrefixKind.None, "pt", "us_pt");
+        Add(Measure.Volume, 4.54609 / 8, PrefixKind.None, "uk_pt");
+        Add(Measure.Volume, Gallon / 4, PrefixKind.None, "qt");
+        Add(Measure.Volume, 4.54609 / 4, PrefixKind.None, "uk_qt");
+        Add(Measure.Volume, Gallon, PrefixKind.None, "gal");
+        Add(Measure.Volume, 4.54609, PrefixKind.None, "uk_gal");
+        Add(Measure.Volume, 1, PrefixKind.Metric, "l", "L", "lt");
+        Add(Measure.Volume, 1e-27, PrefixKind.None, "ang3", "ang^3");
+        Add(Measure.Volume, 158.987294928, PrefixKind.None, "barrel");
+        Add(Measure.Volume, 35.23907016688, PrefixKind.None, "bushel");
+        Add(Measure.Volume, Cube(Foot) * 1000, PrefixKind.None, "ft3", "ft^3");
+        Add(Measure.Volume, Cube(Inch) * 1000, PrefixKind.None, "in3", "in^3");
+        Add(Measure.Volume, Cube(LightYear) * 1000, PrefixKind.None, "ly3", "ly^3");
+        Add(Measure.Volume, 1000, PrefixKind.None, "m3", "m^3");
+        Add(Measure.Volume, Cube(Mile) * 1000, PrefixKind.None, "mi3", "mi^3");
+        Add(Measure.Volume, Cube(Yard) * 1000, PrefixKind.None, "yd3", "yd^3");
+        Add(Measure.Volume, Cube(NauticalMile) * 1000, PrefixKind.None, "Nmi3", "Nmi^3");
+        Add(Measure.Volume, Cube(Inch / 72) * 1000, PrefixKind.None, "Picapt3", "Picapt^3", "Pica3", "Pica^3");
+        Add(Measure.Volume, 2831.6846592, PrefixKind.None, "GRT", "regton");
+        Add(Measure.Volume, 1132.67386368, PrefixKind.None, "MTON");
+
+        // Area — base square metre.
+        Add(Measure.Area, 4046.8564224, PrefixKind.None, "uk_acre");
+        Add(Measure.Area, 4046.87260987425, PrefixKind.None, "us_acre");
+        Add(Measure.Area, 1e-20, PrefixKind.None, "ang2", "ang^2");
+        Add(Measure.Area, 100, PrefixKind.None, "ar");
+        Add(Measure.Area, Square(Foot), PrefixKind.None, "ft2", "ft^2");
+        Add(Measure.Area, 10000, PrefixKind.None, "ha");
+        Add(Measure.Area, Square(Inch), PrefixKind.None, "in2", "in^2");
+        Add(Measure.Area, Square(LightYear), PrefixKind.None, "ly2", "ly^2");
+        Add(Measure.Area, 1, PrefixKind.None, "m2", "m^2");
+        Add(Measure.Area, 2500, PrefixKind.None, "Morgen");
+        Add(Measure.Area, Square(Mile), PrefixKind.None, "mi2", "mi^2");
+        Add(Measure.Area, Square(NauticalMile), PrefixKind.None, "Nmi2", "Nmi^2");
+        Add(Measure.Area, Square(Inch / 72), PrefixKind.None, "Picapt2", "Picapt^2", "Pica2", "Pica^2");
+        Add(Measure.Area, Square(Yard), PrefixKind.None, "yd2", "yd^2");
+
+        // Information — base bit; these are the only units that take a binary prefix.
+        Add(Measure.Information, 1, PrefixKind.Metric | PrefixKind.Binary, "bit");
+        Add(Measure.Information, 8, PrefixKind.Metric | PrefixKind.Binary, "byte");
+
+        // Speed — base metre per second.
+        Add(Measure.Speed, 0.514773333333333, PrefixKind.None, "admkn");
+        Add(Measure.Speed, NauticalMile / 3600, PrefixKind.None, "kn");
+        Add(Measure.Speed, 1 / 3600d, PrefixKind.Metric, "m/h", "m/hr");
+        Add(Measure.Speed, 1, PrefixKind.Metric, "m/s", "m/sec");
+        Add(Measure.Speed, Mile / 3600, PrefixKind.None, "mph");
+
+        return units;
+    }
+
+    private static double Square(double value) => value * value;
+
+    private static double Cube(double value) => value * value * value;
+}

--- a/XLibur/Excel/CalcEngine/Functions/XLMath.cs
+++ b/XLibur/Excel/CalcEngine/Functions/XLMath.cs
@@ -222,6 +222,117 @@ public static class XLMath
     }
 
     /// <summary>
+    /// Regularized lower incomplete gamma function P(a, x) = γ(a, x) / Γ(a). Evaluated by its power
+    /// series below the transition point and as 1 − Q(a, x) above it, where each is convergent.
+    /// </summary>
+    internal static double GammaP(double a, double x)
+    {
+        if (x <= 0 || a <= 0)
+            return 0;
+
+        if (x < a + 1.0)
+            return GammaSeries(a, x);
+
+        return 1.0 - GammaContinuedFraction(a, x);
+    }
+
+    /// <summary>
+    /// Regularized upper incomplete gamma function Q(a, x) = Γ(a, x) / Γ(a), the complement of
+    /// <see cref="GammaP"/>. Computed directly in the tail so that small values keep their precision.
+    /// </summary>
+    internal static double GammaQ(double a, double x)
+    {
+        if (x <= 0 || a <= 0)
+            return 1;
+
+        if (x < a + 1.0)
+            return 1.0 - GammaSeries(a, x);
+
+        return GammaContinuedFraction(a, x);
+    }
+
+    /// <summary>Power series for P(a, x), convergent for x below roughly a + 1.</summary>
+    private static double GammaSeries(double a, double x)
+    {
+        const int maxIterations = 300;
+        const double epsilon = 1e-16;
+
+        var term = 1.0 / a;
+        var sum = term;
+        for (var n = 1; n <= maxIterations; n++)
+        {
+            term *= x / (a + n);
+            sum += term;
+            if (Math.Abs(term) < Math.Abs(sum) * epsilon)
+                break;
+        }
+
+        return sum * Math.Exp(-x + a * Math.Log(x) - LnGamma(a));
+    }
+
+    /// <summary>Continued fraction for Q(a, x) (Lentz's method), convergent for x above roughly a + 1.</summary>
+    private static double GammaContinuedFraction(double a, double x)
+    {
+        const int maxIterations = 300;
+        const double epsilon = 1e-16;
+        const double tiny = 1e-300;
+
+        var b = x + 1.0 - a;
+        var c = 1.0 / tiny;
+        var d = 1.0 / b;
+        var h = d;
+
+        for (var i = 1; i <= maxIterations; i++)
+        {
+            var an = -i * (i - a);
+            b += 2.0;
+
+            d = an * d + b;
+            if (Math.Abs(d) < tiny) d = tiny;
+
+            c = b + an / c;
+            if (Math.Abs(c) < tiny) c = tiny;
+
+            d = 1.0 / d;
+            var delta = d * c;
+            h *= delta;
+
+            if (Math.Abs(delta - 1.0) < epsilon)
+                break;
+        }
+
+        return h * Math.Exp(-x + a * Math.Log(x) - LnGamma(a));
+    }
+
+    /// <summary>
+    /// Error function erf(x), expressed through the regularized incomplete gamma function:
+    /// erf(x) = sign(x) · P(1/2, x²).
+    /// </summary>
+    internal static double Erf(double x)
+    {
+        if (x == 0)
+            return 0;
+
+        var p = GammaP(0.5, x * x);
+        return x < 0 ? -p : p;
+    }
+
+    /// <summary>
+    /// Complementary error function erfc(x) = 1 − erf(x). The positive tail is taken from Q(1/2, x²)
+    /// directly rather than by subtraction, which would lose every significant digit for large x.
+    /// </summary>
+    internal static double Erfc(double x)
+    {
+        if (x == 0)
+            return 1;
+
+        if (x > 0)
+            return GammaQ(0.5, x * x);
+
+        return 1.0 + GammaP(0.5, x * x);
+    }
+
+    /// <summary>
     /// Regularized incomplete beta function I_x(a, b) using the continued fraction expansion.
     /// </summary>
     internal static double BetaRegularized(double x, double a, double b)


### PR DESCRIPTION
Wave D of [spec 07](docs/specs/07-formula-function-coverage.md). Stacked on #252 — **targets `feat/calc-wave-a-financial`**, retarget to `main` once that merges.

## Functions added (42)

| Group | Functions |
|---|---|
| Complex numbers | `COMPLEX` and all 26 `IM*` functions |
| Unit conversion | `CONVERT` (full unit table) |
| Bessel | `BESSELI`, `BESSELJ`, `BESSELK`, `BESSELY` |
| Error function | `ERF`, `ERF.PRECISE`, `ERFC`, `ERFC.PRECISE` |
| Comparison | `DELTA`, `GESTEP` |
| Bitwise | `BITAND`, `BITOR`, `BITXOR`, `BITLSHIFT`, `BITRSHIFT` |

Registry: 281 → 323 functions.

## Notes on the implementation

**Complex numbers are text in Excel** — there is no complex value type, `"3+4i"` is a string. `ComplexNumber` owns the parse and the render, including the suffix, which Excel echoes back and refuses to mix between `i` and `j`. Components are written with 15 significant digits: that is what Excel does, and it is also what makes `IMSQRT("3+4i")` come out as `"2+i"` rather than exposing the last-bit noise of the polar identity.

**`UnitConversion`** stores each unit as a factor to its measure's base, so a conversion is a multiply and a divide. Temperature is affine and is handled separately — and takes no prefixes as a result, since a scale with an offset has no meaningful "milli". Unit names are case sensitive because Excel's are: `Pica` is a point, `pica` is six to the inch.

**`Bessel`** uses the Abramowitz & Stegun order-0/1 approximations and reaches higher orders by recurrence — downwards with Miller normalisation for `J` and `I`, upwards for the dominant `Y` and `K`. The origin is returned exactly rather than through the approximation, which is only good to ~3e-9 there.

**`XLMath` gains `GammaP`/`GammaQ` and `Erf`/`Erfc`** built on them. `Erfc` takes the positive tail from `Q` directly instead of subtracting from one, which would lose every significant digit past x = 6 — there's a test at `ERFC(6) = 2.15e-17`. Wave B reuses all four.

## Verification

252 tests, all passing; full suite green on net8.0 and net10.0; Release build clean.

The Bessel tests lean on the Wronskian identities and the recurrence relations rather than tabulated values — they hold exactly, so they need no external reference, and they're evaluated at three arguments chosen to sit either side of each approximation's crossover. Bessel.cs is at 99% block coverage.

The complex trigonometry is compared component by component rather than as text: the last of the 15 digits Excel prints is at the mercy of how the identity is grouped, and a one-ulp difference there says nothing about correctness.
