### PR TITLE
feat(calc): add AGGREGATE and the .INTL date functions (spec 07 wave F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 #### Formula functions
 
+- **`AGGREGATE`, `NETWORKDAYS.INTL` and `WORKDAY.INTL`**. `AGGREGATE` covers all nineteen function numbers — including `PERCENTILE.EXC` and `QUARTILE.EXC`, which have no standalone registration yet — and all eight option values, so ignoring hidden rows and error values both work rather than being documented limitations. The `.INTL` date functions take a weekend as either one of Excel's numbered codes or a seven-character Monday-to-Sunday mask. ([#255](https://github.com/XLibur/XLibur/pull/255) by [@jafin](https://github.com/jafin))
+
 - **20 modern text and array-shaping functions**: `TEXTSPLIT`, `TEXTBEFORE`, `TEXTAFTER`, `VALUETOTEXT`, `ARRAYTOTEXT`, `UNICHAR`, `UNICODE`, `DBCS`, `ENCODEURL`, and the array-shaping set `VSTACK`, `HSTACK`, `TOROW`, `TOCOL`, `WRAPROWS`, `WRAPCOLS`, `CHOOSEROWS`, `CHOOSECOLS`, `TAKE`, `DROP`, `EXPAND`. The array-shaping functions and `TEXTSPLIT` spill.
 
   `DBCS` derives its mapping by inverting `ASC`'s, so the two are exact inverses. Where Excel would report `#CALC!` — a `DROP` that leaves nothing, a `TOCOL` that ignores every value — XLibur reports `#VALUE!` instead, because the value model has no `#CALC!`. ([#254](https://github.com/XLibur/XLibur/pull/254) by [@jafin](https://github.com/jafin))
@@ -88,6 +90,8 @@
 ### 🐛 Bug Fixes
 
 #### Formulas and references
+
+- **`SUBTOTAL` no longer counts a nested post-2007 function twice.** The check that stops a subtotal counting a subtotal inside its own range compared the function name as the formula stores it, and Excel stores every function added after 2007 under an `_xlfn.` namespace — so a nested `AGGREGATE` was never recognised. The namespace is now stripped before the comparison. ([#255](https://github.com/XLibur/XLibur/pull/255) by [@jafin](https://github.com/jafin))
 
 - **A reference whose rows or columns are all deleted becomes `#REF!`** ([ClosedXML #880](https://github.com/ClosedXML/ClosedXML/issues/880)): endpoints were shifted by the deleted height and clamped to row 1, so deleting rows 1–5 turned `Sheet1!$A$1:$B$2` into `Sheet1!$A$1:$B$1` — a phantom one-row range over whatever data had moved up into it. The same shifter serves cell formulas, so `=SUM(A1:A2)` with those rows deleted now reads `SUM(#REF!)` rather than quietly summing the wrong cells. Deleting the sheet afterwards drops the stale sheet prefix instead of leaving a defined name pointing at a sheet that no longer exists. ([#243](https://github.com/XLibur/XLibur/pull/243) by [@jafin](https://github.com/jafin))
 

--- a/XLibur.Tests/Excel/CalcEngine/AggregateTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/AggregateTests.cs
@@ -1,0 +1,284 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// AGGREGATE, which applies one of nineteen aggregates with an options argument controlling what is
+/// left out of the data set. Expected values are the same as the equivalent standalone function
+/// over the same data, which is what AGGREGATE is documented to compute.
+/// </summary>
+[SetCulture("en-US")]
+public class AggregateTests
+{
+    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    {
+        wb = new XLWorkbook();
+        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+    }
+
+    /// <summary>Put 1, 2, 3, 4 and 5 into A1:A5.</summary>
+    private static void SeedNumbers(XLWorksheet ws)
+    {
+        for (var row = 1; row <= 5; row++)
+            ws.Cell(row, 1).Value = row;
+    }
+
+    [Test]
+    [Arguments(1, 3d)] // AVERAGE
+    [Arguments(2, 5d)] // COUNT
+    [Arguments(3, 5d)] // COUNTA
+    [Arguments(4, 5d)] // MAX
+    [Arguments(5, 1d)] // MIN
+    [Arguments(6, 120d)] // PRODUCT
+    [Arguments(7, 1.5811388300841898d)] // STDEV.S
+    [Arguments(8, 1.4142135623730951d)] // STDEV.P
+    [Arguments(9, 15d)] // SUM
+    [Arguments(10, 2.5d)] // VAR.S
+    [Arguments(11, 2d)] // VAR.P
+    [Arguments(12, 3d)] // MEDIAN
+    public async Task Aggregate_AppliesTheNumberedFunction(int functionNumber, double expected)
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedNumbers(ws);
+            ws.Cell("C1").FormulaA1 = $"AGGREGATE({functionNumber}, 0, A1:A5)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(expected).Within(1e-12);
+        }
+    }
+
+    [Test]
+    public async Task Aggregate_MatchesTheStandaloneFunctions()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedNumbers(ws);
+            ws.Cell("C1").FormulaA1 = "AGGREGATE(1, 0, A1:A5) - AVERAGE(A1:A5)";
+            ws.Cell("C2").FormulaA1 = "AGGREGATE(9, 0, A1:A5) - SUM(A1:A5)";
+            ws.Cell("C3").FormulaA1 = "AGGREGATE(7, 0, A1:A5) - STDEV(A1:A5)";
+            ws.Cell("C4").FormulaA1 = "AGGREGATE(12, 0, A1:A5) - MEDIAN(A1:A5)";
+
+            foreach (var address in new[] { "C1", "C2", "C3", "C4" })
+                await Assert.That((double)ws.Cell(address).Value).IsEqualTo(0d).Within(1e-12);
+        }
+    }
+
+    [Test]
+    public async Task Aggregate_Mode()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 2;
+            ws.Cell("A3").Value = 2;
+            ws.Cell("A4").Value = 3;
+            ws.Cell("C1").FormulaA1 = "AGGREGATE(13, 0, A1:A4)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(2d);
+        }
+    }
+
+    [Test]
+    [Arguments("AGGREGATE(14, 0, A1:A5, 2)", 4d)] // LARGE
+    [Arguments("AGGREGATE(15, 0, A1:A5, 2)", 2d)] // SMALL
+    [Arguments("AGGREGATE(16, 0, A1:A5, 0.5)", 3d)] // PERCENTILE.INC
+    [Arguments("AGGREGATE(17, 0, A1:A5, 1)", 2d)] // QUARTILE.INC
+    // With five values the exclusive rank of the median is 0.5*(5+1) = 3, the third value.
+    [Arguments("AGGREGATE(18, 0, A1:A5, 0.5)", 3d)] // PERCENTILE.EXC
+    [Arguments("AGGREGATE(19, 0, A1:A5, 2)", 3d)] // QUARTILE.EXC
+    public async Task Aggregate_OrderStatisticsTakeAK(string formula, double expected)
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedNumbers(ws);
+            ws.Cell("C1").FormulaA1 = formula;
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(expected).Within(1e-12);
+        }
+    }
+
+    [Test]
+    public async Task Aggregate_ExclusivePercentileRejectsUnreachableRanks()
+    {
+        // With five values the exclusive percentile only spans 1/6 to 5/6.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedNumbers(ws);
+            ws.Cell("C1").FormulaA1 = "AGGREGATE(18, 0, A1:A5, 0.1)";
+            ws.Cell("C2").FormulaA1 = "AGGREGATE(18, 0, A1:A5, 0.9)";
+            ws.Cell("C3").FormulaA1 = "AGGREGATE(19, 0, A1:A5, 0)"; // Only quartiles 1..3 exist.
+            ws.Cell("C4").FormulaA1 = "AGGREGATE(19, 0, A1:A5, 4)";
+
+            foreach (var address in new[] { "C1", "C2", "C3", "C4" })
+                await Assert.That(ws.Cell(address).Value).IsEqualTo(XLError.NumberInvalid);
+        }
+    }
+
+    [Test]
+    public async Task Aggregate_IgnoresErrorsOnlyWhenAskedTo()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").FormulaA1 = "1/0";
+            ws.Cell("A3").Value = 3;
+
+            ws.Cell("C1").FormulaA1 = "AGGREGATE(9, 0, A1:A3)"; // Errors propagate.
+            ws.Cell("C2").FormulaA1 = "AGGREGATE(9, 2, A1:A3)"; // Option 2 ignores them.
+            ws.Cell("C3").FormulaA1 = "AGGREGATE(9, 6, A1:A3)"; // As does option 6.
+            ws.Cell("C4").FormulaA1 = "AGGREGATE(4, 2, A1:A3)"; // MAX over the surviving values.
+
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.DivisionByZero);
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(4d);
+            await Assert.That((double)ws.Cell("C3").Value).IsEqualTo(4d);
+            await Assert.That((double)ws.Cell("C4").Value).IsEqualTo(3d);
+        }
+    }
+
+    [Test]
+    public async Task Aggregate_IgnoresHiddenRowsOnlyWhenAskedTo()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedNumbers(ws);
+            ws.Row(2).Hide();
+            ws.Row(4).Hide();
+
+            ws.Cell("C1").FormulaA1 = "AGGREGATE(9, 0, A1:A5)"; // Every row counts.
+            ws.Cell("C2").FormulaA1 = "AGGREGATE(9, 1, A1:A5)"; // Option 1 skips hidden rows.
+            ws.Cell("C3").FormulaA1 = "AGGREGATE(9, 5, A1:A5)"; // As does option 5.
+            ws.Cell("C4").FormulaA1 = "AGGREGATE(2, 1, A1:A5)"; // COUNT over the visible rows.
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(15d);
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(9d); // 1 + 3 + 5.
+            await Assert.That((double)ws.Cell("C3").Value).IsEqualTo(9d);
+            await Assert.That((double)ws.Cell("C4").Value).IsEqualTo(3d);
+        }
+    }
+
+    [Test]
+    public async Task Aggregate_IgnoresHiddenRowsAndErrorsTogether()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").FormulaA1 = "1/0";
+            ws.Cell("A3").Value = 3;
+            ws.Cell("A4").Value = 4;
+            ws.Row(4).Hide();
+
+            ws.Cell("C1").FormulaA1 = "AGGREGATE(9, 3, A1:A4)";
+            ws.Cell("C2").FormulaA1 = "AGGREGATE(9, 7, A1:A4)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(4d); // 1 + 3.
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(4d);
+        }
+    }
+
+    [Test]
+    public async Task Aggregate_SkipsNestedSubtotalsAndAggregates()
+    {
+        // A subtotal inside the range is not counted again by the aggregate that spans it.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 2;
+            ws.Cell("A3").FormulaA1 = "SUBTOTAL(9, A1:A2)";
+            ws.Cell("A4").FormulaA1 = "AGGREGATE(9, 0, A1:A2)";
+            ws.Cell("A5").Value = 4;
+
+            ws.Cell("C1").FormulaA1 = "AGGREGATE(9, 0, A1:A5)";
+            ws.Cell("C2").FormulaA1 = "SUM(A1:A5)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(7d); // 1 + 2 + 4.
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(13d); // SUM counts them all.
+        }
+    }
+
+    [Test]
+    public async Task Aggregate_TakesSeveralRanges()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedNumbers(ws);
+            ws.Cell("B1").Value = 10;
+            ws.Cell("B2").Value = 20;
+
+            ws.Cell("D1").FormulaA1 = "AGGREGATE(9, 0, A1:A5, B1:B2)";
+
+            await Assert.That((double)ws.Cell("D1").Value).IsEqualTo(45d);
+        }
+    }
+
+    [Test]
+    [Arguments("AGGREGATE(0, 0, A1:A5)")] // Function numbers run 1..19.
+    [Arguments("AGGREGATE(20, 0, A1:A5)")]
+    [Arguments("AGGREGATE(9, -1, A1:A5)")] // Options run 0..7.
+    [Arguments("AGGREGATE(9, 8, A1:A5)")]
+    [Arguments("AGGREGATE(14, 0, A1:A5)")] // The order statistics need a k.
+    [Arguments("AGGREGATE(18, 0, A1:A5)")]
+    public async Task Aggregate_OutOfRangeArgumentsReturnIncompatibleValue(string formula)
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedNumbers(ws);
+            ws.Cell("C1").FormulaA1 = formula;
+
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.IncompatibleValue);
+        }
+    }
+
+    [Test]
+    public async Task Aggregate_OptionDefaultsAndReadsArgumentsFromCells()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedNumbers(ws);
+            ws.Cell("C1").Value = 9;
+            ws.Cell("C2").Value = 0;
+            ws.Cell("D1").FormulaA1 = "AGGREGATE(C1, C2, A1:A5)";
+
+            await Assert.That((double)ws.Cell("D1").Value).IsEqualTo(15d);
+        }
+    }
+
+    [Test]
+    public async Task Subtotal_CoversBothTheVisibleAndTheHiddenRowVariants()
+    {
+        // SUBTOTAL 1..11 count hidden rows and 101..111 do not; this pins that the whole pair of
+        // ranges is wired up, which AGGREGATE's options build on.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedNumbers(ws);
+            ws.Row(2).Hide();
+
+            for (var i = 0; i < 11; i++)
+            {
+                ws.Cell(i + 1, 3).FormulaA1 = $"SUBTOTAL({i + 1}, A1:A5)";
+                ws.Cell(i + 1, 4).FormulaA1 = $"SUBTOTAL({i + 101}, A1:A5)";
+            }
+
+            // Only the aggregates that depend on the hidden value differ between the two ranges.
+            await Assert.That((double)ws.Cell("C9").Value).IsEqualTo(15d); // SUM over everything.
+            await Assert.That((double)ws.Cell("D9").Value).IsEqualTo(13d); // SUM without row 2.
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(5d); // COUNT.
+            await Assert.That((double)ws.Cell("D2").Value).IsEqualTo(4d);
+            await Assert.That((double)ws.Cell("C6").Value).IsEqualTo(120d); // PRODUCT.
+            await Assert.That((double)ws.Cell("D6").Value).IsEqualTo(60d);
+        }
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/WorkdayIntlTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/WorkdayIntlTests.cs
@@ -1,0 +1,202 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// NETWORKDAYS.INTL and WORKDAY.INTL, which take a weekend as either one of Excel's numbered codes
+/// or a seven-character Monday-to-Sunday mask. Expected values are the worked examples from
+/// Microsoft's per-function documentation, or counted from a calendar and shown in the comment.
+/// </summary>
+[SetCulture("en-US")]
+public class WorkdayIntlTests
+{
+    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    {
+        wb = new XLWorkbook();
+        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+    }
+
+    [Test]
+    // 2006-01-01 is a Sunday. To 2006-01-31 there are 22 weekdays with a Sat+Sun weekend.
+    [Arguments("NETWORKDAYS.INTL(DATE(2006,1,1), DATE(2006,1,31))", 22d)]
+    [Arguments("NETWORKDAYS.INTL(DATE(2006,1,1), DATE(2006,1,31), 1)", 22d)] // Code 1 is the default.
+    [Arguments("NETWORKDAYS.INTL(DATE(2006,1,1), DATE(2006,1,31), 7)", 23d)] // Fri+Sat: 31 days less 4 Fridays and 4 Saturdays.
+    [Arguments("NETWORKDAYS.INTL(DATE(2006,1,1), DATE(2006,1,31), 11)", 26d)] // Sunday only: 31 days less 5 Sundays.
+    public async Task NetWorkDaysIntl_ReferenceExamplesFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    // A single calendar week, 2024-01-01 (Monday) to 2024-01-07 (Sunday), so each weekend code
+    // simply removes its own days from seven.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 1)", 5d)] // Sat, Sun.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 2)", 5d)] // Sun, Mon.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 3)", 5d)] // Mon, Tue.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 11)", 6d)] // Sun.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 12)", 6d)] // Mon.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 17)", 6d)] // Sat.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), \"0000011\")", 5d)] // Sat+Sun as a mask.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), \"1000000\")", 6d)] // Monday only.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), \"1111110\")", 1d)] // Only Sunday works.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), \"0000000\")", 7d)] // No weekend at all.
+    public async Task NetWorkDaysIntl_EveryWeekendCodeAndMask(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task NetWorkDaysIntl_MatchesNetWorkDaysForTheDefaultWeekend()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "NETWORKDAYS(DATE(2024,1,1), DATE(2024,12,31))";
+            ws.Cell("A2").FormulaA1 = "NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,12,31))";
+            ws.Cell("A3").FormulaA1 = "NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,12,31), \"0000011\")";
+
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo((double)ws.Cell("A1").Value);
+            await Assert.That((double)ws.Cell("A3").Value).IsEqualTo((double)ws.Cell("A1").Value);
+        }
+    }
+
+    [Test]
+    public async Task NetWorkDaysIntl_CountsBackwardsAsANegativeNumber()
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr("NETWORKDAYS.INTL(DATE(2024,1,7), DATE(2024,1,1))")).IsEqualTo(-5d);
+    }
+
+    [Test]
+    public async Task NetWorkDaysIntl_SubtractsHolidaysThatFallOnAWorkingDay()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "DATE(2024,1,3)"; // A Wednesday, so it counts.
+            ws.Cell("A2").FormulaA1 = "DATE(2024,1,6)"; // A Saturday, already a weekend.
+            ws.Cell("A3").FormulaA1 = "DATE(2024,1,3)"; // A duplicate of the first, only counted once.
+
+            ws.Cell("C1").FormulaA1 = "NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 1, A1:A3)";
+            ws.Cell("C2").FormulaA1 = "NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 1, A2)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(4d);
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(5d);
+        }
+    }
+
+    [Test]
+    public async Task NetWorkDaysIntl_SameDayCountsAsOneOrZero()
+    {
+        // 2024-01-03 is a Wednesday; 2024-01-06 is a Saturday.
+        await Assert.That((double)XLWorkbook.EvaluateExpr("NETWORKDAYS.INTL(DATE(2024,1,3), DATE(2024,1,3))")).IsEqualTo(1d);
+        await Assert.That((double)XLWorkbook.EvaluateExpr("NETWORKDAYS.INTL(DATE(2024,1,6), DATE(2024,1,6))")).IsEqualTo(0d);
+    }
+
+    [Test]
+    // From 2012-01-01, a Sunday, with a Sunday-and-Monday weekend, five days work each week. Thirty
+    // working days is therefore six whole weeks: the first ends Saturday 7 January, so the thirtieth
+    // is the Saturday five weeks later, 11 February.
+    [Arguments("WORKDAY.INTL(DATE(2012,1,1), 30, 2)", "2012-02-11")]
+    // Weekend code 11 leaves Sunday alone, so six days work each week and ninety of them is fifteen
+    // whole weeks. The first ends Saturday 7 January; the fifteenth ends fourteen weeks later.
+    [Arguments("WORKDAY.INTL(DATE(2012,1,1), 90, 11)", "2012-04-14")]
+    public async Task WorkdayIntl_LandsOnTheNthWorkingDay(string formula, string expected)
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = formula;
+            ws.Cell("A2").FormulaA1 = "TEXT(A1, \"yyyy-mm-dd\")";
+
+            await Assert.That(ws.Cell("A2").Value).IsEqualTo(expected);
+        }
+    }
+
+    [Test]
+    // From Monday 2024-01-01 with a Saturday+Sunday weekend, one working day on is Tuesday the 2nd
+    // and five working days on is the following Monday, the 8th.
+    [Arguments("WORKDAY.INTL(DATE(2024,1,1), 1)", "2024-01-02")]
+    [Arguments("WORKDAY.INTL(DATE(2024,1,1), 5)", "2024-01-08")]
+    [Arguments("WORKDAY.INTL(DATE(2024,1,1), 0)", "2024-01-01")] // Zero leaves the date alone.
+    [Arguments("WORKDAY.INTL(DATE(2024,1,8), -5)", "2024-01-01")] // And a negative offset walks back.
+    [Arguments("WORKDAY.INTL(DATE(2024,1,1), 1, 11)", "2024-01-02")] // Sunday-only weekend.
+    [Arguments("WORKDAY.INTL(DATE(2024,1,5), 1, 11)", "2024-01-06")] // Saturday is a working day here.
+    [Arguments("WORKDAY.INTL(DATE(2024,1,1), 1, \"1000000\")", "2024-01-02")] // Monday-only weekend.
+    [Arguments("WORKDAY.INTL(DATE(2024,1,6), 0)", "2024-01-06")] // A weekend start is returned as is.
+    public async Task WorkdayIntl_AdvancesByWorkingDays(string formula, string expected)
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = formula;
+            ws.Cell("A2").FormulaA1 = "TEXT(A1, \"yyyy-mm-dd\")";
+
+            await Assert.That(ws.Cell("A2").Value).IsEqualTo(expected);
+        }
+    }
+
+    [Test]
+    public async Task WorkdayIntl_SkipsHolidays()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "DATE(2024,1,2)"; // The Tuesday that would otherwise be the answer.
+            ws.Cell("B1").FormulaA1 = "WORKDAY.INTL(DATE(2024,1,1), 1, 1, A1)";
+            ws.Cell("B2").FormulaA1 = "TEXT(B1, \"yyyy-mm-dd\")";
+
+            await Assert.That(ws.Cell("B2").Value).IsEqualTo("2024-01-03");
+        }
+    }
+
+    [Test]
+    public async Task WorkdayIntl_AndNetWorkDaysIntl_AgreeWithEachOther()
+    {
+        // Counting the working days up to the date WORKDAY.INTL lands on has to give that same
+        // number back, plus the start day itself.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "WORKDAY.INTL(DATE(2024,3,4), 17, 3)";
+            ws.Cell("A2").FormulaA1 = "NETWORKDAYS.INTL(DATE(2024,3,4), A1, 3)";
+
+            // 2024-03-04 is a Monday, which weekend code 3 (Mon+Tue) makes a weekend day, so the
+            // range covers 17 working days and no more.
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(17d);
+        }
+    }
+
+    [Test]
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 8)")] // 8, 9 and 10 are not codes.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 0)")]
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), 18)")]
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), \"1111111\")")] // No working day left.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), \"000001\")")] // Too short.
+    [Arguments("NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,7), \"000001x\")")] // Not 0 or 1.
+    [Arguments("WORKDAY.INTL(DATE(2024,1,1), 5, 8)")]
+    [Arguments("WORKDAY.INTL(DATE(2024,1,1), 5, \"1111111\")")]
+    public async Task WeekendArgument_OutOfRangeReturnsNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    public async Task IntlFunctions_ReadTheirArgumentsFromCells()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "DATE(2024,1,1)";
+            ws.Cell("A2").FormulaA1 = "DATE(2024,1,7)";
+            ws.Cell("A3").Value = 11;
+
+            ws.Cell("B1").FormulaA1 = "NETWORKDAYS.INTL(A1, A2, A3)";
+            ws.Cell("B2").FormulaA1 = "WORKDAY.INTL(A1, 3, A3)";
+            ws.Cell("B3").FormulaA1 = "TEXT(B2, \"yyyy-mm-dd\")";
+
+            await Assert.That((double)ws.Cell("B1").Value).IsEqualTo(6d);
+            await Assert.That(ws.Cell("B3").Value).IsEqualTo("2024-01-04");
+        }
+    }
+}

