### PR TITLE
feat(calc): add the statistical distributions (spec 07 wave B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 
 #### Formula functions
 
+- **The statistical distributions — 69 functions**. The modern dotted set (`NORM.DIST`, `NORM.INV`, `NORM.S.DIST`, `NORM.S.INV`, `LOGNORM.*`, `CHISQ.*`, `F.*`, `T.DIST*`, `EXPON.DIST`, `POISSON.DIST`, `WEIBULL.DIST`, `GAMMA`, `GAMMA.DIST`, `GAMMA.INV`, `GAMMALN(.PRECISE)`, `BETA.DIST`, `BETA.INV`, `HYPGEOM.DIST`, `NEGBINOM.DIST`, `BINOM.INV`, `CONFIDENCE.NORM`, `CONFIDENCE.T`, `PERCENTILE.EXC`, `QUARTILE.EXC`, `RANK.AVG`, `MODE.MULT`, `PERCENTRANK(.INC/.EXC)`), the hypothesis tests (`CHISQ.TEST`, `F.TEST`, `T.TEST`, `Z.TEST`) and the 26 pre-2010 names (`NORMDIST`, `CHIDIST`, `FINV`, `TDIST`, `CRITBINOM`, …), which are registered against the same implementations rather than copies of them.
+
+  `MODE.MULT` spills. Everything reduces to one of four special functions — the regularized incomplete gamma, the regularized incomplete beta, the error function, or elementary functions — so the inverses invert their own distributions to full double precision rather than to the accuracy of a rational approximation. `T.TEST` with unequal variances truncates the Welch degrees of freedom, as the rest of the `T.DIST` family truncates its own. ([#256](https://github.com/XLibur/XLibur/pull/256) by [@jafin](https://github.com/jafin))
+
 - **`AGGREGATE`, `NETWORKDAYS.INTL` and `WORKDAY.INTL`**. `AGGREGATE` covers all nineteen function numbers — including `PERCENTILE.EXC` and `QUARTILE.EXC`, which have no standalone registration yet — and all eight option values, so ignoring hidden rows and error values both work rather than being documented limitations. The `.INTL` date functions take a weekend as either one of Excel's numbered codes or a seven-character Monday-to-Sunday mask. ([#255](https://github.com/XLibur/XLibur/pull/255) by [@jafin](https://github.com/jafin))
 
 - **20 modern text and array-shaping functions**: `TEXTSPLIT`, `TEXTBEFORE`, `TEXTAFTER`, `VALUETOTEXT`, `ARRAYTOTEXT`, `UNICHAR`, `UNICODE`, `DBCS`, `ENCODEURL`, and the array-shaping set `VSTACK`, `HSTACK`, `TOROW`, `TOCOL`, `WRAPROWS`, `WRAPCOLS`, `CHOOSEROWS`, `CHOOSECOLS`, `TAKE`, `DROP`, `EXPAND`. The array-shaping functions and `TEXTSPLIT` spill.

--- a/XLibur.Tests/Excel/CalcEngine/DistributionTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DistributionTests.cs
@@ -1,0 +1,584 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// The statistical distributions. Expected values are, in order of preference: closed-form results
+/// the distribution takes at a special point (the normal CDF at its mean is exactly a half, a
+/// chi-squared with two degrees of freedom is an exponential), published critical values, and the
+/// worked examples in Microsoft's per-function documentation. Every inverse is additionally checked
+/// by round-tripping it through its own distribution, which pins both directions at once.
+/// </summary>
+[SetCulture("en-US")]
+public class DistributionTests
+{
+    private const double Tolerance = 1e-9;
+
+    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    {
+        wb = new XLWorkbook();
+        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+    }
+
+    #region Normal
+
+    [Test]
+    [Arguments("NORM.S.DIST(0, TRUE)", 0.5d)] // Half the mass lies below the mean.
+    [Arguments("NORM.S.DIST(0, FALSE)", 0.3989422804014327d)] // 1/sqrt(2*pi).
+    [Arguments("NORM.DIST(40, 40, 1.5, TRUE)", 0.5d)]
+    [Arguments("NORM.DIST(40, 40, 1.5, FALSE)", 0.26596152026762186d)] // 1/(1.5*sqrt(2*pi)).
+    // 1.96 and 1.6449 are the standard normal's two best-known critical values.
+    [Arguments("NORM.S.DIST(1.959963984540054, TRUE)", 0.975d)]
+    [Arguments("NORM.S.DIST(1.6448536269514722, TRUE)", 0.95d)]
+    [Arguments("NORM.S.INV(0.975)", 1.959963984540054d)]
+    [Arguments("NORM.S.INV(0.95)", 1.6448536269514722d)]
+    [Arguments("NORM.S.INV(0.5)", 0d)]
+    // Microsoft's NORMDIST example: 42 against a mean of 40 and a standard deviation of 1.5.
+    [Arguments("NORM.DIST(42, 40, 1.5, TRUE)", 0.9087887802741321d)]
+    public async Task Normal_DistributionAndInverse(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(Tolerance);
+    }
+
+    [Test]
+    public async Task Normal_IsSymmetricAboutItsMean()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "NORM.S.DIST(1.3, TRUE) + NORM.S.DIST(-1.3, TRUE)";
+            ws.Cell("A2").FormulaA1 = "NORM.DIST(43, 40, 1.5, TRUE) + NORM.DIST(37, 40, 1.5, TRUE)";
+
+            await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(1d).Within(1e-12);
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(1d).Within(1e-12);
+        }
+    }
+
+    [Test]
+    public async Task Normal_InverseUndoesTheDistribution()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "NORM.S.DIST(NORM.S.INV(0.123), TRUE)";
+            ws.Cell("A2").FormulaA1 = "NORM.DIST(NORM.INV(0.876, 40, 1.5), 40, 1.5, TRUE)";
+            ws.Cell("A3").FormulaA1 = "NORM.S.DIST(NORM.S.INV(0.0000001), TRUE)"; // Deep in the tail.
+
+            await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(0.123d).Within(1e-12);
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(0.876d).Within(1e-12);
+            await Assert.That((double)ws.Cell("A3").Value).IsEqualTo(0.0000001d).Within(1e-16);
+        }
+    }
+
+    [Test]
+    public async Task Normal_LegacyNamesMatchTheDottedOnes()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "NORMDIST(42, 40, 1.5, TRUE) - NORM.DIST(42, 40, 1.5, TRUE)";
+            ws.Cell("A2").FormulaA1 = "NORMINV(0.9, 40, 1.5) - NORM.INV(0.9, 40, 1.5)";
+            ws.Cell("A3").FormulaA1 = "NORMSDIST(1.3) - NORM.S.DIST(1.3, TRUE)";
+            ws.Cell("A4").FormulaA1 = "NORMSINV(0.9) - NORM.S.INV(0.9)";
+
+            foreach (var address in new[] { "A1", "A2", "A3", "A4" })
+                await Assert.That((double)ws.Cell(address).Value).IsEqualTo(0d).Within(1e-15);
+        }
+    }
+
+    [Test]
+    [Arguments("NORM.DIST(1, 0, 0, TRUE)")] // The standard deviation must be positive.
+    [Arguments("NORM.DIST(1, 0, -1, TRUE)")]
+    [Arguments("NORM.INV(0, 0, 1)")] // The probability must be strictly inside 0..1.
+    [Arguments("NORM.INV(1, 0, 1)")]
+    [Arguments("NORM.INV(0.5, 0, 0)")]
+    [Arguments("NORM.S.INV(0)")]
+    [Arguments("NORM.S.INV(1)")]
+    public async Task Normal_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    #endregion
+
+    #region Lognormal
+
+    [Test]
+    // A lognormal variable is the exponential of a normal one, so its CDF at exp(mean) is a half.
+    [Arguments("LOGNORM.DIST(1, 0, 1, TRUE)", 0.5d)]
+    [Arguments("LOGNORM.DIST(2.718281828459045, 1, 1, TRUE)", 0.5d)]
+    [Arguments("LOGNORM.INV(0.5, 0, 1)", 1d)]
+    [Arguments("LOGNORM.INV(0.5, 1, 1)", 2.718281828459045d)]
+    public async Task Lognormal_DistributionAndInverse(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(Tolerance);
+    }
+
+    [Test]
+    public async Task Lognormal_TracksTheNormalOfTheLogarithm()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "LOGNORM.DIST(4, 3.5, 1.2, TRUE) - NORM.DIST(LN(4), 3.5, 1.2, TRUE)";
+            ws.Cell("A2").FormulaA1 = "LOGNORM.DIST(LOGNORM.INV(0.42, 3.5, 1.2), 3.5, 1.2, TRUE)";
+            ws.Cell("A3").FormulaA1 = "LOGNORMDIST(4, 3.5, 1.2) - LOGNORM.DIST(4, 3.5, 1.2, TRUE)";
+            ws.Cell("A4").FormulaA1 = "LOGINV(0.42, 3.5, 1.2) - LOGNORM.INV(0.42, 3.5, 1.2)";
+
+            await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(0d).Within(1e-15);
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(0.42d).Within(1e-12);
+            await Assert.That((double)ws.Cell("A3").Value).IsEqualTo(0d).Within(1e-15);
+            await Assert.That((double)ws.Cell("A4").Value).IsEqualTo(0d).Within(1e-15);
+        }
+    }
+
+    [Test]
+    [Arguments("LOGNORM.DIST(0, 0, 1, TRUE)")] // A lognormal variable is strictly positive.
+    [Arguments("LOGNORM.DIST(-1, 0, 1, TRUE)")]
+    [Arguments("LOGNORM.DIST(1, 0, 0, TRUE)")]
+    [Arguments("LOGNORM.INV(0, 0, 1)")]
+    [Arguments("LOGNORM.INV(1, 0, 1)")]
+    public async Task Lognormal_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    #endregion
+
+    #region Chi-squared
+
+    [Test]
+    // Chi-squared with two degrees of freedom is an exponential with mean two, so its right tail is
+    // exactly exp(-x/2) and its inverse exactly -2*ln(p).
+    [Arguments("CHISQ.DIST.RT(2, 2)", 0.36787944117144233d)]
+    [Arguments("CHISQ.DIST.RT(0, 2)", 1d)]
+    [Arguments("CHISQ.DIST(2, 2, TRUE)", 0.6321205588285577d)]
+    [Arguments("CHISQ.INV.RT(0.5, 2)", 1.3862943611198906d)] // 2*ln(2).
+    [Arguments("CHISQ.INV(0.5, 2)", 1.3862943611198906d)] // The same by symmetry of this case.
+    // The 5% critical values of the chi-squared distribution, as published in every statistics text.
+    [Arguments("CHISQ.INV.RT(0.05, 1)", 3.841458820694124d)]
+    [Arguments("CHISQ.INV.RT(0.05, 2)", 5.991464547107979d)]
+    [Arguments("CHISQ.INV.RT(0.05, 10)", 18.307038053275146d)]
+    [Arguments("CHISQ.DIST.RT(3.841458820694124, 1)", 0.05d)]
+    public async Task ChiSquared_DistributionAndInverse(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-8);
+    }
+
+    [Test]
+    public async Task ChiSquared_TailsSumToOneAndInvertEachOther()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "CHISQ.DIST(7.3, 5, TRUE) + CHISQ.DIST.RT(7.3, 5)";
+            ws.Cell("A2").FormulaA1 = "CHISQ.DIST.RT(CHISQ.INV.RT(0.037, 7), 7)";
+            ws.Cell("A3").FormulaA1 = "CHISQ.DIST(CHISQ.INV(0.037, 7), 7, TRUE)";
+            ws.Cell("A4").FormulaA1 = "CHIDIST(18.307038053275146, 10) - CHISQ.DIST.RT(18.307038053275146, 10)";
+            ws.Cell("A5").FormulaA1 = "CHIINV(0.05, 10) - CHISQ.INV.RT(0.05, 10)";
+
+            await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(1d).Within(1e-12);
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(0.037d).Within(1e-10);
+            await Assert.That((double)ws.Cell("A3").Value).IsEqualTo(0.037d).Within(1e-10);
+            await Assert.That((double)ws.Cell("A4").Value).IsEqualTo(0d).Within(1e-15);
+            await Assert.That((double)ws.Cell("A5").Value).IsEqualTo(0d).Within(1e-15);
+        }
+    }
+
+    [Test]
+    [Arguments("CHISQ.DIST(-1, 2, TRUE)")] // A chi-squared variable is non-negative.
+    [Arguments("CHISQ.DIST(1, 0, TRUE)")] // At least one degree of freedom.
+    [Arguments("CHISQ.DIST.RT(-1, 2)")]
+    [Arguments("CHISQ.INV(-0.1, 2)")]
+    [Arguments("CHISQ.INV(1.1, 2)")]
+    [Arguments("CHISQ.INV.RT(1.1, 2)")]
+    public async Task ChiSquared_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    #endregion
+
+    #region F distribution
+
+    [Test]
+    // The F distribution's median is not closed form, but F(1,1) has CDF (2/pi)*atan(sqrt(x)), so
+    // its median is exactly 1 and its 1/2-quantile checkable by hand.
+    [Arguments("F.DIST(1, 1, 1, TRUE)", 0.5d)]
+    [Arguments("F.INV(0.5, 1, 1)", 1d)]
+    [Arguments("F.DIST(3, 1, 1, TRUE)", 0.66666666666666663d)] // (2/pi)*atan(sqrt(3)) = 2/3.
+    [Arguments("F.DIST.RT(1, 1, 1)", 0.5d)]
+    public async Task FDistribution_ClosedFormCases(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    public async Task FDistribution_TailsAndInversesAgree()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "F.DIST(2.5, 6, 4, TRUE) + F.DIST.RT(2.5, 6, 4)";
+            ws.Cell("A2").FormulaA1 = "F.DIST.RT(F.INV.RT(0.05, 6, 4), 6, 4)";
+            ws.Cell("A3").FormulaA1 = "F.DIST(F.INV(0.05, 6, 4), 6, 4, TRUE)";
+            ws.Cell("A4").FormulaA1 = "FDIST(2.5, 6, 4) - F.DIST.RT(2.5, 6, 4)";
+            ws.Cell("A5").FormulaA1 = "FINV(0.05, 6, 4) - F.INV.RT(0.05, 6, 4)";
+            // The F distribution reciprocates when its degrees of freedom swap over.
+            ws.Cell("A6").FormulaA1 = "F.INV.RT(0.05, 6, 4) * F.INV(0.05, 4, 6)";
+
+            await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(1d).Within(1e-12);
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(0.05d).Within(1e-10);
+            await Assert.That((double)ws.Cell("A3").Value).IsEqualTo(0.05d).Within(1e-10);
+            await Assert.That((double)ws.Cell("A4").Value).IsEqualTo(0d).Within(1e-15);
+            await Assert.That((double)ws.Cell("A5").Value).IsEqualTo(0d).Within(1e-15);
+            await Assert.That((double)ws.Cell("A6").Value).IsEqualTo(1d).Within(1e-9);
+        }
+    }
+
+    [Test]
+    [Arguments("F.DIST(-1, 6, 4, TRUE)")]
+    [Arguments("F.DIST(1, 0, 4, TRUE)")]
+    [Arguments("F.DIST.RT(1, 6, 0)")]
+    [Arguments("F.INV(-0.1, 6, 4)")]
+    [Arguments("F.INV.RT(1.1, 6, 4)")]
+    public async Task FDistribution_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    #endregion
+
+    #region Student's t
+
+    [Test]
+    [Arguments("T.DIST(0, 10, TRUE)", 0.5d)] // The t-distribution is symmetric about zero.
+    [Arguments("T.DIST.RT(0, 10)", 0.5d)]
+    [Arguments("T.DIST.2T(0, 10)", 1d)]
+    // With one degree of freedom the t-distribution is Cauchy: CDF = 1/2 + atan(x)/pi.
+    [Arguments("T.DIST(1, 1, TRUE)", 0.75d)]
+    [Arguments("T.DIST(1, 1, FALSE)", 0.15915494309189535d)] // 1/(pi*(1+x^2)) at x = 1.
+    // The two-tailed 5% critical values, as published in every t-table.
+    [Arguments("T.INV.2T(0.05, 10)", 2.2281388519649385d)]
+    [Arguments("T.INV.2T(0.05, 30)", 2.0422724563012373d)]
+    public async Task StudentT_DistributionAndInverse(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-8);
+    }
+
+    [Test]
+    public async Task StudentT_TailsAndInversesAgree()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "T.DIST(1.7, 12, TRUE) + T.DIST.RT(1.7, 12)";
+            ws.Cell("A2").FormulaA1 = "T.DIST.RT(T.INV(0.95, 12), 12)";
+            ws.Cell("A3").FormulaA1 = "T.DIST.2T(T.INV.2T(0.05, 12), 12)";
+            ws.Cell("A4").FormulaA1 = "T.DIST.2T(1.7, 12) - 2 * T.DIST.RT(1.7, 12)";
+            ws.Cell("A5").FormulaA1 = "TDIST(1.7, 12, 2) - T.DIST.2T(1.7, 12)";
+            ws.Cell("A6").FormulaA1 = "TDIST(1.7, 12, 1) - T.DIST.RT(1.7, 12)";
+
+            await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(1d).Within(1e-12);
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(0.05d).Within(1e-10);
+            await Assert.That((double)ws.Cell("A3").Value).IsEqualTo(0.05d).Within(1e-10);
+            await Assert.That((double)ws.Cell("A4").Value).IsEqualTo(0d).Within(1e-14);
+            await Assert.That((double)ws.Cell("A5").Value).IsEqualTo(0d).Within(1e-14);
+            await Assert.That((double)ws.Cell("A6").Value).IsEqualTo(0d).Within(1e-14);
+        }
+    }
+
+    [Test]
+    [Arguments("T.DIST(1, 0, TRUE)")]
+    [Arguments("T.DIST.2T(-1, 10)")] // The two-tailed form takes a non-negative argument.
+    [Arguments("TDIST(-1, 10, 1)")]
+    [Arguments("TDIST(1, 10, 3)")] // One tail or two.
+    public async Task StudentT_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    #endregion
+
+    #region Exponential families
+
+    [Test]
+    [Arguments("EXPON.DIST(0, 10, TRUE)", 0d)]
+    [Arguments("EXPON.DIST(0, 10, FALSE)", 10d)] // The density at zero is the rate itself.
+    [Arguments("EXPON.DIST(0.2, 10, TRUE)", 0.8646647167633873d)] // 1 - exp(-2).
+    [Arguments("EXPON.DIST(0.2, 10, FALSE)", 1.353352832366127d)] // 10*exp(-2).
+    [Arguments("POISSON.DIST(0, 1, FALSE)", 0.36787944117144233d)] // exp(-1).
+    [Arguments("POISSON.DIST(0, 1, TRUE)", 0.36787944117144233d)]
+    [Arguments("POISSON.DIST(1, 1, TRUE)", 0.7357588823428847d)] // 2*exp(-1).
+    [Arguments("WEIBULL.DIST(1, 1, 1, TRUE)", 0.6321205588285577d)] // Shape one is the exponential.
+    [Arguments("WEIBULL.DIST(1, 1, 1, FALSE)", 0.36787944117144233d)]
+    [Arguments("GAMMA.DIST(1, 1, 1, TRUE)", 0.6321205588285577d)] // Shape one is again exponential.
+    [Arguments("GAMMA.DIST(1, 1, 1, FALSE)", 0.36787944117144233d)]
+    [Arguments("GAMMA(5)", 24d)] // Gamma extends the factorial: GAMMA(n) = (n-1)!.
+    [Arguments("GAMMA(1)", 1d)]
+    [Arguments("GAMMA(0.5)", 1.7724538509055159d)] // sqrt(pi).
+    [Arguments("GAMMA(-0.5)", -3.5449077018110318d)] // -2*sqrt(pi).
+    [Arguments("GAMMALN(5)", 3.1780538303479458d)] // ln(24).
+    [Arguments("GAMMALN.PRECISE(5)", 3.1780538303479458d)]
+    public async Task ExponentialFamilies_ClosedFormCases(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    public async Task Gamma_InvertsItsOwnDistributionAndMatchesTheLegacyNames()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "GAMMA.DIST(GAMMA.INV(0.31, 9, 2), 9, 2, TRUE)";
+            ws.Cell("A2").FormulaA1 = "GAMMADIST(10, 9, 2, TRUE) - GAMMA.DIST(10, 9, 2, TRUE)";
+            ws.Cell("A3").FormulaA1 = "GAMMAINV(0.31, 9, 2) - GAMMA.INV(0.31, 9, 2)";
+            ws.Cell("A4").FormulaA1 = "EXPONDIST(0.2, 10, TRUE) - EXPON.DIST(0.2, 10, TRUE)";
+            ws.Cell("A5").FormulaA1 = "POISSON(2, 5, TRUE) - POISSON.DIST(2, 5, TRUE)";
+            ws.Cell("A6").FormulaA1 = "WEIBULL(105, 20, 100, TRUE) - WEIBULL.DIST(105, 20, 100, TRUE)";
+            // GAMMALN is the logarithm of GAMMA wherever both are defined.
+            ws.Cell("A7").FormulaA1 = "EXP(GAMMALN(7.3)) - GAMMA(7.3)";
+
+            await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(0.31d).Within(1e-10);
+            foreach (var address in new[] { "A2", "A3", "A4", "A5", "A6" })
+                await Assert.That((double)ws.Cell(address).Value).IsEqualTo(0d).Within(1e-15);
+
+            await Assert.That((double)ws.Cell("A7").Value).IsEqualTo(0d).Within(1e-6);
+        }
+    }
+
+    [Test]
+    public async Task Poisson_CumulativeIsTheRunningSumOfItsTerms()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "POISSON.DIST(0, 5, FALSE) + POISSON.DIST(1, 5, FALSE) + POISSON.DIST(2, 5, FALSE)";
+            ws.Cell("A2").FormulaA1 = "POISSON.DIST(2, 5, TRUE)";
+
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo((double)ws.Cell("A1").Value).Within(1e-12);
+        }
+    }
+
+    [Test]
+    [Arguments("EXPON.DIST(-1, 10, TRUE)")]
+    [Arguments("EXPON.DIST(1, 0, TRUE)")]
+    [Arguments("POISSON.DIST(-1, 5, TRUE)")]
+    [Arguments("POISSON.DIST(1, -1, TRUE)")]
+    [Arguments("WEIBULL.DIST(-1, 1, 1, TRUE)")]
+    [Arguments("WEIBULL.DIST(1, 0, 1, TRUE)")]
+    [Arguments("WEIBULL.DIST(1, 1, 0, TRUE)")]
+    [Arguments("GAMMA.DIST(-1, 1, 1, TRUE)")]
+    [Arguments("GAMMA.DIST(1, 0, 1, TRUE)")]
+    [Arguments("GAMMA.INV(1.1, 1, 1)")]
+    [Arguments("GAMMA(0)")] // The gamma function has a pole at every non-positive integer.
+    [Arguments("GAMMA(-1)")]
+    [Arguments("GAMMALN(0)")]
+    [Arguments("GAMMALN(-1)")]
+    public async Task ExponentialFamilies_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    #endregion
+
+    #region Beta
+
+    [Test]
+    // Beta(1,1) is the uniform distribution, so its CDF is the identity and its density is one.
+    [Arguments("BETA.DIST(0.3, 1, 1, TRUE)", 0.3d)]
+    [Arguments("BETA.DIST(0.3, 1, 1, FALSE)", 1d)]
+    [Arguments("BETA.INV(0.3, 1, 1)", 0.3d)]
+    [Arguments("BETA.DIST(0.5, 2, 2, TRUE)", 0.5d)] // Symmetric shapes put the median in the middle.
+    [Arguments("BETA.INV(0.5, 2, 2)", 0.5d)]
+    // Rescaled onto [1, 3]: the uniform CDF is (x-1)/2.
+    [Arguments("BETA.DIST(2, 1, 1, TRUE, 1, 3)", 0.5d)]
+    [Arguments("BETA.INV(0.5, 1, 1, 1, 3)", 2d)]
+    public async Task Beta_DistributionAndInverse(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    public async Task Beta_InverseUndoesTheDistributionAndMatchesTheLegacyNames()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "BETA.DIST(BETA.INV(0.685, 8, 10, 1, 3), 8, 10, TRUE, 1, 3)";
+            ws.Cell("A2").FormulaA1 = "BETADIST(2, 8, 10, 1, 3) - BETA.DIST(2, 8, 10, TRUE, 1, 3)";
+            ws.Cell("A3").FormulaA1 = "BETAINV(0.685, 8, 10, 1, 3) - BETA.INV(0.685, 8, 10, 1, 3)";
+
+            await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(0.685d).Within(1e-10);
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo(0d).Within(1e-15);
+            await Assert.That((double)ws.Cell("A3").Value).IsEqualTo(0d).Within(1e-15);
+        }
+    }
+
+    [Test]
+    [Arguments("BETA.DIST(0.5, 0, 1, TRUE)")]
+    [Arguments("BETA.DIST(0.5, 1, 0, TRUE)")]
+    [Arguments("BETA.DIST(2, 1, 1, TRUE)")] // Outside the default 0..1 support.
+    [Arguments("BETA.DIST(-1, 1, 1, TRUE)")]
+    [Arguments("BETA.DIST(2, 1, 1, TRUE, 3, 1)")] // The bounds must be the right way round.
+    [Arguments("BETA.INV(0, 1, 1)")]
+    [Arguments("BETA.INV(1.1, 1, 1)")]
+    public async Task Beta_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    #endregion
+
+    #region Discrete distributions
+
+    [Test]
+    // Drawing 4 from an urn of 20 holding 8 successes: C(8,1)*C(12,3)/C(20,4) = 8*220/4845.
+    [Arguments("HYPGEOM.DIST(1, 4, 8, 20, FALSE)", 0.36326109391124871d)]
+    [Arguments("HYPGEOMDIST(1, 4, 8, 20)", 0.36326109391124871d)]
+    // A sample of one is just the proportion of successes in the population.
+    [Arguments("HYPGEOM.DIST(1, 1, 8, 20, FALSE)", 0.4d)]
+    [Arguments("HYPGEOM.DIST(0, 1, 8, 20, FALSE)", 0.6d)]
+    [Arguments("HYPGEOM.DIST(1, 1, 8, 20, TRUE)", 1d)]
+    // Ten failures before the fifth success: C(14,4)*0.25^5*0.75^10.
+    [Arguments("NEGBINOM.DIST(10, 5, 0.25, FALSE)", 0.05504866037517786d)]
+    [Arguments("NEGBINOMDIST(10, 5, 0.25)", 0.05504866037517786d)]
+    // With one success required this is the geometric distribution: p*(1-p)^f.
+    [Arguments("NEGBINOM.DIST(2, 1, 0.5, FALSE)", 0.125d)]
+    [Arguments("NEGBINOM.DIST(2, 1, 0.5, TRUE)", 0.875d)] // 1 - 0.5^3.
+    public async Task DiscreteDistributions_ClosedFormCases(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-12);
+    }
+
+    [Test]
+    public async Task HypGeom_CumulativeIsTheRunningSumOfItsTerms()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "HYPGEOM.DIST(0, 4, 8, 20, FALSE) + HYPGEOM.DIST(1, 4, 8, 20, FALSE) + HYPGEOM.DIST(2, 4, 8, 20, FALSE)";
+            ws.Cell("A2").FormulaA1 = "HYPGEOM.DIST(2, 4, 8, 20, TRUE)";
+            ws.Cell("A3").FormulaA1 = "HYPGEOM.DIST(4, 4, 8, 20, TRUE)"; // Every outcome.
+
+            await Assert.That((double)ws.Cell("A2").Value).IsEqualTo((double)ws.Cell("A1").Value).Within(1e-12);
+            await Assert.That((double)ws.Cell("A3").Value).IsEqualTo(1d).Within(1e-12);
+        }
+    }
+
+    [Test]
+    // BINOM.INV finds the first number of successes whose cumulative probability reaches alpha.
+    [Arguments("BINOM.INV(6, 0.5, 0.75)", 4d)]
+    [Arguments("BINOM.INV(10, 0.5, 0.5)", 5d)]
+    [Arguments("BINOM.INV(10, 0.5, 0)", 0d)]
+    [Arguments("BINOM.INV(10, 0.5, 1)", 10d)]
+    [Arguments("CRITBINOM(6, 0.5, 0.75)", 4d)]
+    public async Task BinomInv_FindsTheCriterion(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task BinomInv_AgreesWithTheBinomialCumulative()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "BINOM.DIST(BINOM.INV(20, 0.3, 0.9), 20, 0.3, TRUE)";
+            ws.Cell("A2").FormulaA1 = "BINOM.DIST(BINOM.INV(20, 0.3, 0.9) - 1, 20, 0.3, TRUE)";
+
+            // The chosen k is the first one at or above alpha, so the one before it falls short.
+            await Assert.That((double)ws.Cell("A1").Value).IsGreaterThanOrEqualTo(0.9d);
+            await Assert.That((double)ws.Cell("A2").Value).IsLessThan(0.9d);
+        }
+    }
+
+    [Test]
+    [Arguments("HYPGEOM.DIST(5, 4, 8, 20, FALSE)")] // More successes than the sample holds.
+    [Arguments("HYPGEOM.DIST(1, 4, 8, 3, FALSE)")] // A sample larger than the population.
+    [Arguments("HYPGEOM.DIST(-1, 4, 8, 20, FALSE)")]
+    [Arguments("NEGBINOM.DIST(-1, 5, 0.25, FALSE)")]
+    [Arguments("NEGBINOM.DIST(10, 0, 0.25, FALSE)")] // At least one success is required.
+    [Arguments("NEGBINOM.DIST(10, 5, 0, FALSE)")]
+    [Arguments("NEGBINOM.DIST(10, 5, 1.5, FALSE)")]
+    [Arguments("BINOM.INV(-1, 0.5, 0.5)")]
+    [Arguments("BINOM.INV(10, 1.5, 0.5)")]
+    [Arguments("BINOM.INV(10, 0.5, 1.5)")]
+    public async Task DiscreteDistributions_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    #endregion
+
+    #region Confidence intervals
+
+    [Test]
+    // Microsoft's CONFIDENCE example: alpha 5%, standard deviation 2.5, sample of 50.
+    // 1.959963985 * 2.5 / sqrt(50).
+    [Arguments("CONFIDENCE.NORM(0.05, 2.5, 50)", 0.6929519121748394d)]
+    [Arguments("CONFIDENCE(0.05, 2.5, 50)", 0.6929519121748394d)]
+    public async Task Confidence_ReferenceExampleFromExcelDocumentation(string formula, double expected)
+    {
+        await Assert.That((double)XLWorkbook.EvaluateExpr(formula)).IsEqualTo(expected).Within(1e-9);
+    }
+
+    [Test]
+    public async Task Confidence_TIsWiderThanNormAndNarrowsWithTheSample()
+    {
+        // The t interval allows for the standard deviation being estimated, so it is always wider,
+        // and the gap closes as the sample grows.
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").FormulaA1 = "CONFIDENCE.T(0.05, 2.5, 50) - CONFIDENCE.NORM(0.05, 2.5, 50)";
+            ws.Cell("A2").FormulaA1 = "CONFIDENCE.T(0.05, 2.5, 5000) - CONFIDENCE.NORM(0.05, 2.5, 5000)";
+            ws.Cell("A3").FormulaA1 = "CONFIDENCE.T(0.05, 2.5, 50)";
+            // The t interval is the two-tailed critical value scaled by the standard error.
+            ws.Cell("A4").FormulaA1 = "T.INV.2T(0.05, 49) * 2.5 / SQRT(50)";
+
+            await Assert.That((double)ws.Cell("A1").Value).IsGreaterThan(0d);
+            await Assert.That((double)ws.Cell("A2").Value).IsLessThan((double)ws.Cell("A1").Value);
+            await Assert.That((double)ws.Cell("A3").Value).IsEqualTo((double)ws.Cell("A4").Value).Within(1e-9);
+        }
+    }
+
+    [Test]
+    [Arguments("CONFIDENCE.NORM(0, 2.5, 50)")]
+    [Arguments("CONFIDENCE.NORM(1, 2.5, 50)")]
+    [Arguments("CONFIDENCE.NORM(0.05, 0, 50)")]
+    [Arguments("CONFIDENCE.NORM(0.05, 2.5, 0)")]
+    [Arguments("CONFIDENCE.T(0.05, 2.5, 0)")]
+    public async Task Confidence_OutOfRangeArgumentsReturnNumberInvalid(string formula)
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr(formula)).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    public async Task ConfidenceT_WithASingleObservationIsDivisionByZero()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("CONFIDENCE.T(0.05, 2.5, 1)")).IsEqualTo(XLError.DivisionByZero);
+    }
+
+    #endregion
+
+    [Test]
+    public async Task Distributions_EvaluateAgainstWorksheetCells()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 42;
+            ws.Cell("A2").Value = 40;
+            ws.Cell("A3").Value = 1.5;
+
+            ws.Cell("B1").FormulaA1 = "NORM.DIST(A1, A2, A3, TRUE)";
+            ws.Cell("B2").FormulaA1 = "NORM.INV(B1, A2, A3)";
+
+            await Assert.That((double)ws.Cell("B1").Value).IsEqualTo(0.9087887802741321d).Within(1e-9);
+            await Assert.That((double)ws.Cell("B2").Value).IsEqualTo(42d).Within(1e-9);
+        }
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/HypothesisTestTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/HypothesisTestTests.cs
@@ -1,0 +1,422 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// The hypothesis tests (CHISQ.TEST, F.TEST, T.TEST, Z.TEST) and the rank functions added alongside
+/// them (RANK.AVG, MODE.MULT, PERCENTILE.EXC, QUARTILE.EXC, PERCENTRANK). The tests are checked
+/// against the distribution they are defined in terms of, computed independently in the same
+/// worksheet — which is exactly the identity Microsoft's documentation states for each of them.
+/// </summary>
+[SetCulture("en-US")]
+public class HypothesisTestTests
+{
+    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    {
+        wb = new XLWorkbook();
+        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+    }
+
+    private static void SeedTwoSamples(XLWorksheet ws)
+    {
+        double[] first = [3, 4, 5, 8, 9, 1, 2, 4, 5];
+        double[] second = [6, 19, 3, 2, 14, 4, 5, 17, 1];
+        for (var i = 0; i < first.Length; i++)
+        {
+            ws.Cell(i + 1, 1).Value = first[i];
+            ws.Cell(i + 1, 2).Value = second[i];
+        }
+    }
+
+    [Test]
+    public async Task ChiSqTest_IsTheRightTailOfTheStatisticItComputes()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            // A two-by-three table, so two degrees of freedom.
+            double[,] actual = { { 58, 11, 10 }, { 35, 25, 23 } };
+            double[,] expected = { { 45.35, 17.56, 16.09 }, { 47.65, 18.44, 16.91 } };
+            for (var row = 0; row < 2; row++)
+            {
+                for (var column = 0; column < 3; column++)
+                {
+                    ws.Cell(row + 1, column + 1).Value = actual[row, column];
+                    ws.Cell(row + 1, column + 5).Value = expected[row, column];
+                }
+            }
+
+            ws.Cell("A5").FormulaA1 = "CHISQ.TEST(A1:C2, E1:G2)";
+            ws.Cell("A6").FormulaA1 = "SUMPRODUCT((A1:C2 - E1:G2) ^ 2 / E1:G2)";
+            ws.Cell("A7").FormulaA1 = "CHISQ.DIST.RT(A6, 2)";
+            ws.Cell("A8").FormulaA1 = "CHITEST(A1:C2, E1:G2) - CHISQ.TEST(A1:C2, E1:G2)";
+
+            await Assert.That((double)ws.Cell("A5").Value).IsEqualTo((double)ws.Cell("A7").Value).Within(1e-12);
+            await Assert.That((double)ws.Cell("A5").Value).IsGreaterThan(0d);
+            await Assert.That((double)ws.Cell("A5").Value).IsLessThan(1d);
+            await Assert.That((double)ws.Cell("A8").Value).IsEqualTo(0d);
+        }
+    }
+
+    [Test]
+    public async Task ChiSqTest_UsesOneLessThanTheLengthForAVector()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            for (var row = 1; row <= 4; row++)
+            {
+                ws.Cell(row, 1).Value = row * 10;
+                ws.Cell(row, 2).Value = 25;
+            }
+
+            ws.Cell("D1").FormulaA1 = "CHISQ.TEST(A1:A4, B1:B4)";
+            ws.Cell("D2").FormulaA1 = "SUMPRODUCT((A1:A4 - B1:B4) ^ 2 / B1:B4)";
+            ws.Cell("D3").FormulaA1 = "CHISQ.DIST.RT(D2, 3)";
+
+            await Assert.That((double)ws.Cell("D1").Value).IsEqualTo((double)ws.Cell("D3").Value).Within(1e-12);
+        }
+    }
+
+    [Test]
+    public async Task ChiSqTest_MismatchedShapesAndZeroExpectedValues()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 10;
+            ws.Cell("A2").Value = 20;
+            ws.Cell("A3").Value = 30;
+            ws.Cell("B1").Value = 15;
+            ws.Cell("B2").Value = 15;
+            ws.Cell("B3").Value = 0;
+
+            ws.Cell("D1").FormulaA1 = "CHISQ.TEST(A1:A3, B1:B2)"; // Different shapes.
+            ws.Cell("D2").FormulaA1 = "CHISQ.TEST(A1:A3, B1:B3)"; // A zero expected frequency.
+
+            await Assert.That(ws.Cell("D1").Value).IsEqualTo(XLError.NoValueAvailable);
+            await Assert.That(ws.Cell("D2").Value).IsEqualTo(XLError.DivisionByZero);
+        }
+    }
+
+    [Test]
+    public async Task FTest_IsTwiceTheOneTailedProbabilityOfTheVarianceRatio()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedTwoSamples(ws);
+
+            ws.Cell("D1").FormulaA1 = "F.TEST(A1:A9, B1:B9)";
+            ws.Cell("D2").FormulaA1 = "VAR.S(B1:B9) / VAR.S(A1:A9)"; // B is the more variable sample.
+            ws.Cell("D3").FormulaA1 = "2 * F.DIST.RT(D2, 8, 8)";
+            ws.Cell("D4").FormulaA1 = "FTEST(A1:A9, B1:B9) - F.TEST(A1:A9, B1:B9)";
+            // The test does not care which sample is given first.
+            ws.Cell("D5").FormulaA1 = "F.TEST(B1:B9, A1:A9) - F.TEST(A1:A9, B1:B9)";
+
+            await Assert.That((double)ws.Cell("D1").Value).IsEqualTo((double)ws.Cell("D3").Value).Within(1e-12);
+            await Assert.That((double)ws.Cell("D4").Value).IsEqualTo(0d);
+            await Assert.That((double)ws.Cell("D5").Value).IsEqualTo(0d).Within(1e-15);
+        }
+    }
+
+    [Test]
+    public async Task FTest_OfASampleAgainstItselfIsCertainty()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedTwoSamples(ws);
+            ws.Cell("D1").FormulaA1 = "F.TEST(A1:A9, A1:A9)";
+
+            // Identical variances give a ratio of one, whose two-tailed probability is one.
+            await Assert.That((double)ws.Cell("D1").Value).IsEqualTo(1d).Within(1e-12);
+        }
+    }
+
+    [Test]
+    public async Task TTest_MatchesTheTDistributionOfEachTestStatistic()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedTwoSamples(ws);
+
+            // Type 1, paired: the mean difference over its own standard error, on n-1 degrees.
+            ws.Cell("D1").FormulaA1 = "T.TEST(A1:A9, B1:B9, 2, 1)";
+            ws.Cell("D2").FormulaA1 = "AVERAGE(A1:A9 - B1:B9) / (STDEV.S(A1:A9 - B1:B9) / SQRT(9))";
+            ws.Cell("D3").FormulaA1 = "T.DIST.2T(ABS(D2), 8)";
+
+            // Type 2, equal variances: the pooled standard error on n1+n2-2 degrees.
+            ws.Cell("E1").FormulaA1 = "T.TEST(A1:A9, B1:B9, 2, 2)";
+            ws.Cell("E2").FormulaA1 = "(AVERAGE(A1:A9) - AVERAGE(B1:B9)) / SQRT((8 * VAR.S(A1:A9) + 8 * VAR.S(B1:B9)) / 16 * (1/9 + 1/9))";
+            ws.Cell("E3").FormulaA1 = "T.DIST.2T(ABS(E2), 16)";
+
+            await Assert.That((double)ws.Cell("D1").Value).IsEqualTo((double)ws.Cell("D3").Value).Within(1e-10);
+            await Assert.That((double)ws.Cell("E1").Value).IsEqualTo((double)ws.Cell("E3").Value).Within(1e-10);
+        }
+    }
+
+    [Test]
+    public async Task TTest_UnequalVariancesUsesTheWelchDegreesOfFreedom()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedTwoSamples(ws);
+
+            ws.Cell("D1").FormulaA1 = "T.TEST(A1:A9, B1:B9, 2, 3)";
+            ws.Cell("D2").FormulaA1 = "(AVERAGE(A1:A9) - AVERAGE(B1:B9)) / SQRT(VAR.S(A1:A9)/9 + VAR.S(B1:B9)/9)";
+            // Welch–Satterthwaite, written out.
+            ws.Cell("D3").FormulaA1 = "(VAR.S(A1:A9)/9 + VAR.S(B1:B9)/9)^2 / ((VAR.S(A1:A9)/9)^2/8 + (VAR.S(B1:B9)/9)^2/8)";
+            ws.Cell("D4").FormulaA1 = "T.DIST.2T(ABS(D2), D3)";
+
+            // The adjusted degrees of freedom are generally not a whole number.
+            await Assert.That((double)ws.Cell("D3").Value).IsNotEqualTo(16d);
+            await Assert.That((double)ws.Cell("D1").Value).IsEqualTo((double)ws.Cell("D4").Value).Within(1e-10);
+        }
+    }
+
+    [Test]
+    public async Task TTest_OneTailedIsHalfTheTwoTailed()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedTwoSamples(ws);
+            ws.Cell("D1").FormulaA1 = "T.TEST(A1:A9, B1:B9, 1, 2) * 2 - T.TEST(A1:A9, B1:B9, 2, 2)";
+            ws.Cell("D2").FormulaA1 = "TTEST(A1:A9, B1:B9, 2, 2) - T.TEST(A1:A9, B1:B9, 2, 2)";
+
+            await Assert.That((double)ws.Cell("D1").Value).IsEqualTo(0d).Within(1e-14);
+            await Assert.That((double)ws.Cell("D2").Value).IsEqualTo(0d);
+        }
+    }
+
+    [Test]
+    public async Task TTest_OutOfRangeArguments()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            SeedTwoSamples(ws);
+            ws.Cell("D1").FormulaA1 = "T.TEST(A1:A9, B1:B9, 3, 2)"; // One tail or two.
+            ws.Cell("D2").FormulaA1 = "T.TEST(A1:A9, B1:B9, 2, 4)"; // Types are 1, 2 and 3.
+            ws.Cell("D3").FormulaA1 = "T.TEST(A1:A9, B1:B8, 2, 1)"; // Paired needs equal lengths.
+
+            await Assert.That(ws.Cell("D1").Value).IsEqualTo(XLError.NumberInvalid);
+            await Assert.That(ws.Cell("D2").Value).IsEqualTo(XLError.NumberInvalid);
+            await Assert.That(ws.Cell("D3").Value).IsEqualTo(XLError.NoValueAvailable);
+        }
+    }
+
+    [Test]
+    public async Task ZTest_IsTheUpperTailOfTheStandardisedSampleMean()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            double[] sample = [3, 6, 7, 8, 6, 5, 4, 2, 1, 9];
+            for (var i = 0; i < sample.Length; i++)
+                ws.Cell(i + 1, 1).Value = sample[i];
+
+            ws.Cell("C1").FormulaA1 = "Z.TEST(A1:A10, 4)";
+            ws.Cell("C2").FormulaA1 = "1 - NORM.S.DIST((AVERAGE(A1:A10) - 4) / (STDEV.S(A1:A10) / SQRT(10)), TRUE)";
+            ws.Cell("C3").FormulaA1 = "Z.TEST(A1:A10, 4, 3)"; // With a known population sigma.
+            ws.Cell("C4").FormulaA1 = "1 - NORM.S.DIST((AVERAGE(A1:A10) - 4) / (3 / SQRT(10)), TRUE)";
+            ws.Cell("C5").FormulaA1 = "ZTEST(A1:A10, 4) - Z.TEST(A1:A10, 4)";
+            // Testing against the sample's own mean leaves exactly half the mass above it.
+            ws.Cell("C6").FormulaA1 = "Z.TEST(A1:A10, AVERAGE(A1:A10))";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo((double)ws.Cell("C2").Value).Within(1e-12);
+            await Assert.That((double)ws.Cell("C3").Value).IsEqualTo((double)ws.Cell("C4").Value).Within(1e-12);
+            await Assert.That((double)ws.Cell("C5").Value).IsEqualTo(0d);
+            await Assert.That((double)ws.Cell("C6").Value).IsEqualTo(0.5d).Within(1e-12);
+        }
+    }
+
+    [Test]
+    public async Task ZTest_NonPositiveSigmaReturnsNumberInvalid()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 2;
+            ws.Cell("C1").FormulaA1 = "Z.TEST(A1:A2, 1, 0)";
+
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.NumberInvalid);
+        }
+    }
+
+    [Test]
+    public async Task RankAvg_SharesTheRanksATiedGroupOccupies()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            double[] values = [7, 3.5, 3.5, 1, 2];
+            for (var i = 0; i < values.Length; i++)
+                ws.Cell(i + 1, 1).Value = values[i];
+
+            // Descending: 7 is first, the two 3.5s take ranks two and three, 2 is fourth, 1 is fifth.
+            ws.Cell("C1").FormulaA1 = "RANK.EQ(3.5, A1:A5)";
+            ws.Cell("C2").FormulaA1 = "RANK.AVG(3.5, A1:A5)";
+            ws.Cell("C3").FormulaA1 = "RANK.AVG(7, A1:A5)";
+            ws.Cell("C4").FormulaA1 = "RANK.AVG(1, A1:A5)";
+            ws.Cell("C5").FormulaA1 = "RANK.AVG(1, A1:A5, 1)"; // Ascending.
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(2d);
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(2.5d);
+            await Assert.That((double)ws.Cell("C3").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("C4").Value).IsEqualTo(5d);
+            await Assert.That((double)ws.Cell("C5").Value).IsEqualTo(1d);
+        }
+    }
+
+    [Test]
+    public async Task ModeMult_ReturnsEveryTiedMode()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            double[] values = [1, 2, 2, 3, 3, 4];
+            for (var i = 0; i < values.Length; i++)
+                ws.Cell(i + 1, 1).Value = values[i];
+
+            ws.Range("C1:C2").FormulaArrayA1 = "MODE.MULT(A1:A6)";
+            ws.Cell("D1").FormulaA1 = "MODE.SNGL(A1:A6)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(2d);
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(3d);
+            // MODE.SNGL reports only the first of them.
+            await Assert.That((double)ws.Cell("D1").Value).IsEqualTo(2d);
+        }
+    }
+
+    [Test]
+    public async Task ModeMult_WithoutARepeatedValueReturnsNoValueAvailable()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 2;
+            ws.Cell("C1").FormulaA1 = "MODE.MULT(A1:A2)";
+
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.NoValueAvailable);
+        }
+    }
+
+    [Test]
+    public async Task PercentileAndQuartile_ExclusiveVariants()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            for (var row = 1; row <= 5; row++)
+                ws.Cell(row, 1).Value = row;
+
+            // With five values the exclusive rank of the median is 0.5*(5+1) = 3, the third value.
+            ws.Cell("C1").FormulaA1 = "PERCENTILE.EXC(A1:A5, 0.5)";
+            ws.Cell("C2").FormulaA1 = "PERCENTILE.INC(A1:A5, 0.5)";
+            ws.Cell("C3").FormulaA1 = "QUARTILE.EXC(A1:A5, 2)";
+            ws.Cell("C4").FormulaA1 = "QUARTILE.INC(A1:A5, 2)";
+            // The exclusive form cannot reach the ends of the range.
+            ws.Cell("C5").FormulaA1 = "PERCENTILE.EXC(A1:A5, 0.1)";
+            ws.Cell("C6").FormulaA1 = "QUARTILE.EXC(A1:A5, 0)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(3d).Within(1e-12);
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(3d).Within(1e-12);
+            await Assert.That((double)ws.Cell("C3").Value).IsEqualTo(3d).Within(1e-12);
+            await Assert.That((double)ws.Cell("C4").Value).IsEqualTo(3d).Within(1e-12);
+            await Assert.That(ws.Cell("C5").Value).IsEqualTo(XLError.NumberInvalid);
+            await Assert.That(ws.Cell("C6").Value).IsEqualTo(XLError.NumberInvalid);
+        }
+    }
+
+    [Test]
+    public async Task PercentRank_IsTheInverseOfPercentile()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            for (var row = 1; row <= 5; row++)
+                ws.Cell(row, 1).Value = row;
+
+            // Five evenly spaced values sit at 0, 0.25, 0.5, 0.75 and 1 on the inclusive scale.
+            ws.Cell("C1").FormulaA1 = "PERCENTRANK(A1:A5, 1)";
+            ws.Cell("C2").FormulaA1 = "PERCENTRANK(A1:A5, 3)";
+            ws.Cell("C3").FormulaA1 = "PERCENTRANK(A1:A5, 5)";
+            ws.Cell("C4").FormulaA1 = "PERCENTRANK.INC(A1:A5, 2)";
+            ws.Cell("C5").FormulaA1 = "PERCENTRANK(A1:A5, 2.5)"; // Interpolated between two values.
+            ws.Cell("C6").FormulaA1 = "PERCENTILE.INC(A1:A5, PERCENTRANK(A1:A5, 4))";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(0d);
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(0.5d);
+            await Assert.That((double)ws.Cell("C3").Value).IsEqualTo(1d);
+            await Assert.That((double)ws.Cell("C4").Value).IsEqualTo(0.25d);
+            await Assert.That((double)ws.Cell("C5").Value).IsEqualTo(0.375d);
+            await Assert.That((double)ws.Cell("C6").Value).IsEqualTo(4d).Within(1e-12);
+        }
+    }
+
+    [Test]
+    public async Task PercentRank_TruncatesToTheRequestedSignificance()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            for (var row = 1; row <= 4; row++)
+                ws.Cell(row, 1).Value = row;
+
+            // A rank of 1/3 truncated, not rounded: 0.333 at three digits, 0.3 at one.
+            ws.Cell("C1").FormulaA1 = "PERCENTRANK(A1:A4, 2)";
+            ws.Cell("C2").FormulaA1 = "PERCENTRANK(A1:A4, 2, 1)";
+            ws.Cell("C3").FormulaA1 = "PERCENTRANK(A1:A4, 2, 5)";
+            ws.Cell("C4").FormulaA1 = "PERCENTRANK(A1:A4, 2, 0)"; // At least one digit is required.
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(0.333d);
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(0.3d);
+            await Assert.That((double)ws.Cell("C3").Value).IsEqualTo(0.33333d);
+            await Assert.That(ws.Cell("C4").Value).IsEqualTo(XLError.NumberInvalid);
+        }
+    }
+
+    [Test]
+    public async Task PercentRank_ExclusiveKeepsTheEndsUnreachable()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            for (var row = 1; row <= 5; row++)
+                ws.Cell(row, 1).Value = row;
+
+            // On the exclusive scale the k-th of n values sits at k/(n+1).
+            ws.Cell("C1").FormulaA1 = "PERCENTRANK.EXC(A1:A5, 3)";
+            ws.Cell("C2").FormulaA1 = "PERCENTRANK.EXC(A1:A5, 1)";
+            ws.Cell("C3").FormulaA1 = "PERCENTRANK.EXC(A1:A5, 5)";
+
+            await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(0.5d);
+            await Assert.That((double)ws.Cell("C2").Value).IsEqualTo(0.166d); // 1/6, truncated.
+            await Assert.That((double)ws.Cell("C3").Value).IsEqualTo(0.833d); // 5/6, truncated.
+        }
+    }
+
+    [Test]
+    public async Task PercentRank_OutsideTheDataIsNoValueAvailable()
+    {
+        var ws = NewSheet(out var wb);
+        using (wb)
+        {
+            for (var row = 1; row <= 5; row++)
+                ws.Cell(row, 1).Value = row;
+
+            ws.Cell("C1").FormulaA1 = "PERCENTRANK(A1:A5, 0)";
+            ws.Cell("C2").FormulaA1 = "PERCENTRANK(A1:A5, 6)";
+
+            await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.NoValueAvailable);
+            await Assert.That(ws.Cell("C2").Value).IsEqualTo(XLError.NoValueAvailable);
+        }
+    }
+}

