### PR TITLE
feat(calc): add modern text and array-shaping functions (spec 07 wave E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 
 #### Formula functions
 
+- **20 modern text and array-shaping functions**: `TEXTSPLIT`, `TEXTBEFORE`, `TEXTAFTER`, `VALUETOTEXT`, `ARRAYTOTEXT`, `UNICHAR`, `UNICODE`, `DBCS`, `ENCODEURL`, and the array-shaping set `VSTACK`, `HSTACK`, `TOROW`, `TOCOL`, `WRAPROWS`, `WRAPCOLS`, `CHOOSEROWS`, `CHOOSECOLS`, `TAKE`, `DROP`, `EXPAND`. The array-shaping functions and `TEXTSPLIT` spill.
+
+  `DBCS` derives its mapping by inverting `ASC`'s, so the two are exact inverses. Where Excel would report `#CALC!` — a `DROP` that leaves nothing, a `TOCOL` that ignores every value — XLibur reports `#VALUE!` instead, because the value model has no `#CALC!`. ([#254](https://github.com/XLibur/XLibur/pull/254) by [@jafin](https://github.com/jafin))
+
 - **42 engineering functions**: the complex-number family (`COMPLEX` and all 26 `IM*` functions), `CONVERT` with the full unit table, `BESSELI`/`BESSELJ`/`BESSELK`/`BESSELY`, `ERF`/`ERF.PRECISE`/`ERFC`/`ERFC.PRECISE`, `DELTA`, `GESTEP` and the bitwise set (`BITAND`, `BITOR`, `BITXOR`, `BITLSHIFT`, `BITRSHIFT`).
 
   A complex number in Excel is text, so the `IM*` functions parse `"3+4i"` and write their result back the same way — echoing whichever of `i` or `j` the input used, and refusing to mix the two. `CONVERT` unit names are case sensitive, as Excel's are: `Pica` is a point and `pica` is six to the inch. Prefixes are accepted on metric units, binary prefixes on `bit` and `byte` only, and on no temperature unit — a scale with an offset has no meaningful "milli". ([#253](https://github.com/XLibur/XLibur/pull/253) by [@jafin](https://github.com/jafin))

--- a/XLibur.Tests/Excel/CalcEngine/ArrayShapingTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayShapingTests.cs
@@ -1,0 +1,465 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// The array-shaping functions: VSTACK, HSTACK, TOROW, TOCOL, WRAPROWS, WRAPCOLS, CHOOSEROWS,
+/// CHOOSECOLS, TAKE, DROP and EXPAND. They are pure array-to-array transforms, so most of these
+/// tests enter the formula as an array formula over the target range and read back the grid.
+/// </summary>
+[SetCulture("en-US")]
+public class ArrayShapingTests
+{
+    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    {
+        wb = new XLWorkbook();
+        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+    }
+
+    /// <summary>Fill A1:C2 with 1..6 read left to right, top to bottom.</summary>
+    private static void SeedGrid(XLWorksheet ws)
+    {
+        var value = 1;
+        for (var row = 1; row <= 2; row++)
+        {
+            for (var column = 1; column <= 3; column++)
+                ws.Cell(row, column).Value = value++;
+        }
+    }
+
+    [Test]
+    public async Task VStack_AppendsArraysOneBelowAnother()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("E1:F4").FormulaArrayA1 = "VSTACK({1,2;3,4}, {5,6;7,8})";
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("F2").Value).IsEqualTo(4d);
+            await Assert.That((double)ws.Cell("E3").Value).IsEqualTo(5d);
+            await Assert.That((double)ws.Cell("F4").Value).IsEqualTo(8d);
+        }
+    }
+
+    [Test]
+    public async Task VStack_PadsNarrowerArgumentsWithNoValueAvailable()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("E1:F3").FormulaArrayA1 = "VSTACK({1,2}, {3}, {4,5})";
+
+            await Assert.That((double)ws.Cell("E2").Value).IsEqualTo(3d);
+            await Assert.That(ws.Cell("F2").Value).IsEqualTo(XLError.NoValueAvailable);
+            await Assert.That((double)ws.Cell("F3").Value).IsEqualTo(5d);
+        }
+    }
+
+    [Test]
+    public async Task HStack_AppendsArraysSideBySide()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("E1:H2").FormulaArrayA1 = "HSTACK({1;3}, {2;4}, {5;6}, {7;8})";
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("F1").Value).IsEqualTo(2d);
+            await Assert.That((double)ws.Cell("H2").Value).IsEqualTo(8d);
+        }
+    }
+
+    [Test]
+    public async Task HStack_PadsShorterArgumentsWithNoValueAvailable()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("E1:F2").FormulaArrayA1 = "HSTACK({1;2}, {3})";
+
+            await Assert.That((double)ws.Cell("F1").Value).IsEqualTo(3d);
+            await Assert.That(ws.Cell("F2").Value).IsEqualTo(XLError.NoValueAvailable);
+        }
+    }
+
+    [Test]
+    public async Task ToRow_ReadsTheGridLeftToRightByDefault()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:J1").FormulaArrayA1 = "TOROW(A1:C2)";
+
+            for (var i = 0; i < 6; i++)
+                await Assert.That((double)ws.Cell(1, 5 + i).Value).IsEqualTo(i + 1d);
+        }
+    }
+
+    [Test]
+    public async Task ToRow_ScansByColumnWhenAsked()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:J1").FormulaArrayA1 = "TOROW(A1:C2, 0, TRUE)";
+
+            // Column order over 1 2 3 / 4 5 6 is 1 4 2 5 3 6.
+            var expected = new[] { 1d, 4d, 2d, 5d, 3d, 6d };
+            for (var i = 0; i < expected.Length; i++)
+                await Assert.That((double)ws.Cell(1, 5 + i).Value).IsEqualTo(expected[i]);
+        }
+    }
+
+    [Test]
+    public async Task ToCol_ReadsTheGridIntoASingleColumn()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:E6").FormulaArrayA1 = "TOCOL(A1:C2)";
+
+            for (var i = 0; i < 6; i++)
+                await Assert.That((double)ws.Cell(1 + i, 5).Value).IsEqualTo(i + 1d);
+        }
+    }
+
+    [Test]
+    public async Task ToCol_IgnoresBlanksAndErrorsOnRequest()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            // A2 left blank.
+            ws.Cell("A3").FormulaA1 = "1/0";
+            ws.Cell("A4").Value = 2;
+
+            ws.Range("C1:C4").FormulaArrayA1 = "TOCOL(A1:A4, 1)"; // Ignore blanks.
+            ws.Range("D1:D4").FormulaArrayA1 = "TOCOL(A1:A4, 2)"; // Ignore errors.
+            ws.Range("E1:E4").FormulaArrayA1 = "TOCOL(A1:A4, 3)"; // Ignore both.
+
+            await Assert.That(ws.Cell("C2").Value).IsEqualTo(XLError.DivisionByZero);
+            await Assert.That((double)ws.Cell("D2").Value).IsEqualTo(0d); // The blank survives as an empty value.
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("E2").Value).IsEqualTo(2d);
+            await Assert.That(ws.Cell("E3").Value).IsEqualTo(XLError.NoValueAvailable); // Past the end of the result.
+        }
+    }
+
+    [Test]
+    public async Task ToCol_WithEverythingIgnoredReturnsAnError()
+    {
+        // Excel reports #CALC! here; XLibur has no such error value and reports #VALUE!.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "1/0";
+            ws.Cell("C1").FormulaA1 = "TOCOL(A1:A2, 3)";
+
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.IncompatibleValue);
+        }
+    }
+
+    [Test]
+    public async Task WrapRows_CutsAVectorIntoRows()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("E1:F3").FormulaArrayA1 = "WRAPROWS({1,2,3,4,5}, 2)";
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("F1").Value).IsEqualTo(2d);
+            await Assert.That((double)ws.Cell("E3").Value).IsEqualTo(5d);
+            await Assert.That(ws.Cell("F3").Value).IsEqualTo(XLError.NoValueAvailable); // The short last row.
+        }
+    }
+
+    [Test]
+    public async Task WrapRows_PadsWithTheGivenValue()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("E1:F3").FormulaArrayA1 = "WRAPROWS({1,2,3,4,5}, 2, \"-\")";
+
+            await Assert.That(ws.Cell("F3").Value).IsEqualTo("-");
+        }
+    }
+
+    [Test]
+    public async Task WrapCols_CutsAVectorIntoColumns()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("E1:G2").FormulaArrayA1 = "WRAPCOLS({1,2,3,4,5}, 2)";
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("E2").Value).IsEqualTo(2d);
+            await Assert.That((double)ws.Cell("F1").Value).IsEqualTo(3d);
+            await Assert.That((double)ws.Cell("G1").Value).IsEqualTo(5d);
+            await Assert.That(ws.Cell("G2").Value).IsEqualTo(XLError.NoValueAvailable);
+        }
+    }
+
+    [Test]
+    public async Task Wrap_RejectsARectangleAndANonPositiveCount()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Cell("E1").FormulaA1 = "WRAPROWS(A1:C2, 2)";
+            ws.Cell("E2").FormulaA1 = "WRAPROWS({1,2,3}, 0)";
+
+            await Assert.That(ws.Cell("E1").Value).IsEqualTo(XLError.IncompatibleValue);
+            await Assert.That(ws.Cell("E2").Value).IsEqualTo(XLError.NumberInvalid);
+        }
+    }
+
+    [Test]
+    public async Task ChooseRows_PicksRowsInTheOrderAsked()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:G3").FormulaArrayA1 = "CHOOSEROWS(A1:C2, 2, 1, 2)";
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(4d);
+            await Assert.That((double)ws.Cell("E2").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("G3").Value).IsEqualTo(6d); // Repeats are allowed.
+        }
+    }
+
+    [Test]
+    public async Task ChooseRows_CountsBackFromTheEndForNegativeIndices()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:G1").FormulaArrayA1 = "CHOOSEROWS(A1:C2, -1)";
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(4d);
+        }
+    }
+
+    [Test]
+    public async Task ChooseCols_PicksColumns()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:F2").FormulaArrayA1 = "CHOOSECOLS(A1:C2, 3, 1)";
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(3d);
+            await Assert.That((double)ws.Cell("F1").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("E2").Value).IsEqualTo(6d);
+        }
+    }
+
+    [Test]
+    public async Task ChooseRows_AcceptsAnArrayOfIndices()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:G2").FormulaArrayA1 = "CHOOSEROWS(A1:C2, {2,1})";
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(4d);
+            await Assert.That((double)ws.Cell("E2").Value).IsEqualTo(1d);
+        }
+    }
+
+    [Test]
+    [Arguments("CHOOSEROWS(A1:C2, 0)")] // Rows are one-based.
+    [Arguments("CHOOSEROWS(A1:C2, 3)")]
+    [Arguments("CHOOSEROWS(A1:C2, -3)")]
+    [Arguments("CHOOSECOLS(A1:C2, 4)")]
+    public async Task Choose_OutOfRangeIndicesReturnIncompatibleValue(string formula)
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Cell("E1").FormulaA1 = formula;
+
+            await Assert.That(ws.Cell("E1").Value).IsEqualTo(XLError.IncompatibleValue);
+        }
+    }
+
+    [Test]
+    public async Task Take_KeepsFromTheStartAndTheEnd()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:F1").FormulaArrayA1 = "TAKE(A1:C2, 1, 2)"; // First row, first two columns.
+            ws.Range("E3:F3").FormulaArrayA1 = "TAKE(A1:C2, -1, -2)"; // Last row, last two columns.
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("F1").Value).IsEqualTo(2d);
+            await Assert.That((double)ws.Cell("E3").Value).IsEqualTo(5d);
+            await Assert.That((double)ws.Cell("F3").Value).IsEqualTo(6d);
+        }
+    }
+
+    [Test]
+    public async Task Take_LeavesAnAxisAloneWhenItsCountIsOmitted()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:G1").FormulaArrayA1 = "TAKE(A1:C2, 1)"; // All three columns kept.
+            ws.Range("E3:E4").FormulaArrayA1 = "TAKE(A1:C2, , 1)"; // Both rows kept.
+
+            await Assert.That((double)ws.Cell("G1").Value).IsEqualTo(3d);
+            await Assert.That((double)ws.Cell("E3").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("E4").Value).IsEqualTo(4d);
+        }
+    }
+
+    [Test]
+    public async Task Drop_DiscardsFromTheStartAndTheEnd()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:G1").FormulaArrayA1 = "DROP(A1:C2, 1)"; // Drop the first row.
+            ws.Range("E3:F4").FormulaArrayA1 = "DROP(A1:C2, , -1)"; // Drop the last column.
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(4d);
+            await Assert.That((double)ws.Cell("E3").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("F4").Value).IsEqualTo(5d);
+        }
+    }
+
+    [Test]
+    public async Task TakeAndDrop_AreComplementary()
+    {
+        // Dropping the first row leaves what taking the last row leaves.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Range("E1:G1").FormulaArrayA1 = "DROP(A1:C2, 1)";
+            ws.Range("E2:G2").FormulaArrayA1 = "TAKE(A1:C2, -1)";
+
+            for (var column = 5; column <= 7; column++)
+                await Assert.That((double)ws.Cell(1, column).Value).IsEqualTo((double)ws.Cell(2, column).Value);
+        }
+    }
+
+    [Test]
+    public async Task Drop_ThatLeavesNothingReturnsAnError()
+    {
+        // Excel reports #CALC! here; XLibur has no such error value and reports #VALUE!.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Cell("E1").FormulaA1 = "DROP(A1:C2, 2)";
+            ws.Cell("E2").FormulaA1 = "TAKE(A1:C2, 0)";
+
+            await Assert.That(ws.Cell("E1").Value).IsEqualTo(XLError.IncompatibleValue);
+            await Assert.That(ws.Cell("E2").Value).IsEqualTo(XLError.IncompatibleValue);
+        }
+    }
+
+    [Test]
+    public async Task Expand_GrowsAnArrayAndPadsTheNewCells()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("E1:G3").FormulaArrayA1 = "EXPAND({1,2;3,4}, 3, 3, \"-\")";
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("F2").Value).IsEqualTo(4d);
+            await Assert.That(ws.Cell("G1").Value).IsEqualTo("-");
+            await Assert.That(ws.Cell("E3").Value).IsEqualTo("-");
+        }
+    }
+
+    [Test]
+    public async Task Expand_DefaultsToNoValueAvailableAndLeavesOmittedAxesAlone()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("E1:F3").FormulaArrayA1 = "EXPAND({1,2;3,4}, 3)";
+
+            await Assert.That(ws.Cell("E3").Value).IsEqualTo(XLError.NoValueAvailable);
+            await Assert.That((double)ws.Cell("F2").Value).IsEqualTo(4d);
+        }
+    }
+
+    [Test]
+    public async Task Expand_RefusesToShrink()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("E1").FormulaA1 = "EXPAND({1,2;3,4}, 1)";
+
+            await Assert.That(ws.Cell("E1").Value).IsEqualTo(XLError.IncompatibleValue);
+        }
+    }
+
+    [Test]
+    public async Task ShapingFunctionsSpillIntoTheGrid()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Cell("E1").SetDynamicFormulaA1("TOCOL(A1:C2)");
+
+            for (var i = 0; i < 6; i++)
+                await Assert.That((double)ws.Cell(1 + i, 5).Value).IsEqualTo(i + 1d);
+        }
+    }
+
+    [Test]
+    public async Task ShapingFunctionsCompose()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            // Flatten, wrap back into rows of three, and the original grid comes out again.
+            ws.Cell("E1").SetDynamicFormulaA1("WRAPROWS(TOROW(A1:C2), 3)");
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("G1").Value).IsEqualTo(3d);
+            await Assert.That((double)ws.Cell("E2").Value).IsEqualTo(4d);
+            await Assert.That((double)ws.Cell("G2").Value).IsEqualTo(6d);
+        }
+    }
+
+    [Test]
+    public async Task StackingSpillsIntoTheGrid()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedGrid(ws);
+            ws.Cell("E1").SetDynamicFormulaA1("VSTACK(A1:C2, A1:C2)");
+
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("G4").Value).IsEqualTo(6d);
+        }
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/ModernTextTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ModernTextTests.cs
@@ -1,0 +1,365 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// The modern text functions: TEXTSPLIT, TEXTBEFORE, TEXTAFTER, VALUETOTEXT, ARRAYTOTEXT, UNICHAR,
+/// UNICODE, DBCS and ENCODEURL. Expected values are the worked examples from Microsoft's
+/// per-function documentation, or the documented behaviour applied to the arguments.
+/// </summary>
+[SetCulture("en-US")]
+public class ModernTextTests
+{
+    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    {
+        wb = new XLWorkbook();
+        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+    }
+
+    [Test]
+    [Arguments("UNICHAR(65)", "A")]
+    [Arguments("UNICHAR(66)", "B")]
+    [Arguments("UNICHAR(9731)", "☃")]
+    [Arguments("UNICHAR(128512)", "😀")] // Beyond the basic plane: a surrogate pair.
+    public async Task UniChar_ReturnsTheCharacterForACodePoint(string formula, string expected)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("UNICHAR(0)")] // Zero is not a character.
+    [Arguments("UNICHAR(-1)")]
+    [Arguments("UNICHAR(1114112)")] // One past the last code point.
+    public async Task UniChar_OutOfRangeReturnsIncompatibleValue(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.IncompatibleValue);
+    }
+
+    [Test]
+    [Arguments("UNICODE(\"A\")", 65d)]
+    [Arguments("UNICODE(\"Ant\")", 65d)] // Only the first character counts.
+    [Arguments("UNICODE(\"☃\")", 9731d)]
+    [Arguments("UNICODE(\"😀\")", 128512d)] // The pair is read as one code point.
+    public async Task Unicode_ReturnsTheCodePointOfTheFirstCharacter(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task Unicode_OfEmptyTextReturnsIncompatibleValue()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("UNICODE(\"\")")).IsEqualTo(XLError.IncompatibleValue);
+    }
+
+    [Test]
+    public async Task UniCharAndUnicode_RoundTrip()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "UNICHAR(1000)";
+            ws.Cell("A2").FormulaA1 = "UNICODE(A1)";
+
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(1000d);
+        }
+    }
+
+    [Test]
+    // Microsoft's ENCODEURL example escapes the whole URL, colons and slashes included.
+    [Arguments("ENCODEURL(\"http://contoso.sharepoint.com/teams/Finance/Documents/April Reports/Profit and Loss Statement.xlsx\")",
+        "http%3A%2F%2Fcontoso.sharepoint.com%2Fteams%2FFinance%2FDocuments%2FApril%20Reports%2FProfit%20and%20Loss%20Statement.xlsx")]
+    [Arguments("ENCODEURL(\"a b\")", "a%20b")]
+    [Arguments("ENCODEURL(\"abcXYZ012-_.~\")", "abcXYZ012-_.~")] // The unreserved set passes through.
+    [Arguments("ENCODEURL(\"a+b\")", "a%2Bb")]
+    [Arguments("ENCODEURL(\"é\")", "%C3%A9")] // Escaped as its UTF-8 bytes.
+    [Arguments("ENCODEURL(\"\")", "")]
+    public async Task EncodeUrl_PercentEncodesEverythingOutsideTheUnreservedSet(string formula, string expected)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("DBCS(\"A\")", "Ａ")]
+    [Arguments("DBCS(\"123\")", "１２３")]
+    [Arguments("DBCS(\" \")", "　")]
+    [Arguments("DBCS(\"ｱ\")", "ア")] // Half-width katakana.
+    [Arguments("DBCS(\"ｶﾞ\")", "ガ")] // Base plus the voiced mark becomes one character.
+    [Arguments("DBCS(\"ﾊﾟ\")", "パ")] // And the semi-voiced mark likewise.
+    public async Task Dbcs_ConvertsHalfWidthToFullWidth(string formula, string expected)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("ＡＢＣ")]
+    [Arguments("アイウエオ")]
+    [Arguments("ガギグゲゴ")]
+    [Arguments("パピプペポ")]
+    public async Task Dbcs_IsTheInverseOfAsc(string fullWidth)
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = fullWidth;
+            ws.Cell("A2").FormulaA1 = "DBCS(ASC(A1))";
+
+            await Assert.That(ws.Cell("A2").Value).IsEqualTo(fullWidth);
+        }
+    }
+
+    [Test]
+    [Arguments("VALUETOTEXT(1234.01)", "1234.01")]
+    [Arguments("VALUETOTEXT(\"abc\")", "abc")]
+    [Arguments("VALUETOTEXT(TRUE)", "TRUE")]
+    [Arguments("VALUETOTEXT(1234.01, 1)", "1234.01")] // Numbers read the same in either format.
+    [Arguments("VALUETOTEXT(\"abc\", 1)", "\"abc\"")] // Strict form quotes text.
+    [Arguments("VALUETOTEXT(1/0)", "#DIV/0!")] // Errors become their own text.
+    [Arguments("VALUETOTEXT(1/0, 1)", "#DIV/0!")]
+    public async Task ValueToText_RendersAnyValue(string formula, string expected)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ValueToText_StrictFormDoublesInnerQuotes()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = "say \"hi\"";
+            ws.Cell("A2").FormulaA1 = "VALUETOTEXT(A1, 1)";
+
+            await Assert.That(ws.Cell("A2").Value).IsEqualTo("\"say \"\"hi\"\"\"");
+        }
+    }
+
+    [Test]
+    public async Task ArrayToText_JoinsWithCommasInConciseForm()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("B1").Value = "b";
+            ws.Cell("A2").Value = true;
+            ws.Cell("B2").Value = 4;
+            ws.Cell("D1").FormulaA1 = "ARRAYTOTEXT(A1:B2)";
+
+            await Assert.That(ws.Cell("D1").Value).IsEqualTo("1, b, TRUE, 4");
+        }
+    }
+
+    [Test]
+    public async Task ArrayToText_ReproducesTheArrayLiteralInStrictForm()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("B1").Value = "b";
+            ws.Cell("A2").Value = true;
+            ws.Cell("B2").Value = 4;
+            ws.Cell("D1").FormulaA1 = "ARRAYTOTEXT(A1:B2, 1)";
+
+            await Assert.That(ws.Cell("D1").Value).IsEqualTo("{1,\"b\";TRUE,4}");
+        }
+    }
+
+    [Test]
+    [Arguments("VALUETOTEXT(1, 2)")] // Only formats 0 and 1 exist.
+    [Arguments("ARRAYTOTEXT(1, -1)")]
+    public async Task ValueRendering_UnknownFormatReturnsIncompatibleValue(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.IncompatibleValue);
+    }
+
+    [Test]
+    [Arguments("TEXTBEFORE(\"Red riding hood\", \" \")", "Red")]
+    [Arguments("TEXTAFTER(\"Red riding hood\", \" \")", "riding hood")]
+    [Arguments("TEXTBEFORE(\"Red riding hood\", \" \", 2)", "Red riding")]
+    [Arguments("TEXTAFTER(\"Red riding hood\", \" \", 2)", "hood")]
+    [Arguments("TEXTBEFORE(\"Red riding hood\", \" \", -1)", "Red riding")] // Counting from the end.
+    [Arguments("TEXTAFTER(\"Red riding hood\", \" \", -2)", "riding hood")]
+    public async Task TextBeforeAndAfter_CutAtTheNthDelimiter(string formula, string expected)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("TEXTBEFORE(\"Jones,Bob\", \",\")", "Jones")]
+    [Arguments("TEXTAFTER(\"Jones,Bob\", \",\")", "Bob")]
+    [Arguments("TEXTBEFORE(\"abc\", \"b\")", "a")]
+    [Arguments("TEXTAFTER(\"abc\", \"b\")", "c")]
+    [Arguments("TEXTBEFORE(\"abc\", \"a\")", "")] // Nothing before a leading delimiter.
+    [Arguments("TEXTAFTER(\"abc\", \"c\")", "")]
+    public async Task TextBeforeAndAfter_SplitOnASingleOccurrence(string formula, string expected)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task TextBefore_IsCaseSensitiveUnlessTold()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTBEFORE(\"aXbXc\", \"x\")")).IsEqualTo(XLError.NoValueAvailable);
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTBEFORE(\"aXbXc\", \"x\", 1, 1)")).IsEqualTo("a");
+    }
+
+    [Test]
+    public async Task TextBeforeAndAfter_CanTreatTheEndOfTheTextAsADelimiter()
+    {
+        // With match_end set, the very end counts as one more delimiter, so the last instance
+        // returns the whole remaining text instead of not being found.
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTAFTER(\"a-b\", \"-\", 2, 0, 1)")).IsEqualTo("");
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTBEFORE(\"a-b\", \"-\", 2, 0, 1)")).IsEqualTo("a-b");
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTBEFORE(\"a-b\", \"-\", 2)")).IsEqualTo(XLError.NoValueAvailable);
+    }
+
+    [Test]
+    public async Task TextBefore_AcceptsSeveralDelimitersAndPrefersTheLongestMatch()
+    {
+        // Splitting on both "<br>" and "<b>" must not leave a stray "r>".
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTBEFORE(\"a<br>b\", {\"<b>\",\"<br>\"})")).IsEqualTo("a");
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTAFTER(\"a<br>b\", {\"<b>\",\"<br>\"})")).IsEqualTo("b");
+    }
+
+    [Test]
+    public async Task TextBefore_NotFoundReturnsTheFallbackWhenGiven()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTBEFORE(\"abc\", \"z\")")).IsEqualTo(XLError.NoValueAvailable);
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTBEFORE(\"abc\", \"z\", 1, 0, 0, \"none\")")).IsEqualTo("none");
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTBEFORE(\"abc\", \"b\", 5, 0, 0, \"none\")")).IsEqualTo("none");
+    }
+
+    [Test]
+    public async Task TextBefore_ZeroInstanceReturnsIncompatibleValue()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTBEFORE(\"abc\", \"b\", 0)")).IsEqualTo(XLError.IncompatibleValue);
+    }
+
+    [Test]
+    public async Task TextSplit_SplitsIntoColumns()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("A1:C1").FormulaArrayA1 = "TEXTSPLIT(\"a,b,c\", \",\")";
+
+            await Assert.That(ws.Cell("A1").Value).IsEqualTo("a");
+            await Assert.That(ws.Cell("B1").Value).IsEqualTo("b");
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo("c");
+        }
+    }
+
+    [Test]
+    public async Task TextSplit_SplitsIntoRowsWhenOnlyARowDelimiterIsGiven()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("A1:A3").FormulaArrayA1 = "TEXTSPLIT(\"a;b;c\", , \";\")";
+
+            await Assert.That(ws.Cell("A1").Value).IsEqualTo("a");
+            await Assert.That(ws.Cell("A3").Value).IsEqualTo("c");
+        }
+    }
+
+    [Test]
+    public async Task TextSplit_ProducesATwoDimensionalGrid()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("A1:B2").FormulaArrayA1 = "TEXTSPLIT(\"a,b;c,d\", \",\", \";\")";
+
+            await Assert.That(ws.Cell("A1").Value).IsEqualTo("a");
+            await Assert.That(ws.Cell("B1").Value).IsEqualTo("b");
+            await Assert.That(ws.Cell("A2").Value).IsEqualTo("c");
+            await Assert.That(ws.Cell("B2").Value).IsEqualTo("d");
+        }
+    }
+
+    [Test]
+    public async Task TextSplit_PadsShortRows()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("A1:C2").FormulaArrayA1 = "TEXTSPLIT(\"a,b,c;d\", \",\", \";\")";
+            ws.Range("E1:G2").FormulaArrayA1 = "TEXTSPLIT(\"a,b,c;d\", \",\", \";\", FALSE, 0, \"-\")";
+
+            await Assert.That(ws.Cell("B2").Value).IsEqualTo(XLError.NoValueAvailable);
+            await Assert.That(ws.Cell("F2").Value).IsEqualTo("-");
+        }
+    }
+
+    [Test]
+    public async Task TextSplit_CanDropEmptyPieces()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("A1:C1").FormulaArrayA1 = "TEXTSPLIT(\"a,,b\", \",\")";
+            ws.Range("E1:F1").FormulaArrayA1 = "TEXTSPLIT(\"a,,b\", \",\", , TRUE)";
+
+            await Assert.That(ws.Cell("B1").Value).IsEqualTo(string.Empty);
+            await Assert.That(ws.Cell("E1").Value).IsEqualTo("a");
+            await Assert.That(ws.Cell("F1").Value).IsEqualTo("b");
+        }
+    }
+
+    [Test]
+    public async Task TextSplit_SpillsIntoTheGrid()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").SetDynamicFormulaA1("TEXTSPLIT(\"a,b;c,d\", \",\", \";\")");
+
+            await Assert.That(ws.Cell("A1").Value).IsEqualTo("a");
+            await Assert.That(ws.Cell("B1").Value).IsEqualTo("b");
+            await Assert.That(ws.Cell("A2").Value).IsEqualTo("c");
+            await Assert.That(ws.Cell("B2").Value).IsEqualTo("d");
+        }
+    }
+
+    [Test]
+    public async Task TextSplit_WithNoDelimiterAtAllReturnsIncompatibleValue()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("TEXTSPLIT(\"a,b\", )")).IsEqualTo(XLError.IncompatibleValue);
+    }
+
+    [Test]
+    public async Task TextSplit_IsCaseSensitiveUnlessTold()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Range("A1:A1").FormulaArrayA1 = "TEXTSPLIT(\"aXb\", \"x\")";
+            ws.Range("C1:D1").FormulaArrayA1 = "TEXTSPLIT(\"aXb\", \"x\", , FALSE, 1)";
+
+            await Assert.That(ws.Cell("A1").Value).IsEqualTo("aXb");
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo("a");
+            await Assert.That(ws.Cell("D1").Value).IsEqualTo("b");
+        }
+    }
+
+    [Test]
+    public async Task ModernTextFunctions_ReadTheirArgumentsFromCells()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = "first.second.third";
+            ws.Cell("A2").Value = ".";
+
+            ws.Cell("B1").FormulaA1 = "TEXTBEFORE(A1, A2)";
+            ws.Cell("B2").FormulaA1 = "TEXTAFTER(A1, A2, -1)";
+            ws.Cell("B3").FormulaA1 = "ENCODEURL(A1)";
+
+            await Assert.That(ws.Cell("B1").Value).IsEqualTo("first");
+            await Assert.That(ws.Cell("B2").Value).IsEqualTo("third");
+            await Assert.That(ws.Cell("B3").Value).IsEqualTo("first.second.third");
+        }
+    }
+}