--- a/XLibur/Excel/CalcEngine/CalcContext.cs
+++ b/XLibur/Excel/CalcEngine/CalcContext.cs
@@ -243,11 +243,16 @@ internal sealed class CalcContext
         }
     }
 
-    internal IEnumerable<ScalarValue> GetFilteredNonBlankValues(Reference reference, string function,
+    /// <summary>
+    /// Values of a reference, skipping blanks and any cell whose own formula calls one of
+    /// <paramref name="functions"/> — which is how SUBTOTAL and AGGREGATE avoid counting a nested
+    /// subtotal twice. AGGREGATE has to skip both function names, so more than one may be given.
+    /// </summary>
+    internal IEnumerable<ScalarValue> GetFilteredNonBlankValues(Reference reference, string[] functions,
         bool skipHiddenRows = false)
     {
         // Allocate one per call, because visitor holds info whether function was found in a formula.
-        var visitor = new FunctionVisitor(function);
+        var visitor = new FunctionVisitor(functions);
         foreach (var area in reference)
         {
             var sheet = area.Worksheet ?? Worksheet;
@@ -279,7 +284,7 @@ internal sealed class CalcContext
             if (formula is null)
                 return false;
 
-            if (!formula.A1.Contains(visitor.FunctionName, StringComparison.OrdinalIgnoreCase))
+            if (!visitor.MightBeCalledBy(formula.A1))
                 return false;
 
             FormulaParser<object?, object?, FunctionVisitor>.CellFormulaA1(formula.A1, visitor, visitor);
@@ -337,22 +342,59 @@ internal sealed class CalcContext
 
     private sealed class FunctionVisitor : CollectVisitor<FunctionVisitor>
     {
-        public FunctionVisitor(string function)
-        {
-            FunctionName = function;
-        }
+        private readonly string[] _functionNames;
 
-        internal string FunctionName { get; }
+        public FunctionVisitor(string[] functionNames)
+        {
+            _functionNames = functionNames;
+        }
 
         public bool Found { get; private set; }
 
         public void Clear() => Found = false;
 
+        /// <summary>
+        /// A cheap substring test that rules out most formulas before the parser is involved. A
+        /// false positive only costs a parse; a false negative would be wrong, so this must stay
+        /// at least as permissive as <see cref="Function"/>.
+        /// </summary>
+        public bool MightBeCalledBy(string formula)
+        {
+            foreach (var name in _functionNames)
+            {
+                if (formula.Contains(name, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
+
         public override object? Function(FunctionVisitor context, SymbolRange range, ReadOnlySpan<char> functionName,
             IReadOnlyList<object?> arguments)
         {
-            Found = Found || functionName.Equals(FunctionName.AsSpan(), StringComparison.OrdinalIgnoreCase);
+            var bareName = StripNameSpace(functionName);
+            foreach (var name in _functionNames)
+                Found = Found || bareName.Equals(name.AsSpan(), StringComparison.OrdinalIgnoreCase);
+
             return null;
+        }
+
+        /// <summary>
+        /// Drop the namespace a post-2007 function is stored under. AGGREGATE is one of them, so a
+        /// cell holding it reads back as <c>_xlfn.AGGREGATE(…)</c> and would not match its own name.
+        /// </summary>
+        private static ReadOnlySpan<char> StripNameSpace(ReadOnlySpan<char> functionName)
+        {
+            const string futureNameSpace = "_xlfn.";
+            const string worksheetNameSpace = "_xlws.";
+
+            if (functionName.StartsWith(futureNameSpace, StringComparison.OrdinalIgnoreCase))
+                functionName = functionName[futureNameSpace.Length..];
+
+            if (functionName.StartsWith(worksheetNameSpace, StringComparison.OrdinalIgnoreCase))
+                functionName = functionName[worksheetNameSpace.Length..];
+
+            return functionName;
         }
     }
 }

--- a/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -30,6 +30,7 @@ internal static class DateAndTime
         ce.RegisterFunction("MINUTE", 1, 1, Adapt(Minute), FunctionFlags.Scalar); // Converts a serial number to a minute
         ce.RegisterFunction("MONTH", 1, 1, Adapt(GetMonth), FunctionFlags.Scalar); // Converts a serial number to a month
         ce.RegisterFunction("NETWORKDAYS", 2, 3, AdaptLastOptional(NetWorkDays), FunctionFlags.Range, AllowRange.Only, 2); // Returns the number of whole workdays between two dates
+        ce.RegisterFunction("NETWORKDAYS.INTL", 2, 4, NetWorkDaysIntl, FunctionFlags.Range | FunctionFlags.Future, AllowRange.Only, 3); // Whole workdays between two dates, with a configurable weekend
         ce.RegisterFunction("NOW", 0, 0, Adapt(Now), FunctionFlags.Scalar | FunctionFlags.Volatile); // Returns the serial number of the current date and time
         ce.RegisterFunction("SECOND", 1, 1, Adapt(Second), FunctionFlags.Scalar); // Converts a serial number to a second
         ce.RegisterFunction("TIME", 3, 3, Adapt(Time), FunctionFlags.Scalar); // Returns the serial number of a particular time
@@ -38,6 +39,7 @@ internal static class DateAndTime
         ce.RegisterFunction("WEEKDAY", 1, 2, AdaptLastOptional(Weekday), FunctionFlags.Scalar); // Converts a serial number to a day of the week
         ce.RegisterFunction("WEEKNUM", 1, 2, AdaptLastOptional(WeekNum, 1), FunctionFlags.Scalar); // Converts a serial number to a number representing where the week falls numerically with a year
         ce.RegisterFunction("WORKDAY", 2, 3, AdaptLastOptional(Workday), FunctionFlags.Range, AllowRange.Only, 2); // Returns the serial number of the date before or after a specified number of workdays
+        ce.RegisterFunction("WORKDAY.INTL", 2, 4, WorkdayIntl, FunctionFlags.Range | FunctionFlags.Future, AllowRange.Only, 3); // The date a number of workdays away, with a configurable weekend
         ce.RegisterFunction("YEAR", 1, 1, Adapt(GetYear), FunctionFlags.Scalar); // Converts a serial number to a year
         ce.RegisterFunction("YEARFRAC", 2, 3, AdaptLastOptional(YearFrac, 0), FunctionFlags.Scalar); // Returns the year fraction representing the number of whole days between start_date and end_date
     }
@@ -377,6 +379,237 @@ internal static class DateAndTime
 
         return BusinessDaysUntil(startSerialDate, endSerialDate, allHolidays);
     }
+
+    #region Configurable weekends
+
+    /// <summary>
+    /// Every day of the week is a weekend — the one mask Excel rejects, since it would leave no
+    /// working day for NETWORKDAYS.INTL to count or WORKDAY.INTL to land on.
+    /// </summary>
+    private const int AllDaysWeekend = 0b111_1111;
+
+    /// <summary>
+    /// The numbered weekend codes, as bitmasks over the days of the week with bit 0 = Monday.
+    /// 1..7 are the two-day weekends, sliding one day later each time from Saturday+Sunday; 11..17
+    /// are the single-day weekends, from Sunday to Saturday.
+    /// </summary>
+    private static bool TryGetWeekendMaskFromCode(int code, out int mask)
+    {
+        mask = 0;
+        if (code is >= 1 and <= 7)
+        {
+            // Code 1 is Sat+Sun (bits 5 and 6); each later code slides the pair one day on.
+            var first = (5 + code - 1) % 7;
+            mask = (1 << first) | (1 << ((first + 1) % 7));
+            return true;
+        }
+
+        if (code is >= 11 and <= 17)
+        {
+            // Code 11 is Sunday alone (bit 6), 12 is Monday (bit 0), and so on.
+            mask = 1 << ((code - 11 + 6) % 7);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Read the <c>weekend</c> argument of the .INTL functions: either one of the numbered codes, or
+    /// a seven-character string of 0s and 1s running Monday to Sunday where 1 marks a weekend day.
+    /// </summary>
+    private static bool TryGetWeekendMask(CalcContext ctx, in AnyValue value, out int mask, out XLError error)
+    {
+        mask = 0;
+        error = XLError.NumberInvalid;
+
+        var scalar = ToScalar(ctx, value);
+        if (scalar.TryPickError(out var scalarError))
+        {
+            error = scalarError;
+            return false;
+        }
+
+        // An omitted weekend is the ordinary Saturday and Sunday.
+        if (scalar.IsBlank)
+        {
+            mask = (1 << 5) | (1 << 6);
+            error = default;
+            return true;
+        }
+
+        if (scalar.TryPickText(out var pattern, out _))
+        {
+            if (pattern!.Length != 7)
+                return false;
+
+            for (var day = 0; day < 7; day++)
+            {
+                switch (pattern[day])
+                {
+                    case '1':
+                        mask |= 1 << day;
+                        break;
+                    case '0':
+                        break;
+                    default:
+                        return false;
+                }
+            }
+        }
+        else
+        {
+            if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var number, out var numberError))
+            {
+                error = numberError;
+                return false;
+            }
+
+            if (!TryGetWeekendMaskFromCode((int)Math.Truncate(number), out mask))
+                return false;
+        }
+
+        // A week with no working day in it has no answer.
+        if (mask == AllDaysWeekend)
+            return false;
+
+        error = default;
+        return true;
+    }
+
+    /// <summary>Day of the week of a serial date as a bit index, 0 = Monday … 6 = Sunday.</summary>
+    private static int WeekdayBit(int serialDate) => (WeekdayCalc(serialDate) + 5) % 7;
+
+    private static bool IsWeekend(int serialDate, int mask) => (mask & (1 << WeekdayBit(serialDate))) != 0;
+
+    /// <summary>
+    /// Collect the holidays argument into distinct serial dates, dropping the ones that already
+    /// fall on a weekend — they are not working days to begin with, so they must not be subtracted
+    /// twice.
+    /// </summary>
+    private static bool TryGetHolidays(CalcContext ctx, in AnyValue holidays, int mask, out HashSet<int> dates, out XLError error)
+    {
+        dates = [];
+        error = default;
+        foreach (var holidayValue in ctx.GetNonBlankValues(holidays))
+        {
+            if (!TryGetDate(ctx, holidayValue, out var holidayDate, out error))
+                return false;
+
+            if (!IsWeekend(holidayDate, mask))
+                dates.Add(holidayDate);
+        }
+
+        return true;
+    }
+
+    private static AnyValue NetWorkDaysIntl(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryGetDate(ctx, ToScalar(ctx, args[0]), out var startDate, out var startError))
+            return startError;
+
+        if (!TryGetDate(ctx, ToScalar(ctx, args[1]), out var endDate, out var endError))
+            return endError;
+
+        if (!TryGetWeekendMask(ctx, args.Length > 2 ? args[2] : ScalarValue.Blank.ToAnyValue(), out var mask, out var maskError))
+            return maskError;
+
+        if (!TryGetHolidays(ctx, args.Length > 3 ? args[3] : ScalarValue.Blank.ToAnyValue(), mask, out var holidays, out var holidayError))
+            return holidayError;
+
+        // Counting backwards gives the same magnitude with the opposite sign.
+        var reversed = startDate > endDate;
+        if (reversed)
+            (startDate, endDate) = (endDate, startDate);
+
+        var total = CountWorkdays(startDate, endDate, mask);
+        foreach (var holiday in holidays)
+        {
+            if (holiday >= startDate && holiday <= endDate)
+                total--;
+        }
+
+        return reversed ? -total : total;
+    }
+
+    /// <summary>
+    /// Working days in an inclusive date range. Whole weeks contribute a fixed number, so only the
+    /// days that spill past the last whole week have to be looked at one by one.
+    /// </summary>
+    private static int CountWorkdays(int startDate, int endDate, int mask)
+    {
+        var weekendDaysPerWeek = System.Numerics.BitOperations.PopCount((uint)mask);
+        var days = endDate - startDate + 1;
+        var wholeWeeks = days / 7;
+
+        var total = days - wholeWeeks * weekendDaysPerWeek;
+        for (var day = startDate + wholeWeeks * 7; day <= endDate; day++)
+        {
+            if (IsWeekend(day, mask))
+                total--;
+        }
+
+        return total;
+    }
+
+    private static AnyValue WorkdayIntl(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryGetDate(ctx, ToScalar(ctx, args[0]), out var startDate, out var startError))
+            return startError;
+
+        if (!ToScalar(ctx, args[1]).ToNumber(ctx.Culture).TryPickT0(out var offsetNumber, out var offsetError))
+            return offsetError;
+
+        if (!TryGetWeekendMask(ctx, args.Length > 2 ? args[2] : ScalarValue.Blank.ToAnyValue(), out var mask, out var maskError))
+            return maskError;
+
+        if (!TryGetHolidays(ctx, args.Length > 3 ? args[3] : ScalarValue.Blank.ToAnyValue(), mask, out var holidays, out var holidayError))
+            return holidayError;
+
+        var offset = (int)Math.Truncate(offsetNumber);
+
+        // A zero offset returns the start date untouched, weekend or not.
+        if (offset == 0)
+            return startDate;
+
+        var step = offset > 0 ? 1 : -1;
+        var remaining = Math.Abs(offset);
+        var date = startDate;
+        while (remaining > 0)
+        {
+            date += step;
+            if (date < 0 || date > Year10K)
+                return XLError.NumberInvalid;
+
+            if (!IsWeekend(date, mask) && !holidays.Contains(date))
+                remaining--;
+        }
+
+        return date;
+    }
+
+    /// <summary>
+    /// Reduce an argument of the .INTL functions to the single value it expects. Only the holidays
+    /// parameter is marked as taking a range, so the others arrive unreduced and a reference to one
+    /// cell has to be unwrapped here.
+    /// </summary>
+    private static ScalarValue ToScalar(CalcContext ctx, in AnyValue value)
+    {
+        if (value.TryPickScalar(out var scalar, out var collection))
+            return scalar;
+
+        if (collection.TryPickT0(out var array, out var reference))
+            return array[0, 0];
+
+        if (reference.TryGetSingleCellValue(out var single, ctx))
+            return single;
+
+        return value.ImplicitIntersection(ctx).TryPickScalar(out var intersected, out _)
+            ? intersected
+            : XLError.IncompatibleValue;
+    }
+
+    #endregion
 
     private static ScalarValue Now()
     {

--- a/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
@@ -47,6 +47,7 @@ internal static class MathTrig
         ce.RegisterFunction("ACOSH", 1, 1, Adapt(Acosh), FunctionFlags.Scalar);
         ce.RegisterFunction("ACOT", 1, 1, Adapt(Acot), FunctionFlags.Scalar | FunctionFlags.Future);
         ce.RegisterFunction("ACOTH", 1, 1, Adapt(Acoth), FunctionFlags.Scalar | FunctionFlags.Future);
+        ce.RegisterFunction("AGGREGATE", 3, 255, Aggregate, FunctionFlags.Range | FunctionFlags.Future, AllowRange.Except, 0, 1); // Applies one of nineteen aggregates, with control over what is ignored
         ce.RegisterFunction("ARABIC", 1, 1, Adapt(Arabic), FunctionFlags.Scalar | FunctionFlags.Future);
         ce.RegisterFunction("ASIN", 1, 1, Adapt(Asin), FunctionFlags.Scalar);
         ce.RegisterFunction("ASINH", 1, 1, Adapt(Asinh), FunctionFlags.Scalar);
@@ -1011,6 +1012,98 @@ internal static class MathTrig
             111 => Statistical.VarP(ctx, args, TallyNumbers.Subtotal100),
             _ => throw new UnreachableException(),
         };
+    }
+
+    /// <summary>
+    /// AGGREGATE(function_num, options, …) — one of nineteen aggregates over the remaining
+    /// arguments, with the <c>options</c> argument choosing what is left out of the data set.
+    /// Functions 1..13 take any number of ranges; 14..19 take one array and a k, because they pick
+    /// a position within a single ordered set.
+    /// </summary>
+    private static AnyValue Aggregate(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryGetAggregateArgument(ctx, args[0], out var functionArgument, out var functionError))
+            return functionError;
+        if (!TryGetAggregateArgument(ctx, args[1], out var optionsArgument, out var optionsError))
+            return optionsError;
+
+        var functionNumber = Math.Truncate(functionArgument);
+        var options = Math.Truncate(optionsArgument);
+        if (functionNumber is < 1 or > 19 || options is < 0 or > 7)
+            return XLError.IncompatibleValue;
+
+        // Options 1, 3, 5 and 7 hide rows; 2, 3, 6 and 7 ignore errors. Nested SUBTOTAL and
+        // AGGREGATE are skipped under every option — the "ignore nothing" of option 4 is about
+        // hidden rows and errors, not about double counting.
+        var skipHiddenRows = options is 1 or 3 or 5 or 7;
+        var ignoreErrors = options is 2 or 3 or 6 or 7;
+        var tally = TallyNumbers.Aggregate(skipHiddenRows, ignoreErrors);
+
+        var values = args[2..];
+        if (functionNumber <= 13)
+        {
+            return functionNumber switch
+            {
+                1 => Statistical.Average(ctx, values, tally),
+                2 => Statistical.Count(ctx, values, tally),
+                3 => Statistical.Count(ctx, values, skipHiddenRows ? TallyAll.AggregateCountAVisible : TallyAll.AggregateCountA),
+                4 => Statistical.Max(ctx, values, tally),
+                5 => Statistical.Min(ctx, values, tally),
+                6 => Product(ctx, values, tally),
+                7 => Statistical.StDev(ctx, values, tally),
+                8 => Statistical.StDevP(ctx, values, tally),
+                9 => Sum(ctx, values, tally),
+                10 => Statistical.Var(ctx, values, tally),
+                11 => Statistical.VarP(ctx, values, tally),
+                12 => Statistical.Median(ctx, values, tally),
+                _ => Statistical.Mode(ctx, values, tally),
+            };
+        }
+
+        // The order statistics need the whole data set materialized, and a k to index it with.
+        if (args.Length < 4)
+            return XLError.IncompatibleValue;
+
+        if (!TryGetAggregateArgument(ctx, args[3], out var k, out var kError))
+            return kError;
+
+        if (!Statistical.CollectNumbers(ctx, args[2..3], tally).TryPickT0(out var numbers, out var valuesError))
+            return valuesError;
+
+        return functionNumber switch
+        {
+            14 => Statistical.NthLargest(numbers, k),
+            15 => Statistical.NthSmallest(numbers, k),
+            16 => Statistical.PercentileInclusive(numbers, k),
+            17 => Statistical.QuartileInclusive(numbers, k),
+            18 => Statistical.PercentileExclusive(numbers, k),
+            _ => Statistical.QuartileExclusive(numbers, k),
+        };
+    }
+
+    /// <summary>Read one of AGGREGATE's scalar arguments — the function number, the options or the k.</summary>
+    private static bool TryGetAggregateArgument(CalcContext ctx, in AnyValue value, out double number, out XLError error)
+    {
+        number = 0;
+        error = default;
+
+        // Only the data parameters are marked as taking a range, so these arrive unreduced and a
+        // reference to a single cell has to be unwrapped here.
+        if (!value.TryPickScalar(out var scalar, out var collection))
+        {
+            if (collection.TryPickT0(out var array, out var reference))
+            {
+                scalar = array[0, 0];
+            }
+            else if (!reference.TryGetSingleCellValue(out scalar, ctx)
+                     && !value.ImplicitIntersection(ctx).TryPickScalar(out scalar, out _))
+            {
+                error = XLError.IncompatibleValue;
+                return false;
+            }
+        }
+
+        return scalar.ToNumber(ctx.Culture).TryPickT0(out number, out error);
     }
 
     private static AnyValue Sum(CalcContext ctx, Span<AnyValue> args)