--- a/XLibur/Excel/CalcEngine/Functions/Distributions.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Distributions.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using XLibur.Excel.CalcEngine.Functions;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
+#pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility
+
 namespace XLibur.Excel.CalcEngine;
 
 /// <summary>
@@ -157,8 +159,15 @@ internal static class Distributions
         if (cumulative)
             return XLMath.GammaP(df / 2, x / 2);
 
+        // At the origin the density diverges below two degrees of freedom, is exactly a half at
+        // two, and vanishes above.
         if (x == 0)
-            return df < 2 ? XLError.NumberInvalid : df == 2 ? 0.5 : 0d;
+        {
+            if (df < 2)
+                return XLError.NumberInvalid;
+
+            return df == 2 ? 0.5 : 0d;
+        }
 
         var logDensity = (df / 2 - 1) * Math.Log(x) - x / 2 - df / 2 * Math.Log(2) - XLMath.LnGamma(df / 2);
         return Math.Exp(logDensity);
@@ -251,8 +260,15 @@ internal static class Distributions
         if (cumulative)
             return XLMath.BetaRegularized(d1 * x / (d1 * x + d2), d1 / 2, d2 / 2);
 
+        // As for chi-squared, the origin is a special case governed by the numerator's degrees of
+        // freedom alone.
         if (x == 0)