--- a/XLibur/Excel/CalcEngine/Functions/DynamicArray.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DynamicArray.cs
@@ -15,16 +15,368 @@ namespace XLibur.Excel.CalcEngine;
 /// </summary>
 internal static class DynamicArray
 {
+    /// <summary>
+    /// What Excel reports as <c>#CALC!</c> when a dynamic-array function would produce nothing at
+    /// all — every row dropped, every value ignored. XLibur's value model has no <c>#CALC!</c>, so
+    /// these cases report <c>#VALUE!</c> instead; the argument was of the right shape, it just left
+    /// no result behind.
+    /// </summary>
+    private const XLError EmptyResult = XLError.IncompatibleValue;
+
+    private const FunctionFlags Spilling = FunctionFlags.Range | FunctionFlags.ReturnsArray;
+
     public static void Register(FunctionRegistry ce)
     {
-        ce.RegisterFunction("SEQUENCE", 1, 4, Sequence, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Generates a list of sequential numbers
-        ce.RegisterFunction("UNIQUE", 1, 3, Unique, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Returns the distinct values from a range or array
-        ce.RegisterFunction("SORT", 1, 4, Sort, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Sorts the contents of a range or array
-        ce.RegisterFunction("SORTBY", 2, 255, SortBy, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Sorts a range or array based on the values in a corresponding range or array
-        ce.RegisterFunction("FILTER", 2, 3, Filter, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Filters a range or array based on criteria
-        ce.RegisterFunction("XLOOKUP", 3, 6, XLookup, FunctionFlags.Range | FunctionFlags.ReturnsArray, AllowRange.All); // Searches a range or array and returns the matching item(s)
+        ce.RegisterFunction("CHOOSECOLS", 2, 255, ChooseCols, Spilling, AllowRange.All); // Returns the specified columns from an array
+        ce.RegisterFunction("CHOOSEROWS", 2, 255, ChooseRows, Spilling, AllowRange.All); // Returns the specified rows from an array
+        ce.RegisterFunction("DROP", 2, 3, Drop, Spilling, AllowRange.All); // Drops rows or columns from the start or end of an array
+        ce.RegisterFunction("EXPAND", 2, 4, Expand, Spilling, AllowRange.All); // Expands an array to the given dimensions
+        ce.RegisterFunction("FILTER", 2, 3, Filter, Spilling, AllowRange.All); // Filters a range or array based on criteria
+        ce.RegisterFunction("HSTACK", 1, 255, HStack, Spilling, AllowRange.All); // Appends arrays side by side
+        ce.RegisterFunction("SEQUENCE", 1, 4, Sequence, Spilling, AllowRange.All); // Generates a list of sequential numbers
+        ce.RegisterFunction("SORT", 1, 4, Sort, Spilling, AllowRange.All); // Sorts the contents of a range or array
+        ce.RegisterFunction("SORTBY", 2, 255, SortBy, Spilling, AllowRange.All); // Sorts a range or array based on the values in a corresponding range or array
+        ce.RegisterFunction("TAKE", 2, 3, Take, Spilling, AllowRange.All); // Takes rows or columns from the start or end of an array
+        ce.RegisterFunction("TOCOL", 1, 3, ToCol, Spilling, AllowRange.All); // Returns the array as one column
+        ce.RegisterFunction("TOROW", 1, 3, ToRow, Spilling, AllowRange.All); // Returns the array as one row
+        ce.RegisterFunction("UNIQUE", 1, 3, Unique, Spilling, AllowRange.All); // Returns the distinct values from a range or array
+        ce.RegisterFunction("VSTACK", 1, 255, VStack, Spilling, AllowRange.All); // Appends arrays one below another
+        ce.RegisterFunction("WRAPCOLS", 2, 3, WrapCols, Spilling, AllowRange.All); // Wraps a vector into columns of a given length
+        ce.RegisterFunction("WRAPROWS", 2, 3, WrapRows, Spilling, AllowRange.All); // Wraps a vector into rows of a given length
+        ce.RegisterFunction("XLOOKUP", 3, 6, XLookup, Spilling, AllowRange.All); // Searches a range or array and returns the matching item(s)
         ce.RegisterFunction("XMATCH", 2, 4, XMatch, FunctionFlags.Range, AllowRange.All); // Returns the relative position of an item in a range or array
     }
+
+    #region Stacking
+
+    private static AnyValue VStack(CalcContext ctx, Span<AnyValue> args)
+        => Stack(ctx, args, vertically: true);
+
+    private static AnyValue HStack(CalcContext ctx, Span<AnyValue> args)
+        => Stack(ctx, args, vertically: false);
+
+    /// <summary>
+    /// Append the arguments along one axis. The other axis grows to the widest (or tallest)
+    /// argument, and the arguments that fall short are padded with <c>#N/A</c>.
+    /// </summary>
+    private static AnyValue Stack(CalcContext ctx, Span<AnyValue> args, bool vertically)
+    {
+        var parts = new List<Array>(args.Length);
+        foreach (var arg in args)
+        {
+            if (!arg.TryPickCollectionArray(out var array, ctx))
+                return XLError.IncompatibleValue;
+
+            parts.Add(vertically ? array! : new TransposedArray(array!));
+        }
+
+        var width = 0;
+        var height = 0;
+        foreach (var part in parts)
+        {
+            width = Math.Max(width, part.Width);
+            height += part.Height;
+        }
+
+        var data = new ScalarValue[height, width];
+        var row = 0;
+        foreach (var part in parts)
+        {
+            for (var y = 0; y < part.Height; y++, row++)
+            {
+                for (var x = 0; x < width; x++)
+                    data[row, x] = x < part.Width ? part[y, x] : XLError.NoValueAvailable;
+            }
+        }
+
+        return Orient(new ConstArray(data), !vertically);
+    }
+
+    #endregion
+
+    #region Flattening and wrapping
+
+    private static AnyValue ToRow(CalcContext ctx, Span<AnyValue> args)
+        => Flatten(ctx, args, intoRow: true);
+
+    private static AnyValue ToCol(CalcContext ctx, Span<AnyValue> args)
+        => Flatten(ctx, args, intoRow: false);
+
+    /// <summary>
+    /// TOROW/TOCOL(array, [ignore], [scan_by_column]) — read every value in scan order, optionally
+    /// skipping blanks (1), errors (2) or both (3), and lay the result out along a single axis.
+    /// </summary>
+    private static AnyValue Flatten(CalcContext ctx, Span<AnyValue> args, bool intoRow)
+    {
+        if (!args[0].TryPickCollectionArray(out var array, ctx))
+            return XLError.IncompatibleValue;
+
+        var ignore = 0;
+        if (args.Length > 1 && !TryIntArg(ctx, args[1], out ignore, out var ignoreError))
+            return ignoreError;
+        if (ignore is < 0 or > 3)
+            return XLError.IncompatibleValue;
+
+        var byColumn = false;
+        if (args.Length > 2 && !TryBoolArg(ctx, args[2], out byColumn, out var byColumnError))
+            return byColumnError;
+
+        var skipBlanks = (ignore & 1) != 0;
+        var skipErrors = (ignore & 2) != 0;
+
+        // Scanning by column is the same walk over the transpose.
+        var source = byColumn ? new TransposedArray(array!) : array!;
+        var kept = new List<ScalarValue>(source.Height * source.Width);
+        foreach (var value in source)
+        {
+            if (skipBlanks && value.IsBlank)
+                continue;
+            if (skipErrors && value.IsError)
+                continue;
+
+            kept.Add(value);
+        }
+
+        if (kept.Count == 0)
+            return EmptyResult;
+
+        var data = intoRow ? new ScalarValue[1, kept.Count] : new ScalarValue[kept.Count, 1];
+        for (var i = 0; i < kept.Count; i++)
+        {
+            if (intoRow)
+                data[0, i] = kept[i];
+            else
+                data[i, 0] = kept[i];
+        }
+
+        return new ConstArray(data);
+    }
+
+    private static AnyValue WrapRows(CalcContext ctx, Span<AnyValue> args)
+        => Wrap(ctx, args, intoRows: true);
+
+    private static AnyValue WrapCols(CalcContext ctx, Span<AnyValue> args)
+        => Wrap(ctx, args, intoRows: false);
+
+    /// <summary>
+    /// WRAPROWS/WRAPCOLS(vector, wrap_count, [pad_with]) — cut a one-dimensional vector into pieces
+    /// of <c>wrap_count</c> values. Only the last piece can be short, and it is padded.
+    /// </summary>
+    private static AnyValue Wrap(CalcContext ctx, Span<AnyValue> args, bool intoRows)
+    {
+        if (!args[0].TryPickCollectionArray(out var array, ctx))
+            return XLError.IncompatibleValue;
+
+        // The input has to be a vector; a rectangle has no unambiguous reading order to wrap.
+        if (array!.Width != 1 && array.Height != 1)
+            return XLError.IncompatibleValue;
+
+        if (!TryIntArg(ctx, args[1], out var wrapCount, out var wrapCountError))
+            return wrapCountError;
+        if (wrapCount < 1)
+            return XLError.NumberInvalid;
+
+        var padding = args.Length > 2 ? ScalarOf(ctx, args[2]) : XLError.NoValueAvailable;
+
+        var values = new List<ScalarValue>(array.Height * array.Width);
+        foreach (var value in array)
+            values.Add(value);
+
+        var pieces = (values.Count + wrapCount - 1) / wrapCount;
+        var data = intoRows ? new ScalarValue[pieces, wrapCount] : new ScalarValue[wrapCount, pieces];
+        for (var piece = 0; piece < pieces; piece++)
+        {
+            for (var offset = 0; offset < wrapCount; offset++)
+            {
+                var index = piece * wrapCount + offset;
+                var value = index < values.Count ? values[index] : padding;
+                if (intoRows)
+                    data[piece, offset] = value;
+                else
+                    data[offset, piece] = value;
+            }
+        }
+
+        return new ConstArray(data);
+    }
+
+    #endregion
+
+    #region Selecting rows and columns
+
+    private static AnyValue ChooseRows(CalcContext ctx, Span<AnyValue> args)
+        => Choose(ctx, args, byRow: true);
+
+    private static AnyValue ChooseCols(CalcContext ctx, Span<AnyValue> args)
+        => Choose(ctx, args, byRow: false);
+
+    /// <summary>
+    /// CHOOSEROWS/CHOOSECOLS(array, num1, …) — pick lines out of the array in the order asked for,
+    /// repeats included. A negative index counts back from the end.
+    /// </summary>
+    private static AnyValue Choose(CalcContext ctx, Span<AnyValue> args, bool byRow)
+    {
+        if (!args[0].TryPickCollectionArray(out var array, ctx))
+            return XLError.IncompatibleValue;
+
+        var source = byRow ? array! : new TransposedArray(array!);
+        var count = source.Height;
+
+        var selected = new List<int>();
+        for (var i = 1; i < args.Length; i++)
+        {
+            // An argument is usually a single index, but Excel also accepts a whole array of them,
+            // as in CHOOSEROWS(A1:C5, {1,3}).
+            IEnumerable<ScalarValue> indices;
+            if (args[i].TryPickScalar(out var scalar, out _))
+                indices = [scalar];
+            else if (args[i].TryPickCollectionArray(out var indexArray, ctx))
+                indices = indexArray!;
+            else
+                return XLError.IncompatibleValue;
+
+            foreach (var index in indices)
+            {
+                if (!index.ToNumber(ctx.Culture).TryPickT0(out var number, out var indexError))
+                    return indexError;
+
+                var line = (int)Math.Truncate(number);
+
+                // A negative index counts back from the end: -1 is the last line.
+                if (line < 0)
+                    line = count + line + 1;
+
+                if (line < 1 || line > count)
+                    return XLError.IncompatibleValue;
+
+                selected.Add(line - 1);
+            }
+        }
+
+        if (selected.Count == 0)
+            return EmptyResult;
+
+        return Orient(BuildRows(source, selected), !byRow);
+    }
+
+    #endregion
+
+    #region Slicing and padding
+
+    private static AnyValue Take(CalcContext ctx, Span<AnyValue> args)
+        => Slice(ctx, args, dropping: false);
+
+    private static AnyValue Drop(CalcContext ctx, Span<AnyValue> args)
+        => Slice(ctx, args, dropping: true);
+
+    /// <summary>
+    /// TAKE/DROP(array, rows, [columns]) — keep (or discard) that many lines from the start of each
+    /// axis, or from the end when the count is negative. An omitted or blank count leaves the axis
+    /// alone.
+    /// </summary>
+    private static AnyValue Slice(CalcContext ctx, Span<AnyValue> args, bool dropping)
+    {
+        if (!args[0].TryPickCollectionArray(out var array, ctx))
+            return XLError.IncompatibleValue;
+
+        if (!TryOptionalIntArg(ctx, args, 1, out var rows, out var rowsError))
+            return rowsError;
+        if (!TryOptionalIntArg(ctx, args, 2, out var columns, out var columnsError))
+            return columnsError;
+
+        if (!TrySliceAxis(array!.Height, rows, dropping, out var rowOffset, out var rowCount) ||
+            !TrySliceAxis(array.Width, columns, dropping, out var columnOffset, out var columnCount))
+        {
+            return EmptyResult;
+        }
+
+        if (rowOffset == 0 && rowCount == array.Height && columnOffset == 0 && columnCount == array.Width)
+            return array;
+
+        return new SlicedArray(array, rowOffset, rowCount, columnOffset, columnCount);
+    }
+
+    /// <summary>Resolve one axis of TAKE/DROP into an offset and a length, or false if nothing is left.</summary>
+    private static bool TrySliceAxis(int length, int? count, bool dropping, out int offset, out int result)
+    {
+        offset = 0;
+        result = length;
+        if (count is null)
+            return true;
+
+        var requested = count.Value;
+        var magnitude = Math.Min(Math.Abs(requested), length);
+
+        // DROP(n) keeps what TAKE(-(length - n)) would; both directions collapse to "how many
+        // lines survive, counted from which end".
+        var kept = dropping ? length - magnitude : magnitude;
+        if (kept <= 0)
+            return false;
+
+        var fromEnd = requested < 0 ? !dropping : dropping;
+        offset = fromEnd ? length - kept : 0;
+        result = kept;
+        return true;
+    }
+
+    /// <summary>
+    /// EXPAND(array, rows, [columns], [pad_with]) — grow the array to the given size, filling the
+    /// new cells. Shrinking is not expansion, so a smaller size is rejected.
+    /// </summary>
+    private static AnyValue Expand(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!args[0].TryPickCollectionArray(out var array, ctx))
+            return XLError.IncompatibleValue;
+
+        if (!TryOptionalIntArg(ctx, args, 1, out var rows, out var rowsError))
+            return rowsError;
+        if (!TryOptionalIntArg(ctx, args, 2, out var columns, out var columnsError))
+            return columnsError;
+
+        var height = rows ?? array!.Height;
+        var width = columns ?? array!.Width;
+        if (height < array!.Height || width < array.Width)
+            return XLError.IncompatibleValue;
+        if (height > XLHelper.MaxRowNumber || width > XLHelper.MaxColumnNumber)
+            return XLError.NumberInvalid;
+
+        var padding = args.Length > 3 ? ScalarOf(ctx, args[3]) : XLError.NoValueAvailable;
+
+        var data = new ScalarValue[height, width];
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+                data[y, x] = y < array.Height && x < array.Width ? array[y, x] : padding;
+        }
+
+        return new ConstArray(data);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Read an argument that may be left out entirely or written as an empty placeholder, as in
+    /// <c>TAKE(A1:C3,,2)</c>. Both mean "leave this axis alone".
+    /// </summary>
+    private static bool TryOptionalIntArg(CalcContext ctx, Span<AnyValue> args, int index, out int? value, out XLError error)
+    {
+        value = null;
+        error = default;
+        if (args.Length <= index)
+            return true;
+
+        if (args[index].TryPickScalar(out var scalar, out _) && scalar.IsBlank)
+            return true;
+
+        if (!TryIntArg(ctx, args[index], out var number, out error))
+            return false;
+
+        value = number;
+        return true;
+    }
+
+    private static ScalarValue ScalarOf(CalcContext ctx, in AnyValue value)
+        => TryScalarArg(ctx, value, out var scalar) ? scalar : XLError.NoValueAvailable;
 
     private static AnyValue Sequence(CalcContext ctx, Span<AnyValue> args)
     {

--- a/XLibur/Excel/CalcEngine/Functions/Text.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Text.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using ExcelNumberFormat;
+using XLibur.Extensions;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
 #pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility
@@ -36,6 +37,8 @@ internal static class Text
 
     public static void Register(FunctionRegistry ce)
     {
+        ce.RegisterFunction("ARRAYTOTEXT", 1, 2, ArrayToText, FunctionFlags.Range | FunctionFlags.Future,
+            AllowRange.Only, 0); // Renders a range or array as text
         ce.RegisterFunction("ASC", 1, 1, Adapt(Asc),
             FunctionFlags
                 .Scalar); // Changes full-width (double-byte) English letters or katakana within a character string to half-width (single-byte) characters
@@ -50,8 +53,12 @@ internal static class Text
             AllowRange.All); // Joins several text items into one text item
         ce.RegisterFunction("CONCATENATE", 1, 255, Adapt(Concatenate),
             FunctionFlags.Scalar); //	Joins several text items into one text item
+        ce.RegisterFunction("DBCS", 1, 1, Adapt(Dbcs),
+            FunctionFlags.Scalar); // Changes half-width (single-byte) characters to full-width (double-byte) characters
         ce.RegisterFunction("DOLLAR", 1, 2, AdaptLastOptional(Dollar, 2),
             FunctionFlags.Scalar); // Converts a number to text, using the $ (dollar) currency format
+        ce.RegisterFunction("ENCODEURL", 1, 1, Adapt(EncodeUrl),
+            FunctionFlags.Scalar | FunctionFlags.Future); // Percent-encodes a string for use in a URL
         ce.RegisterFunction("EXACT", 2, 2, Adapt(Exact),
             FunctionFlags.Scalar); // Checks to see if two text values are identical
         ce.RegisterFunction("FIND", 2, 3, AdaptLastOptional(Find),
@@ -85,14 +92,539 @@ internal static class Text
             AllowRange.All); // Converts its arguments to text
         ce.RegisterFunction("TEXT", 2, 2, Adapt(_Text),
             FunctionFlags.Scalar); // Formats a number and converts it to text
+        ce.RegisterFunction("TEXTAFTER", 2, 6, TextAfter, FunctionFlags.Range | FunctionFlags.Future,
+            AllowRange.Only, 1); // Returns the text after a delimiter
+        ce.RegisterFunction("TEXTBEFORE", 2, 6, TextBefore, FunctionFlags.Range | FunctionFlags.Future,
+            AllowRange.Only, 1); // Returns the text before a delimiter
         ce.RegisterFunction("TEXTJOIN", 3, 255, Adapt(TextJoin), FunctionFlags.Range | FunctionFlags.Future,
             AllowRange.Except, 0, 1); // Joins text via delimiter
+        // AllowRange.All keeps the array-formula engine from broadcasting the arguments element by
+        // element: TEXTSPLIT produces the array itself, and reduces its own arguments.
+        ce.RegisterFunction("TEXTSPLIT", 2, 6, TextSplit,
+            FunctionFlags.Range | FunctionFlags.Future | FunctionFlags.ReturnsArray,
+            AllowRange.All); // Splits text into a grid on column and row delimiters
         ce.RegisterFunction("TRIM", 1, 1, Adapt(Trim), FunctionFlags.Scalar); // Removes spaces from text
+        ce.RegisterFunction("UNICHAR", 1, 1, Adapt(UniChar),
+            FunctionFlags.Scalar | FunctionFlags.Future); // Returns the character for a Unicode code point
+        ce.RegisterFunction("UNICODE", 1, 1, Adapt(Unicode),
+            FunctionFlags.Scalar | FunctionFlags.Future); // Returns the Unicode code point of the first character
         ce.RegisterFunction("UPPER", 1, 1, Adapt(Upper), FunctionFlags.Scalar); // Converts text to uppercase
         ce.RegisterFunction("VALUE", 1, 1, Adapt(Value), FunctionFlags.Scalar); // Converts a text argument to a number
+        ce.RegisterFunction("VALUETOTEXT", 1, 2, ValueToText, FunctionFlags.Range | FunctionFlags.Future,
+            AllowRange.Only, 0); // Renders any value as text
     }
 
-    private static ScalarValue Asc(CalcContext ctx, string text)
+    #region Unicode and URL encoding
+
+    private static ScalarValue UniChar(CalcContext ctx, double number)
+    {
+        var codePoint = (int)Math.Truncate(number);
+        if (codePoint < 1 || codePoint > 0x10FFFF)
+            return XLError.IncompatibleValue;
+
+        // Lone surrogates are not valid code points, but Excel hands them back as the raw UTF-16
+        // unit rather than refusing, and a formula can use that to build a pair by hand.
+        if (codePoint is >= 0xD800 and <= 0xDFFF)
+            return ((char)codePoint).ToString();
+
+        return char.ConvertFromUtf32(codePoint);
+    }
+
+    private static ScalarValue Unicode(CalcContext ctx, string text)
+    {
+        if (text.Length == 0)
+            return XLError.IncompatibleValue;
+
+        // A surrogate pair is one character to Excel, and its code point is the combined value.
+        if (char.IsHighSurrogate(text[0]) && text.Length > 1 && char.IsLowSurrogate(text[1]))
+            return (double)char.ConvertToUtf32(text[0], text[1]);
+
+        return (double)text[0];
+    }
+
+    /// <summary>
+    /// Percent-encode for use in a URL. Everything outside the RFC 3986 unreserved set is escaped
+    /// as the uppercase hex of its UTF-8 bytes, so "/" and ":" are encoded too — Excel escapes a
+    /// whole URL, not just the part after the host.
+    /// </summary>
+    private static ScalarValue EncodeUrl(CalcContext ctx, string text)
+    {
+        var sb = new StringBuilder(text.Length);
+        foreach (var b in Encoding.UTF8.GetBytes(text))
+        {
+            var c = (char)b;
+            if (c is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '_' or '.' or '~')
+                sb.Append(c);
+            else
+                sb.Append('%').Append(b.ToString("X2", CultureInfo.InvariantCulture));
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The inverse of <see cref="Asc"/>: half-width ASCII and katakana become their full-width
+    /// forms. Like ASC, real Excel only does this when the authoring language is East Asian; the
+    /// mapping is applied unconditionally here, which is what makes DBCS(ASC(x)) an identity.
+    /// </summary>
+    private static ScalarValue Dbcs(CalcContext ctx, string text)
+    {
+        const char dakuten = 'ﾞ';
+        const char handakuten = 'ﾟ';
+        var inverse = HalfToFullKatakana.Value;
+
+        var sb = new StringBuilder(text.Length);
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+
+            // A voiced katakana is written half-width as a base plus a combining mark, so the two
+            // have to be recombined into one full-width character before the base is translated.
+            if (i + 1 < text.Length)
+            {
+                var marked = text[i + 1] switch
+                {
+                    dakuten => inverse.Voiced,
+                    handakuten => inverse.SemiVoiced,
+                    _ => null,
+                };
+
+                if (marked is not null && marked.TryGetValue(c, out var composed))
+                {
+                    sb.Append(composed);
+                    i++;
+                    continue;
+                }
+            }
+
+            if (c is >= '!' and <= '~')
+                sb.Append((char)(c - 0x0021 + 0xFF01));
+            else if (c == ' ')
+                sb.Append('　');
+            else if (inverse.Plain.TryGetValue(c, out var katakana))
+                sb.Append(katakana);
+            else
+                sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The half-width to full-width katakana mapping, derived by running every full-width katakana
+    /// through <see cref="ToHalfWidth"/> and inverting what comes back. Deriving it rather than
+    /// writing a second table by hand is what keeps DBCS and ASC exact inverses of each other.
+    /// </summary>
+    private static readonly Lazy<KatakanaInverse> HalfToFullKatakana = new(static () =>
+    {
+        var plain = new Dictionary<char, string>();
+        var voiced = new Dictionary<char, string>();
+        var semiVoiced = new Dictionary<char, string>();
+
+        for (var codePoint = 0x30A1; codePoint <= 0x30FC; codePoint++)
+        {
+            var full = ((char)codePoint).ToString();
+            var half = ToHalfWidth(full);
+            switch (half.Length)
+            {
+                case 1 when half[0] != codePoint:
+                    plain.TryAdd(half[0], full);
+                    break;
+                case 2:
+                    var target = half[1] == 'ﾟ' ? semiVoiced : voiced;
+                    target.TryAdd(half[0], full);
+                    break;
+            }
+        }
+
+        return new KatakanaInverse(plain, voiced, semiVoiced);
+    });
+
+    private sealed record KatakanaInverse(
+        Dictionary<char, string> Plain,
+        Dictionary<char, string> Voiced,
+        Dictionary<char, string> SemiVoiced);
+
+    #endregion
+
+    #region Splitting on delimiters
+
+    private static AnyValue TextBefore(CalcContext ctx, Span<AnyValue> args)
+        => TextAround(ctx, args, before: true);
+
+    private static AnyValue TextAfter(CalcContext ctx, Span<AnyValue> args)
+        => TextAround(ctx, args, before: false);
+
+    /// <summary>
+    /// TEXTBEFORE/TEXTAFTER(text, delimiter, [instance_num], [match_mode], [match_end],
+    /// [if_not_found]) — cut the text at the nth occurrence of a delimiter and return one side of
+    /// it. A negative instance counts occurrences from the end.
+    /// </summary>
+    private static AnyValue TextAround(CalcContext ctx, Span<AnyValue> args, bool before)
+    {
+        if (!TryGetText(ctx, args[0], out var text, out var textError))
+            return textError;
+
+        if (!TryGetDelimiters(ctx, args[1], out var delimiters, out var delimiterError))
+            return delimiterError;
+
+        var instance = 1;
+        if (args.Length > 2 && !TryOptionalInt(ctx, args[2], 1, out instance, out var instanceError))
+            return instanceError;
+        if (instance == 0)
+            return XLError.IncompatibleValue;
+
+        var ignoreCase = false;
+        if (args.Length > 3 && !TryOptionalFlag(ctx, args[3], out ignoreCase, out var matchModeError))
+            return matchModeError;
+
+        var endCounts = false;
+        if (args.Length > 4 && !TryOptionalFlag(ctx, args[4], out endCounts, out var matchEndError))
+            return matchEndError;
+
+        var notFound = args.Length > 5 ? args[5] : AnyValue.From(XLError.NoValueAvailable);
+
+        var matches = FindDelimiters(text, delimiters, ignoreCase);
+
+        // With match_end set, the very end of the text counts as one more delimiter, which is how
+        // TEXTBEFORE(text, delim, -1, , 1) returns the whole text when there is no trailing delimiter.
+        if (endCounts)
+            matches.Add((text.Length, 0));
+
+        var index = instance > 0 ? instance - 1 : matches.Count + instance;
+        if (index < 0 || index >= matches.Count)
+            return notFound;
+
+        var (start, length) = matches[index];
+        return before ? text[..start] : text[(start + length)..];
+    }
+
+    /// <summary>
+    /// TEXTSPLIT(text, col_delimiter, [row_delimiter], [ignore_empty], [match_mode], [pad_with]) —
+    /// split into a grid, rows first and then columns within each row, and pad the short rows.
+    /// </summary>
+    private static AnyValue TextSplit(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryGetText(ctx, args[0], out var text, out var textError))
+            return textError;
+
+        var hasColumnDelimiters = !IsOmitted(args, 1);
+        List<string> columnDelimiters = [];
+        if (hasColumnDelimiters && !TryGetDelimiters(ctx, args[1], out columnDelimiters, out var columnError))
+            return columnError;
+
+        var hasRowDelimiters = !IsOmitted(args, 2);
+        List<string> rowDelimiters = [];
+        if (hasRowDelimiters && !TryGetDelimiters(ctx, args[2], out rowDelimiters, out var rowError))
+            return rowError;
+
+        if (!hasColumnDelimiters && !hasRowDelimiters)
+            return XLError.IncompatibleValue;
+
+        var ignoreEmpty = false;
+        if (args.Length > 3 && !TryOptionalFlag(ctx, args[3], out ignoreEmpty, out var ignoreError))
+            return ignoreError;
+
+        var ignoreCase = false;
+        if (args.Length > 4 && !TryOptionalFlag(ctx, args[4], out ignoreCase, out var matchModeError))
+            return matchModeError;
+
+        var padding = args.Length > 5 && !IsOmitted(args, 5)
+            ? ToScalar(ctx, args[5])
+            : ScalarValue.From(XLError.NoValueAvailable);
+
+        var rows = new List<List<string>>();
+        foreach (var line in Split(text, rowDelimiters, ignoreCase, ignoreEmpty))
+            rows.Add(Split(line, columnDelimiters, ignoreCase, ignoreEmpty));
+
+        if (ignoreEmpty)
+            rows.RemoveAll(static row => row.Count == 0);
+
+        if (rows.Count == 0)
+            return XLError.IncompatibleValue;
+
+        var width = 0;
+        foreach (var row in rows)
+            width = Math.Max(width, row.Count);
+
+        var data = new ScalarValue[rows.Count, Math.Max(width, 1)];
+        for (var y = 0; y < rows.Count; y++)
+        {
+            for (var x = 0; x < data.GetLength(1); x++)
+                data[y, x] = x < rows[y].Count ? rows[y][x] : padding;
+        }
+
+        return new ConstArray(data);
+    }
+
+    /// <summary>Split on any of the delimiters; no delimiters at all leaves the text in one piece.</summary>
+    private static List<string> Split(string text, List<string> delimiters, bool ignoreCase, bool ignoreEmpty)
+    {
+        var pieces = new List<string>();
+        if (delimiters.Count == 0)
+        {
+            pieces.Add(text);
+            return pieces;
+        }
+
+        var position = 0;
+        foreach (var (start, length) in FindDelimiters(text, delimiters, ignoreCase))
+        {
+            pieces.Add(text[position..start]);
+            position = start + length;
+        }
+
+        pieces.Add(text[position..]);
+
+        if (ignoreEmpty)
+            pieces.RemoveAll(string.IsNullOrEmpty);
+
+        return pieces;
+    }
+
+    /// <summary>
+    /// Every non-overlapping occurrence of any delimiter, left to right. When two delimiters could
+    /// match at the same place the longer one wins, so splitting on both "&lt;br&gt;" and "&lt;b&gt;"
+    /// does not leave a stray "r&gt;".
+    /// </summary>
+    private static List<(int Start, int Length)> FindDelimiters(string text, List<string> delimiters, bool ignoreCase)
+    {
+        var comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var matches = new List<(int Start, int Length)>();
+
+        var position = 0;
+        while (position <= text.Length)
+        {
+            var bestStart = -1;
+            var bestLength = 0;
+            foreach (var delimiter in delimiters)
+            {
+                if (delimiter.Length == 0)
+                    continue;
+
+                var found = text.IndexOf(delimiter, position, comparison);
+                if (found < 0)
+                    continue;
+
+                if (bestStart < 0 || found < bestStart || (found == bestStart && delimiter.Length > bestLength))
+                {
+                    bestStart = found;
+                    bestLength = delimiter.Length;
+                }
+            }
+
+            if (bestStart < 0)
+                break;
+
+            matches.Add((bestStart, bestLength));
+            position = bestStart + bestLength;
+        }
+
+        return matches;
+    }
+
+    /// <summary>Read a delimiter argument, which Excel lets you write as an array of alternatives.</summary>
+    private static bool TryGetDelimiters(CalcContext ctx, in AnyValue value, out List<string> delimiters, out XLError error)
+    {
+        delimiters = [];
+        error = default;
+
+        if (value.TryPickScalar(out var scalar, out _))
+        {
+            if (!scalar.ToText(ctx.Culture).TryPickT0(out var single, out error))
+                return false;
+
+            delimiters.Add(single);
+            return true;
+        }
+
+        if (!value.TryPickCollectionArray(out var array, ctx))
+        {
+            error = XLError.IncompatibleValue;
+            return false;
+        }
+
+        foreach (var item in array!)
+        {
+            if (item.IsBlank)
+                continue;
+
+            if (!item.ToText(ctx.Culture).TryPickT0(out var text, out error))
+                return false;
+
+            delimiters.Add(text);
+        }
+
+        return true;
+    }
+
+    private static bool IsOmitted(Span<AnyValue> args, int index)
+        => args.Length <= index || (args[index].TryPickScalar(out var scalar, out _) && scalar.IsBlank);
+
+    private static bool TryOptionalInt(CalcContext ctx, in AnyValue value, int fallback, out int result, out XLError error)
+    {
+        result = fallback;
+        error = default;
+        if (!value.TryPickScalar(out var scalar, out _))
+        {
+            error = XLError.IncompatibleValue;
+            return false;
+        }
+
+        if (scalar.IsBlank)
+            return true;
+
+        if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var number, out error))
+            return false;
+
+        result = (int)Math.Truncate(number);
+        return true;
+    }
+
+    /// <summary>Read one of the 0/1 mode arguments the modern text functions use as booleans.</summary>
+    private static bool TryOptionalFlag(CalcContext ctx, in AnyValue value, out bool flag, out XLError error)
+    {
+        if (!TryOptionalInt(ctx, value, 0, out var mode, out error))
+        {
+            flag = false;
+            return false;
+        }
+
+        if (mode is not (0 or 1))
+        {
+            flag = false;
+            error = XLError.IncompatibleValue;
+            return false;
+        }
+
+        flag = mode == 1;
+        return true;
+    }
+
+    /// <summary>
+    /// Reduce an argument to the single value a scalar parameter wants. Registering a function with
+    /// <see cref="AllowRange.All"/> stops the engine from doing this, which these functions need so
+    /// that the array-formula path hands them their arguments whole rather than one element at a
+    /// time — so they have to do the reduction themselves.
+    /// </summary>
+    private static ScalarValue ToScalar(CalcContext ctx, in AnyValue value)
+    {
+        if (value.TryPickScalar(out var scalar, out var collection))
+            return scalar;
+
+        if (collection.TryPickT0(out var array, out var reference))
+            return array[0, 0];
+
+        if (reference.TryGetSingleCellValue(out var single, ctx))
+            return single;
+
+        return value.ImplicitIntersection(ctx).TryPickScalar(out var intersected, out _)
+            ? intersected
+            : XLError.IncompatibleValue;
+    }
+
+    private static bool TryGetText(CalcContext ctx, in AnyValue value, out string text, out XLError error)
+    {
+        return ToScalar(ctx, value).ToText(ctx.Culture).TryPickT0(out text!, out error);
+    }
+
+    #endregion
+
+    #region Value rendering
+
+    private static AnyValue ValueToText(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryGetFormat(ctx, args, 1, out var strict, out var formatError))
+            return formatError;
+
+        return Render(ctx, ToScalar(ctx, args[0]), strict);
+    }
+
+    private static AnyValue ArrayToText(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryGetFormat(ctx, args, 1, out var strict, out var formatError))
+            return formatError;
+
+        if (!args[0].TryPickCollectionArray(out var array, ctx))
+            return Render(ctx, ToScalar(ctx, args[0]), strict);
+
+        // Concise form is a flat comma-separated list; strict form reproduces the array literal,
+        // with commas between columns and semicolons between rows.
+        var sb = new StringBuilder();
+        if (strict)
+            sb.Append('{');
+
+        for (var y = 0; y < array!.Height; y++)
+        {
+            if (y > 0)
+                sb.Append(strict ? ";" : ", ");
+
+            for (var x = 0; x < array.Width; x++)
+            {
+                if (x > 0)
+                    sb.Append(strict ? "," : ", ");
+
+                sb.Append(Render(ctx, array[y, x], strict));
+            }
+        }
+
+        if (strict)
+            sb.Append('}');
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Read the shared <c>format</c> argument of VALUETOTEXT and ARRAYTOTEXT: 0 is the concise form
+    /// a cell would display, 1 the strict form that could be pasted back into a formula.
+    /// </summary>
+    private static bool TryGetFormat(CalcContext ctx, Span<AnyValue> args, int index, out bool strict, out XLError error)
+    {
+        strict = false;
+        error = default;
+        if (args.Length <= index)
+            return true;
+
+        if (!args[index].TryPickScalar(out var scalar, out _))
+        {
+            error = XLError.IncompatibleValue;
+            return false;
+        }
+
+        if (scalar.IsBlank)
+            return true;
+
+        if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var number, out error))
+            return false;
+
+        var format = (int)Math.Truncate(number);
+        if (format is not (0 or 1))
+        {
+            error = XLError.IncompatibleValue;
+            return false;
+        }
+
+        strict = format == 1;
+        return true;
+    }
+
+    private static string Render(CalcContext ctx, in ScalarValue value, bool strict)
+    {
+        if (value.TryPickError(out var error))
+            return error.ToDisplayString();
+
+        if (value.TryPickText(out var text, out _))
+            return strict ? "\"" + text!.Replace("\"", "\"\"") + "\"" : text!;
+
+        // Numbers, logicals and blanks read the same either way.
+        return value.ToText(ctx.Culture).Match(t => t!, e => e.ToDisplayString());
+    }
+
+    #endregion
+
+    private static ScalarValue Asc(CalcContext ctx, string text) => ToHalfWidth(text);
+
+    private static string ToHalfWidth(string text)
     {
         // Excel version only works when the authoring language is set to specific languages (e.g., Japanese).
         // Function doesn't do anything when Excel is set to most locales (e.g., English). There is no further


### PR DESCRIPTION
Wave E of [spec 07](docs/specs/07-formula-function-coverage.md). Stacked on #253 — **targets `feat/calc-wave-d-engineering`**, retarget as the stack merges.

## Functions added (20)

| Group | Functions |
|---|---|
| Modern text | `TEXTSPLIT`, `TEXTBEFORE`, `TEXTAFTER`, `VALUETOTEXT`, `ARRAYTOTEXT`, `UNICHAR`, `UNICODE`, `DBCS`, `ENCODEURL` |
| Array shaping | `VSTACK`, `HSTACK`, `TOROW`, `TOCOL`, `WRAPROWS`, `WRAPCOLS`, `CHOOSEROWS`, `CHOOSECOLS`, `TAKE`, `DROP`, `EXPAND` |

The shaping set and `TEXTSPLIT` spill. Registry: 323 → 343 functions.

## Notes on the implementation

**`TAKE` and `DROP` share one axis resolver.** Both reduce to "how many lines survive, counted from which end", which is why `DROP(n)` and `TAKE(-(len-n))` agree — there's a test for that.

**The delimiter search** behind `TEXTBEFORE`/`TEXTAFTER`/`TEXTSPLIT` prefers the longest match at a position, so splitting on both `"<br>"` and `"<b>"` does not leave a stray `"r>"`.

**`DBCS` derives its half-to-full-width table by inverting `ASC`'s** rather than restating it, which keeps the two exact inverses by construction. `ToHalfWidth` is split out of `ASC` so the table can be built from it; `DBCS(ASC(x))` is tested as an identity over ASCII, katakana, and both the voiced and semi-voiced forms.

## Two deviations, both in the changelog

- **No `#CALC!` in the value model.** Excel reports it when a shaping function would produce nothing at all — a `DROP` that discards every row, a `TOCOL` that ignores every value. XLibur has no such error value, so those cases report `#VALUE!`. Adding `#CALC!` properly would ripple through `ERROR.TYPE`, the error-text parser and IO, so it is left alone here; the substitution is behind one named constant if it's wanted later.
- **`TEXTSPLIT` is registered `AllowRange.All`** so the array-formula engine hands it its arguments whole instead of broadcasting them element by element. It produces the array itself and reduces its own arguments.

## Verification

99 tests, all passing; full suite green on net8.0 and net10.0; Release build clean.

Coverage of the additions to `DynamicArray.cs` is 94.2%. The file reads 77.9% overall — the remainder is pre-existing `XLOOKUP`/`FILTER`/`SORTBY` paths (67.6%) that had no tests before this work. Happy to cover those too if you'd like it in this PR rather than a follow-up.