--- a/XLibur/Excel/CalcEngine/Functions/Statistical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Statistical.cs
@@ -448,9 +448,14 @@ internal static class Statistical
 
     private static AnyValue Median(CalcContext ctx, Span<AnyValue> args)
     {
+        return Median(ctx, args, TallyNumbers.Default);
+    }
+
+    internal static AnyValue Median(CalcContext ctx, Span<AnyValue> args, ITally tally)
+    {
         // There is a better median algorithm that uses two heaps, but NetFx
         // doesn't have heap structure.
-        var result = TallyNumbers.Default.Tally(ctx, args, new ValuesState([]));
+        var result = tally.Tally(ctx, args, new ValuesState([]));
         if (!result.TryPickT0(out var state, out var error))
             return error;
 
@@ -578,38 +583,60 @@ internal static class Statistical
 
     private static AnyValue Large(CalcContext ctx, AnyValue arrayParam, double kParam)
     {
-        if (kParam < 1)
-            return XLError.NumberInvalid;
-
-        var k = (int)Math.Ceiling(kParam);
         if (!TryGetNumbers(ctx, arrayParam, out var total, out var error))
             return error;
 
-        if (k > total.Count)
-            return XLError.NumberInvalid;
-
-        total.Sort();
-
-        // k-th largest.
-        return total[^k];
+        return NthLargest(total, kParam);
     }
 
     private static AnyValue Small(CalcContext ctx, AnyValue arrayParam, double kParam)
+    {
+        if (!TryGetNumbers(ctx, arrayParam, out var total, out var error))
+            return error;
+
+        return NthSmallest(total, kParam);
+    }
+
+    /// <summary>
+    /// Materialize every number a tally would see. The order statistics need the whole data set in
+    /// hand rather than a running total, and AGGREGATE needs them read through its own tally so
+    /// that its ignore options apply.
+    /// </summary>
+    internal static OneOf<List<double>, XLError> CollectNumbers(CalcContext ctx, Span<AnyValue> args, ITally tally)
+    {
+        var result = tally.Tally(ctx, args, new ValuesState([]));
+        if (!result.TryPickT0(out var state, out var error))
+            return error;
+
+        return state.Values;
+    }
+
+    /// <summary>The k-th largest of a materialized list, as LARGE and AGGREGATE function 14 return it.</summary>
+    internal static AnyValue NthLargest(List<double> numbers, double kParam)
     {
         if (kParam < 1)
             return XLError.NumberInvalid;
 
         var k = (int)Math.Ceiling(kParam);
-        if (!TryGetNumbers(ctx, arrayParam, out var total, out var error))
-            return error;
-
-        if (k > total.Count)
+        if (k > numbers.Count)
             return XLError.NumberInvalid;
 
-        total.Sort();
+        numbers.Sort();
+        return numbers[^k];
+    }
 
-        // k-th smallest.
-        return total[k - 1];
+    /// <summary>The k-th smallest of a materialized list, as SMALL and AGGREGATE function 15 return it.</summary>
+    internal static AnyValue NthSmallest(List<double> numbers, double kParam)
+    {
+        if (kParam < 1)
+            return XLError.NumberInvalid;
+
+        var k = (int)Math.Ceiling(kParam);
+        if (k > numbers.Count)
+            return XLError.NumberInvalid;
+
+        numbers.Sort();
+        return numbers[k - 1];
     }
 
     private static AnyValue Rank(CalcContext ctx, Span<AnyValue> args)
@@ -646,7 +673,12 @@ internal static class Statistical
 
     private static AnyValue Mode(CalcContext ctx, Span<AnyValue> args)
     {
-        var result = TallyNumbers.Default.Tally(ctx, args, new ValuesState([]));
+        return Mode(ctx, args, TallyNumbers.Default);
+    }
+
+    internal static AnyValue Mode(CalcContext ctx, Span<AnyValue> args, ITally tally)
+    {
+        var result = tally.Tally(ctx, args, new ValuesState([]));
         if (!result.TryPickT0(out var state, out var error))
             return error;
 
@@ -688,19 +720,14 @@ internal static class Statistical
         if (!TryGetNumbers(ctx, arrayParam, out var numbers, out var error))
             return error;
 
-        // Excel truncates the quart argument toward zero and accepts only 0..4.
-        var quart = (int)quartParam;
-        if (quart < 0 || quart > 4)
-            return XLError.NumberInvalid;
-
-        return PercentileInclusive(numbers, quart * 0.25);
+        return QuartileInclusive(numbers, quartParam);
     }
 
     /// <summary>
     /// PERCENTILE.INC over a materialized list: the <paramref name="k"/>-th percentile
     /// (<c>k</c> in <c>[0, 1]</c>) with linear interpolation between the two closest ranks.
     /// </summary>
-    private static AnyValue PercentileInclusive(List<double> numbers, double k)
+    internal static AnyValue PercentileInclusive(List<double> numbers, double k)
     {
         if (numbers.Count == 0 || k < 0 || k > 1)
             return XLError.NumberInvalid;
@@ -714,6 +741,55 @@ internal static class Statistical
 
         var fraction = rank - low;
         return numbers[low] + fraction * (numbers[low + 1] - numbers[low]);
+    }
+
+    /// <summary>
+    /// PERCENTILE.EXC over a materialized list. The exclusive variant places the n values at ranks
+    /// 1/(n+1) … n/(n+1) rather than at 0 … 1, so the extremes of the range are not attainable and
+    /// a <paramref name="k"/> outside them is a domain error rather than the smallest or largest value.
+    /// </summary>
+    internal static AnyValue PercentileExclusive(List<double> numbers, double k)
+    {
+        var count = numbers.Count;
+        if (count == 0)
+            return XLError.NumberInvalid;
+
+        var rank = k * (count + 1);
+        if (rank < 1 || rank > count)
+            return XLError.NumberInvalid;
+
+        numbers.Sort();
+
+        var low = (int)Math.Floor(rank);
+        if (low >= count)
+            return numbers[count - 1];
+
+        var fraction = rank - low;
+        return numbers[low - 1] + fraction * (numbers[low] - numbers[low - 1]);
+    }
+
+    /// <summary>QUARTILE.INC — the quartile as a percentile of 0, 0.25, 0.5, 0.75 or 1.</summary>
+    internal static AnyValue QuartileInclusive(List<double> numbers, double quartParam)
+    {
+        // Excel truncates the quart argument toward zero and accepts only 0..4.
+        var quart = (int)quartParam;
+        if (quart < 0 || quart > 4)
+            return XLError.NumberInvalid;
+
+        return PercentileInclusive(numbers, quart * 0.25);
+    }
+
+    /// <summary>
+    /// QUARTILE.EXC — only the three inner quartiles exist, since the exclusive percentile cannot
+    /// reach 0 or 1.
+    /// </summary>
+    internal static AnyValue QuartileExclusive(List<double> numbers, double quartParam)
+    {
+        var quart = (int)quartParam;
+        if (quart < 1 || quart > 3)
+            return XLError.NumberInvalid;
+
+        return PercentileExclusive(numbers, quart * 0.25);
     }
 
     /// <summary>

--- a/XLibur/Excel/CalcEngine/Functions/TallyAll.cs
+++ b/XLibur/Excel/CalcEngine/Functions/TallyAll.cs
@@ -46,12 +46,18 @@ internal sealed class TallyAll : ITally
     /// <summary>
     /// Tally algorithm for <c>SUBTOTAL</c> functions 1..11.
     /// </summary>
-    internal static readonly ITally Subtotal10 = new TallyAll(getNonBlankValues: static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, "SUBTOTAL"));
+    internal static readonly ITally Subtotal10 = new TallyAll(getNonBlankValues: static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, TallyNumbers.SubtotalOnly));
 
     /// <summary>
     /// Tally algorithm for <c>SUBTOTAL</c> functions 101..111.
     /// </summary>