-            return d1 < 2 ? XLError.NumberInvalid : d1 == 2 ? 1d : 0d;
+        {
+            if (d1 < 2)
+                return XLError.NumberInvalid;
+
+            return d1 == 2 ? 1d : 0d;
+        }
 
         var logDensity = d1 / 2 * Math.Log(d1) + d2 / 2 * Math.Log(d2)
             + (d1 / 2 - 1) * Math.Log(x)
@@ -418,61 +434,82 @@ internal static class Distributions
         if (tails is not (1 or 2) || type is not (1 or 2 or 3))
             return XLError.NumberInvalid;
 
-        double t, degreesOfFreedom;
-        if (type == 1)
+        var statistic = type switch
         {
-            if (first.Count != second.Count)
-                return XLError.NoValueAvailable;
-            if (first.Count < 2)
-                return XLError.DivisionByZero;
+            1 => PairedStatistic(first, second),
+            2 => PooledStatistic(first, second),
+            _ => WelchStatistic(first, second),
+        };
 
-            var differences = new List<double>(first.Count);
-            for (var i = 0; i < first.Count; i++)
-                differences.Add(first[i] - second[i]);
+        if (!statistic.TryPickT0(out var test, out var statisticError))
+            return statisticError;
 
-            var standardError = Math.Sqrt(SampleVariance(differences) / differences.Count);
-            if (standardError == 0)
-                return XLError.DivisionByZero;
-
-            t = Mean(differences) / standardError;
-            degreesOfFreedom = differences.Count - 1;
-        }
-        else if (type == 2)
-        {
-            if (first.Count < 2 || second.Count < 2)
-                return XLError.DivisionByZero;
-
-            var n1 = first.Count;
-            var n2 = second.Count;
-            var pooled = ((n1 - 1) * SampleVariance(first) + (n2 - 1) * SampleVariance(second)) / (n1 + n2 - 2);
-            var standardError = Math.Sqrt(pooled * (1.0 / n1 + 1.0 / n2));
-            if (standardError == 0)
-                return XLError.DivisionByZero;
-
-            t = (Mean(first) - Mean(second)) / standardError;
-            degreesOfFreedom = n1 + n2 - 2;
-        }
-        else
-        {
-            if (first.Count < 2 || second.Count < 2)
-                return XLError.DivisionByZero;
-
-            var a = SampleVariance(first) / first.Count;
-            var b = SampleVariance(second) / second.Count;
-            if (a + b == 0)
-                return XLError.DivisionByZero;
-
-            t = (Mean(first) - Mean(second)) / Math.Sqrt(a + b);
-
-            // Welch–Satterthwaite: the variance of the difference behaves like a chi-squared with
-            // this many degrees of freedom, which is generally not a whole number. Excel truncates
-            // it, as every other function in the T.DIST family truncates its own — which is what
-            // lets T.TEST(…, 3) be reproduced from T.DIST.2T and the Welch formula in a worksheet.
-            degreesOfFreedom = Math.Truncate((a + b) * (a + b) / (a * a / (first.Count - 1) + b * b / (second.Count - 1)));
-        }
-
-        var rightTail = 1 - StudentTCdf(Math.Abs(t), degreesOfFreedom);
+        var rightTail = 1 - StudentTCdf(Math.Abs(test.T), test.DegreesOfFreedom);
         return Math.Min(tails * rightTail, 1);
+    }
+
+    /// <summary>A t statistic and the degrees of freedom to read it against.</summary>
+    private readonly record struct TStatistic(double T, double DegreesOfFreedom);
+
+    /// <summary>Type 1 — the observations are paired, so the test is a one-sample test of their differences.</summary>
+    private static OneOf<TStatistic, XLError> PairedStatistic(List<double> first, List<double> second)
+    {
+        if (first.Count != second.Count)
+            return XLError.NoValueAvailable;
+        if (first.Count < 2)
+            return XLError.DivisionByZero;
+
+        var differences = new List<double>(first.Count);
+        for (var i = 0; i < first.Count; i++)
+            differences.Add(first[i] - second[i]);
+
+        var standardError = Math.Sqrt(SampleVariance(differences) / differences.Count);
+        if (standardError == 0)
+            return XLError.DivisionByZero;
+
+        return new TStatistic(Mean(differences) / standardError, differences.Count - 1);
+    }
+
+    /// <summary>Type 2 — the two populations are assumed to share a variance, which is pooled from both samples.</summary>
+    private static OneOf<TStatistic, XLError> PooledStatistic(List<double> first, List<double> second)
+    {
+        if (first.Count < 2 || second.Count < 2)
+            return XLError.DivisionByZero;
+
+        var n1 = first.Count;
+        var n2 = second.Count;
+        var pooled = ((n1 - 1) * SampleVariance(first) + (n2 - 1) * SampleVariance(second)) / (n1 + n2 - 2);
+        var standardError = Math.Sqrt(pooled * (1.0 / n1 + 1.0 / n2));
+        if (standardError == 0)
+            return XLError.DivisionByZero;
+
+        return new TStatistic((Mean(first) - Mean(second)) / standardError, n1 + n2 - 2);
+    }
+
+    /// <summary>
+    /// Type 3 — the variances are not assumed equal, so each sample contributes its own and the
+    /// degrees of freedom are adjusted to match.
+    /// </summary>
+    private static OneOf<TStatistic, XLError> WelchStatistic(List<double> first, List<double> second)
+    {
+        if (first.Count < 2 || second.Count < 2)
+            return XLError.DivisionByZero;
+
+        var a = SampleVariance(first) / first.Count;
+        var b = SampleVariance(second) / second.Count;
+        if (a + b == 0)
+            return XLError.DivisionByZero;
+
+        var t = (Mean(first) - Mean(second)) / Math.Sqrt(a + b);
+
+        // Welch–Satterthwaite: the variance of the difference behaves like a chi-squared with this
+        // many degrees of freedom, which is generally not a whole number. Excel truncates it, as
+        // every other function in the T.DIST family truncates its own — which is what lets
+        // T.TEST(…, 3) be reproduced from T.DIST.2T and the Welch formula in a worksheet.
+        var degreesOfFreedom = Math.Truncate(
+            (a + b) * (a + b) / (a * a / (first.Count - 1) + b * b / (second.Count - 1)));
+
+        return new TStatistic(t, degreesOfFreedom);
     }
 
     /// <summary>