-    internal static readonly ITally Subtotal100 = new TallyAll(getNonBlankValues: static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, "SUBTOTAL", skipHiddenRows: true));
+    internal static readonly ITally Subtotal100 = new TallyAll(getNonBlankValues: static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, TallyNumbers.SubtotalOnly, skipHiddenRows: true));
+
+    /// <summary>Tally algorithm for <c>AGGREGATE</c> function 3 (COUNTA).</summary>
+    internal static readonly ITally AggregateCountA = new TallyAll(getNonBlankValues: static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, TallyNumbers.SubtotalAndAggregate));
+
+    /// <summary>Tally algorithm for <c>AGGREGATE</c> function 3 with an option that hides rows.</summary>
+    internal static readonly ITally AggregateCountAVisible = new TallyAll(getNonBlankValues: static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, TallyNumbers.SubtotalAndAggregate, skipHiddenRows: true));
 
     private TallyAll(bool ignoreArrayText = true, bool includeErrors = false, Func<CalcContext, Reference, IEnumerable<ScalarValue>>? getNonBlankValues = null)
     {

--- a/XLibur/Excel/CalcEngine/Functions/TallyNumbers.cs
+++ b/XLibur/Excel/CalcEngine/Functions/TallyNumbers.cs
@@ -19,15 +19,36 @@ internal sealed class TallyNumbers : ITally
     /// </summary>
     internal static readonly TallyNumbers WithoutScalarBlank = new(ignoreScalarBlank: true);
 
+    /// <summary>A nested SUBTOTAL is not counted again by the SUBTOTAL that contains it.</summary>
+    internal static readonly string[] SubtotalOnly = ["SUBTOTAL"];
+
+    /// <summary>AGGREGATE skips nested SUBTOTAL and nested AGGREGATE alike.</summary>
+    internal static readonly string[] SubtotalAndAggregate = ["SUBTOTAL", "AGGREGATE"];
+
     /// <summary>
     /// Tally algorithm for <c>SUBTOTAL</c> functions 1..11.
     /// </summary>
-    internal static readonly TallyNumbers Subtotal10 = new(static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, "SUBTOTAL"));
+    internal static readonly TallyNumbers Subtotal10 = new(static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, SubtotalOnly));
 
     /// <summary>
     /// Tally algorithm for <c>SUBTOTAL</c> functions 101..111.
     /// </summary>