--- a/XLibur/Excel/CalcEngine/Functions/Distributions.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Distributions.cs
@@ -1,0 +1,821 @@
+using System;
+using System.Collections.Generic;
+using XLibur.Excel.CalcEngine.Functions;
+using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
+
+namespace XLibur.Excel.CalcEngine;
+
+/// <summary>
+/// The statistical distributions and the hypothesis tests built on them.
+/// <para>
+/// Excel carries two spellings of most of these: the modern dotted names (NORM.DIST) and the
+/// pre-2010 ones (NORMDIST). Where the two compute the same thing the legacy name is registered
+/// against the same implementation rather than a copy of it; where they differ — a legacy name
+/// that only offers the cumulative form, or that returns the right tail where the dotted name
+/// returns the left — the difference is in a thin wrapper, and the comment says which.
+/// </para>
+/// <para>
+/// Every distribution here reduces to one of four special functions in <see cref="XLMath"/>: the
+/// regularized incomplete gamma (chi-squared, gamma, Poisson), the regularized incomplete beta
+/// (F, t, binomial), the error function (normal), or plain elementary functions.
+/// </para>
+/// </summary>
+internal static class Distributions
+{
+    public static void Register(FunctionRegistry ce)
+    {
+        ce.RegisterFunction("BETA.DIST", 4, 6, AdaptLastTwoOptional(BetaDist, 0, 1), FunctionFlags.Scalar | FunctionFlags.Future); // Beta probability distribution
+        ce.RegisterFunction("BETA.INV", 3, 5, AdaptLastTwoOptional(BetaInv, 0, 1), FunctionFlags.Scalar | FunctionFlags.Future); // Inverse of the beta cumulative distribution
+        ce.RegisterFunction("BETADIST", 3, 5, AdaptLastTwoOptional(BetaDistLegacy, 0, 1), FunctionFlags.Scalar); // Cumulative beta distribution
+        ce.RegisterFunction("BETAINV", 3, 5, AdaptLastTwoOptional(BetaInv, 0, 1), FunctionFlags.Scalar);
+        ce.RegisterFunction("BINOM.INV", 3, 3, Adapt(BinomInv), FunctionFlags.Scalar | FunctionFlags.Future); // Smallest value whose binomial cumulative distribution reaches a criterion
+        ce.RegisterFunction("CHISQ.DIST", 3, 3, AdaptLastOptional(ChiSqDist, true), FunctionFlags.Scalar | FunctionFlags.Future); // Left-tailed chi-squared distribution
+        ce.RegisterFunction("CHISQ.DIST.RT", 2, 2, Adapt(ChiSqDistRt), FunctionFlags.Scalar | FunctionFlags.Future); // Right-tailed chi-squared distribution
+        ce.RegisterFunction("CHISQ.INV", 2, 2, Adapt(ChiSqInv), FunctionFlags.Scalar | FunctionFlags.Future); // Inverse of the left-tailed chi-squared distribution
+        ce.RegisterFunction("CHISQ.INV.RT", 2, 2, Adapt(ChiSqInvRt), FunctionFlags.Scalar | FunctionFlags.Future); // Inverse of the right-tailed chi-squared distribution
+        ce.RegisterFunction("CHISQ.TEST", 2, 2, ChiSqTest, FunctionFlags.Range | FunctionFlags.Future, AllowRange.All); // Chi-squared test of independence
+        ce.RegisterFunction("CHIDIST", 2, 2, Adapt(ChiSqDistRt), FunctionFlags.Scalar);
+        ce.RegisterFunction("CHIINV", 2, 2, Adapt(ChiSqInvRt), FunctionFlags.Scalar);
+        ce.RegisterFunction("CHITEST", 2, 2, ChiSqTest, FunctionFlags.Range, AllowRange.All);
+        ce.RegisterFunction("CONFIDENCE", 3, 3, Adapt(ConfidenceNorm), FunctionFlags.Scalar);
+        ce.RegisterFunction("CONFIDENCE.NORM", 3, 3, Adapt(ConfidenceNorm), FunctionFlags.Scalar | FunctionFlags.Future); // Confidence interval using the normal distribution
+        ce.RegisterFunction("CONFIDENCE.T", 3, 3, Adapt(ConfidenceT), FunctionFlags.Scalar | FunctionFlags.Future); // Confidence interval using the Student's t-distribution
+        ce.RegisterFunction("CRITBINOM", 3, 3, Adapt(BinomInv), FunctionFlags.Scalar);
+        ce.RegisterFunction("EXPON.DIST", 3, 3, AdaptLastOptional(ExponDist, true), FunctionFlags.Scalar | FunctionFlags.Future); // Exponential distribution
+        ce.RegisterFunction("EXPONDIST", 3, 3, AdaptLastOptional(ExponDist, true), FunctionFlags.Scalar);
+        ce.RegisterFunction("F.DIST", 4, 4, Adapt(FDist), FunctionFlags.Scalar | FunctionFlags.Future); // Left-tailed F probability distribution
+        ce.RegisterFunction("F.DIST.RT", 3, 3, Adapt(FDistRt), FunctionFlags.Scalar | FunctionFlags.Future); // Right-tailed F probability distribution
+        ce.RegisterFunction("F.INV", 3, 3, Adapt(FInv), FunctionFlags.Scalar | FunctionFlags.Future); // Inverse of the left-tailed F distribution
+        ce.RegisterFunction("F.INV.RT", 3, 3, Adapt(FInvRt), FunctionFlags.Scalar | FunctionFlags.Future); // Inverse of the right-tailed F distribution
+        ce.RegisterFunction("F.TEST", 2, 2, FTest, FunctionFlags.Range | FunctionFlags.Future, AllowRange.All); // Two-tailed F-test of two variances
+        ce.RegisterFunction("FDIST", 3, 3, Adapt(FDistRt), FunctionFlags.Scalar);
+        ce.RegisterFunction("FINV", 3, 3, Adapt(FInvRt), FunctionFlags.Scalar);
+        ce.RegisterFunction("FTEST", 2, 2, FTest, FunctionFlags.Range, AllowRange.All);
+        ce.RegisterFunction("GAMMA", 1, 1, Adapt(Gamma), FunctionFlags.Scalar | FunctionFlags.Future); // The gamma function
+        ce.RegisterFunction("GAMMA.DIST", 4, 4, Adapt(GammaDist), FunctionFlags.Scalar | FunctionFlags.Future); // Gamma distribution
+        ce.RegisterFunction("GAMMA.INV", 3, 3, Adapt(GammaInv), FunctionFlags.Scalar | FunctionFlags.Future); // Inverse of the gamma cumulative distribution
+        ce.RegisterFunction("GAMMADIST", 4, 4, Adapt(GammaDist), FunctionFlags.Scalar);
+        ce.RegisterFunction("GAMMAINV", 3, 3, Adapt(GammaInv), FunctionFlags.Scalar);
+        ce.RegisterFunction("GAMMALN", 1, 1, Adapt(GammaLn), FunctionFlags.Scalar); // Natural logarithm of the gamma function
+        ce.RegisterFunction("GAMMALN.PRECISE", 1, 1, Adapt(GammaLn), FunctionFlags.Scalar | FunctionFlags.Future);
+        ce.RegisterFunction("HYPGEOM.DIST", 5, 5, Adapt(HypGeomDist), FunctionFlags.Scalar | FunctionFlags.Future); // Hypergeometric distribution
+        ce.RegisterFunction("HYPGEOMDIST", 4, 4, Adapt(HypGeomDistLegacy), FunctionFlags.Scalar);
+        ce.RegisterFunction("LOGINV", 3, 3, Adapt(LogNormInv), FunctionFlags.Scalar);
+        ce.RegisterFunction("LOGNORM.DIST", 4, 4, Adapt(LogNormDist), FunctionFlags.Scalar | FunctionFlags.Future); // Lognormal distribution
+        ce.RegisterFunction("LOGNORM.INV", 3, 3, Adapt(LogNormInv), FunctionFlags.Scalar | FunctionFlags.Future); // Inverse of the lognormal cumulative distribution
+        ce.RegisterFunction("LOGNORMDIST", 3, 3, Adapt(LogNormDistLegacy), FunctionFlags.Scalar);
+        ce.RegisterFunction("NEGBINOM.DIST", 4, 4, Adapt(NegBinomDist), FunctionFlags.Scalar | FunctionFlags.Future); // Negative binomial distribution
+        ce.RegisterFunction("NEGBINOMDIST", 3, 3, Adapt(NegBinomDistLegacy), FunctionFlags.Scalar);
+        ce.RegisterFunction("NORM.DIST", 4, 4, Adapt(NormDist), FunctionFlags.Scalar | FunctionFlags.Future); // Normal distribution
+        ce.RegisterFunction("NORM.INV", 3, 3, Adapt(NormInv), FunctionFlags.Scalar | FunctionFlags.Future); // Inverse of the normal cumulative distribution
+        ce.RegisterFunction("NORM.S.DIST", 2, 2, Adapt(NormSDist), FunctionFlags.Scalar | FunctionFlags.Future); // Standard normal distribution
+        ce.RegisterFunction("NORM.S.INV", 1, 1, Adapt(NormSInv), FunctionFlags.Scalar | FunctionFlags.Future); // Inverse of the standard normal cumulative distribution
+        ce.RegisterFunction("NORMDIST", 4, 4, Adapt(NormDist), FunctionFlags.Scalar);
+        ce.RegisterFunction("NORMINV", 3, 3, Adapt(NormInv), FunctionFlags.Scalar);
+        ce.RegisterFunction("NORMSDIST", 1, 1, Adapt(NormSDistLegacy), FunctionFlags.Scalar);
+        ce.RegisterFunction("NORMSINV", 1, 1, Adapt(NormSInv), FunctionFlags.Scalar);
+        ce.RegisterFunction("POISSON", 3, 3, AdaptLastOptional(PoissonDist, true), FunctionFlags.Scalar);
+        ce.RegisterFunction("POISSON.DIST", 3, 3, AdaptLastOptional(PoissonDist, true), FunctionFlags.Scalar | FunctionFlags.Future); // Poisson distribution
+        ce.RegisterFunction("T.DIST", 3, 3, AdaptLastOptional(TDist, true), FunctionFlags.Scalar | FunctionFlags.Future); // Left-tailed Student's t-distribution
+        ce.RegisterFunction("T.DIST.2T", 2, 2, Adapt(TDist2T), FunctionFlags.Scalar | FunctionFlags.Future); // Two-tailed Student's t-distribution
+        ce.RegisterFunction("T.DIST.RT", 2, 2, Adapt(TDistRt), FunctionFlags.Scalar | FunctionFlags.Future); // Right-tailed Student's t-distribution
+        ce.RegisterFunction("T.TEST", 4, 4, TTest, FunctionFlags.Range | FunctionFlags.Future, AllowRange.Only, 0, 1); // Probability associated with a Student's t-test
+        ce.RegisterFunction("TDIST", 3, 3, Adapt(TDistLegacy), FunctionFlags.Scalar);
+        ce.RegisterFunction("TTEST", 4, 4, TTest, FunctionFlags.Range, AllowRange.Only, 0, 1);
+        ce.RegisterFunction("WEIBULL", 4, 4, Adapt(WeibullDist), FunctionFlags.Scalar);
+        ce.RegisterFunction("WEIBULL.DIST", 4, 4, Adapt(WeibullDist), FunctionFlags.Scalar | FunctionFlags.Future); // Weibull distribution
+        ce.RegisterFunction("Z.TEST", 2, 3, ZTest, FunctionFlags.Range | FunctionFlags.Future, AllowRange.Only, 0); // One-tailed probability value of a z-test
+        ce.RegisterFunction("ZTEST", 2, 3, ZTest, FunctionFlags.Range, AllowRange.Only, 0);
+    }
+
+    #region Normal and lognormal
+
+    private static ScalarValue NormDist(CalcContext ctx, double x, double mean, double standardDeviation, bool cumulative)
+    {
+        if (standardDeviation <= 0)
+            return XLError.NumberInvalid;
+
+        var z = (x - mean) / standardDeviation;
+        return cumulative ? XLMath.NormalSDist(z) : XLMath.NormalSPdf(z) / standardDeviation;
+    }
+
+    private static ScalarValue NormInv(CalcContext ctx, double probability, double mean, double standardDeviation)
+    {
+        if (probability <= 0 || probability >= 1 || standardDeviation <= 0)
+            return XLError.NumberInvalid;
+
+        return mean + standardDeviation * XLMath.NormalSInv(probability);
+    }
+
+    private static ScalarValue NormSDist(CalcContext ctx, double z, bool cumulative)
+        => cumulative ? XLMath.NormalSDist(z) : XLMath.NormalSPdf(z);
+
+    /// <summary>The pre-2010 NORMSDIST has no cumulative flag — it is always the cumulative form.</summary>
+    private static ScalarValue NormSDistLegacy(CalcContext ctx, double z) => XLMath.NormalSDist(z);
+
+    private static ScalarValue NormSInv(CalcContext ctx, double probability)
+    {
+        if (probability <= 0 || probability >= 1)
+            return XLError.NumberInvalid;
+
+        return XLMath.NormalSInv(probability);
+    }
+
+    private static ScalarValue LogNormDist(CalcContext ctx, double x, double mean, double standardDeviation, bool cumulative)
+    {
+        if (x <= 0 || standardDeviation <= 0)
+            return XLError.NumberInvalid;
+
+        // A lognormal variable is the exponential of a normal one, so its distribution is the
+        // normal distribution of the logarithm — with the density divided by x, the derivative of
+        // that change of variable.
+        var z = (Math.Log(x) - mean) / standardDeviation;
+        return cumulative ? XLMath.NormalSDist(z) : XLMath.NormalSPdf(z) / (x * standardDeviation);
+    }
+
+    private static ScalarValue LogNormDistLegacy(CalcContext ctx, double x, double mean, double standardDeviation)
+        => LogNormDist(ctx, x, mean, standardDeviation, cumulative: true);
+
+    private static ScalarValue LogNormInv(CalcContext ctx, double probability, double mean, double standardDeviation)
+    {
+        if (probability <= 0 || probability >= 1 || standardDeviation <= 0)
+            return XLError.NumberInvalid;
+
+        return Math.Exp(mean + standardDeviation * XLMath.NormalSInv(probability));
+    }
+
+    #endregion
+
+    #region Chi-squared
+
+    private static ScalarValue ChiSqDist(CalcContext ctx, double x, double degreesOfFreedom, bool cumulative)
+    {
+        if (x < 0 || !IsValidDegreesOfFreedom(degreesOfFreedom))
+            return XLError.NumberInvalid;
+
+        var df = Math.Truncate(degreesOfFreedom);
+        if (cumulative)
+            return XLMath.GammaP(df / 2, x / 2);
+
+        if (x == 0)
+            return df < 2 ? XLError.NumberInvalid : df == 2 ? 0.5 : 0d;
+
+        var logDensity = (df / 2 - 1) * Math.Log(x) - x / 2 - df / 2 * Math.Log(2) - XLMath.LnGamma(df / 2);
+        return Math.Exp(logDensity);
+    }
+
+    private static ScalarValue ChiSqDistRt(CalcContext ctx, double x, double degreesOfFreedom)
+    {
+        if (x < 0 || !IsValidDegreesOfFreedom(degreesOfFreedom))
+            return XLError.NumberInvalid;
+
+        return XLMath.GammaQ(Math.Truncate(degreesOfFreedom) / 2, x / 2);
+    }
+
+    private static ScalarValue ChiSqInv(CalcContext ctx, double probability, double degreesOfFreedom)
+    {
+        if (probability < 0 || probability > 1 || !IsValidDegreesOfFreedom(degreesOfFreedom))
+            return XLError.NumberInvalid;
+
+        // Chi-squared with k degrees of freedom is gamma with shape k/2 and scale 2.
+        return 2 * XLMath.InverseGammaP(probability, Math.Truncate(degreesOfFreedom) / 2);
+    }
+
+    private static ScalarValue ChiSqInvRt(CalcContext ctx, double probability, double degreesOfFreedom)
+    {
+        if (probability < 0 || probability > 1 || !IsValidDegreesOfFreedom(degreesOfFreedom))
+            return XLError.NumberInvalid;
+
+        return 2 * XLMath.InverseGammaP(1 - probability, Math.Truncate(degreesOfFreedom) / 2);
+    }
+
+    /// <summary>
+    /// CHISQ.TEST(actual, expected) — the chi-squared statistic Σ(a−e)²/e turned into the
+    /// probability of seeing one at least that large by chance. The degrees of freedom come from
+    /// the shape of the ranges: a two-dimensional table has (rows−1)(columns−1), a single row or
+    /// column has one less than its length.
+    /// </summary>
+    private static AnyValue ChiSqTest(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!args[0].TryPickCollectionArray(out var actual, ctx) ||
+            !args[1].TryPickCollectionArray(out var expected, ctx))
+        {
+            return XLError.IncompatibleValue;
+        }
+
+        if (actual!.Height != expected!.Height || actual.Width != expected.Width)
+            return XLError.NoValueAvailable;
+
+        var statistic = 0d;
+        var count = 0;
+        for (var row = 0; row < actual.Height; row++)
+        {
+            for (var column = 0; column < actual.Width; column++)
+            {
+                if (!TryPairOfNumbers(ctx, actual[row, column], expected[row, column], out var a, out var e, out var error))
+                    return error;
+
+                if (e == 0)
+                    return XLError.DivisionByZero;
+
+                statistic += (a - e) * (a - e) / e;
+                count++;
+            }
+        }
+
+        var degreesOfFreedom = actual.Height > 1 && actual.Width > 1
+            ? (actual.Height - 1) * (actual.Width - 1)
+            : count - 1;
+
+        if (degreesOfFreedom < 1)
+            return XLError.NoValueAvailable;
+
+        return XLMath.GammaQ(degreesOfFreedom / 2.0, statistic / 2);
+    }
+
+    private static bool IsValidDegreesOfFreedom(double degreesOfFreedom)
+        => degreesOfFreedom >= 1 && degreesOfFreedom < 1e10;
+
+    #endregion
+
+    #region F distribution
+
+    private static ScalarValue FDist(CalcContext ctx, double x, double degreesOfFreedom1, double degreesOfFreedom2, bool cumulative)
+    {
+        if (x < 0 || !IsValidDegreesOfFreedom(degreesOfFreedom1) || !IsValidDegreesOfFreedom(degreesOfFreedom2))
+            return XLError.NumberInvalid;
+
+        var d1 = Math.Truncate(degreesOfFreedom1);
+        var d2 = Math.Truncate(degreesOfFreedom2);
+
+        if (cumulative)
+            return XLMath.BetaRegularized(d1 * x / (d1 * x + d2), d1 / 2, d2 / 2);
+
+        if (x == 0)
+            return d1 < 2 ? XLError.NumberInvalid : d1 == 2 ? 1d : 0d;
+
+        var logDensity = d1 / 2 * Math.Log(d1) + d2 / 2 * Math.Log(d2)
+            + (d1 / 2 - 1) * Math.Log(x)
+            - (d1 + d2) / 2 * Math.Log(d2 + d1 * x)
+            - (XLMath.LnGamma(d1 / 2) + XLMath.LnGamma(d2 / 2) - XLMath.LnGamma((d1 + d2) / 2));
+        return Math.Exp(logDensity);
+    }
+
+    private static ScalarValue FDistRt(CalcContext ctx, double x, double degreesOfFreedom1, double degreesOfFreedom2)
+    {
+        if (x < 0 || !IsValidDegreesOfFreedom(degreesOfFreedom1) || !IsValidDegreesOfFreedom(degreesOfFreedom2))
+            return XLError.NumberInvalid;
+
+        var d1 = Math.Truncate(degreesOfFreedom1);
+        var d2 = Math.Truncate(degreesOfFreedom2);
+
+        // Taking the complementary tail through the beta function's own symmetry keeps the small
+        // p-values that matter for a test from being lost to 1 − (something very close to 1).
+        return XLMath.BetaRegularized(d2 / (d2 + d1 * x), d2 / 2, d1 / 2);
+    }
+
+    private static ScalarValue FInv(CalcContext ctx, double probability, double degreesOfFreedom1, double degreesOfFreedom2)
+    {
+        if (probability < 0 || probability > 1 || !IsValidDegreesOfFreedom(degreesOfFreedom1) || !IsValidDegreesOfFreedom(degreesOfFreedom2))
+            return XLError.NumberInvalid;
+
+        return InvertF(probability, Math.Truncate(degreesOfFreedom1), Math.Truncate(degreesOfFreedom2));
+    }
+
+    private static ScalarValue FInvRt(CalcContext ctx, double probability, double degreesOfFreedom1, double degreesOfFreedom2)
+    {
+        if (probability < 0 || probability > 1 || !IsValidDegreesOfFreedom(degreesOfFreedom1) || !IsValidDegreesOfFreedom(degreesOfFreedom2))
+            return XLError.NumberInvalid;
+
+        return InvertF(1 - probability, Math.Truncate(degreesOfFreedom1), Math.Truncate(degreesOfFreedom2));
+    }
+
+    /// <summary>
+    /// Invert the F CDF by inverting the beta function it is built from: if
+    /// <c>y = I⁻¹(p; d1/2, d2/2)</c> then <c>d1·x/(d1·x + d2) = y</c>, which rearranges to x.
+    /// </summary>
+    private static double InvertF(double probability, double d1, double d2)
+    {
+        var y = XLMath.InverseBetaRegularized(probability, d1 / 2, d2 / 2);
+        if (y >= 1)
+            return double.PositiveInfinity;
+
+        return d2 * y / (d1 * (1 - y));
+    }
+
+    /// <summary>
+    /// F.TEST(array1, array2) — the two-tailed probability that two samples come from populations
+    /// with the same variance. The ratio is always taken with the larger variance on top, and the
+    /// one-tailed probability of that is doubled.
+    /// </summary>
+    private static AnyValue FTest(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryGetSample(ctx, args[0], out var first, out var firstError))
+            return firstError;
+        if (!TryGetSample(ctx, args[1], out var second, out var secondError))
+            return secondError;
+
+        if (first.Count < 2 || second.Count < 2)
+            return XLError.DivisionByZero;
+
+        var varianceA = SampleVariance(first);
+        var varianceB = SampleVariance(second);
+        if (varianceA == 0 || varianceB == 0)
+            return XLError.DivisionByZero;
+
+        double ratio, dfNumerator, dfDenominator;
+        if (varianceA > varianceB)
+        {
+            ratio = varianceA / varianceB;
+            dfNumerator = first.Count - 1;
+            dfDenominator = second.Count - 1;
+        }
+        else
+        {
+            ratio = varianceB / varianceA;
+            dfNumerator = second.Count - 1;
+            dfDenominator = first.Count - 1;
+        }
+
+        var oneTailed = XLMath.BetaRegularized(dfDenominator / (dfDenominator + dfNumerator * ratio), dfDenominator / 2, dfNumerator / 2);
+        return Math.Min(2 * oneTailed, 1);
+    }
+
+    #endregion
+
+    #region Student's t
+
+    private static ScalarValue TDist(CalcContext ctx, double x, double degreesOfFreedom, bool cumulative)
+    {
+        if (!IsValidDegreesOfFreedom(degreesOfFreedom))
+            return XLError.NumberInvalid;
+
+        var df = Math.Truncate(degreesOfFreedom);
+        if (cumulative)
+            return StudentTCdf(x, df);
+
+        var logDensity = -0.5 * Math.Log(df * Math.PI) + XLMath.LnGamma((df + 1) / 2) - XLMath.LnGamma(df / 2)
+            - (df + 1) / 2 * Math.Log(1 + x * x / df);
+        return Math.Exp(logDensity);
+    }
+
+    private static ScalarValue TDistRt(CalcContext ctx, double x, double degreesOfFreedom)
+    {
+        if (!IsValidDegreesOfFreedom(degreesOfFreedom))
+            return XLError.NumberInvalid;
+
+        return 1 - StudentTCdf(x, Math.Truncate(degreesOfFreedom));
+    }
+
+    private static ScalarValue TDist2T(CalcContext ctx, double x, double degreesOfFreedom)
+    {
+        if (x < 0 || !IsValidDegreesOfFreedom(degreesOfFreedom))
+            return XLError.NumberInvalid;
+
+        return Math.Min(2 * (1 - StudentTCdf(x, Math.Truncate(degreesOfFreedom))), 1);
+    }
+
+    /// <summary>The pre-2010 TDIST takes the number of tails instead of offering a left tail at all.</summary>
+    private static ScalarValue TDistLegacy(CalcContext ctx, double x, double degreesOfFreedom, double tails)
+    {
+        var tailCount = Math.Truncate(tails);
+        if (x < 0 || !IsValidDegreesOfFreedom(degreesOfFreedom) || tailCount is not (1 or 2))
+            return XLError.NumberInvalid;
+
+        var rightTail = 1 - StudentTCdf(x, Math.Truncate(degreesOfFreedom));
+        return Math.Min(tailCount * rightTail, 1);
+    }
+
+    /// <summary>
+    /// CDF of the t-distribution, through the regularized incomplete beta function. Written so the
+    /// small tail is the one computed directly, which is where a test's p-value lives.
+    /// </summary>
+    private static double StudentTCdf(double t, double df)
+    {
+        var x = df / (df + t * t);
+        var half = 0.5 * XLMath.BetaRegularized(x, df / 2, 0.5);
+        return t >= 0 ? 1 - half : half;
+    }
+
+    /// <summary>
+    /// T.TEST(array1, array2, tails, type) — type 1 pairs the observations, type 2 assumes the two
+    /// populations share a variance, and type 3 (Welch) does not and adjusts the degrees of freedom
+    /// to match.
+    /// </summary>
+    private static AnyValue TTest(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryGetSample(ctx, args[0], out var first, out var firstError))
+            return firstError;
+        if (!TryGetSample(ctx, args[1], out var second, out var secondError))
+            return secondError;
+        if (!TryGetScalarNumber(ctx, args[2], out var tailsValue, out var tailsError))
+            return tailsError;
+        if (!TryGetScalarNumber(ctx, args[3], out var typeValue, out var typeError))
+            return typeError;
+
+        var tails = Math.Truncate(tailsValue);
+        var type = Math.Truncate(typeValue);
+        if (tails is not (1 or 2) || type is not (1 or 2 or 3))
+            return XLError.NumberInvalid;
+
+        double t, degreesOfFreedom;
+        if (type == 1)
+        {
+            if (first.Count != second.Count)
+                return XLError.NoValueAvailable;
+            if (first.Count < 2)
+                return XLError.DivisionByZero;
+
+            var differences = new List<double>(first.Count);
+            for (var i = 0; i < first.Count; i++)
+                differences.Add(first[i] - second[i]);
+
+            var standardError = Math.Sqrt(SampleVariance(differences) / differences.Count);
+            if (standardError == 0)
+                return XLError.DivisionByZero;
+
+            t = Mean(differences) / standardError;
+            degreesOfFreedom = differences.Count - 1;
+        }
+        else if (type == 2)
+        {
+            if (first.Count < 2 || second.Count < 2)
+                return XLError.DivisionByZero;
+
+            var n1 = first.Count;
+            var n2 = second.Count;
+            var pooled = ((n1 - 1) * SampleVariance(first) + (n2 - 1) * SampleVariance(second)) / (n1 + n2 - 2);
+            var standardError = Math.Sqrt(pooled * (1.0 / n1 + 1.0 / n2));
+            if (standardError == 0)
+                return XLError.DivisionByZero;
+
+            t = (Mean(first) - Mean(second)) / standardError;
+            degreesOfFreedom = n1 + n2 - 2;
+        }
+        else
+        {
+            if (first.Count < 2 || second.Count < 2)
+                return XLError.DivisionByZero;
+
+            var a = SampleVariance(first) / first.Count;
+            var b = SampleVariance(second) / second.Count;
+            if (a + b == 0)
+                return XLError.DivisionByZero;
+
+            t = (Mean(first) - Mean(second)) / Math.Sqrt(a + b);
+
+            // Welch–Satterthwaite: the variance of the difference behaves like a chi-squared with
+            // this many degrees of freedom, which is generally not a whole number. Excel truncates
+            // it, as every other function in the T.DIST family truncates its own — which is what
+            // lets T.TEST(…, 3) be reproduced from T.DIST.2T and the Welch formula in a worksheet.
+            degreesOfFreedom = Math.Truncate((a + b) * (a + b) / (a * a / (first.Count - 1) + b * b / (second.Count - 1)));
+        }
+
+        var rightTail = 1 - StudentTCdf(Math.Abs(t), degreesOfFreedom);
+        return Math.Min(tails * rightTail, 1);
+    }
+
+    /// <summary>
+    /// Z.TEST(array, x, [sigma]) — the one-tailed probability that the sample mean is as far above
+    /// <c>x</c> as it is. With no sigma given the sample standard deviation stands in for it.
+    /// </summary>
+    private static AnyValue ZTest(CalcContext ctx, Span<AnyValue> args)
+    {
+        if (!TryGetSample(ctx, args[0], out var sample, out var sampleError))
+            return sampleError;
+        if (!TryGetScalarNumber(ctx, args[1], out var hypothesizedMean, out var meanError))
+            return meanError;
+
+        if (sample.Count < 1)
+            return XLError.NoValueAvailable;
+
+        var sigma = 0d;
+        if (args.Length > 2)
+        {
+            if (!TryGetScalarNumber(ctx, args[2], out sigma, out var sigmaError))
+                return sigmaError;
+            if (sigma <= 0)
+                return XLError.NumberInvalid;
+        }
+        else
+        {
+            if (sample.Count < 2)
+                return XLError.DivisionByZero;
+
+            sigma = Math.Sqrt(SampleVariance(sample));
+            if (sigma == 0)
+                return XLError.DivisionByZero;
+        }
+
+        var z = (Mean(sample) - hypothesizedMean) / (sigma / Math.Sqrt(sample.Count));
+        return 1 - XLMath.NormalSDist(z);
+    }
+
+    #endregion
+
+    #region Exponential families
+
+    private static ScalarValue ExponDist(CalcContext ctx, double x, double lambda, bool cumulative)
+    {
+        if (x < 0 || lambda <= 0)
+            return XLError.NumberInvalid;
+
+        return cumulative ? 1 - Math.Exp(-lambda * x) : lambda * Math.Exp(-lambda * x);
+    }
+
+    private static ScalarValue PoissonDist(CalcContext ctx, double x, double mean, bool cumulative)
+    {
+        var k = Math.Truncate(x);
+        if (k < 0 || mean < 0)
+            return XLError.NumberInvalid;
+
+        // The Poisson CDF is the regularized upper incomplete gamma, which stays accurate for a
+        // large mean where summing the terms one at a time would not.
+        if (cumulative)
+            return mean == 0 ? 1d : XLMath.GammaQ(k + 1, mean);
+
+        return Math.Exp(-mean + k * Math.Log(mean == 0 ? 1 : mean) - XLMath.LnGamma(k + 1)) * (mean == 0 && k > 0 ? 0 : 1);
+    }
+
+    private static ScalarValue WeibullDist(CalcContext ctx, double x, double alpha, double beta, bool cumulative)
+    {
+        if (x < 0 || alpha <= 0 || beta <= 0)
+            return XLError.NumberInvalid;
+
+        var scaled = Math.Pow(x / beta, alpha);
+        if (cumulative)
+            return 1 - Math.Exp(-scaled);
+
+        return alpha / Math.Pow(beta, alpha) * Math.Pow(x, alpha - 1) * Math.Exp(-scaled);
+    }
+
+    private static ScalarValue GammaDist(CalcContext ctx, double x, double alpha, double beta, bool cumulative)
+    {
+        if (x < 0 || alpha <= 0 || beta <= 0)
+            return XLError.NumberInvalid;
+
+        if (cumulative)
+            return XLMath.GammaP(alpha, x / beta);
+
+        if (x == 0)
+            return alpha < 1 ? XLError.NumberInvalid : alpha == 1 ? 1 / beta : 0d;
+
+        var logDensity = (alpha - 1) * Math.Log(x) - x / beta - alpha * Math.Log(beta) - XLMath.LnGamma(alpha);
+        return Math.Exp(logDensity);
+    }
+
+    private static ScalarValue GammaInv(CalcContext ctx, double probability, double alpha, double beta)
+    {
+        if (probability < 0 || probability > 1 || alpha <= 0 || beta <= 0)
+            return XLError.NumberInvalid;
+
+        return beta * XLMath.InverseGammaP(probability, alpha);
+    }
+
+    private static ScalarValue Gamma(CalcContext ctx, double x)
+    {
+        // The gamma function has a pole at every non-positive integer.
+        if (x <= 0 && x == Math.Truncate(x))
+            return XLError.NumberInvalid;
+
+        var result = XLMath.Gamma(x);
+        return double.IsNaN(result) || double.IsInfinity(result) ? XLError.NumberInvalid : result;
+    }
+
+    private static ScalarValue GammaLn(CalcContext ctx, double x)
+    {
+        if (x <= 0)
+            return XLError.NumberInvalid;
+
+        return XLMath.LnGamma(x);
+    }
+
+    #endregion
+
+    #region Beta
+
+    private static ScalarValue BetaDist(CalcContext ctx, double x, double alpha, double beta, bool cumulative, double lowerBound, double upperBound)
+    {
+        if (alpha <= 0 || beta <= 0 || upperBound <= lowerBound || x < lowerBound || x > upperBound)
+            return XLError.NumberInvalid;
+
+        var width = upperBound - lowerBound;
+        var scaled = (x - lowerBound) / width;
+
+        if (cumulative)
+            return XLMath.BetaRegularized(scaled, alpha, beta);
+
+        if (scaled is 0 or 1)
+        {
+            // The density is finite at an endpoint only when the matching shape parameter allows it.
+            var shape = scaled == 0 ? alpha : beta;
+            if (shape < 1)
+                return XLError.NumberInvalid;
+        }
+
+        var logDensity = (alpha - 1) * Math.Log(scaled) + (beta - 1) * Math.Log(1 - scaled)
+            - (XLMath.LnGamma(alpha) + XLMath.LnGamma(beta) - XLMath.LnGamma(alpha + beta));
+        return Math.Exp(logDensity) / width;
+    }
+
+    /// <summary>The pre-2010 BETADIST offers only the cumulative form.</summary>
+    private static ScalarValue BetaDistLegacy(CalcContext ctx, double x, double alpha, double beta, double lowerBound, double upperBound)
+        => BetaDist(ctx, x, alpha, beta, cumulative: true, lowerBound, upperBound);
+
+    private static AnyValue BetaInv(double probability, double alpha, double beta, double lowerBound, double upperBound)
+    {
+        if (probability <= 0 || probability > 1 || alpha <= 0 || beta <= 0 || upperBound <= lowerBound)
+            return XLError.NumberInvalid;
+
+        return lowerBound + (upperBound - lowerBound) * XLMath.InverseBetaRegularized(probability, alpha, beta);
+    }
+
+    #endregion
+
+    #region Discrete distributions
+
+    private static ScalarValue HypGeomDist(CalcContext ctx, double sampleSuccesses, double sampleSize, double populationSuccesses, double populationSize, bool cumulative)
+    {
+        var x = Math.Truncate(sampleSuccesses);
+        var n = Math.Truncate(sampleSize);
+        var successes = Math.Truncate(populationSuccesses);
+        var population = Math.Truncate(populationSize);
+
+        if (n <= 0 || n > population || successes <= 0 || successes > population || population <= 0)
+            return XLError.NumberInvalid;
+
+        // The number of successes drawn cannot exceed the sample, the successes available, or fall
+        // below what the failures in the population force.
+        if (x < 0 || x > n || x > successes || x < n - (population - successes))
+            return XLError.NumberInvalid;
+
+        if (!cumulative)
+            return HypGeomTerm(x, n, successes, population);
+
+        var total = 0d;
+        var from = Math.Max(0, n - (population - successes));
+        for (var k = from; k <= x; k++)
+            total += HypGeomTerm(k, n, successes, population);
+
+        return Math.Min(total, 1);
+    }
+
+    private static ScalarValue HypGeomDistLegacy(CalcContext ctx, double sampleSuccesses, double sampleSize, double populationSuccesses, double populationSize)
+        => HypGeomDist(ctx, sampleSuccesses, sampleSize, populationSuccesses, populationSize, cumulative: false);
+
+    /// <summary>
+    /// One term of the hypergeometric distribution, C(M,k)·C(N−M,n−k)/C(N,n), evaluated through log
+    /// factorials so that a large population does not overflow on the way to a small probability.
+    /// </summary>
+    private static double HypGeomTerm(double k, double n, double successes, double population)
+    {
+        var logProbability = LogChoose(successes, k)
+            + LogChoose(population - successes, n - k)
+            - LogChoose(population, n);
+        return Math.Exp(logProbability);
+    }
+
+    private static double LogChoose(double n, double k)
+        => XLMath.LnGamma(n + 1) - XLMath.LnGamma(k + 1) - XLMath.LnGamma(n - k + 1);
+
+    private static AnyValue NegBinomDist(double failures, double successes, double probability, bool cumulative)
+    {
+        var f = Math.Truncate(failures);
+        var s = Math.Truncate(successes);
+        if (f < 0 || s < 1 || probability <= 0 || probability > 1)
+            return XLError.NumberInvalid;
+
+        if (!cumulative)
+            return NegBinomTerm(f, s, probability);
+
+        var total = 0d;
+        for (var k = 0d; k <= f; k++)
+            total += NegBinomTerm(k, s, probability);
+
+        return Math.Min(total, 1);
+    }
+
+    private static ScalarValue NegBinomDistLegacy(CalcContext ctx, double failures, double successes, double probability)
+    {
+        var result = NegBinomDist(failures, successes, probability, cumulative: false);
+        return result.TryPickScalar(out var scalar, out _) ? scalar : XLError.NumberInvalid;
+    }
+
+    private static double NegBinomTerm(double failures, double successes, double probability)
+    {
+        var logProbability = LogChoose(failures + successes - 1, successes - 1)
+            + successes * Math.Log(probability)
+            + failures * Math.Log(1 - probability);
+        return Math.Exp(logProbability);
+    }
+
+    /// <summary>
+    /// BINOM.INV(trials, probability, alpha) — the smallest number of successes whose cumulative
+    /// binomial probability reaches <paramref name="alpha"/>.
+    /// </summary>
+    private static ScalarValue BinomInv(CalcContext ctx, double trials, double probability, double alpha)
+    {
+        var n = Math.Truncate(trials);
+        if (n < 0 || probability < 0 || probability > 1 || alpha < 0 || alpha > 1)
+            return XLError.NumberInvalid;
+
+        var cumulative = 0d;
+        for (var k = 0d; k <= n; k++)
+        {
+            cumulative += Math.Exp(LogChoose(n, k) + k * SafeLog(probability) + (n - k) * SafeLog(1 - probability));
+            if (cumulative >= alpha)
+                return k;
+        }
+
+        return n;
+    }
+
+    /// <summary>Logarithm that returns negative infinity at zero rather than throwing off the sum.</summary>
+    private static double SafeLog(double value) => value <= 0 ? double.NegativeInfinity : Math.Log(value);
+
+    #endregion
+
+    #region Confidence intervals
+
+    private static ScalarValue ConfidenceNorm(CalcContext ctx, double alpha, double standardDeviation, double size)
+    {
+        var n = Math.Truncate(size);
+        if (alpha <= 0 || alpha >= 1 || standardDeviation <= 0 || n < 1)
+            return XLError.NumberInvalid;
+
+        return XLMath.NormalSInv(1 - alpha / 2) * standardDeviation / Math.Sqrt(n);
+    }
+
+    private static ScalarValue ConfidenceT(CalcContext ctx, double alpha, double standardDeviation, double size)
+    {
+        var n = Math.Truncate(size);
+        if (alpha <= 0 || alpha >= 1 || standardDeviation <= 0 || n < 1)
+            return XLError.NumberInvalid;
+
+        // With a single observation there is no spread to estimate from.
+        if (n == 1)
+            return XLError.DivisionByZero;
+
+        return XLMath.StudentTInv(1 - alpha / 2, n - 1) * standardDeviation / Math.Sqrt(n);
+    }
+
+    #endregion
+
+    #region Sample helpers
+
+    private static bool TryGetSample(CalcContext ctx, in AnyValue value, out List<double> numbers, out XLError error)
+        => Statistical.TryGetNumbers(ctx, value, out numbers, out error);
+
+    private static bool TryGetScalarNumber(CalcContext ctx, in AnyValue value, out double number, out XLError error)
+    {
+        number = 0;
+        error = default;
+
+        if (!value.TryPickScalar(out var scalar, out var collection))
+        {
+            if (collection.TryPickT0(out var array, out var reference))
+            {
+                scalar = array[0, 0];
+            }
+            else if (!reference.TryGetSingleCellValue(out scalar, ctx)
+                     && !value.ImplicitIntersection(ctx).TryPickScalar(out scalar, out _))
+            {
+                error = XLError.IncompatibleValue;
+                return false;
+            }
+        }
+
+        return scalar.ToNumber(ctx.Culture).TryPickT0(out number, out error);
+    }
+
+    private static bool TryPairOfNumbers(CalcContext ctx, in ScalarValue left, in ScalarValue right, out double a, out double b, out XLError error)
+    {
+        a = 0;
+        b = 0;
+        if (!left.ToNumber(ctx.Culture).TryPickT0(out a, out error))
+            return false;
+
+        return right.ToNumber(ctx.Culture).TryPickT0(out b, out error);
+    }
+
+    private static double Mean(List<double> values)
+    {
+        var total = 0d;
+        foreach (var value in values)
+            total += value;
+
+        return total / values.Count;
+    }
+
+    private static double SampleVariance(List<double> values)
+    {
+        var mean = Mean(values);
+        var sumOfSquares = 0d;
+        foreach (var value in values)
+            sumOfSquares += (value - mean) * (value - mean);
+
+        return sumOfSquares / (values.Count - 1);
+    }
+
+    #endregion
+}

--- a/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -970,6 +970,131 @@ internal static class SignatureAdapter
         };
     }
 
+    public static CalcEngineFunction Adapt(Func<CalcContext, double, double, double, bool, ScalarValue> f)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = ToNumber(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            var arg2Converted = ToNumber(args[2], ctx);
+            if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                return err2;
+
+            var arg3Converted = CoerceToLogical(args[3], ctx);
+            if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                return err3;
+
+            return f(ctx, arg0, arg1, arg2, arg3).ToAnyValue();
+        };
+    }
+
+    public static CalcEngineFunction AdaptLastTwoOptional(Func<CalcContext, double, double, double, double, double, ScalarValue> f, double defaultValue0, double defaultValue1)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = ToNumber(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            var arg2Converted = ToNumber(args[2], ctx);
+            if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                return err2;
+
+            if (!ToOptionalNumber(args, 3, defaultValue0, ctx).TryPickT0(out var arg3, out var err3))
+                return err3;
+
+            if (!ToOptionalNumber(args, 4, defaultValue1, ctx).TryPickT0(out var arg4, out var err4))
+                return err4;
+
+            return f(ctx, arg0, arg1, arg2, arg3, arg4).ToAnyValue();
+        };
+    }
+
+    public static CalcEngineFunction Adapt(Func<CalcContext, double, bool, ScalarValue> f)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = CoerceToLogical(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            return f(ctx, arg0, arg1).ToAnyValue();
+        };
+    }
+
+    public static CalcEngineFunction Adapt(Func<CalcContext, double, double, double, double, bool, ScalarValue> f)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = ToNumber(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            var arg2Converted = ToNumber(args[2], ctx);
+            if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                return err2;
+
+            var arg3Converted = ToNumber(args[3], ctx);
+            if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                return err3;
+
+            var arg4Converted = CoerceToLogical(args[4], ctx);
+            if (!arg4Converted.TryPickT0(out var arg4, out var err4))
+                return err4;
+
+            return f(ctx, arg0, arg1, arg2, arg3, arg4).ToAnyValue();
+        };
+    }
+
+    /// <summary>Three numbers and a flag, then two optional numbers — the shape of BETA.DIST.</summary>
+    public static CalcEngineFunction AdaptLastTwoOptional(Func<CalcContext, double, double, double, bool, double, double, ScalarValue> f, double defaultValue0, double defaultValue1)
+    {
+        return (ctx, args) =>
+        {
+            var arg0Converted = ToNumber(args[0], ctx);
+            if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                return err0;
+
+            var arg1Converted = ToNumber(args[1], ctx);
+            if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                return err1;
+
+            var arg2Converted = ToNumber(args[2], ctx);
+            if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                return err2;
+
+            var arg3Converted = CoerceToLogical(args[3], ctx);
+            if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                return err3;
+
+            if (!ToOptionalNumber(args, 4, defaultValue0, ctx).TryPickT0(out var arg4, out var err4))
+                return err4;
+
+            if (!ToOptionalNumber(args, 5, defaultValue1, ctx).TryPickT0(out var arg5, out var err5))
+                return err5;
+
+            return f(ctx, arg0, arg1, arg2, arg3, arg4, arg5).ToAnyValue();
+        };
+    }
+
     public static CalcEngineFunction Adapt(Func<CalcContext, double, string, string, ScalarValue> f)
     {
         return (ctx, args) =>

--- a/XLibur/Excel/CalcEngine/Functions/Statistical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Statistical.cs
@@ -70,6 +70,7 @@ internal static class Statistical
         ce.RegisterFunction("MINIFS", 3, 255, AdaptIfs(MinIfs), FunctionFlags.Range, AllowRange.Only, ValueAndCriteriaRangeParams); // Returns the minimum of cells that meet multiple criteria
         ce.RegisterFunction("MODE", 1, 255, Mode, FunctionFlags.Range, AllowRange.All); // Returns the most common value in a data set
         ce.RegisterFunction("MODE.SNGL", 1, 255, Mode, FunctionFlags.Range, AllowRange.All);
+        ce.RegisterFunction("MODE.MULT", 1, 255, ModeMult, FunctionFlags.Range | FunctionFlags.Future | FunctionFlags.ReturnsArray, AllowRange.All); // Returns every value tied for most common
         //NEGBINOMDIST	Returns the negative binomial distribution
         //NORMDIST	Returns the normal cumulative distribution
         //NORMINV	Returns the inverse of the normal cumulative distribution
@@ -78,14 +79,19 @@ internal static class Statistical
         //PEARSON	Returns the Pearson product moment correlation coefficient
         ce.RegisterFunction("PERCENTILE", 2, 2, Adapt(Percentile), FunctionFlags.Range, AllowRange.Only, 0); // Returns the k-th percentile of values in a range
         ce.RegisterFunction("PERCENTILE.INC", 2, 2, Adapt(Percentile), FunctionFlags.Range, AllowRange.Only, 0);
-        //PERCENTRANK	Returns the percentage rank of a value in a data set
+        ce.RegisterFunction("PERCENTILE.EXC", 2, 2, Adapt(PercentileExc), FunctionFlags.Range | FunctionFlags.Future, AllowRange.Only, 0); // The k-th percentile, exclusive of the endpoints
+        ce.RegisterFunction("PERCENTRANK", 2, 3, PercentRankInc, FunctionFlags.Range, AllowRange.Only, 0); // Returns the percentage rank of a value in a data set
+        ce.RegisterFunction("PERCENTRANK.INC", 2, 3, PercentRankInc, FunctionFlags.Range | FunctionFlags.Future, AllowRange.Only, 0);
+        ce.RegisterFunction("PERCENTRANK.EXC", 2, 3, PercentRankExc, FunctionFlags.Range | FunctionFlags.Future, AllowRange.Only, 0);
         //PERMUT	Returns the number of permutations for a given number of objects
         //POISSON	Returns the Poisson distribution
         //PROB	Returns the probability that values in a range are between two limits
         ce.RegisterFunction("QUARTILE", 2, 2, Adapt(Quartile), FunctionFlags.Range, AllowRange.Only, 0); // Returns the quartile of a data set
         ce.RegisterFunction("QUARTILE.INC", 2, 2, Adapt(Quartile), FunctionFlags.Range, AllowRange.Only, 0);
+        ce.RegisterFunction("QUARTILE.EXC", 2, 2, Adapt(QuartileExc), FunctionFlags.Range | FunctionFlags.Future, AllowRange.Only, 0); // The quartile, exclusive of the endpoints
         ce.RegisterFunction("RANK", 2, 3, Rank, FunctionFlags.Range, AllowRange.Only, 1); // Returns the rank of a number in a list of numbers
         ce.RegisterFunction("RANK.EQ", 2, 3, Rank, FunctionFlags.Range, AllowRange.Only, 1);
+        ce.RegisterFunction("RANK.AVG", 2, 3, RankAvg, FunctionFlags.Range | FunctionFlags.Future, AllowRange.Only, 1); // Rank, with tied values sharing the average of the ranks they span
         //RSQ	Returns the square of the Pearson product moment correlation coefficient
         //SKEW	Returns the skewness of a distribution
         //SLOPE	Returns the slope of the linear regression line
@@ -641,6 +647,16 @@ internal static class Statistical
 
     private static AnyValue Rank(CalcContext ctx, Span<AnyValue> args)
     {
+        return Rank(ctx, args, averageTies: false);
+    }
+
+    private static AnyValue RankAvg(CalcContext ctx, Span<AnyValue> args)
+    {
+        return Rank(ctx, args, averageTies: true);
+    }
+
+    private static AnyValue Rank(CalcContext ctx, Span<AnyValue> args, bool averageTies)
+    {
         // RANK(number, ref, [order]). number/order are scalars (implicitly intersected); ref is the
         // range/array (marked param 1). order = 0 or omitted ranks descending, non-zero ascending.
         if (!args[0].TryPickScalar(out var numberScalar, out _))
@@ -668,7 +684,14 @@ internal static class Statistical
         var rank = ascending
             ? numbers.Count(v => v < number) + 1
             : numbers.Count(v => v > number) + 1;
-        return rank;
+
+        if (!averageTies)
+            return rank;
+
+        // RANK.AVG spreads the ranks a tied group occupies evenly across its members: a pair tied
+        // for third takes ranks three and four, so both are reported as 3.5.
+        var tied = numbers.Count(v => v == number);
+        return rank + (tied - 1) / 2.0;
     }
 
     private static AnyValue Mode(CalcContext ctx, Span<AnyValue> args)
@@ -707,12 +730,130 @@ internal static class Statistical
         return XLError.NoValueAvailable;
     }
 