-    internal static readonly TallyNumbers Subtotal100 = new(static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, "SUBTOTAL", skipHiddenRows: true));
+    internal static readonly TallyNumbers Subtotal100 = new(static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, SubtotalOnly, skipHiddenRows: true));
+
+    /// <summary>
+    /// The four tally algorithms <c>AGGREGATE</c> needs, indexed by whether its options ask for
+    /// hidden rows to be skipped and for errors to be ignored.
+    /// </summary>
+    private static readonly TallyNumbers[] AggregateVariants =
+    [
+        new(static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, SubtotalAndAggregate)),
+        new(static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, SubtotalAndAggregate), ignoreErrors: true),
+        new(static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, SubtotalAndAggregate, skipHiddenRows: true)),
+        new(static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, SubtotalAndAggregate, skipHiddenRows: true), ignoreErrors: true),
+    ];
+
+    internal static TallyNumbers Aggregate(bool skipHiddenRows, bool ignoreErrors)
+        => AggregateVariants[(skipHiddenRows ? 2 : 0) + (ignoreErrors ? 1 : 0)];
 
     /// <summary>
     /// Tally numbers. Any error (including conversion), logical, text is ignored and not tallied.


### PR DESCRIPTION
Wave F of [spec 07](docs/specs/07-formula-function-coverage.md). Stacked on #254 — **targets `feat/calc-wave-e-text-array`**, retarget as the stack merges.