+    /// <summary>
+    /// MODE.MULT — every value tied for most common, as a column. MODE.SNGL returns only the first
+    /// of them, which is the whole difference between the two.
+    /// </summary>
+    private static AnyValue ModeMult(CalcContext ctx, Span<AnyValue> args)
+    {
+        var result = TallyNumbers.Default.Tally(ctx, args, new ValuesState([]));
+        if (!result.TryPickT0(out var state, out var error))
+            return error;
+
+        var values = state.Values;
+        var counts = new Dictionary<double, int>();
+        var maxCount = 0;
+        foreach (var value in values)
+        {
+            var count = counts.GetValueOrDefault(value) + 1;
+            counts[value] = count;
+            if (count > maxCount)
+                maxCount = count;
+        }
+
+        if (maxCount <= 1)
+            return XLError.NoValueAvailable;
+
+        // Report them in order of first appearance, which is the order Excel uses.
+        var modes = new List<double>();
+        var seen = new HashSet<double>();
+        foreach (var value in values)
+        {
+            if (counts[value] == maxCount && seen.Add(value))
+                modes.Add(value);
+        }
+
+        var data = new ScalarValue[modes.Count, 1];
+        for (var i = 0; i < modes.Count; i++)
+            data[i, 0] = modes[i];
+
+        return new ConstArray(data);
+    }
+
     private static AnyValue Percentile(CalcContext ctx, AnyValue arrayParam, double k)
     {
         if (!TryGetNumbers(ctx, arrayParam, out var numbers, out var error))
             return error;
 
         return PercentileInclusive(numbers, k);
+    }
+
+    private static AnyValue PercentileExc(CalcContext ctx, AnyValue arrayParam, double k)
+    {
+        if (!TryGetNumbers(ctx, arrayParam, out var numbers, out var error))
+            return error;
+
+        return PercentileExclusive(numbers, k);
+    }
+
+    private static AnyValue QuartileExc(CalcContext ctx, AnyValue arrayParam, double quartParam)
+    {
+        if (!TryGetNumbers(ctx, arrayParam, out var numbers, out var error))
+            return error;
+
+        return QuartileExclusive(numbers, quartParam);
+    }
+
+    private static AnyValue PercentRankInc(CalcContext ctx, Span<AnyValue> args)
+        => PercentRank(ctx, args, exclusive: false);
+
+    private static AnyValue PercentRankExc(CalcContext ctx, Span<AnyValue> args)
+        => PercentRank(ctx, args, exclusive: true);
+
+    /// <summary>
+    /// PERCENTRANK(array, x, [significance]) — where <c>x</c> sits within the data set, as a
+    /// fraction between 0 and 1. It is the inverse of PERCENTILE, and comes in the same inclusive
+    /// and exclusive flavours: inclusive spreads the n values over 0…1, exclusive over
+    /// 1/(n+1)…n/(n+1). The result is truncated, not rounded, to <c>significance</c> decimals.
+    /// </summary>
+    private static AnyValue PercentRank(CalcContext ctx, Span<AnyValue> args, bool exclusive)
+    {
+        if (!TryGetNumbers(ctx, args[0], out var numbers, out var arrayError))
+            return arrayError;
+
+        if (!args[1].TryPickScalar(out var xScalar, out _))
+            return XLError.IncompatibleValue;
+        if (!xScalar.ToNumber(ctx.Culture).TryPickT0(out var x, out var xError))
+            return xError;
+
+        var significance = 3d;
+        if (args.Length > 2)
+        {
+            if (!args[2].TryPickScalar(out var significanceScalar, out _))
+                return XLError.IncompatibleValue;
+            if (!significanceScalar.ToNumber(ctx.Culture).TryPickT0(out significance, out var significanceError))
+                return significanceError;
+
+            significance = Math.Truncate(significance);
+            if (significance < 1)
+                return XLError.NumberInvalid;
+        }
+
+        if (numbers.Count == 0)
+            return XLError.NumberInvalid;
+
+        numbers.Sort();
+        if (x < numbers[0] || x > numbers[^1])
+            return XLError.NoValueAvailable;
+
+        // Position within the sorted values, interpolating between the two that straddle x.
+        var below = 0;
+        while (below + 1 < numbers.Count && numbers[below + 1] <= x)
+            below++;
+
+        var position = (double)below;
+        if (numbers[below] < x && below + 1 < numbers.Count)
+            position += (x - numbers[below]) / (numbers[below + 1] - numbers[below]);
+
+        var rank = exclusive
+            ? (position + 1) / (numbers.Count + 1)
+            : numbers.Count > 1 ? position / (numbers.Count - 1) : 1d;
+
+        if (exclusive && (rank <= 0 || rank >= 1))
+            return XLError.NoValueAvailable;
+
+        var scale = Math.Pow(10, significance);
+        return Math.Truncate(rank * scale) / scale;
     }
 
     private static AnyValue Quartile(CalcContext ctx, AnyValue arrayParam, double quartParam)
@@ -796,7 +937,7 @@ internal static class Statistical
     /// Collect the numeric values of an array/range/scalar argument (skipping blanks and text,
     /// short-circuiting on an error value), mirroring how <see cref="Large"/> reads its data set.
     /// </summary>
-    private static bool TryGetNumbers(CalcContext ctx, AnyValue arrayParam, out List<double> numbers, out XLError error)
+    internal static bool TryGetNumbers(CalcContext ctx, AnyValue arrayParam, out List<double> numbers, out XLError error)
     {
         error = default;
 

--- a/XLibur/Excel/CalcEngine/Functions/XLMath.cs
+++ b/XLibur/Excel/CalcEngine/Functions/XLMath.cs
@@ -222,6 +222,143 @@ public static class XLMath
     }
 
     /// <summary>
+    /// The gamma function Γ(x). Negative arguments go through the reflection formula, which is
+    /// undefined at the non-positive integers — the poles of the function.
+    /// </summary>
+    internal static double Gamma(double x)
+    {
+        if (x > 0)
+            return Math.Exp(LnGamma(x));
+
+        if (x == Math.Floor(x))
+            return double.NaN;
+
+        // Γ(x)·Γ(1−x) = π / sin(πx).
+        return Math.PI / (Math.Sin(Math.PI * x) * Math.Exp(LnGamma(1 - x)));
+    }
+
+    /// <summary>
+    /// Inverse of the standard normal CDF: the z with P(Z ≤ z) = <paramref name="p"/>.
+    /// <para>
+    /// Acklam's rational approximation gets within about 1e-9 relative, and a single Halley step
+    /// against the true CDF — which <see cref="Erfc"/> gives to full precision — takes it the rest
+    /// of the way. Doing it in two stages is what keeps NORM.S.INV accurate deep in the tails,
+    /// where the rational form alone starts to drift.
+    /// </para>
+    /// </summary>
+    internal static double NormalSInv(double p)
+    {
+        if (p <= 0)
+            return double.NegativeInfinity;
+        if (p >= 1)
+            return double.PositiveInfinity;
+
+        ReadOnlySpan<double> a = [
+            -3.969683028665376e+01, 2.209460984245205e+02, -2.759285104469687e+02,
+            1.383577518672690e+02, -3.066479806614716e+01, 2.506628277459239e+00];
+        ReadOnlySpan<double> b = [
+            -5.447609879822406e+01, 1.615858368580409e+02, -1.556989798598866e+02,
+            6.680131188771972e+01, -1.328068155288572e+01];
+        ReadOnlySpan<double> c = [
+            -7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e+00,
+            -2.549732539343734e+00, 4.374664141464968e+00, 2.938163982698783e+00];
+        ReadOnlySpan<double> d = [
+            7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e+00,
+            3.754408661907416e+00];
+
+        const double lowerBreak = 0.02425;
+        double x;
+        if (p < lowerBreak)
+        {
+            var q = Math.Sqrt(-2 * Math.Log(p));
+            x = (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+                ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1);
+        }
+        else if (p <= 1 - lowerBreak)
+        {
+            var q = p - 0.5;
+            var r = q * q;
+            x = (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q /
+                (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1);
+        }
+        else
+        {
+            var q = Math.Sqrt(-2 * Math.Log(1 - p));
+            x = -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+                ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1);
+        }
+
+        var error = NormalSDist(x) - p;
+        var correction = error * Math.Sqrt(2 * Math.PI) * Math.Exp(x * x / 2);
+        return x - correction / (1 + x * correction / 2);
+    }
+
+    /// <summary>Standard normal CDF, P(Z ≤ z).</summary>
+    internal static double NormalSDist(double z) => 0.5 * Erfc(-z / Math.Sqrt(2));
+
+    /// <summary>Standard normal probability density.</summary>
+    internal static double NormalSPdf(double z) => Math.Exp(-z * z / 2) / Math.Sqrt(2 * Math.PI);
+
+    /// <summary>
+    /// Inverse of <see cref="GammaP"/>: the x with P(a, x) = <paramref name="p"/>. Newton's method
+    /// on the CDF, with the bracket it has narrowed so far as a fallback whenever a step would jump
+    /// outside it — the density vanishes in both tails, where Newton alone would run away.
+    /// </summary>
+    internal static double InverseGammaP(double p, double a)
+    {
+        if (p <= 0)
+            return 0;
+        if (p >= 1)
+            return double.PositiveInfinity;
+
+        var x = InverseGammaInitialGuess(p, a);
+        var lo = 0.0;
+        var hi = double.PositiveInfinity;
+        var lnGammaA = LnGamma(a);
+
+        for (var i = 0; i < 200; i++)
+        {
+            var error = GammaP(a, x) - p;
+            if (error < 0)
+                lo = x;
+            else
+                hi = x;
+
+            if (Math.Abs(error) < 1e-15)
+                break;
+
+            var pdf = Math.Exp((a - 1) * Math.Log(x) - x - lnGammaA);
+            var next = pdf > 0 ? x - error / pdf : double.NaN;
+
+            // Outside the bracket the step is not trusted: bisect, or double when there is still no
+            // upper bound to bisect against.
+            if (double.IsNaN(next) || next <= lo || next >= hi)
+                next = double.IsPositiveInfinity(hi) ? x * 2 : (lo + hi) / 2;
+
+            if (Math.Abs(next - x) < 1e-15 * Math.Abs(x))
+                return next;
+
+            x = next;
+        }
+
+        return x;
+    }
+
+    private static double InverseGammaInitialGuess(double p, double a)
+    {
+        if (a > 1)
+        {
+            // Wilson–Hilferty: the cube root of a gamma variate is nearly normal.
+            var z = NormalSInv(p);
+            var guess = a * Math.Pow(1 - 1.0 / (9 * a) + z / (3 * Math.Sqrt(a)), 3);
+            return Math.Max(guess, 1e-8);
+        }
+
+        var t = 1 - a * (0.253 + a * 0.12);
+        return p < t ? Math.Pow(p / t, 1 / a) : 1 - Math.Log(1 - (p - t) / (1 - t));
+    }
+
+    /// <summary>
     /// Regularized lower incomplete gamma function P(a, x) = γ(a, x) / Γ(a). Evaluated by its power
     /// series below the transition point and as 1 − Q(a, x) above it, where each is convergent.
     /// </summary>

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -621,6 +621,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
         MathTrig.Register(fr);
         Text.Register(fr);
         Statistical.Register(fr);
+        Distributions.Register(fr);
         DateAndTime.Register(fr);
         Financial.Register(fr);
         DynamicArray.Register(fr);


### PR DESCRIPTION
Wave B of [spec 07](docs/specs/07-formula-function-coverage.md) — the largest wave. Stacked on #255 — **targets `feat/calc-wave-f-datetime`**, retarget as the stack merges.

## Functions added (69 registrations)

| Group | Functions |
|---|---|
| Normal | `NORM.DIST`, `NORM.INV`, `NORM.S.DIST`, `NORM.S.INV`, `LOGNORM.DIST`, `LOGNORM.INV` |
| Chi-squared | `CHISQ.DIST`, `CHISQ.DIST.RT`, `CHISQ.INV`, `CHISQ.INV.RT` |
| F | `F.DIST`, `F.DIST.RT`, `F.INV`, `F.INV.RT` |
| Student's t | `T.DIST`, `T.DIST.2T`, `T.DIST.RT` |
| Other continuous | `EXPON.DIST`, `POISSON.DIST`, `WEIBULL.DIST`, `GAMMA`, `GAMMA.DIST`, `GAMMA.INV`, `GAMMALN`, `GAMMALN.PRECISE`, `BETA.DIST`, `BETA.INV` |
| Discrete | `HYPGEOM.DIST`, `NEGBINOM.DIST`, `BINOM.INV` |
| Confidence | `CONFIDENCE.NORM`, `CONFIDENCE.T` |
| Hypothesis tests | `CHISQ.TEST`, `F.TEST`, `T.TEST`, `Z.TEST` |
| Order statistics | `PERCENTILE.EXC`, `QUARTILE.EXC`, `RANK.AVG`, `MODE.MULT`, `PERCENTRANK`, `PERCENTRANK.INC`, `PERCENTRANK.EXC` |
| Legacy names (26) | `NORMDIST`, `NORMINV`, `NORMSDIST`, `NORMSINV`, `LOGNORMDIST`, `LOGINV`, `CHIDIST`, `CHIINV`, `CHITEST`, `FDIST`, `FINV`, `FTEST`, `TDIST`, `TTEST`, `ZTEST`, `EXPONDIST`, `POISSON`, `WEIBULL`, `GAMMADIST`, `GAMMAINV`, `BETADIST`, `BETAINV`, `HYPGEOMDIST`, `NEGBINOMDIST`, `CONFIDENCE`, `CRITBINOM` |

The legacy names point at the same implementations rather than copies; where a legacy form genuinely differs — cumulative-only, or a right tail where the dotted name gives a left — the difference is a thin wrapper and the comment says which. `MODE.MULT` spills.

Registry: 346 → 415 functions.

## Notes on the implementation

Everything reduces to one of four special functions in `XLMath`, three of them new here:

- **`NormalSInv`** — Acklam's rational approximation finished with a Halley step against the true CDF, so it stays accurate in the tails where the rational form alone drifts. Tested by round-tripping at p = 1e-7.
- **`InverseGammaP`** — Newton on the CDF, falling back to the bracket it has narrowed whenever a step would leave it. The density vanishes in both tails, where Newton alone runs away.
- **`Gamma`** — with the reflection formula for negative arguments and the poles rejected.

**Tails are computed on the side that matters** rather than by subtracting from one: `F.DIST.RT` goes through the beta function's own symmetry, and the Poisson CDF through the upper incomplete gamma. A small p-value keeps its significant digits instead of being lost to `1 - (1 - ε)` — which is the whole point of these functions in a test.

**`T.TEST` with unequal variances truncates the Welch degrees of freedom**, as every other function in the `T.DIST` family truncates its own. That is what lets the result be reproduced from `T.DIST.2T` and the Welch formula in a worksheet, which is how the test checks it.

## Verification

171 tests, all passing; full suite green on net8.0 and net10.0; Release build clean.

Expected values are, in order of preference: closed-form results the distribution takes at a special point (a chi-squared with two degrees of freedom is an exponential; Beta(1,1) is uniform; t with one degree of freedom is Cauchy), published critical values (1.96, 1.6449, the 5% chi-squared and t points), and Microsoft's worked examples. **Every inverse is additionally round-tripped through its own distribution**, which pins both directions at once and needs no external reference. The four hypothesis tests are each checked against the distribution they are defined in terms of, computed independently in the same worksheet.