## Functions added

`AGGREGATE`, `NETWORKDAYS.INTL`, `WORKDAY.INTL`. `DAYS`, `ISOWEEKNUM` and `SUBTOTAL` were verified as already complete (`SUBTOTAL` covers all of 1–11 and 101–111; there's now a test pinning both ranges).

Registry: 343 → 346 functions.

## Bug fixed

**`SUBTOTAL` counted a nested `AGGREGATE` twice.** The check that stops a subtotal counting a subtotal inside its own range compared the function name as the formula stores it — and every function added after 2007 is stored under an `_xlfn.` namespace, so a cell holding `AGGREGATE` read back as `_xlfn.AGGREGATE` and was invisible to the comparison. The namespace is now stripped before comparing, and the filter takes a set of names so `AGGREGATE` can exclude both itself and `SUBTOTAL`.

This was pre-existing and would affect any future function in that exclusion list.

## Notes on the implementation

**`AGGREGATE` covers all nineteen function numbers and all eight option values.** The spec allowed hidden-row awareness to be deferred as a documented limitation, but the machinery `SUBTOTAL` 101–111 already uses covers it — so options 1, 3, 5 and 7 work for real rather than being a stub.

Functions 18 and 19 need `PERCENTILE.EXC` and `QUARTILE.EXC`, which have no standalone registration until wave B. Rather than leave a hole, the two are implemented as internal helpers in `Statistical` alongside the inclusive pair; wave B registers them over the same code.

**The `.INTL` date functions share a weekend engine** that reads either one of Excel's numbered codes or a seven-character Monday-to-Sunday mask into a bitmask. `NETWORKDAYS.INTL` counts whole weeks arithmetically and only walks the days past the last whole week.

## Verification

73 tests, all passing; full suite green on net8.0 and net10.0; Release build clean.

Every weekend code (1–7, 11–17) and several masks are tested against a single calendar week where the expected count is just seven minus the weekend days. Two of my initial expectations were wrong and the implementation was right — both are now derived in the test comment rather than recalled.
