### PR TITLE
feat(comments): model threaded comments and round-trip them

### DIFF
--- a/XLibur.Tests/Excel/Comments/CommentsTests.cs
+++ b/XLibur.Tests/Excel/Comments/CommentsTests.cs
@@ -200,9 +200,32 @@ public partial class CommentsTests
         var ws = wb.Worksheets.First();
         var c = ws.FirstCellUsed()!;
 
-        // Threaded comment text is loaded from the threadedComments part,
-        // replacing the legacy placeholder from comments1.xml.
-        await Assert.That(c.GetComment().Text).IsEqualTo("This is a threaded comment.\nThis is a reply.");
+        // The thread is the user-visible annotation; the "[Threaded comment]" note Excel pairs with
+        // it is a fallback for older versions and must not surface as a note.
+        await Assert.That(c.HasThreadedComment).IsTrue();
+        await Assert.That(c.HasComment).IsFalse();
+
+        var thread = c.GetThreadedComment()!;
+        await Assert.That(thread.Text).IsEqualTo("This is a threaded comment.");
+        await Assert.That(thread.Author.DisplayName).IsEqualTo("Herzog, Bernd");
+        await Assert.That(thread.Author.ProviderId).IsEqualTo("AD");
+        await Assert.That(thread.Author.UserId).IsEqualTo("S-1-5-21-2931304574-606859833-1339073683-15873");
+        await Assert.That(thread.Id).IsEqualTo(Guid.Parse("{9E032651-3A03-49E4-A15E-A90318F086F4}"));
+        await Assert.That(thread.Parent).IsNull();
+        await Assert.That(thread.Resolved).IsFalse();
+        await Assert.That(thread.CreatedUtc)
+            .IsEqualTo(new DateTime(2020, 7, 1, 6, 20, 6, 20, DateTimeKind.Utc));
+
+        await Assert.That(thread.Replies.Count).IsEqualTo(1);
+        var reply = thread.Replies[0];
+        await Assert.That(reply.Text).IsEqualTo("This is a reply.");
+        await Assert.That(reply.Parent).IsEqualTo(thread);
+        await Assert.That(reply.Author).IsEqualTo(thread.Author);
+        await Assert.That(reply.CreatedUtc)
+            .IsEqualTo(new DateTime(2020, 7, 1, 6, 20, 22, 880, DateTimeKind.Utc));
+
+        // The person is registered once at workbook level, not once per comment.
+        await Assert.That(wb.Persons.Count).IsEqualTo(1);
     }
 
     [Test]
@@ -213,8 +236,13 @@ public partial class CommentsTests
         var ws = wb.Worksheets.First();
         var c = ws.Cell("B2");
 
-        await Assert.That(c.HasComment).IsTrue();
-        await Assert.That(c.GetComment().Text).IsEqualTo("This is the comment in b2");
+        // A thread with no replies is still a thread, not a note.
+        await Assert.That(c.HasThreadedComment).IsTrue();
+        await Assert.That(c.HasComment).IsFalse();
+
+        var thread = c.GetThreadedComment()!;
+        await Assert.That(thread.Text).IsEqualTo("This is the comment in b2");
+        await Assert.That(thread.Replies.Count).IsEqualTo(0);
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Comments/ThreadedCommentEditingTests.cs
+++ b/XLibur.Tests/Excel/Comments/ThreadedCommentEditingTests.cs
@@ -1,0 +1,382 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Comments;
+
+/// <summary>
+/// Threads live in the misc slice next to legacy notes, so shifting, swapping, clearing and copying
+/// should treat the two the same. These tests pin that down.
+/// </summary>
+public class ThreadedCommentEditingTests
+{
+    #region Deleting
+
+    [Test]
+    public async Task Deleting_the_root_deletes_the_whole_thread()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        var thread = ws.Cell("A1").CreateThreadedComment(person, "Root.");
+        thread.AddReply(person, "First reply.");
+        thread.AddReply(person, "Second reply.");
+
+        thread.Delete();
+
+        await Assert.That(ws.Cell("A1").HasThreadedComment).IsFalse();
+        await Assert.That(ws.Cell("A1").GetThreadedComment()).IsNull();
+    }
+
+    [Test]
+    public async Task Deleting_a_reply_leaves_the_rest_of_the_thread()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        var thread = ws.Cell("A1").CreateThreadedComment(person, "Root.");
+        var first = thread.AddReply(person, "First reply.");
+        thread.AddReply(person, "Second reply.");
+
+        first.Delete();
+
+        await Assert.That(ws.Cell("A1").HasThreadedComment).IsTrue();
+        await Assert.That(thread.Replies.Count).IsEqualTo(1);
+        await Assert.That(thread.Replies[0].Text).IsEqualTo("Second reply.");
+    }
+
+    [Test]
+    public async Task Clearing_comments_removes_a_thread()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A1").CreateThreadedComment(person, "Root.");
+
+        ws.Cell("A1").Clear(XLClearOptions.Comments);
+
+        await Assert.That(ws.Cell("A1").HasThreadedComment).IsFalse();
+    }
+
+    [Test]
+    public async Task Clearing_contents_leaves_a_thread_alone()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A1").Value = "text";
+        ws.Cell("A1").CreateThreadedComment(person, "Root.");
+
+        ws.Cell("A1").Clear(XLClearOptions.Contents);
+
+        await Assert.That(ws.Cell("A1").HasThreadedComment).IsTrue();
+    }
+
+    [Test]
+    public async Task Deleting_comments_over_a_range_removes_threads()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A1").CreateThreadedComment(person, "First.");
+        ws.Cell("A2").CreateThreadedComment(person, "Second.");
+
+        ws.Range("A1:A2").DeleteComments();
+
+        await Assert.That(ws.Cell("A1").HasThreadedComment).IsFalse();
+        await Assert.That(ws.Cell("A2").HasThreadedComment).IsFalse();
+    }
+
+    #endregion
+
+    #region Shifting
+
+    [Test]
+    public async Task Inserting_rows_shifts_a_thread_down()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        var thread = ws.Cell("A5").CreateThreadedComment(person, "Root.");
+        thread.AddReply(person, "Reply.");
+
+        ws.Row(1).InsertRowsAbove(2);
+
+        await Assert.That(ws.Cell("A5").HasThreadedComment).IsFalse();
+        await Assert.That(ws.Cell("A7").HasThreadedComment).IsTrue();
+
+        var moved = ws.Cell("A7").GetThreadedComment()!;
+        await Assert.That(moved.Text).IsEqualTo("Root.");
+        await Assert.That(moved.Replies.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Deleting_rows_shifts_a_thread_up()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A5").CreateThreadedComment(person, "Root.");
+
+        ws.Row(1).Delete();
+
+        await Assert.That(ws.Cell("A5").HasThreadedComment).IsFalse();
+        await Assert.That(ws.Cell("A4").GetThreadedComment()!.Text).IsEqualTo("Root.");
+    }
+
+    [Test]
+    public async Task Inserting_columns_shifts_a_thread_right()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("C1").CreateThreadedComment(person, "Root.");
+
+        ws.Column(1).InsertColumnsBefore(2);
+
+        await Assert.That(ws.Cell("C1").HasThreadedComment).IsFalse();
+        await Assert.That(ws.Cell("E1").GetThreadedComment()!.Text).IsEqualTo("Root.");
+    }
+
+    [Test]
+    public async Task Deleting_a_row_deletes_the_threads_on_it()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A1").CreateThreadedComment(person, "Doomed.");
+        ws.Cell("A2").CreateThreadedComment(person, "Survivor.");
+
+        ws.Row(1).Delete();
+
+        await Assert.That(ws.Cell("A1").GetThreadedComment()!.Text).IsEqualTo("Survivor.");
+    }
+
+    [Test]
+    public async Task A_shifted_thread_still_saves_against_its_new_address()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            var person = wb.Persons.Add("Reviewer");
+            ws.Cell("A5").CreateThreadedComment(person, "Root.");
+            ws.Row(1).InsertRowsAbove(2);
+            wb.SaveAs(ms, validate: true);
+        }
+
+        using var reloaded = new XLWorkbook(ms);
+        var loadedWs = reloaded.Worksheet("Sheet1");
+        await Assert.That(loadedWs.Cell("A5").HasThreadedComment).IsFalse();
+        await Assert.That(loadedWs.Cell("A7").GetThreadedComment()!.Text).IsEqualTo("Root.");
+    }
+
+    #endregion
+
+    #region Copying
+
+    [Test]
+    public async Task Copying_a_cell_copies_the_thread_with_a_new_id()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        var source = ws.Cell("A1").CreateThreadedComment(person, "Root.");
+        source.AddReply(person, "Reply.");
+
+        ws.Cell("A1").CopyTo(ws.Cell("C3"));
+
+        var copy = ws.Cell("C3").GetThreadedComment()!;
+        await Assert.That(copy.Text).IsEqualTo("Root.");
+        await Assert.That(copy.Replies.Count).IsEqualTo(1);
+        await Assert.That(copy.Replies[0].Text).IsEqualTo("Reply.");
+        await Assert.That(copy.Author).IsEqualTo(source.Author);
+
+        // Two threads may not share an id: it is what the fallback note's uid points at.
+        await Assert.That(copy.Id).IsNotEqualTo(source.Id);
+        await Assert.That(copy.Replies[0].Id).IsNotEqualTo(source.Replies[0].Id);
+
+        // The original is untouched.
+        await Assert.That(ws.Cell("A1").GetThreadedComment()!.Text).IsEqualTo("Root.");
+    }
+
+    [Test]
+    public async Task Copying_a_thread_over_a_note_replaces_it()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A1").CreateThreadedComment(person, "Root.");
+        ws.Cell("C3").GetComment().AddText("A plain note.");
+
+        ws.Cell("A1").CopyTo(ws.Cell("C3"));
+
+        await Assert.That(ws.Cell("C3").HasThreadedComment).IsTrue();
+        await Assert.That(ws.Cell("C3").HasComment).IsFalse();
+    }
+
+    [Test]
+    public async Task Copying_a_note_over_a_thread_replaces_it()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A1").GetComment().AddText("A plain note.");
+        ws.Cell("C3").CreateThreadedComment(person, "Root.");
+
+        ws.Cell("A1").CopyTo(ws.Cell("C3"));
+
+        await Assert.That(ws.Cell("C3").HasComment).IsTrue();
+        await Assert.That(ws.Cell("C3").HasThreadedComment).IsFalse();
+    }
+
+    [Test]
+    public async Task Copying_across_workbooks_maps_the_person_into_the_target()
+    {
+        using var source = new XLWorkbook();
+        var sourceWs = source.AddWorksheet("Sheet1");
+        var sourcePerson = source.Persons.Add("Reviewer", "S-1-5-21-1", "AD");
+        sourceWs.Cell("A1").CreateThreadedComment(sourcePerson, "Root.");
+
+        using var target = new XLWorkbook();
+        var targetWs = target.AddWorksheet("Sheet1");
+
+        sourceWs.Cell("A1").CopyTo(targetWs.Cell("A1"));
+
+        var copied = targetWs.Cell("A1").GetThreadedComment()!;
+        await Assert.That(copied.Text).IsEqualTo("Root.");
+        await Assert.That(copied.Author.DisplayName).IsEqualTo("Reviewer");
+        await Assert.That(copied.Author.UserId).IsEqualTo("S-1-5-21-1");
+
+        // The person is now owned by the target workbook, not borrowed from the source.
+        await Assert.That(target.Persons.Count).IsEqualTo(1);
+        await Assert.That(target.Persons.Get(copied.Author.Id)).IsEqualTo(copied.Author);
+    }
+
+    [Test]
+    public async Task Copying_two_threads_by_the_same_person_adds_that_person_once()
+    {
+        using var source = new XLWorkbook();
+        var sourceWs = source.AddWorksheet("Sheet1");
+        var sourcePerson = source.Persons.Add("Reviewer", "S-1-5-21-1", "AD");
+        sourceWs.Cell("A1").CreateThreadedComment(sourcePerson, "First.");
+        sourceWs.Cell("A2").CreateThreadedComment(sourcePerson, "Second.");
+
+        using var target = new XLWorkbook();
+        var targetWs = target.AddWorksheet("Sheet1");
+        sourceWs.Range("A1:A2").CopyTo(targetWs.Cell("A1"));
+
+        await Assert.That(target.Persons.Count).IsEqualTo(1);
+        await Assert.That(targetWs.Cell("A1").GetThreadedComment()!.Author)
+            .IsEqualTo(targetWs.Cell("A2").GetThreadedComment()!.Author);
+    }
+
+    [Test]
+    public async Task A_thread_copied_across_workbooks_saves_and_reloads()
+    {
+        using var ms = new MemoryStream();
+        using (var source = new XLWorkbook())
+        using (var target = new XLWorkbook())
+        {
+            var sourceWs = source.AddWorksheet("Sheet1");
+            var person = source.Persons.Add("Reviewer", "S-1-5-21-1", "AD");
+            var thread = sourceWs.Cell("A1").CreateThreadedComment(person, "Root.");
+            thread.AddReply(person, "Reply.");
+
+            var targetWs = target.AddWorksheet("Sheet1");
+            sourceWs.Cell("A1").CopyTo(targetWs.Cell("B2"));
+            target.SaveAs(ms, validate: true);
+        }
+
+        using var reloaded = new XLWorkbook(ms);
+        var loaded = reloaded.Worksheet("Sheet1").Cell("B2").GetThreadedComment()!;
+        await Assert.That(loaded.Text).IsEqualTo("Root.");
+        await Assert.That(loaded.Replies.Count).IsEqualTo(1);
+        await Assert.That(loaded.Author.DisplayName).IsEqualTo("Reviewer");
+        await Assert.That(reloaded.Persons.Count).IsEqualTo(1);
+    }
+
+    #endregion
+
+    #region Cells used
+
+    [Test]
+    public async Task A_cell_with_only_a_thread_counts_as_used_for_comments()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("C3").CreateThreadedComment(person, "Root.");
+
+        var used = ws.CellsUsed(XLCellsUsedOptions.All).ToList();
+        await Assert.That(used.Count).IsEqualTo(1);
+        await Assert.That(used[0].Address.ToString()).IsEqualTo("C3");
+
+        // A thread is an annotation, not content.
+        await Assert.That(ws.CellsUsed(XLCellsUsedOptions.Contents).Any()).IsFalse();
+    }
+
+    #endregion
+
+    #region Replies
+
+    [Test]
+    public async Task Replies_are_flat_so_replying_to_a_reply_appends_to_the_thread()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        var thread = ws.Cell("A1").CreateThreadedComment(person, "Root.");
+        var first = thread.AddReply(person, "First.");
+        var second = first.AddReply(person, "Second.");
+
+        await Assert.That(thread.Replies.Count).IsEqualTo(2);
+        await Assert.That(first.Replies.Count).IsEqualTo(0);
+        await Assert.That(second.Parent).IsEqualTo(thread);
+    }
+
+    [Test]
+    public async Task Reply_order_survives_a_round_trip()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            var person = wb.Persons.Add("Reviewer");
+            var thread = ws.Cell("A1").CreateThreadedComment(person, "Root.");
+            for (var i = 1; i <= 5; i++)
+                thread.AddReply(person, $"Reply {i}.");
+
+            wb.SaveAs(ms, validate: true);
+        }
+
+        using var reloaded = new XLWorkbook(ms);
+        var loaded = reloaded.Worksheet("Sheet1").Cell("A1").GetThreadedComment()!;
+
+        await Assert.That(loaded.Replies.Count).IsEqualTo(5);
+        for (var i = 1; i <= 5; i++)
+            await Assert.That(loaded.Replies[i - 1].Text).IsEqualTo($"Reply {i}.");
+    }
+
+    [Test]
+    public async Task A_reply_by_a_person_from_another_workbook_is_mapped_in()
+    {
+        using var other = new XLWorkbook();
+        var stranger = other.Persons.Add("Stranger", "S-1-5-21-9", "AD");
+
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        var thread = ws.Cell("A1").CreateThreadedComment(person, "Root.");
+
+        var reply = thread.AddReply(stranger, "Reply from elsewhere.");
+
+        await Assert.That(reply.Author.DisplayName).IsEqualTo("Stranger");
+        await Assert.That(wb.Persons.Count).IsEqualTo(2);
+        await Assert.That(wb.Persons.Get(reply.Author.Id)).IsNotNull();
+    }
+
+    #endregion
+}

--- a/XLibur.Tests/Excel/Comments/ThreadedCommentReviewTests.cs
+++ b/XLibur.Tests/Excel/Comments/ThreadedCommentReviewTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Comments;
+
+public class ThreadedCommentReviewTests
+{
+    [Test]
+    public async Task Deleting_a_thread_that_has_been_shifted_clears_the_right_cell()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A5").CreateThreadedComment(person, "Root.");
+
+        ws.Row(1).InsertRowsAbove(2);
+        ws.Cell("A7").GetThreadedComment()!.Delete();
+
+        await Assert.That(ws.Cell("A7").HasThreadedComment).IsFalse();
+    }
+
+    [Test]
+    public async Task A_person_still_referenced_by_a_thread_is_written_even_if_removed_from_the_list()
+    {
+        using var ms = new MemoryStream();
+        Guid authorId;
+
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            var person = wb.Persons.Add("Reviewer", "S-1-5-21-1", "AD");
+            authorId = person.Id;
+            ws.Cell("A1").CreateThreadedComment(person, "Root.");
+
+            wb.Persons.Remove(person.Id);
+            wb.SaveAs(ms, validate: true);
+        }
+
+        // A personId with no matching <person> is a dangling reference Excel cannot resolve.
+        var personXml = ReadPart(ms, "xl/persons/");
+        await Assert.That(personXml).Contains(authorId.ToString("B").ToUpperInvariant());
+
+        using var reloaded = new XLWorkbook(ms);
+        await Assert.That(reloaded.Worksheet("Sheet1").Cell("A1").GetThreadedComment()!.Author.DisplayName)
+            .IsEqualTo("Reviewer");
+    }
+
+    [Test]
+    public async Task Two_provider_less_people_sharing_a_name_are_not_merged_across_workbooks()
+    {
+        using var source = new XLWorkbook();
+        var sourceWs = source.AddWorksheet("Sheet1");
+        var sourcePerson = source.Persons.Add("Reviewer");
+        sourceWs.Cell("A1").CreateThreadedComment(sourcePerson, "From the source workbook.");
+
+        using var target = new XLWorkbook();
+        var targetWs = target.AddWorksheet("Sheet1");
+        var targetPerson = target.Persons.Add("Reviewer");
+        targetWs.Cell("B2").CreateThreadedComment(targetPerson, "Already here.");
+
+        sourceWs.Cell("A1").CopyTo(targetWs.Cell("A1"));
+
+        // Without a userId or providerId there is nothing that says these are the same human, and
+        // merging them would reattribute one person's comment to the other.
+        var copiedAuthor = targetWs.Cell("A1").GetThreadedComment()!.Author;
+        await Assert.That(copiedAuthor.Id).IsNotEqualTo(targetPerson.Id);
+        await Assert.That(target.Persons.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Two_people_sharing_a_provider_identity_are_still_merged()
+    {
+        using var source = new XLWorkbook();
+        var sourceWs = source.AddWorksheet("Sheet1");
+        var sourcePerson = source.Persons.Add("Reviewer", "S-1-5-21-1", "AD");
+        sourceWs.Cell("A1").CreateThreadedComment(sourcePerson, "From the source workbook.");
+
+        using var target = new XLWorkbook();
+        var targetWs = target.AddWorksheet("Sheet1");
+        var targetPerson = target.Persons.Add("Reviewer", "S-1-5-21-1", "AD");
+        targetWs.Cell("B2").CreateThreadedComment(targetPerson, "Already here.");
+
+        sourceWs.Cell("A1").CopyTo(targetWs.Cell("A1"));
+
+        await Assert.That(target.Persons.Count).IsEqualTo(1);
+        await Assert.That(targetWs.Cell("A1").GetThreadedComment()!.Author.Id).IsEqualTo(targetPerson.Id);
+    }
+
+    [Test]
+    public async Task A_comment_with_no_timestamp_still_reports_a_utc_created_date()
+    {
+        // Excel always writes dT, but a hand-edited or third-party file need not.
+        var package = BuildPackageWithThreadMissingTimestamp();
+        using var wb = new XLWorkbook(package);
+
+        var thread = wb.Worksheets.First().Cell("A1").GetThreadedComment()!;
+        await Assert.That(thread.CreatedUtc.Kind).IsEqualTo(DateTimeKind.Utc);
+    }
+
+    private static MemoryStream BuildPackageWithThreadMissingTimestamp()
+    {
+        var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            var person = wb.Persons.Add("Reviewer");
+            ws.Cell("A1").CreateThreadedComment(person, "No timestamp.");
+            wb.SaveAs(ms, validate: true);
+        }
+
+        // Strip the dT attribute the writer emitted.
+        ms.Position = 0;
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var entry = archive.Entries.First(e =>
+                e.FullName.StartsWith("xl/threadedcomments/", StringComparison.OrdinalIgnoreCase));
+
+            string xml;
+            using (var reader = new StreamReader(entry.Open(), Encoding.UTF8))
+                xml = reader.ReadToEnd();
+
+            xml = System.Text.RegularExpressions.Regex.Replace(xml, " dT=\"[^\"]*\"", string.Empty);
+
+            using var stream = entry.Open();
+            stream.SetLength(0);
+            using var writer = new StreamWriter(stream, new UTF8Encoding(false));
+            writer.Write(xml);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static string ReadPart(MemoryStream package, string partPathPrefix)
+    {
+        package.Position = 0;
+        using var archive = new ZipArchive(package, ZipArchiveMode.Read, leaveOpen: true);
+        var entry = archive.Entries.FirstOrDefault(e =>
+                        e.FullName.StartsWith(partPathPrefix, StringComparison.OrdinalIgnoreCase))
+                    ?? throw new InvalidOperationException(
+                        $"The package has no part under '{partPathPrefix}'. It has: " +
+                        string.Join(", ", archive.Entries.Select(e => e.FullName)));
+
+        using var entryStream = entry.Open();
+        using var reader = new StreamReader(entryStream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/XLibur.Tests/Excel/Comments/ThreadedCommentsTests.cs
+++ b/XLibur.Tests/Excel/Comments/ThreadedCommentsTests.cs
@@ -362,6 +362,8 @@ public class ThreadedCommentsTests
         return FindEntry(archive, partPathPrefix) is not null;
     }
 
+    // Not annotated ZipArchiveEntry? even though FirstOrDefault can return null: this project has
+    // no <Nullable>enable</Nullable>, so the annotation only earns a CS8632. Both callers handle null.
     private static ZipArchiveEntry FindEntry(ZipArchive archive, string partPathPrefix)
     {
         return archive.Entries.FirstOrDefault(e =>

--- a/XLibur.Tests/Excel/Comments/ThreadedCommentsTests.cs
+++ b/XLibur.Tests/Excel/Comments/ThreadedCommentsTests.cs
@@ -1,0 +1,372 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Comments;
+
+public class ThreadedCommentsTests
+{
+    private const string ThreadRootId = "{9E032651-3A03-49E4-A15E-A90318F086F4}";
+
+    private const string PersonId = "{273A9FF0-C2D7-46D8-8991-E442B5127E22}";
+
+    #region Round trip of an Excel authored file
+
+    [Test]
+    public async Task Round_trip_preserves_thread_structure()
+    {
+        using var saved = LoadResourceAndSave(@"TryToLoad\ThreadedComment.xlsx");
+        using var wb = new XLWorkbook(saved);
+        var thread = wb.Worksheets.First().Cell("A1").GetThreadedComment()!;
+
+        await Assert.That(thread.Text).IsEqualTo("This is a threaded comment.");
+        await Assert.That(thread.Id).IsEqualTo(Guid.Parse(ThreadRootId));
+        await Assert.That(thread.Author.DisplayName).IsEqualTo("Herzog, Bernd");
+        await Assert.That(thread.Author.Id).IsEqualTo(Guid.Parse(PersonId));
+        await Assert.That(thread.CreatedUtc)
+            .IsEqualTo(new DateTime(2020, 7, 1, 6, 20, 6, 20, DateTimeKind.Utc));
+
+        await Assert.That(thread.Replies.Count).IsEqualTo(1);
+        await Assert.That(thread.Replies[0].Text).IsEqualTo("This is a reply.");
+        await Assert.That(thread.Replies[0].CreatedUtc)
+            .IsEqualTo(new DateTime(2020, 7, 1, 6, 20, 22, 880, DateTimeKind.Utc));
+    }
+
+    [Test]
+    public async Task Round_trip_keeps_person_and_thread_ids_stable()
+    {
+        using var saved = LoadResourceAndSave(@"TryToLoad\ThreadedComment.xlsx");
+
+        var personXml = ReadPart(saved, "xl/persons/");
+        await Assert.That(personXml).Contains($"id=\"{PersonId}\"");
+        await Assert.That(personXml).Contains("displayName=\"Herzog, Bernd\"");
+        await Assert.That(personXml).Contains("providerId=\"AD\"");
+        await Assert.That(personXml).Contains("userId=\"S-1-5-21-2931304574-606859833-1339073683-15873\"");
+
+        var threadXml = ReadPart(saved, "xl/threadedComments/");
+        await Assert.That(threadXml).Contains($"id=\"{ThreadRootId}\"");
+        await Assert.That(threadXml).Contains($"personId=\"{PersonId}\"");
+        await Assert.That(threadXml).Contains($"parentId=\"{ThreadRootId}\"");
+        await Assert.That(threadXml).Contains("dT=\"2020-07-01T06:20:06.02\"");
+        await Assert.That(threadXml).Contains("<text>This is a threaded comment.</text>");
+        await Assert.That(threadXml).Contains("<text>This is a reply.</text>");
+    }
+
+    [Test]
+    public async Task Round_trip_writes_the_legacy_fallback_note_excel_pairs_with_a_thread()
+    {
+        using var saved = LoadResourceAndSave(@"TryToLoad\ThreadedComment.xlsx");
+
+        // Older Excel shows this note; 365 hides it and shows the thread. The pairing is the
+        // "tc={rootId}" author together with the xr:uid pointing at the same root.
+        var commentsXml = ReadPart(saved, "xl/comments1.xml");
+        await Assert.That(commentsXml).Contains($">tc={ThreadRootId}<");
+        await Assert.That(commentsXml).Contains($"uid=\"{ThreadRootId}\"");
+        await Assert.That(commentsXml).Contains("[Threaded comment]");
+        await Assert.That(commentsXml).Contains("Comment:");
+        await Assert.That(commentsXml).Contains("Reply:");
+    }
+
+    [Test]
+    public async Task Round_trip_regenerates_the_fallback_note_from_the_edited_thread()
+    {
+        using var stream = TestHelper.GetStreamFromResource(
+            TestHelper.GetResourcePath(@"TryToLoad\ThreadedComment.xlsx"));
+        using var ms = new MemoryStream();
+
+        using (var wb = new XLWorkbook(stream))
+        {
+            wb.Worksheets.First().Cell("A1").GetThreadedComment()!.Text = "Edited root.";
+            wb.SaveAs(ms, validate: true);
+        }
+
+        // The fallback is derived from the thread on every save, so an edit cannot leave the two
+        // showing different text to different Excel versions.
+        var commentsXml = ReadPart(ms, "xl/comments1.xml");
+        await Assert.That(commentsXml).Contains("Edited root.");
+        await Assert.That(commentsXml).DoesNotContain("This is a threaded comment.");
+    }
+
+    #endregion
+
+    #region Threads created through the API
+
+    [Test]
+    public async Task Can_create_a_thread_from_scratch_and_read_it_back()
+    {
+        using var ms = new MemoryStream();
+        DateTime createdUtc;
+        DateTime repliedUtc;
+
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            var reviewer = wb.Persons.Add("Reviewer");
+            var author = wb.Persons.Add("Author", "S-1-5-21-1", "AD");
+
+            var thread = ws.Cell("B2").CreateThreadedComment(reviewer, "Please check this figure.");
+            var reply = thread.AddReply(author, "Checked, it is right.");
+            createdUtc = thread.CreatedUtc;
+            repliedUtc = reply.CreatedUtc;
+
+            wb.SaveAs(ms, validate: true);
+        }
+
+        using var reloaded = new XLWorkbook(ms);
+        var loadedWs = reloaded.Worksheet("Sheet1");
+        var loaded = loadedWs.Cell("B2").GetThreadedComment()!;
+
+        await Assert.That(loaded.Text).IsEqualTo("Please check this figure.");
+        await Assert.That(loaded.Author.DisplayName).IsEqualTo("Reviewer");
+        await Assert.That(loaded.Author.UserId).IsNull();
+        await Assert.That(loaded.CreatedUtc).IsEqualTo(createdUtc);
+        await Assert.That(loaded.CreatedUtc.Kind).IsEqualTo(DateTimeKind.Utc);
+
+        await Assert.That(loaded.Replies.Count).IsEqualTo(1);
+        await Assert.That(loaded.Replies[0].Text).IsEqualTo("Checked, it is right.");
+        await Assert.That(loaded.Replies[0].Author.DisplayName).IsEqualTo("Author");
+        await Assert.That(loaded.Replies[0].Author.UserId).IsEqualTo("S-1-5-21-1");
+        await Assert.That(loaded.Replies[0].Author.ProviderId).IsEqualTo("AD");
+        await Assert.That(loaded.Replies[0].CreatedUtc).IsEqualTo(repliedUtc);
+
+        await Assert.That(reloaded.Persons.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Resolved_state_survives_a_round_trip()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            var person = wb.Persons.Add("Reviewer");
+            ws.Cell("A1").CreateThreadedComment(person, "Resolved thread.").Resolved = true;
+            ws.Cell("A2").CreateThreadedComment(person, "Open thread.");
+            wb.SaveAs(ms, validate: true);
+        }
+
+        await Assert.That(ReadPart(ms, "xl/threadedComments/")).Contains("done=\"1\"");
+
+        using var reloaded = new XLWorkbook(ms);
+        var ws2 = reloaded.Worksheet("Sheet1");
+        await Assert.That(ws2.Cell("A1").GetThreadedComment()!.Resolved).IsTrue();
+        await Assert.That(ws2.Cell("A2").GetThreadedComment()!.Resolved).IsFalse();
+    }
+
+    [Test]
+    public async Task Resolved_reads_through_from_a_reply_but_cannot_be_set_on_one()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        var thread = ws.Cell("A1").CreateThreadedComment(person, "Root.");
+        var reply = thread.AddReply(person, "Reply.");
+
+        thread.Resolved = true;
+        await Assert.That(reply.Resolved).IsTrue();
+
+        await Assert.That(() => reply.Resolved = false).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task A_sheet_without_threads_writes_no_threaded_comment_part()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").GetComment().AddText("A plain note.");
+            wb.SaveAs(ms, validate: true);
+        }
+
+        await Assert.That(PartExists(ms, "xl/threadedComments/")).IsFalse();
+        await Assert.That(PartExists(ms, "xl/persons/")).IsFalse();
+        await Assert.That(PartExists(ms, "xl/comments1.xml")).IsTrue();
+    }
+
+    [Test]
+    public async Task Deleting_every_thread_removes_the_threaded_comment_part()
+    {
+        using var stream = TestHelper.GetStreamFromResource(
+            TestHelper.GetResourcePath(@"TryToLoad\ThreadedComment.xlsx"));
+        using var ms = new MemoryStream();
+
+        using (var wb = new XLWorkbook(stream))
+        {
+            wb.Worksheets.First().Cell("A1").GetThreadedComment()!.Delete();
+            wb.SaveAs(ms, validate: true);
+        }
+
+        await Assert.That(PartExists(ms, "xl/threadedComments/")).IsFalse();
+
+        using var reloaded = new XLWorkbook(ms);
+        var cell = reloaded.Worksheets.First().Cell("A1");
+        await Assert.That(cell.HasThreadedComment).IsFalse();
+
+        // The fallback note went with the thread rather than being left behind as an orphan.
+        await Assert.That(cell.HasComment).IsFalse();
+    }
+
+    [Test]
+    public async Task Mentions_survive_a_round_trip_of_an_untouched_comment()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            var person = wb.Persons.Add("Reviewer", "S-1-5-21-1", "AD");
+            var thread = (XLibur.Excel.XLThreadedComment)ws.Cell("A1")
+                .CreateThreadedComment(person, "@Reviewer please look");
+            thread.MentionsXml =
+                "<mentions xmlns=\"http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments\">" +
+                $"<mention mentionpersonId=\"{{{person.Id.ToString().ToUpperInvariant()}}}\" " +
+                "mentionId=\"{11111111-1111-1111-1111-111111111111}\" startIndex=\"0\" length=\"9\"/></mentions>";
+
+            wb.SaveAs(ms, validate: true);
+        }
+
+        var threadXml = ReadPart(ms, "xl/threadedComments/");
+        await Assert.That(threadXml).Contains("<mention");
+        await Assert.That(threadXml).Contains("startIndex=\"0\"");
+    }
+
+    [Test]
+    public async Task Editing_the_text_drops_mentions_whose_offsets_no_longer_apply()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        var thread = (XLibur.Excel.XLThreadedComment)ws.Cell("A1").CreateThreadedComment(person, "@Reviewer hi");
+        thread.MentionsXml = "<mentions/>";
+
+        thread.Text = "Something else entirely";
+
+        await Assert.That(thread.MentionsXml).IsNull();
+    }
+
+    #endregion
+
+    #region A cell holds either a note or a thread
+
+    [Test]
+    public async Task Creating_a_thread_on_a_cell_with_a_note_throws()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A1").GetComment().AddText("A plain note.");
+
+        await Assert.That(() => ws.Cell("A1").CreateThreadedComment(person, "Thread"))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Creating_a_note_on_a_cell_with_a_thread_throws()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A1").CreateThreadedComment(person, "Thread");
+
+        await Assert.That(() => ws.Cell("A1").GetComment()).Throws<InvalidOperationException>();
+        await Assert.That(() => ws.Cell("A1").CreateComment()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Deleting_a_note_frees_the_cell_for_a_thread()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var person = wb.Persons.Add("Reviewer");
+        ws.Cell("A1").GetComment().AddText("A plain note.");
+        ws.Cell("A1").Clear(XLClearOptions.Comments);
+
+        var thread = ws.Cell("A1").CreateThreadedComment(person, "Thread");
+        await Assert.That(thread.Text).IsEqualTo("Thread");
+        await Assert.That(ws.Cell("A1").HasComment).IsFalse();
+    }
+
+    #endregion
+
+    #region Persons
+
+    [Test]
+    public async Task Adding_a_person_generates_a_unique_id()
+    {
+        using var wb = new XLWorkbook();
+        var first = wb.Persons.Add("Reviewer");
+        var second = wb.Persons.Add("Reviewer");
+
+        await Assert.That(first.Id).IsNotEqualTo(second.Id);
+        await Assert.That(wb.Persons.Count).IsEqualTo(2);
+        await Assert.That(wb.Persons.Get(first.Id)).IsEqualTo(first);
+        await Assert.That(wb.Persons.GetByDisplayName("Reviewer")).IsEqualTo(first);
+        await Assert.That(wb.Persons.Get(Guid.NewGuid())).IsNull();
+    }
+
+    [Test]
+    public async Task Removing_a_person_takes_it_out_of_the_list()
+    {
+        using var wb = new XLWorkbook();
+        var person = wb.Persons.Add("Reviewer");
+
+        await Assert.That(wb.Persons.Remove(person.Id)).IsTrue();
+        await Assert.That(wb.Persons.Count).IsEqualTo(0);
+        await Assert.That(wb.Persons.Remove(person.Id)).IsFalse();
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static MemoryStream LoadResourceAndSave(string resourcePath)
+    {
+        using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(resourcePath));
+        var ms = new MemoryStream();
+
+        using (var wb = new XLWorkbook(stream))
+            wb.SaveAs(ms, validate: true);
+
+        return ms;
+    }
+
+    /// <summary>
+    /// Reads the single part under <paramref name="partPathPrefix"/>. Parts are matched by prefix
+    /// and case insensitively because the OpenXML SDK names a part it creates itself differently
+    /// from one Excel wrote — "xl/threadedcomments/threadedcomment.xml" rather than
+    /// "xl/threadedComments/". Excel resolves parts through relationships, so
+    /// the name is not part of the contract.
+    /// </summary>
+    private static string ReadPart(MemoryStream package, string partPathPrefix)
+    {
+        package.Position = 0;
+        using var archive = new ZipArchive(package, ZipArchiveMode.Read, leaveOpen: true);
+        var entry = FindEntry(archive, partPathPrefix)
+                    ?? throw new InvalidOperationException(
+                        $"The package has no part under '{partPathPrefix}'. It has: " +
+                        string.Join(", ", archive.Entries.Select(e => e.FullName)));
+
+        using var entryStream = entry.Open();
+        using var reader = new StreamReader(entryStream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    private static bool PartExists(MemoryStream package, string partPathPrefix)
+    {
+        package.Position = 0;
+        using var archive = new ZipArchive(package, ZipArchiveMode.Read, leaveOpen: true);
+        return FindEntry(archive, partPathPrefix) is not null;
+    }
+
+    private static ZipArchiveEntry FindEntry(ZipArchive archive, string partPathPrefix)
+    {
+        return archive.Entries.FirstOrDefault(e =>
+            e.FullName.StartsWith(partPathPrefix, StringComparison.OrdinalIgnoreCase));
+    }
+
+    #endregion
+}

--- a/XLibur.Tests/Excel/RoundTripFidelityTests.cs
+++ b/XLibur.Tests/Excel/RoundTripFidelityTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel;
+
+/// <summary>
+/// Pins down what survives a load/save round trip for content XLibur has no model for.
+/// </summary>
+/// <remarks>
+/// XLibur saves by reopening the package it loaded and rewriting the parts it understands, so a part
+/// it never touches is carried through untouched. These tests exist so that a future change which
+/// starts deleting unknown parts fails here rather than silently dropping a user's chartsheets.
+/// The findings are written up in docs/round-trip-fidelity.md.
+/// </remarks>
+public class RoundTripFidelityTests
+{
+    [Test]
+    public async Task Chartsheets_survive_a_round_trip()
+    {
+        using var saved = LoadAndSave(@"Other\PivotTableReferenceFiles\ChartsheetAndPivotTable.xlsx");
+
+        await Assert.That(PartExists(saved, "xl/chartsheets/sheet1.xml")).IsTrue();
+
+        // The sheet entry has to stay in workbook.xml too, or the surviving part is an orphan.
+        // WorkbookPartWriter reorders the sheets it models around the unsupported ones instead of
+        // rewriting the list from scratch, which is what keeps this entry alive.
+        var workbookXml = ReadPart(saved, "xl/workbook.xml");
+        await Assert.That(workbookXml).Contains("name=\"Chart\"");
+    }
+
+    [Test]
+    public async Task A_chartsheet_still_loads_after_a_round_trip()
+    {
+        using var saved = LoadAndSave(@"Other\PivotTableReferenceFiles\ChartsheetAndPivotTable.xlsx");
+
+        // Reopening proves the relationships and content types survived, not just the part bytes.
+        // The chartsheet is not an IXLWorksheet — it stays in the unsupported-sheet list — so only
+        // the two real worksheets are counted here.
+        using var wb = new XLWorkbook(saved);
+        await Assert.That(wb.Worksheets.Count).IsEqualTo(2);
+        await Assert.That(wb.Worksheets.Select(ws => ws.Name)).Contains("Data");
+        await Assert.That(wb.Worksheets.Select(ws => ws.Name)).Contains("Pivot");
+    }
+
+    [Test]
+    public async Task ActiveX_controls_survive_a_round_trip()
+    {
+        using var saved = LoadAndSave(@"TryToLoad\LO\xlsx\activex_checkbox.xlsx");
+
+        await Assert.That(PartExists(saved, "xl/activeX/activeX1.xml")).IsTrue();
+        await Assert.That(PartExists(saved, "xl/activeX/activeX1.bin")).IsTrue();
+    }
+
+    [Test]
+    public async Task Form_control_references_survive_in_the_worksheet_xml()
+    {
+        using var saved = LoadAndSave(@"TryToLoad\LO\xlsx\activex_checkbox.xlsx");
+
+        // Surviving parts are not enough: the worksheet is rewritten from the model on every save,
+        // so if <controls> were dropped the activeX parts would be left as unreachable orphans.
+        var sheetXml = ReadPart(saved, "xl/worksheets/sheet1.xml");
+        await Assert.That(sheetXml).Contains("controls>");
+        await Assert.That(sheetXml).Contains("CheckBox1343");
+        await Assert.That(sheetXml).Contains("legacyDrawing");
+
+        // The anchor inside controlPr is what positions the control, and it is nested in an
+        // mc:AlternateContent that a naive rewrite would flatten or drop.
+        await Assert.That(sheetXml).Contains("mc:AlternateContent");
+        await Assert.That(sheetXml).Contains("438150");
+    }
+
+    [Test]
+    public async Task Custom_xml_parts_survive_a_round_trip()
+    {
+        using var saved = LoadAndSave(@"TryToLoad\LO\xlsx\customxml.xlsx");
+
+        await Assert.That(PartExists(saved, "customXml/item1.xml")).IsTrue();
+        await Assert.That(PartExists(saved, "customXml/itemProps1.xml")).IsTrue();
+    }
+
+    [Test]
+    public async Task Timelines_and_their_caches_survive_a_round_trip()
+    {
+        using var saved = LoadAndSave(@"TryToLoad\Timelines_Missing_21232.xlsx");
+
+        await Assert.That(PartExists(saved, "xl/timelines/timeline1.xml")).IsTrue();
+        await Assert.That(PartExists(saved, "xl/timelineCaches/timelineCache1.xml")).IsTrue();
+    }
+
+    [Test]
+    public async Task Saving_to_a_new_file_also_preserves_unmodelled_parts()
+    {
+        // SaveAs to a fresh path copies the original package first, so the pass-through holds for
+        // more than the save-in-place case.
+        var target = Path.Combine(Path.GetTempPath(), $"xlibur-fidelity-{Guid.NewGuid():N}.xlsx");
+        try
+        {
+            using (var stream = TestHelper.GetStreamFromResource(
+                       TestHelper.GetResourcePath(@"Other\PivotTableReferenceFiles\ChartsheetAndPivotTable.xlsx")))
+            using (var wb = new XLWorkbook(stream))
+            {
+                wb.Worksheets.First().Cell("A1").Value = "touched";
+                wb.SaveAs(target);
+            }
+
+            using var fs = new FileStream(target, FileMode.Open, FileAccess.Read);
+            using var ms = new MemoryStream();
+            fs.CopyTo(ms);
+
+            await Assert.That(PartExists(ms, "xl/chartsheets/sheet1.xml")).IsTrue();
+        }
+        finally
+        {
+            if (File.Exists(target))
+                File.Delete(target);
+        }
+    }
+
+    [Test]
+    public async Task A_workbook_built_from_scratch_has_no_unmodelled_parts_to_lose()
+    {
+        // The pass-through above depends on there being an original package. There is none here,
+        // which is the boundary of what preservation can do.
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            wb.AddWorksheet("Sheet1").Cell("A1").Value = 1;
+            wb.SaveAs(ms, validate: true);
+        }
+
+        await Assert.That(PartExists(ms, "xl/chartsheets/sheet1.xml")).IsFalse();
+    }
+
+    #region Helpers
+
+    private static MemoryStream LoadAndSave(string resourcePath)
+    {
+        using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(resourcePath));
+        var ms = new MemoryStream();
+
+        using (var wb = new XLWorkbook(stream))
+            wb.SaveAs(ms);
+
+        return ms;
+    }
+
+    private static bool PartExists(MemoryStream package, string partPath)
+    {
+        package.Position = 0;
+        using var archive = new ZipArchive(package, ZipArchiveMode.Read, leaveOpen: true);
+        return archive.Entries.Any(e =>
+            e.FullName.Equals(partPath, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ReadPart(MemoryStream package, string partPath)
+    {
+        package.Position = 0;
+        using var archive = new ZipArchive(package, ZipArchiveMode.Read, leaveOpen: true);
+        var entry = archive.Entries.First(e =>
+            e.FullName.Equals(partPath, StringComparison.OrdinalIgnoreCase));
+
+        using var entryStream = entry.Open();
+        using var reader = new StreamReader(entryStream);
+        return reader.ReadToEnd();
+    }
+
+    #endregion
+}

--- a/XLibur/Excel/Cells/IXLCell.cs
+++ b/XLibur/Excel/Cells/IXLCell.cs
@@ -77,6 +77,12 @@ public interface IXLCell
 
     bool HasComment { get; }
 
+    /// <summary>
+    /// Returns <c>true</c> if the cell carries an Office 365 style comment thread. Mutually
+    /// exclusive with <see cref="HasComment"/>.
+    /// </summary>
+    bool HasThreadedComment { get; }
+
     bool HasDataValidation { get; }
 
     bool HasFormula { get; }
@@ -250,6 +256,25 @@ public interface IXLCell
     /// Returns the comment for the cell or create a new instance if there is no comment on the cell.
     /// </summary>
     IXLComment GetComment();
+
+    /// <summary>
+    /// Returns the root of the cell's comment thread, or null when the cell has none. Unlike
+    /// <see cref="GetComment"/> this never creates one — use <see cref="CreateThreadedComment"/>.
+    /// </summary>
+    IXLThreadedComment? GetThreadedComment();
+
+    /// <summary>
+    /// Starts a comment thread on the cell, replacing any thread already there.
+    /// </summary>
+    /// <param name="author">
+    /// The thread author. A person from another workbook is matched against this workbook's
+    /// <see cref="IXLWorkbook.Persons"/> by display name and identity provider, and added when absent.
+    /// </param>
+    /// <param name="text">The text of the first comment in the thread.</param>
+    /// <exception cref="InvalidOperationException">
+    /// When the cell already has a legacy note. A cell cannot carry both.
+    /// </exception>
+    IXLThreadedComment CreateThreadedComment(IXLPerson author, string text);
 
     /// <summary>
     /// Returns a data validation rule assigned to the cell, if any, or creates a new instance of data validation rule if no rule exists.

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -97,6 +97,21 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         }
     }
 
+    internal XLThreadedComment? SliceThreadedComment
+    {
+        get => _cellsCollection.MiscSlice[_point].ThreadedComment;
+        set
+        {
+            ref readonly var original = ref _cellsCollection.MiscSlice[_point];
+            if (original.ThreadedComment != value)
+            {
+                var modified = original;
+                modified.ThreadedComment = value;
+                _cellsCollection.MiscSlice.Set(_point, in modified);
+            }
+        }
+    }
+
     internal uint? CellMetaIndex
     {
         get => _cellsCollection.MiscSlice[_point].CellMetaIndex;
@@ -170,7 +185,31 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
 
     internal XLComment CreateComment(int? shapeId = null)
     {
+        if (SliceThreadedComment is not null)
+        {
+            throw new InvalidOperationException(
+                $"Cell {Address} has a threaded comment. A cell cannot have both a threaded comment " +
+                "and a note; delete the threaded comment first.");
+        }
+
         return SliceComment = new XLComment(this, shapeId: shapeId);
+    }
+
+    internal XLThreadedComment CreateThreadedComment(IXLPerson author, string text)
+    {
+        ArgumentNullException.ThrowIfNull(author);
+        ArgumentNullException.ThrowIfNull(text);
+
+        if (SliceComment is not null)
+        {
+            throw new InvalidOperationException(
+                $"Cell {Address} has a note. A cell cannot have both a threaded comment and a note; " +
+                "delete the note first.");
+        }
+
+        var mapped = Worksheet.Workbook.PersonsInternal.Map(author);
+        return SliceThreadedComment = new XLThreadedComment(this, Guid.NewGuid(), mapped, text,
+            XLThreadedComment.UtcNowForFile());
     }
 
     public XLRichText GetRichText()
@@ -526,7 +565,10 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
             AsRange().RemoveConditionalFormatting();
 
         if (clearOptions.HasFlag(XLClearOptions.Comments))
+        {
             SliceComment = null;
+            SliceThreadedComment = null;
+        }
 
         if (clearOptions.HasFlag(XLClearOptions.Sparklines))
             AsRange().RemoveSparklines();
@@ -698,6 +740,13 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         return CreateComment(shapeId: null);
     }
 
+    IXLThreadedComment? IXLCell.GetThreadedComment() => SliceThreadedComment;
+
+    IXLThreadedComment IXLCell.CreateThreadedComment(IXLPerson author, string text)
+        => CreateThreadedComment(author, text);
+
+    public bool HasThreadedComment => SliceThreadedComment is not null;
+
     public bool IsMerged()
     {
         // Short-circuit on the count before touching the range index. This runs on every
@@ -738,7 +787,7 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         if (options.HasFlag(XLCellsUsedOptions.MergedRanges) && IsMerged())
             return false;
 
-        if (options.HasFlag(XLCellsUsedOptions.Comments) && HasComment)
+        if (options.HasFlag(XLCellsUsedOptions.Comments) && (HasComment || HasThreadedComment))
             return false;
 
         if (options.HasFlag(XLCellsUsedOptions.DataValidation) && HasDataValidation)

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -208,7 +208,7 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         }
 
         var mapped = Worksheet.Workbook.PersonsInternal.Map(author);
-        return SliceThreadedComment = new XLThreadedComment(this, Guid.NewGuid(), mapped, text,
+        return SliceThreadedComment = new XLThreadedComment(Worksheet, Guid.NewGuid(), mapped, text,
             XLThreadedComment.UtcNowForFile());
     }
 

--- a/XLibur/Excel/Cells/XLCellCopyHelper.cs
+++ b/XLibur/Excel/Cells/XLCellCopyHelper.cs
@@ -18,9 +18,20 @@ internal static class XLCellCopyHelper
             target.SliceRichText = sourceRichText;
 
         target.FormulaR1C1 = source.FormulaR1C1;
-        target.SliceComment = source.SliceComment == null
-            ? null
-            : new XLComment(target, source.SliceComment, source.Style.Font, source.SliceComment.Style);
+        // Clear both annotation kinds before assigning, because a note and a thread cannot coexist
+        // and the target may currently hold the other kind.
+        target.SliceComment = null;
+        target.SliceThreadedComment = null;
+
+        if (source.SliceComment is { } sourceComment)
+        {
+            target.SliceComment =
+                new XLComment(target, sourceComment, source.Style.Font, sourceComment.Style);
+        }
+        else if (source.SliceThreadedComment is { } sourceThread)
+        {
+            target.SliceThreadedComment = sourceThread.CopyTo(target);
+        }
 
         if (source.Worksheet.Hyperlinks.TryGet(source.SheetPoint, out var sourceHyperlink))
         {

--- a/XLibur/Excel/Cells/XLCellsCollection.cs
+++ b/XLibur/Excel/Cells/XLCellsCollection.cs
@@ -215,8 +215,10 @@ internal sealed class XLCellsCollection : IWorkbookListener
     }
 
     /// <summary>
-    /// Whether any cell in the sheet has a comment. Scans the misc slice directly, so it costs
-    /// nothing on sheets that never touched comments, phonetics or metadata.
+    /// Whether any cell in the sheet has a note or a comment thread. Both count, because a thread is
+    /// written out with a paired legacy note and so needs the same comments and VML parts. Scans the
+    /// misc slice directly, so it costs nothing on sheets that never touched comments, phonetics or
+    /// metadata.
     /// </summary>
     internal bool HasAnyComment()
     {
@@ -226,7 +228,26 @@ internal sealed class XLCellsCollection : IWorkbookListener
         var enumerator = new Slice<XLMiscSliceContent>.Enumerator(MiscSlice, Area.Full);
         while (enumerator.MoveNext())
         {
-            if (enumerator.Current.Comment is not null)
+            if (enumerator.Current.Comment is not null || enumerator.Current.ThreadedComment is not null)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether any cell in the sheet has a comment thread, i.e. whether the sheet needs a
+    /// <c>threadedComment</c> part.
+    /// </summary>
+    internal bool HasAnyThreadedComment()
+    {
+        if (MiscSlice.IsEmpty)
+            return false;
+
+        var enumerator = new Slice<XLMiscSliceContent>.Enumerator(MiscSlice, Area.Full);
+        while (enumerator.MoveNext())
+        {
+            if (enumerator.Current.ThreadedComment is not null)
                 return true;
         }
 

--- a/XLibur/Excel/Cells/XLMiscSliceContent.cs
+++ b/XLibur/Excel/Cells/XLMiscSliceContent.cs
@@ -4,6 +4,14 @@ internal struct XLMiscSliceContent
 {
     internal XLComment? Comment { get; set; }
 
+    /// <summary>
+    /// The root of the cell's comment thread, if any. Mutually exclusive with <see cref="Comment"/>:
+    /// a cell shows either a legacy note or a thread, never both. Lives here rather than in a side
+    /// table so that row/column shifting, swapping and clearing — all of which run over the slices —
+    /// treat a thread exactly like a note.
+    /// </summary>
+    internal XLThreadedComment? ThreadedComment { get; set; }
+
     internal uint? CellMetaIndex { get; set; }
 
     internal uint? ValueMetaIndex { get; set; }

--- a/XLibur/Excel/Comments/Threaded/IXLPerson.cs
+++ b/XLibur/Excel/Comments/Threaded/IXLPerson.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// An identity that can author a <see cref="IXLThreadedComment"/>. Persons are stored once per
+/// workbook in <c>xl/persons/person.xml</c> and referenced by threaded comments through
+/// <see cref="Id"/>.
+/// </summary>
+public interface IXLPerson
+{
+    /// <summary>
+    /// The name Excel displays next to the person's comments.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// The identifier of the person within <see cref="ProviderId"/>, e.g. a Windows SID for the
+    /// <c>AD</c> provider. Null for persons created through the API without an identity provider.
+    /// </summary>
+    string? UserId { get; }
+
+    /// <summary>
+    /// The identity provider that issued <see cref="UserId"/>, e.g. <c>AD</c>, <c>PeoplePicker</c>
+    /// or <c>Windows Live</c>. Null for persons created through the API without an identity provider.
+    /// </summary>
+    string? ProviderId { get; }
+
+    /// <summary>
+    /// The workbook-unique identifier of the person. Preserved across a load/save round trip so
+    /// that threaded comments keep pointing at the same person.
+    /// </summary>
+    Guid Id { get; }
+}

--- a/XLibur/Excel/Comments/Threaded/IXLPersons.cs
+++ b/XLibur/Excel/Comments/Threaded/IXLPersons.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// The workbook-level set of identities that author threaded comments.
+/// </summary>
+public interface IXLPersons : IEnumerable<IXLPerson>
+{
+    /// <summary>
+    /// The number of persons in the workbook.
+    /// </summary>
+    int Count { get; }
+
+    /// <summary>
+    /// Adds a person with a freshly generated <see cref="IXLPerson.Id"/> and no identity provider.
+    /// </summary>
+    /// <param name="displayName">The name Excel shows next to the person's comments.</param>
+    IXLPerson Add(string displayName);
+
+    /// <summary>
+    /// Adds a person with a freshly generated <see cref="IXLPerson.Id"/>.
+    /// </summary>
+    /// <param name="displayName">The name Excel shows next to the person's comments.</param>
+    /// <param name="userId">The identifier of the person within <paramref name="providerId"/>.</param>
+    /// <param name="providerId">The identity provider, e.g. <c>AD</c> or <c>PeoplePicker</c>.</param>
+    IXLPerson Add(string displayName, string? userId, string? providerId);
+
+    /// <summary>
+    /// Returns the person with the specified <paramref name="id"/>, or null when the workbook has none.
+    /// </summary>
+    IXLPerson? Get(Guid id);
+
+    /// <summary>
+    /// Returns the first person whose <see cref="IXLPerson.DisplayName"/> matches
+    /// <paramref name="displayName"/> ordinally, or null when the workbook has none.
+    /// </summary>
+    IXLPerson? GetByDisplayName(string displayName);
+
+    /// <summary>
+    /// Removes a person. Threaded comments already authored by the person keep referencing it, so
+    /// the person is written back out on save; this only removes it from the workbook-level list.
+    /// </summary>
+    /// <returns><c>true</c> when the person was present.</returns>
+    bool Remove(Guid id);
+}

--- a/XLibur/Excel/Comments/Threaded/IXLThreadedComment.cs
+++ b/XLibur/Excel/Comments/Threaded/IXLThreadedComment.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// A comment in an Office 365 style comment thread. A cell holds at most one thread, whose root is
+/// returned by <see cref="IXLCell.GetThreadedComment"/>; every other comment in the thread is a
+/// reply reachable through <see cref="Replies"/>.
+/// </summary>
+/// <remarks>
+/// Threads are flat: Excel supports a root and its direct replies, so <see cref="Parent"/> is the
+/// root for every reply and null for the root itself. A cell cannot carry both a threaded comment
+/// and a legacy note — see <see cref="IXLCell.CreateThreadedComment"/>.
+/// </remarks>
+public interface IXLThreadedComment
+{
+    /// <summary>
+    /// The comment's text. Setting it discards any mentions the comment was loaded with, because
+    /// their offsets into the text would no longer be meaningful.
+    /// </summary>
+    string Text { get; set; }
+
+    /// <summary>
+    /// The person who wrote the comment.
+    /// </summary>
+    IXLPerson Author { get; }
+
+    /// <summary>
+    /// When the comment was written, in UTC. Excel stores this without a time zone designator and
+    /// interprets it as UTC.
+    /// </summary>
+    DateTime CreatedUtc { get; }
+
+    /// <summary>
+    /// The thread root, or null when this comment <em>is</em> the root.
+    /// </summary>
+    IXLThreadedComment? Parent { get; }
+
+    /// <summary>
+    /// The replies to the thread, oldest first. Always empty for a reply, since threads are flat.
+    /// </summary>
+    IReadOnlyList<IXLThreadedComment> Replies { get; }
+
+    /// <summary>
+    /// The identifier Excel uses to tie a reply to its root and the legacy fallback note to the
+    /// thread. Preserved across a load/save round trip.
+    /// </summary>
+    Guid Id { get; }
+
+    /// <summary>
+    /// Whether the thread has been marked resolved. This is a property of the whole thread: reading
+    /// it from a reply returns the root's value, and setting it on a reply throws.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">When set on a reply rather than the thread root.</exception>
+    bool Resolved { get; set; }
+
+    /// <summary>
+    /// Appends a reply to the thread. Because threads are flat, the reply is added to the thread
+    /// root even when this is called on another reply.
+    /// </summary>
+    /// <param name="author">The reply's author. Must belong to the same workbook.</param>
+    /// <param name="text">The reply's text.</param>
+    IXLThreadedComment AddReply(IXLPerson author, string text);
+
+    /// <summary>
+    /// Removes this comment. Deleting the thread root removes the whole thread, including replies,
+    /// from the cell; deleting a reply leaves the rest of the thread intact.
+    /// </summary>
+    void Delete();
+}

--- a/XLibur/Excel/Comments/Threaded/XLPerson.cs
+++ b/XLibur/Excel/Comments/Threaded/XLPerson.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace XLibur.Excel;
+
+internal sealed class XLPerson : IXLPerson
+{
+    internal XLPerson(Guid id, string displayName, string? userId, string? providerId)
+    {
+        Id = id;
+        DisplayName = displayName;
+        UserId = userId;
+        ProviderId = providerId;
+    }
+
+    public string DisplayName { get; }
+
+    public string? UserId { get; }
+
+    public string? ProviderId { get; }
+
+    public Guid Id { get; }
+
+    public override string ToString() => DisplayName;
+}

--- a/XLibur/Excel/Comments/Threaded/XLPersons.cs
+++ b/XLibur/Excel/Comments/Threaded/XLPersons.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace XLibur.Excel;
+
+internal sealed class XLPersons : IXLPersons
+{
+    /// <summary>
+    /// Insertion ordered, because <c>person.xml</c> is written in this order and keeping it stable
+    /// keeps a load/save round trip free of gratuitous diffs.
+    /// </summary>
+    private readonly Dictionary<Guid, XLPerson> _persons = new();
+
+    private readonly List<Guid> _order = new();
+
+    public int Count => _order.Count;
+
+    public IXLPerson Add(string displayName) => Add(displayName, userId: null, providerId: null);
+
+    public IXLPerson Add(string displayName, string? userId, string? providerId)
+    {
+        ArgumentNullException.ThrowIfNull(displayName);
+
+        return AddCore(Guid.NewGuid(), displayName, userId, providerId);
+    }
+
+    public IXLPerson? Get(Guid id) => _persons.TryGetValue(id, out var person) ? person : null;
+
+    public IXLPerson? GetByDisplayName(string displayName)
+    {
+        ArgumentNullException.ThrowIfNull(displayName);
+
+        foreach (var id in _order)
+        {
+            var person = _persons[id];
+            if (string.Equals(person.DisplayName, displayName, StringComparison.Ordinal))
+                return person;
+        }
+
+        return null;
+    }
+
+    public bool Remove(Guid id)
+    {
+        if (!_persons.Remove(id))
+            return false;
+
+        _order.Remove(id);
+        return true;
+    }
+
+    public IEnumerator<IXLPerson> GetEnumerator()
+    {
+        foreach (var id in _order)
+            yield return _persons[id];
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Adds a person with an id read from a file. Existing ids win, so that a person referenced by
+    /// several sheets is added once and threaded comments keep resolving to the same instance.
+    /// </summary>
+    internal XLPerson AddOrGet(Guid id, string displayName, string? userId, string? providerId)
+    {
+        return _persons.TryGetValue(id, out var existing)
+            ? existing
+            : AddCore(id, displayName, userId, providerId);
+    }
+
+    /// <summary>
+    /// Returns a person with the same display name and provider identity, adding one when the
+    /// workbook has none. Used when a threaded comment is copied into another workbook, where the
+    /// source person's id may already be taken by a different identity.
+    /// </summary>
+    internal XLPerson Map(IXLPerson source)
+    {
+        if (_persons.TryGetValue(source.Id, out var byId) && IsSameIdentity(byId, source))
+            return byId;
+
+        foreach (var id in _order)
+        {
+            var candidate = _persons[id];
+            if (IsSameIdentity(candidate, source))
+                return candidate;
+        }
+
+        var newId = _persons.ContainsKey(source.Id) ? Guid.NewGuid() : source.Id;
+        return AddCore(newId, source.DisplayName, source.UserId, source.ProviderId);
+    }
+
+    private static bool IsSameIdentity(IXLPerson left, IXLPerson right)
+    {
+        return string.Equals(left.DisplayName, right.DisplayName, StringComparison.Ordinal)
+               && string.Equals(left.UserId, right.UserId, StringComparison.Ordinal)
+               && string.Equals(left.ProviderId, right.ProviderId, StringComparison.Ordinal);
+    }
+
+    private XLPerson AddCore(Guid id, string displayName, string? userId, string? providerId)
+    {
+        var person = new XLPerson(id, displayName, userId, providerId);
+        _persons.Add(id, person);
+        _order.Add(id);
+        return person;
+    }
+}

--- a/XLibur/Excel/Comments/Threaded/XLPersons.cs
+++ b/XLibur/Excel/Comments/Threaded/XLPersons.cs
@@ -79,15 +79,27 @@ internal sealed class XLPersons : IXLPersons
         if (_persons.TryGetValue(source.Id, out var byId) && IsSameIdentity(byId, source))
             return byId;
 
-        foreach (var id in _order)
+        // Only match on identity when there is an identity provider to match on. Two persons with no
+        // userId and no providerId who happen to share a display name are indistinguishable in the
+        // file yet may well be different people, and merging them would reattribute one person's
+        // comments to the other.
+        if (HasProviderIdentity(source))
         {
-            var candidate = _persons[id];
-            if (IsSameIdentity(candidate, source))
-                return candidate;
+            foreach (var id in _order)
+            {
+                var candidate = _persons[id];
+                if (IsSameIdentity(candidate, source))
+                    return candidate;
+            }
         }
 
         var newId = _persons.ContainsKey(source.Id) ? Guid.NewGuid() : source.Id;
         return AddCore(newId, source.DisplayName, source.UserId, source.ProviderId);
+    }
+
+    private static bool HasProviderIdentity(IXLPerson person)
+    {
+        return !string.IsNullOrEmpty(person.UserId) || !string.IsNullOrEmpty(person.ProviderId);
     }
 
     private static bool IsSameIdentity(IXLPerson left, IXLPerson right)

--- a/XLibur/Excel/Comments/Threaded/XLThreadedComment.cs
+++ b/XLibur/Excel/Comments/Threaded/XLThreadedComment.cs
@@ -13,9 +13,9 @@ internal sealed class XLThreadedComment : IXLThreadedComment
 
     private bool _resolved;
 
-    internal XLThreadedComment(XLCell cell, Guid id, XLPerson author, string text, DateTime createdUtc)
+    internal XLThreadedComment(XLWorksheet worksheet, Guid id, XLPerson author, string text, DateTime createdUtc)
     {
-        Cell = cell;
+        Worksheet = worksheet;
         Id = id;
         AuthorInternal = author;
         _text = text;
@@ -65,9 +65,12 @@ internal sealed class XLThreadedComment : IXLThreadedComment
     }
 
     /// <summary>
-    /// The cell the thread belongs to. Replies share the root's cell.
+    /// The sheet the thread belongs to. Deliberately not the cell: shifting rows or columns moves
+    /// the thread's entry within the misc slice without telling the thread, so a cell back-reference
+    /// would go stale and <see cref="Delete"/> would clear the address the thread used to be at. A
+    /// thread never changes sheet — copying builds a new one — so this reference cannot go stale.
     /// </summary>
-    internal XLCell Cell { get; private set; }
+    internal XLWorksheet Worksheet { get; }
 
     internal XLPerson AuthorInternal { get; private set; }
 
@@ -99,8 +102,8 @@ internal sealed class XLThreadedComment : IXLThreadedComment
         ArgumentNullException.ThrowIfNull(text);
 
         var root = Root;
-        var mapped = root.Cell.Worksheet.Workbook.PersonsInternal.Map(author);
-        var reply = new XLThreadedComment(root.Cell, Guid.NewGuid(), mapped, text, UtcNowForFile())
+        var mapped = root.Worksheet.Workbook.PersonsInternal.Map(author);
+        var reply = new XLThreadedComment(root.Worksheet, Guid.NewGuid(), mapped, text, UtcNowForFile())
         {
             ParentInternal = root
         };
@@ -112,9 +115,22 @@ internal sealed class XLThreadedComment : IXLThreadedComment
     public void Delete()
     {
         if (ParentInternal is { } parent)
+        {
             parent._replies?.Remove(this);
-        else
-            Cell.SliceThreadedComment = null;
+            return;
+        }
+
+        // Look the thread up by identity rather than trusting a remembered address: rows and columns
+        // may have shifted since it was created, which moves the slice entry silently. Threads are
+        // rare, so this only walks the handful of cells that have one.
+        foreach (var cell in Worksheet.Internals.CellsCollection.GetCells(c => c.HasThreadedComment))
+        {
+            if (ReferenceEquals(cell.SliceThreadedComment, this))
+            {
+                cell.SliceThreadedComment = null;
+                return;
+            }
+        }
     }
 
     internal XLThreadedComment Root => ParentInternal ?? this;
@@ -130,7 +146,7 @@ internal sealed class XLThreadedComment : IXLThreadedComment
     /// </summary>
     internal XLThreadedComment AddLoadedReply(Guid id, XLPerson author, string text, DateTime createdUtc)
     {
-        var reply = new XLThreadedComment(Cell, id, author, text, createdUtc)
+        var reply = new XLThreadedComment(Worksheet, id, author, text, createdUtc)
         {
             ParentInternal = this
         };
@@ -151,8 +167,8 @@ internal sealed class XLThreadedComment : IXLThreadedComment
 
         // A copy always lands on a different cell, so it is a different thread and needs its own id
         // even inside one workbook — the id is what the fallback note's xr:uid points at.
-        var copy = new XLThreadedComment(targetCell, Guid.NewGuid(), targetPersons.Map(AuthorInternal), _text,
-            CreatedUtc)
+        var copy = new XLThreadedComment(targetCell.Worksheet, Guid.NewGuid(),
+            targetPersons.Map(AuthorInternal), _text, CreatedUtc)
         {
             _resolved = _resolved,
             MentionsXml = MentionsXml
@@ -168,7 +184,7 @@ internal sealed class XLThreadedComment : IXLThreadedComment
             copy._replies = new List<XLThreadedComment>(_replies.Count);
             foreach (var reply in _replies)
             {
-                copy._replies.Add(new XLThreadedComment(targetCell, Guid.NewGuid(),
+                copy._replies.Add(new XLThreadedComment(targetCell.Worksheet, Guid.NewGuid(),
                     targetPersons.Map(reply.AuthorInternal), reply._text, reply.CreatedUtc)
                 {
                     ParentInternal = copy,
@@ -178,18 +194,5 @@ internal sealed class XLThreadedComment : IXLThreadedComment
         }
 
         return copy;
-    }
-
-    /// <summary>
-    /// Re-points the thread and its replies at another cell after the thread has been moved.
-    /// </summary>
-    internal void Rehome(XLCell cell)
-    {
-        Cell = cell;
-        if (_replies is null)
-            return;
-
-        foreach (var reply in _replies)
-            reply.Cell = cell;
     }
 }

--- a/XLibur/Excel/Comments/Threaded/XLThreadedComment.cs
+++ b/XLibur/Excel/Comments/Threaded/XLThreadedComment.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+
+namespace XLibur.Excel;
+
+internal sealed class XLThreadedComment : IXLThreadedComment
+{
+    private static readonly IReadOnlyList<IXLThreadedComment> NoReplies = Array.Empty<IXLThreadedComment>();
+
+    private List<XLThreadedComment>? _replies;
+
+    private string _text;
+
+    private bool _resolved;
+
+    internal XLThreadedComment(XLCell cell, Guid id, XLPerson author, string text, DateTime createdUtc)
+    {
+        Cell = cell;
+        Id = id;
+        AuthorInternal = author;
+        _text = text;
+        CreatedUtc = createdUtc;
+    }
+
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+
+            if (string.Equals(_text, value, StringComparison.Ordinal))
+                return;
+
+            _text = value;
+
+            // The offsets a mention carries index into the old text, so they cannot survive an edit.
+            MentionsXml = null;
+        }
+    }
+
+    public IXLPerson Author => AuthorInternal;
+
+    public DateTime CreatedUtc { get; internal set; }
+
+    public IXLThreadedComment? Parent => ParentInternal;
+
+    public IReadOnlyList<IXLThreadedComment> Replies => _replies ?? NoReplies;
+
+    public Guid Id { get; }
+
+    public bool Resolved
+    {
+        get => ParentInternal?._resolved ?? _resolved;
+        set
+        {
+            if (ParentInternal is not null)
+            {
+                throw new InvalidOperationException(
+                    "Resolved is a property of the whole thread and can only be set on the thread root.");
+            }
+
+            _resolved = value;
+        }
+    }
+
+    /// <summary>
+    /// The cell the thread belongs to. Replies share the root's cell.
+    /// </summary>
+    internal XLCell Cell { get; private set; }
+
+    internal XLPerson AuthorInternal { get; private set; }
+
+    internal XLThreadedComment? ParentInternal { get; private set; }
+
+    /// <summary>
+    /// The mutable reply list, or null when the thread has no replies. Prefer <see cref="Replies"/>
+    /// for reading; this exists so the loader and the writers can work without allocating.
+    /// </summary>
+    internal List<XLThreadedComment>? RepliesInternal => _replies;
+
+    /// <summary>
+    /// The serialized <c>&lt;xltc:mentions&gt;</c> element the comment was loaded with, so that
+    /// mentions survive a round trip even though there is no API to inspect or build them. Null for
+    /// comments created through the API and for comments whose <see cref="Text"/> has been changed.
+    /// </summary>
+    internal string? MentionsXml { get; set; }
+
+    /// <summary>
+    /// The legacy fallback note Excel pairs with the thread, kept only for its shape geometry so a
+    /// round trip preserves the note's position and size. Null for threads created through the API,
+    /// in which case the writer emits a default shape. Only ever set on a thread root.
+    /// </summary>
+    internal XLComment? LegacyNote { get; set; }
+
+    public IXLThreadedComment AddReply(IXLPerson author, string text)
+    {
+        ArgumentNullException.ThrowIfNull(author);
+        ArgumentNullException.ThrowIfNull(text);
+
+        var root = Root;
+        var mapped = root.Cell.Worksheet.Workbook.PersonsInternal.Map(author);
+        var reply = new XLThreadedComment(root.Cell, Guid.NewGuid(), mapped, text, UtcNowForFile())
+        {
+            ParentInternal = root
+        };
+
+        (root._replies ??= new List<XLThreadedComment>()).Add(reply);
+        return reply;
+    }
+
+    public void Delete()
+    {
+        if (ParentInternal is { } parent)
+            parent._replies?.Remove(this);
+        else
+            Cell.SliceThreadedComment = null;
+    }
+
+    internal XLThreadedComment Root => ParentInternal ?? this;
+
+    /// <summary>
+    /// The current time at the precision a threaded comment part stores, so that the value held in
+    /// memory is the one a later load reads back rather than one rounded on the way out.
+    /// </summary>
+    internal static DateTime UtcNowForFile() => IO.ThreadedCommentPartWriter.TruncateToFilePrecision(DateTime.UtcNow);
+
+    /// <summary>
+    /// Appends a reply that already has an identity, used when loading a file or copying a thread.
+    /// </summary>
+    internal XLThreadedComment AddLoadedReply(Guid id, XLPerson author, string text, DateTime createdUtc)
+    {
+        var reply = new XLThreadedComment(Cell, id, author, text, createdUtc)
+        {
+            ParentInternal = this
+        };
+
+        (_replies ??= new List<XLThreadedComment>()).Add(reply);
+        return reply;
+    }
+
+    /// <summary>
+    /// Deep copies the thread onto <paramref name="targetCell"/>, mapping every author into the
+    /// target workbook's person list. Ids are preserved within a workbook and regenerated when the
+    /// copy crosses into another one, because Excel keys the legacy fallback note off the root id
+    /// and two threads may not share it.
+    /// </summary>
+    internal XLThreadedComment CopyTo(XLCell targetCell)
+    {
+        var targetPersons = targetCell.Worksheet.Workbook.PersonsInternal;
+
+        // A copy always lands on a different cell, so it is a different thread and needs its own id
+        // even inside one workbook — the id is what the fallback note's xr:uid points at.
+        var copy = new XLThreadedComment(targetCell, Guid.NewGuid(), targetPersons.Map(AuthorInternal), _text,
+            CreatedUtc)
+        {
+            _resolved = _resolved,
+            MentionsXml = MentionsXml
+        };
+
+        if (LegacyNote is not null)
+        {
+            copy.LegacyNote = new XLComment(targetCell, LegacyNote, targetCell.Style.Font, LegacyNote.Style);
+        }
+
+        if (_replies is not null)
+        {
+            copy._replies = new List<XLThreadedComment>(_replies.Count);
+            foreach (var reply in _replies)
+            {
+                copy._replies.Add(new XLThreadedComment(targetCell, Guid.NewGuid(),
+                    targetPersons.Map(reply.AuthorInternal), reply._text, reply.CreatedUtc)
+                {
+                    ParentInternal = copy,
+                    MentionsXml = reply.MentionsXml
+                });
+            }
+        }
+
+        return copy;
+    }
+
+    /// <summary>
+    /// Re-points the thread and its replies at another cell after the thread has been moved.
+    /// </summary>
+    internal void Rehome(XLCell cell)
+    {
+        Cell = cell;
+        if (_replies is null)
+            return;
+
+        foreach (var reply in _replies)
+            reply.Cell = cell;
+    }
+}

--- a/XLibur/Excel/IO/CommentPartWriter.cs
+++ b/XLibur/Excel/IO/CommentPartWriter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using DocumentFormat.OpenXml.Packaging;
@@ -21,20 +21,26 @@ internal static class CommentPartWriter
         var partStream = worksheetCommentsPart.GetStream(FileMode.Create);
         using var xml = XmlWriter.Create(partStream, settings);
 
-        var commentCells = new List<XLCell>();
+        var entries = CommentWriteSource.Collect(xlWorksheet);
         var authorsDict = new Dictionary<string, int>();
+        var hasThreads = false;
         xml.WriteStartElement("x", "comments", Main2006SsNs);
-        foreach (var c in xlWorksheet.Internals.CellsCollection.GetCells(c => c.HasComment))
+
+        foreach (var entry in entries)
         {
-            var authorName = c.GetComment().Author;
+            if (!authorsDict.ContainsKey(entry.Comment.Author))
+                authorsDict.Add(entry.Comment.Author, authorsDict.Count);
 
-            if (!authorsDict.TryGetValue(authorName, out var authorId))
-            {
-                authorId = authorsDict.Count;
-                authorsDict.Add(authorName, authorId);
-            }
+            hasThreads |= entry.Thread is not null;
+        }
 
-            commentCells.Add(c);
+        // The uid a thread's fallback note carries lives in the revision namespace, which older
+        // consumers must be able to skip over.
+        if (hasThreads)
+        {
+            xml.WriteAttributeString("xmlns", "mc", null, MarkupCompatibilityNs);
+            xml.WriteAttributeString("mc", "Ignorable", MarkupCompatibilityNs, "xr");
+            xml.WriteAttributeString("xmlns", "xr", null, RevisionNs);
         }
 
         xml.WriteStartElement("authors", Main2006SsNs);
@@ -45,21 +51,25 @@ internal static class CommentPartWriter
 
         var refBuffer = new char[10];
         xml.WriteStartElement("commentList", Main2006SsNs);
-        foreach (var commentCell in commentCells)
+        foreach (var entry in entries)
         {
-            var comment = commentCell.GetComment();
+            var comment = entry.Comment;
             xml.WriteStartElement("comment", Main2006SsNs);
 
-            var refLen = commentCell.SheetPoint.Format(refBuffer);
+            var refLen = entry.Cell.SheetPoint.Format(refBuffer);
             xml.WriteStartAttribute("ref");
             xml.WriteRaw(refBuffer, 0, refLen);
             xml.WriteEndAttribute(); // ref
 
-            var authorId = authorsDict[comment.Author];
-            xml.WriteAttribute("authorId", authorId);
+            xml.WriteAttribute("authorId", authorsDict[comment.Author]);
 
-            // Excel specifies @guid is optional if the workbook is not shared
-            // Excel ignores the shapeId attribute.
+            // Excel specifies @guid is optional if the workbook is not shared.
+            // Excel ignores the shapeId attribute, and the strict schema the OpenXML SDK validates
+            // against does not declare it at all, so it is left out even though Excel writes it.
+            // What actually pairs a fallback note with its thread is the uid below, matching the
+            // thread root's id, together with the "tc={rootId}" author.
+            if (entry.Thread is { } thread)
+                xml.WriteAttributeString("xr", "uid", RevisionNs, CommentWriteSource.FormatId(thread.Id));
 
             xml.WriteStartElement("text", Main2006SsNs);
             var richText = XLImmutableRichText.Create(comment);

--- a/XLibur/Excel/IO/CommentWriteSource.cs
+++ b/XLibur/Excel/IO/CommentWriteSource.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// One entry of <c>comments{N}.xml</c> and its matching VML shape.
+/// </summary>
+/// <param name="Cell">The cell the note is anchored to.</param>
+/// <param name="Comment">
+/// The note to write. For a threaded cell this is the compatibility fallback rather than anything
+/// the user set, since a cell with a thread has no note of its own.
+/// </param>
+/// <param name="Thread">
+/// The comment thread this note is the fallback for, or null for a plain note.
+/// </param>
+internal readonly record struct CommentWriteEntry(XLCell Cell, XLComment Comment, XLThreadedComment? Thread);
+
+/// <summary>
+/// Collects everything that belongs in a sheet's comments and VML parts.
+/// </summary>
+/// <remarks>
+/// Excel pairs every comment thread with a legacy note whose text is "[Threaded comment]"
+/// boilerplate followed by the thread's contents, so that a version of Excel too old to understand
+/// threads still shows something. XLibur writes the same pairing: the note below is generated from
+/// the thread on every save rather than round-tripped, so that it cannot drift out of sync with the
+/// thread after an edit.
+/// </remarks>
+internal static class CommentWriteSource
+{
+    /// <summary>
+    /// The prefix Excel uses to mark a note as a thread's fallback. The rest of the author string is
+    /// the thread root's id.
+    /// </summary>
+    internal const string ThreadAuthorPrefix = "tc=";
+
+    private const string BoilerplateHeader =
+        "[Threaded comment]\n\nYour version of Excel allows you to read this threaded comment; however, " +
+        "any edits to it will get removed if the file is opened in a newer version of Excel. " +
+        "Learn more: https://go.microsoft.com/fwlink/?linkid=870924";
+
+    internal static List<CommentWriteEntry> Collect(XLWorksheet worksheet)
+    {
+        var entries = new List<CommentWriteEntry>();
+        foreach (var cell in worksheet.Internals.CellsCollection
+            .GetCells(c => c.HasComment || c.HasThreadedComment))
+        {
+            if (cell.SliceComment is { } note)
+                entries.Add(new CommentWriteEntry(cell, note, Thread: null));
+            else if (cell.SliceThreadedComment is { } thread)
+                entries.Add(new CommentWriteEntry(cell, GetOrCreateFallbackNote(cell, thread), thread));
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// The author string Excel writes for a thread's fallback note, e.g. <c>tc={9E032651-...}</c>.
+    /// </summary>
+    internal static string ThreadAuthor(XLThreadedComment root) => ThreadAuthorPrefix + FormatId(root.Id);
+
+    /// <summary>
+    /// Formats a GUID the way Excel writes ids in threaded comment parts: braced and upper case.
+    /// </summary>
+    internal static string FormatId(Guid id) => id.ToString("B").ToUpperInvariant();
+
+    /// <summary>
+    /// Returns the note that stands in for <paramref name="thread"/> in the compatibility parts,
+    /// refreshing its author and text from the thread's current contents.
+    /// </summary>
+    /// <remarks>
+    /// The note object is cached on the thread so that a shape id allocated on one save is reused by
+    /// the next, and so that a note loaded from a file keeps the position and size Excel gave it.
+    /// </remarks>
+    private static XLComment GetOrCreateFallbackNote(XLCell cell, XLThreadedComment thread)
+    {
+        var note = thread.LegacyNote ??= new XLComment(cell);
+
+        note.Author = ThreadAuthor(thread);
+        note.ClearText();
+        note.AddText(BuildFallbackText(thread));
+        return note;
+    }
+
+    private static string BuildFallbackText(XLThreadedComment root)
+    {
+        var sb = new StringBuilder(BoilerplateHeader);
+
+        sb.Append("\n\nComment:\n    ").Append(root.Text);
+        if (root.RepliesInternal is { } replies)
+        {
+            foreach (var reply in replies)
+                sb.Append("\nReply:\n    ").Append(reply.Text);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/XLibur/Excel/IO/PersonPartWriter.cs
+++ b/XLibur/Excel/IO/PersonPartWriter.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using System.Xml;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Writes <c>xl/persons/person.xml</c>, the workbook-level list of identities that threaded
+/// comments are attributed to.
+/// </summary>
+internal static class PersonPartWriter
+{
+    internal const string ThreadedCommentsNs =
+        "http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments";
+
+    internal static void GenerateContent(WorkbookPersonPart personPart, XLWorkbook workbook)
+    {
+        var settings = new XmlWriterSettings
+        {
+            CloseOutput = true,
+            Encoding = XLHelper.NoBomUTF8
+        };
+
+        var partStream = personPart.GetStream(FileMode.Create);
+        using var xml = XmlWriter.Create(partStream, settings);
+
+        xml.WriteStartElement("personList", ThreadedCommentsNs);
+        xml.WriteAttributeString("xmlns", "x", null, OpenXmlConst.Main2006SsNs);
+
+        foreach (var person in workbook.PersonsInternal)
+        {
+            xml.WriteStartElement("person", ThreadedCommentsNs);
+            xml.WriteAttributeString("displayName", person.DisplayName);
+            xml.WriteAttributeString("id", CommentWriteSource.FormatId(person.Id));
+
+            // Excel omits both attributes for a person with no identity provider rather than
+            // writing them empty.
+            if (person.UserId is not null)
+                xml.WriteAttributeString("userId", person.UserId);
+
+            if (person.ProviderId is not null)
+                xml.WriteAttributeString("providerId", person.ProviderId);
+
+            xml.WriteEndElement(); // person
+        }
+
+        xml.WriteEndElement(); // personList
+        xml.Close();
+    }
+}

--- a/XLibur/Excel/IO/PersonPartWriter.cs
+++ b/XLibur/Excel/IO/PersonPartWriter.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using DocumentFormat.OpenXml.Packaging;
@@ -13,6 +15,47 @@ internal static class PersonPartWriter
     internal const string ThreadedCommentsNs =
         "http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments";
 
+    /// <summary>
+    /// The persons that have to appear in <c>person.xml</c>: the workbook's list, plus any author a
+    /// thread still references. Removing a person from the list does not rewrite the comments they
+    /// authored, and a <c>personId</c> with no matching <c>&lt;person&gt;</c> is a dangling
+    /// reference Excel cannot resolve.
+    /// </summary>
+    internal static List<XLPerson> CollectReferencedPersons(XLWorkbook workbook)
+    {
+        var persons = new List<XLPerson>();
+        var seen = new HashSet<Guid>();
+
+        foreach (var person in workbook.PersonsInternal)
+        {
+            if (seen.Add(person.Id))
+                persons.Add((XLPerson)person);
+        }
+
+        foreach (var worksheet in workbook.WorksheetsInternal)
+        {
+            foreach (var cell in worksheet.Internals.CellsCollection.GetCells(c => c.HasThreadedComment))
+            {
+                var root = cell.SliceThreadedComment!;
+                AddIfNew(persons, seen, root.AuthorInternal);
+
+                if (root.RepliesInternal is { } replies)
+                {
+                    foreach (var reply in replies)
+                        AddIfNew(persons, seen, reply.AuthorInternal);
+                }
+            }
+        }
+
+        return persons;
+    }
+
+    private static void AddIfNew(List<XLPerson> persons, HashSet<Guid> seen, XLPerson person)
+    {
+        if (seen.Add(person.Id))
+            persons.Add(person);
+    }
+
     internal static void GenerateContent(WorkbookPersonPart personPart, XLWorkbook workbook)
     {
         var settings = new XmlWriterSettings
@@ -27,7 +70,7 @@ internal static class PersonPartWriter
         xml.WriteStartElement("personList", ThreadedCommentsNs);
         xml.WriteAttributeString("xmlns", "x", null, OpenXmlConst.Main2006SsNs);
 
-        foreach (var person in workbook.PersonsInternal)
+        foreach (var person in CollectReferencedPersons(workbook))
         {
             xml.WriteStartElement("person", ThreadedCommentsNs);
             xml.WriteAttributeString("displayName", person.DisplayName);

--- a/XLibur/Excel/IO/ThreadedCommentPartWriter.cs
+++ b/XLibur/Excel/IO/ThreadedCommentPartWriter.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Xml;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Writes a sheet's <c>xl/threadedComments/threadedComment{N}.xml</c>.
+/// </summary>
+internal static class ThreadedCommentPartWriter
+{
+    /// <summary>
+    /// The timestamp format Excel writes: no time zone designator, hundredths of a second, and UTC
+    /// by convention. Writing more precision than this makes Excel rewrite the part on open.
+    /// </summary>
+    private const string DateFormat = "yyyy-MM-ddTHH:mm:ss.ff";
+
+    internal static void GenerateContent(WorksheetThreadedCommentsPart part, XLWorksheet worksheet)
+    {
+        var settings = new XmlWriterSettings
+        {
+            CloseOutput = true,
+            Encoding = XLHelper.NoBomUTF8
+        };
+
+        var partStream = part.GetStream(FileMode.Create);
+        using var xml = XmlWriter.Create(partStream, settings);
+
+        xml.WriteStartElement("ThreadedComments", PersonPartWriter.ThreadedCommentsNs);
+        xml.WriteAttributeString("xmlns", "x", null, OpenXmlConst.Main2006SsNs);
+
+        var refBuffer = new char[10];
+        foreach (var cell in worksheet.Internals.CellsCollection.GetCells(c => c.HasThreadedComment))
+        {
+            var root = cell.SliceThreadedComment!;
+            var reference = new string(refBuffer, 0, cell.SheetPoint.Format(refBuffer));
+
+            WriteComment(xml, root, reference, root);
+            if (root.RepliesInternal is { } replies)
+            {
+                foreach (var reply in replies)
+                    WriteComment(xml, reply, reference, root);
+            }
+        }
+
+        xml.WriteEndElement(); // ThreadedComments
+        xml.Close();
+    }
+
+    private static void WriteComment(XmlWriter xml, XLThreadedComment comment, string reference,
+        XLThreadedComment root)
+    {
+        var isRoot = ReferenceEquals(comment, root);
+
+        xml.WriteStartElement("threadedComment", PersonPartWriter.ThreadedCommentsNs);
+        xml.WriteAttributeString("ref", reference);
+        xml.WriteAttributeString("dT", comment.CreatedUtc.ToString(DateFormat, CultureInfo.InvariantCulture));
+        xml.WriteAttributeString("personId", CommentWriteSource.FormatId(comment.Author.Id));
+        xml.WriteAttributeString("id", CommentWriteSource.FormatId(comment.Id));
+
+        if (!isRoot)
+            xml.WriteAttributeString("parentId", CommentWriteSource.FormatId(root.Id));
+
+        // 'done' is a property of the thread and only meaningful on the root. Excel omits it when
+        // the thread is unresolved.
+        if (isRoot && comment.Resolved)
+            xml.WriteAttributeString("done", OpenXmlConst.TrueValue);
+
+        xml.WriteElementString("text", PersonPartWriter.ThreadedCommentsNs, comment.Text);
+
+        // Mentions are preserved verbatim from the file they were loaded from. There is no API to
+        // build or inspect them, and editing the text drops them because their offsets index into
+        // the text they were written against.
+        if (comment.MentionsXml is { } mentions)
+            xml.WriteRaw(mentions);
+
+        xml.WriteEndElement(); // threadedComment
+    }
+
+    /// <summary>
+    /// Truncates a timestamp to the precision <see cref="DateFormat"/> persists, so that a thread
+    /// created through the API holds exactly the value a later load will read back.
+    /// </summary>
+    internal static DateTime TruncateToFilePrecision(DateTime value)
+    {
+        const long centisecond = TimeSpan.TicksPerMillisecond * 10;
+        return new DateTime(value.Ticks - value.Ticks % centisecond, value.Kind);
+    }
+}

--- a/XLibur/Excel/IO/VmlDrawingPartWriter.cs
+++ b/XLibur/Excel/IO/VmlDrawingPartWriter.cs
@@ -48,13 +48,12 @@ internal static class VmlDrawingPartWriter
         }
             .WriteTo(writer);
 
-        var cellWithComments = xlWorksheet.Internals.CellsCollection.GetCells(c => c.HasComment);
-
         var hasAnyVmlElements = false;
 
-        foreach (var c in cellWithComments)
+        // Threads get a shape too: Excel draws the fallback note, and a note without VML is invisible.
+        foreach (var entry in CommentWriteSource.Collect(xlWorksheet))
         {
-            GenerateCommentShape(c).WriteTo(writer);
+            GenerateCommentShape(entry.Cell, entry.Comment).WriteTo(writer);
             hasAnyVmlElements = true;
         }
 
@@ -74,12 +73,11 @@ internal static class VmlDrawingPartWriter
     }
 
     // VML Shape for Comment
-    private static Vml.Shape GenerateCommentShape(XLCell c)
+    private static Vml.Shape GenerateCommentShape(XLCell c, XLComment comment)
     {
         var rowNumber = c.Address.RowNumber;
         var columnNumber = c.Address.ColumnNumber;
 
-        var comment = c.GetComment();
         var shapeId = string.Concat("_x0000_s", comment.ShapeId);
 
         // When AutomaticSize is enabled, calculate dimensions that fit the text.
@@ -93,13 +91,13 @@ internal static class VmlDrawingPartWriter
         }
 
         // Unique per cell (workbook?), e.g.: "_x0000_s1026"
-        var anchor = GetAnchor(c, effectiveWidth, effectiveHeight);
+        var anchor = GetAnchor(c, comment, effectiveWidth, effectiveHeight);
         var textBox = GetTextBox(comment.Style);
         var fill = new Vml.Fill { Color2 = string.Concat("#", comment.Style.ColorsAndLines.FillColor.Color.ToHex().AsSpan(2)) };
         if (comment.Style.ColorsAndLines.FillTransparency < 1)
             fill.Opacity =
                 Math.Round(Convert.ToDouble(comment.Style.ColorsAndLines.FillTransparency), 2).ToInvariantString();
-        var stroke = GetStroke(c);
+        var stroke = GetStroke(comment);
         var shape = new Vml.Shape(
             fill,
             stroke,
@@ -128,7 +126,7 @@ internal static class VmlDrawingPartWriter
         {
             Id = shapeId,
             Type = "#" + XLConstants.Comment.ShapeTypeId,
-            Style = GetCommentStyle(c, effectiveWidth, effectiveHeight),
+            Style = GetCommentStyle(comment, effectiveWidth, effectiveHeight),
             FillColor = string.Concat("#", comment.Style.ColorsAndLines.FillColor.Color.ToHex().AsSpan(2)),
             StrokeColor = string.Concat("#", comment.Style.ColorsAndLines.LineColor.Color.ToHex().AsSpan(2)),
             StrokeWeight = string.Concat(comment.Style.ColorsAndLines.LineWeight.ToInvariantString(), "pt"),
@@ -140,12 +138,12 @@ internal static class VmlDrawingPartWriter
         return shape;
     }
 
-    private static Vml.Stroke GetStroke(XLCell c)
+    private static Vml.Stroke GetStroke(XLComment comment)
     {
-        var lineDash = c.GetComment().Style.ColorsAndLines.LineDash;
+        var lineDash = comment.Style.ColorsAndLines.LineDash;
         var stroke = new Vml.Stroke
         {
-            LineStyle = c.GetComment().Style.ColorsAndLines.LineStyle.ToOpenXml(),
+            LineStyle = comment.Style.ColorsAndLines.LineStyle.ToOpenXml(),
             DashStyle =
                 lineDash == XLDashStyle.RoundDot || lineDash == XLDashStyle.SquareDot
                     ? "shortDot"
@@ -153,9 +151,9 @@ internal static class VmlDrawingPartWriter
         };
         if (lineDash == XLDashStyle.RoundDot)
             stroke.EndCap = Vml.StrokeEndCapValues.Round;
-        if (c.GetComment().Style.ColorsAndLines.LineTransparency < 1)
+        if (comment.Style.ColorsAndLines.LineTransparency < 1)
             stroke.Opacity =
-                Math.Round(Convert.ToDouble(c.GetComment().Style.ColorsAndLines.LineTransparency), 2).ToInvariantString();
+                Math.Round(Convert.ToDouble(comment.Style.ColorsAndLines.LineTransparency), 2).ToInvariantString();
         return stroke;
     }
 
@@ -196,9 +194,8 @@ internal static class VmlDrawingPartWriter
         return tb;
     }
 
-    private static Anchor GetAnchor(XLCell cell, double cWidth, double cHeight)
+    private static Anchor GetAnchor(XLCell cell, XLComment c, double cWidth, double cHeight)
     {
-        var c = cell.GetComment();
         var fcNumber = c.Position.Column - 1;
         var fcOffset = Convert.ToInt32(c.Position.ColumnOffset * 7.5);
         var widthFromColumns = cell.Worksheet.Column(c.Position.Column).Width - c.Position.ColumnOffset;
@@ -235,9 +232,8 @@ internal static class VmlDrawingPartWriter
         };
     }
 
-    private static StringValue GetCommentStyle(XLCell cell, double widthInColumns, double heightPt)
+    private static StringValue GetCommentStyle(XLComment c, double widthInColumns, double heightPt)
     {
-        var c = cell.GetComment();
         var sb = new StringBuilder("position:absolute; ");
 
         sb.Append("visibility:");

--- a/XLibur/Excel/IXLWorkbook.cs
+++ b/XLibur/Excel/IXLWorkbook.cs
@@ -45,6 +45,12 @@ public interface IXLWorkbook : IXLProtectable<IXLWorkbookProtection, XLWorkbookP
 
     IXLFileSharing FileSharing { get; }
 
+    /// <summary>
+    /// The identities that author threaded comments in this workbook, stored in
+    /// <c>xl/persons/person.xml</c>.
+    /// </summary>
+    IXLPersons Persons { get; }
+
     bool ForceFullCalculation { get; set; }
 
     bool FullCalculationOnLoad { get; set; }

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -247,6 +247,10 @@ public partial class XLWorkbook : IXLWorkbook
 
     public IXLFileSharing FileSharing { get; } = new XLFileSharing();
 
+    public IXLPersons Persons => PersonsInternal;
+
+    internal XLPersons PersonsInternal { get; } = new();
+
     public bool DefaultRightToLeft => false;
 
     private void InitializeTheme()

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -812,7 +812,7 @@ public partial class XLWorkbook
         var fallbackNote = cell.SliceComment;
         cell.SliceComment = null;
 
-        var root = new XLThreadedComment(cell, id, author, tc.ThreadedCommentText?.InnerText ?? string.Empty,
+        var root = new XLThreadedComment(ws, id, author, tc.ThreadedCommentText?.InnerText ?? string.Empty,
             ParseThreadedCommentDate(tc.DT?.Value))
         {
             LegacyNote = fallbackNote,
@@ -891,8 +891,10 @@ public partial class XLWorkbook
     /// </summary>
     private static DateTime ParseThreadedCommentDate(DateTime? value)
     {
+        // Kind matters even with no value to convert: CreatedUtc promises UTC, and a bare default
+        // would hand back an Unspecified DateTime that silently shifts if anyone converts it.
         if (value is not { } dt)
-            return default;
+            return DateTime.SpecifyKind(default, DateTimeKind.Utc);
 
         return dt.Kind switch
         {

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -156,6 +156,10 @@ public partial class XLWorkbook
         // We do this mainly because it skips a very costly calculation invalidation step, but it also make things more consistent,
         // e.g. when reading calculations that reference other sheets, we know that those sheets always already exist.
         // That consistency point isn't required yet but could be taken advantage of in the future.
+        // Persons are workbook level and referenced by the threaded comments of every sheet, so they
+        // have to be in place before the sheets are read.
+        LoadPersons(workbookPart);
+
         var sheets = workbookPart.Workbook!.Sheets;
         LoadSheetsPass1(workbookPart, sheets!);
 
@@ -732,55 +736,170 @@ public partial class XLWorkbook
         }
     }
 
-    private static void LoadThreadedComments(WorksheetPart worksheetPart, XLWorksheet ws)
+    /// <summary>
+    /// Reads <c>xl/persons/person.xml</c>, the workbook-level list of identities that threaded
+    /// comments are attributed to.
+    /// </summary>
+    private void LoadPersons(WorkbookPart workbookPart)
     {
-        // Modern Excel stores threaded comments in a separate part. The legacy
-        // comments1.xml file contains only a placeholder ("[Threaded comment] ...").
-        // When the threaded comments part is present, replace the placeholder
-        // text with the actual comment text from the threaded comments.
-        foreach (var threadedComments in worksheetPart.WorksheetThreadedCommentsParts
-            .Select(p => p.ThreadedComments)
-            .Where(tc => tc is not null))
+        foreach (var personPart in workbookPart.GetPartsOfType<WorkbookPersonPart>())
         {
-            // Group threaded comments by cell reference. Root comments have no
-            // ParentId; replies reference the root via ParentId. Order: root
-            // first (no ParentId), then replies sorted by timestamp.
-            var byRef = threadedComments!.Elements<TC.ThreadedComment>()
-                .GroupBy(tc => tc.Ref?.Value ?? string.Empty);
+            var personList = personPart.PersonList;
+            if (personList is null)
+                continue;
 
-            foreach (var group in byRef)
+            foreach (var person in personList.Elements<TC.Person>())
             {
-                ApplyThreadedCommentsToCell(group, ws);
+                // A person without a parsable id cannot be referenced by a threaded comment, so
+                // there is nothing meaningful to attach it to.
+                if (!TryParseGuid(person.Id?.Value, out var id))
+                    continue;
+
+                PersonsInternal.AddOrGet(
+                    id,
+                    person.DisplayName?.Value ?? string.Empty,
+                    person.UserId?.Value,
+                    person.ProviderId?.Value);
             }
         }
     }
 
-    private static void ApplyThreadedCommentsToCell(
-        IGrouping<string, TC.ThreadedComment> group, XLWorksheet ws)
+    /// <summary>
+    /// Reads the threaded comments of a sheet into the cell model. Excel pairs every thread with a
+    /// legacy note carrying "[Threaded comment]" boilerplate so that older versions show something;
+    /// that note is taken off the cell here and kept only for its shape, because the thread is what
+    /// the user model exposes.
+    /// </summary>
+    private void LoadThreadedComments(WorksheetPart worksheetPart, XLWorksheet ws)
     {
-        if (string.IsNullOrEmpty(group.Key))
-            return;
-
-        var cell = ws.Cell(group.Key);
-        if (cell?.SliceComment is null)
-            return;
-
-        var ordered = group
-            .OrderBy(tc => tc.ParentId is not null ? 1 : 0)
-            .ThenBy(tc => tc.DT?.Value)
-            .ToList();
-
-        var texts = ordered
-            .Select(tc => tc.ThreadedCommentText?.InnerText)
-            .Where(t => !string.IsNullOrEmpty(t))
-            .ToList();
-
-        if (texts.Count > 0)
+        foreach (var threadedComments in worksheetPart.WorksheetThreadedCommentsParts
+            .Select(p => p.ThreadedComments)
+            .Where(tc => tc is not null))
         {
-            var xlComment = cell.SliceComment;
-            xlComment.ClearText();
-            xlComment.AddText(string.Join("\n", texts));
+            // Roots have no parentId; replies point at their root through it. A file may list them
+            // in any order, so roots are created first and replies attached afterwards.
+            var all = threadedComments!.Elements<TC.ThreadedComment>().ToList();
+            var rootsById = new Dictionary<Guid, XLThreadedComment>();
+
+            foreach (var tc in all)
+            {
+                if (tc.ParentId is not null)
+                    continue;
+
+                if (LoadThreadRoot(tc, ws) is { } root)
+                    rootsById[root.Id] = root;
+            }
+
+            LoadThreadReplies(all, rootsById);
         }
+    }
+
+    private XLThreadedComment? LoadThreadRoot(TC.ThreadedComment tc, XLWorksheet ws)
+    {
+        var reference = tc.Ref?.Value;
+        if (string.IsNullOrEmpty(reference) || !TryParseGuid(tc.Id?.Value, out var id))
+            return null;
+
+        var cell = ws.Cell(reference);
+        if (cell is null)
+            return null;
+
+        var author = ResolvePerson(tc.PersonId?.Value);
+
+        // The paired fallback note was loaded moments ago by LoadComments. Move it onto the thread
+        // so that its position and size survive a round trip, and take it off the cell so that
+        // HasComment reports what the user actually sees.
+        var fallbackNote = cell.SliceComment;
+        cell.SliceComment = null;
+
+        var root = new XLThreadedComment(cell, id, author, tc.ThreadedCommentText?.InnerText ?? string.Empty,
+            ParseThreadedCommentDate(tc.DT?.Value))
+        {
+            LegacyNote = fallbackNote,
+            MentionsXml = tc.ThreadedCommentMentions?.OuterXml
+        };
+
+        if (tc.Done?.Value == true)
+            root.Resolved = true;
+
+        cell.SliceThreadedComment = root;
+        return root;
+    }
+
+    private void LoadThreadReplies(List<TC.ThreadedComment> all, Dictionary<Guid, XLThreadedComment> rootsById)
+    {
+        // Excel writes replies in thread order, but the schema does not guarantee it, so sort by
+        // timestamp to get a deterministic order regardless of producer.
+        foreach (var tc in all
+            .Where(tc => tc.ParentId is not null)
+            .OrderBy(tc => ParseThreadedCommentDate(tc.DT?.Value)))
+        {
+            if (!TryParseGuid(tc.ParentId?.Value, out var parentId) ||
+                !rootsById.TryGetValue(parentId, out var root))
+            {
+                // A reply whose root is missing has nothing to attach to. Excel does not produce
+                // this, but a damaged or hand-edited file can.
+                continue;
+            }
+
+            if (!TryParseGuid(tc.Id?.Value, out var id))
+                continue;
+
+            var reply = root.AddLoadedReply(
+                id,
+                ResolvePerson(tc.PersonId?.Value),
+                tc.ThreadedCommentText?.InnerText ?? string.Empty,
+                ParseThreadedCommentDate(tc.DT?.Value));
+
+            reply.MentionsXml = tc.ThreadedCommentMentions?.OuterXml;
+        }
+    }
+
+    /// <summary>
+    /// Returns the person a threaded comment is attributed to, inventing a placeholder when the
+    /// file references an id that <c>person.xml</c> does not define. Losing the comment over a
+    /// dangling reference would be worse than showing it without a real author.
+    /// </summary>
+    private XLPerson ResolvePerson(string? personId)
+    {
+        if (TryParseGuid(personId, out var id))
+        {
+            if (PersonsInternal.Get(id) is XLPerson known)
+                return known;
+
+            return PersonsInternal.AddOrGet(id, string.Empty, userId: null, providerId: null);
+        }
+
+        return PersonsInternal.AddOrGet(Guid.NewGuid(), string.Empty, userId: null, providerId: null);
+    }
+
+    /// <summary>
+    /// Parses the <c>{XXXXXXXX-XXXX-...}</c> braced GUIDs Excel writes for person and comment ids.
+    /// </summary>
+    private static bool TryParseGuid(string? value, out Guid guid)
+    {
+        if (!string.IsNullOrEmpty(value))
+            return Guid.TryParse(value, out guid);
+
+        guid = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Excel writes the timestamp without a time zone designator and means UTC by it, so a parsed
+    /// value has to be pinned to UTC rather than left as Unspecified or shifted by the local zone.
+    /// </summary>
+    private static DateTime ParseThreadedCommentDate(DateTime? value)
+    {
+        if (value is not { } dt)
+            return default;
+
+        return dt.Kind switch
+        {
+            DateTimeKind.Utc => dt,
+            DateTimeKind.Local => dt.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(dt, DateTimeKind.Utc)
+        };
     }
 
     private void LoadActiveTab(Workbook workbook)

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -818,7 +818,10 @@ public partial class XLWorkbook
     private void GeneratePersonPart(WorkbookPart workbookPart, SaveContext context)
     {
         var existing = workbookPart.GetPartsOfType<WorkbookPersonPart>().ToList();
-        if (PersonsInternal.Count == 0)
+
+        // Counts authors a thread still references, not just the workbook list, so that removing a
+        // person who has commented does not delete the part their comments point at.
+        if (PersonPartWriter.CollectReferencedPersons(this).Count == 0)
         {
             foreach (var part in existing)
                 workbookPart.DeletePart(part);

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -678,7 +678,11 @@ public partial class XLWorkbook
     private static void GenerateCommentsAndVmlParts(WorksheetPart worksheetPart, XLWorksheet worksheet,
         SaveContext context)
     {
+        // Counts threads too: each is written with a paired legacy note, so a sheet holding only
+        // threads still needs the comments and VML parts.
         var worksheetHasComments = worksheet.Internals.CellsCollection.HasAnyComment();
+
+        GenerateThreadedCommentsPart(worksheetPart, worksheet, context);
 
         // VML part is the source of truth for shapes of comments, form controls and likely others.
         // Excel won't display any shape without VML. The drawing part is always present but is likely
@@ -711,6 +715,34 @@ public partial class XLWorkbook
 
         CommentPartWriter.GenerateWorksheetCommentsPartContent(commentsPart, worksheet);
         return VmlDrawingPartWriter.GenerateContent(vmlDrawingPart, worksheet);
+    }
+
+    /// <summary>
+    /// Synchronises the sheet's threaded comments part with the model: written when the sheet has
+    /// threads, deleted when it no longer does. A sheet needs at most one part, so any extras a
+    /// producer left behind are removed.
+    /// </summary>
+    private static void GenerateThreadedCommentsPart(WorksheetPart worksheetPart, XLWorksheet worksheet,
+        SaveContext context)
+    {
+        var existing = worksheetPart.WorksheetThreadedCommentsParts.ToList();
+        if (!worksheet.Internals.CellsCollection.HasAnyThreadedComment())
+        {
+            foreach (var part in existing)
+                worksheetPart.DeletePart(part);
+
+            return;
+        }
+
+        for (var i = 1; i < existing.Count; i++)
+            worksheetPart.DeletePart(existing[i]);
+
+        var threadedCommentsPart = existing.Count > 0
+            ? existing[0]
+            : worksheetPart.AddNewPart<WorksheetThreadedCommentsPart>(
+                context.RelIdGenerator.GetNext(RelType.Workbook));
+
+        ThreadedCommentPartWriter.GenerateContent(threadedCommentsPart, worksheet);
     }
 
     private static void RemoveCommentsPartIfPresent(WorksheetPart worksheetPart)
@@ -773,7 +805,35 @@ public partial class XLWorkbook
                 document.DeletePart(document.CustomFilePropertiesPart);
         }
 
+        GeneratePersonPart(workbookPart, context);
+
         SetPackageProperties(document);
+    }
+
+    /// <summary>
+    /// Synchronises <c>xl/persons/person.xml</c> with the workbook's person list. An unreferenced
+    /// person is still written out rather than pruned, matching Excel, which keeps the list around
+    /// after the last comment by someone is deleted.
+    /// </summary>
+    private void GeneratePersonPart(WorkbookPart workbookPart, SaveContext context)
+    {
+        var existing = workbookPart.GetPartsOfType<WorkbookPersonPart>().ToList();
+        if (PersonsInternal.Count == 0)
+        {
+            foreach (var part in existing)
+                workbookPart.DeletePart(part);
+
+            return;
+        }
+
+        for (var i = 1; i < existing.Count; i++)
+            workbookPart.DeletePart(existing[i]);
+
+        var personPart = existing.Count > 0
+            ? existing[0]
+            : workbookPart.AddNewPart<WorkbookPersonPart>(context.RelIdGenerator.GetNext(RelType.Workbook));
+
+        PersonPartWriter.GenerateContent(personPart, this);
     }
 
     private static bool DeleteExistingCommentsShapes(VmlDrawingPart? vmlDrawingPart)

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -1,111 +1,116 @@
 #nullable enable
+*REMOVED*static XLibur.Graphics.DefaultGraphicEngine.CreateOnlyWithFonts(System.IO.Stream! fallbackFontStream, params System.IO.Stream![]! fontStreams) -> XLibur.Graphics.IXLGraphicEngine!
+*REMOVED*static XLibur.Graphics.DefaultGraphicEngine.CreateWithFontsAndSystemFonts(System.IO.Stream! fallbackFontStream, params System.IO.Stream![]! fontStreams) -> XLibur.Graphics.IXLGraphicEngine!
+*REMOVED*static XLibur.Graphics.DefaultGraphicEngine.Instance.get -> System.Lazy<XLibur.Graphics.DefaultGraphicEngine!>!
+*REMOVED*XLibur.Excel.IXLCFDataBarMax.HighestValue() -> void
+*REMOVED*XLibur.Excel.IXLCFDataBarMax.Maximum(XLibur.Excel.XLCFContentType type, double value) -> void
+*REMOVED*XLibur.Excel.IXLCFDataBarMax.Maximum(XLibur.Excel.XLCFContentType type, string! value) -> void
+*REMOVED*XLibur.Excel.XLColorType.Color = 0 -> XLibur.Excel.XLColorType
+*REMOVED*XLibur.Excel.XLColorType.Indexed = 2 -> XLibur.Excel.XLColorType
+*REMOVED*XLibur.Excel.XLColorType.Theme = 1 -> XLibur.Excel.XLColorType
+*REMOVED*XLibur.Graphics.DefaultGraphicEngine.DefaultGraphicEngine(string! fallbackFont) -> void
+~override XLibur.Excel.XLAlignmentKey.Equals(object obj) -> bool
+override XLibur.Excel.XLAlignmentKey.GetHashCode() -> int
+static XLibur.AttributeExtensions.GetMethod<T>(this T instance, System.Linq.Expressions.Expression<System.Action<T>!>! methodSelector) -> System.Reflection.MethodInfo!
+static XLibur.AttributeExtensions.GetMethod<T>(this T instance, System.Linq.Expressions.Expression<System.Func<T, object!>!>! methodSelector) -> System.Reflection.MethodInfo!
 static XLibur.Excel.IO.PartStructureException.IncorrectElementFormat(string! elementName) -> XLibur.Excel.IO.PartStructureException!
 static XLibur.Excel.IO.PartStructureException.RequiredElementIsMissing() -> XLibur.Excel.IO.PartStructureException!
-static XLibur.Excel.XLCellValue.operator ==(XLibur.Excel.XLCellValue left, XLibur.Excel.XLCellValue right) -> bool
+static XLibur.Excel.LoadOptions.DefaultFontEngine.get -> XLibur.Graphics.IXLFontEngine?
+static XLibur.Excel.LoadOptions.DefaultFontEngine.set -> void
+static XLibur.Excel.XLAlignmentKey.operator !=(XLibur.Excel.XLAlignmentKey left, XLibur.Excel.XLAlignmentKey right) -> bool
+static XLibur.Excel.XLAlignmentKey.operator ==(XLibur.Excel.XLAlignmentKey left, XLibur.Excel.XLAlignmentKey right) -> bool
 static XLibur.Excel.XLCellValue.operator !=(XLibur.Excel.XLCellValue left, XLibur.Excel.XLCellValue right) -> bool
+static XLibur.Excel.XLCellValue.operator ==(XLibur.Excel.XLCellValue left, XLibur.Excel.XLCellValue right) -> bool
+static XLibur.Excel.XLColor.Automatic.get -> XLibur.Excel.XLColor!
 virtual XLibur.Excel.XLWorkbook.Dispose(bool disposing) -> void
+XLibur.Excel.Drawings.IXLPicture.Group.get -> XLibur.Excel.Drawings.IXLPictureGroup?
+XLibur.Excel.Drawings.IXLPicture.IsInGroup.get -> bool
+XLibur.Excel.Drawings.IXLPictureGroup
+XLibur.Excel.Drawings.IXLPictureGroup.Add(System.IO.Stream! stream, string! name) -> XLibur.Excel.Drawings.IXLPicture!
+XLibur.Excel.Drawings.IXLPictureGroup.Add(System.IO.Stream! stream) -> XLibur.Excel.Drawings.IXLPicture!
+XLibur.Excel.Drawings.IXLPictureGroup.Pictures.get -> System.Collections.Generic.IEnumerable<XLibur.Excel.Drawings.IXLPicture!>!
+XLibur.Excel.Drawings.IXLPictureGroup.Remove(XLibur.Excel.Drawings.IXLPicture! picture) -> void
+XLibur.Excel.Drawings.IXLPictureGroup.Worksheet.get -> XLibur.Excel.IXLWorksheet!
+XLibur.Excel.Drawings.IXLPictures.Group(params XLibur.Excel.Drawings.IXLPicture![]! pictures) -> XLibur.Excel.Drawings.IXLPictureGroup!
+XLibur.Excel.Exceptions.XLEncryptionException
+XLibur.Excel.Exceptions.XLEncryptionException.XLEncryptionException() -> void
+XLibur.Excel.Exceptions.XLEncryptionException.XLEncryptionException(string! message, System.Exception! inner) -> void
+XLibur.Excel.Exceptions.XLEncryptionException.XLEncryptionException(string! message) -> void
+XLibur.Excel.Exceptions.XLInvalidPasswordException
+XLibur.Excel.Exceptions.XLInvalidPasswordException.XLInvalidPasswordException() -> void
+XLibur.Excel.Exceptions.XLInvalidPasswordException.XLInvalidPasswordException(string! message, System.Exception! inner) -> void
+XLibur.Excel.Exceptions.XLInvalidPasswordException.XLInvalidPasswordException(string! message) -> void
 XLibur.Excel.IO.PartStructureException
+XLibur.Excel.IXLCell.CreateThreadedComment(XLibur.Excel.IXLPerson! author, string! text) -> XLibur.Excel.IXLThreadedComment!
+XLibur.Excel.IXLCell.Focus() -> XLibur.Excel.IXLCell!
+XLibur.Excel.IXLCell.GetThreadedComment() -> XLibur.Excel.IXLThreadedComment?
+XLibur.Excel.IXLCell.HasThreadedComment.get -> bool
+XLibur.Excel.IXLCFDataBarMax.HighestValue() -> XLibur.Excel.IXLConditionalFormat!
+XLibur.Excel.IXLCFDataBarMax.Maximum(XLibur.Excel.XLCFContentType type, double value) -> XLibur.Excel.IXLConditionalFormat!
+XLibur.Excel.IXLCFDataBarMax.Maximum(XLibur.Excel.XLCFContentType type, string! value) -> XLibur.Excel.IXLConditionalFormat!
+XLibur.Excel.IXLChart.Anchor.get -> XLibur.Excel.XLDrawingAnchor
+XLibur.Excel.IXLChart.Anchor.set -> void
+XLibur.Excel.IXLChart.CategoryAxis.get -> XLibur.Excel.IXLChartAxis!
+XLibur.Excel.IXLChart.DataLabels.get -> XLibur.Excel.IXLDataLabels!
+XLibur.Excel.IXLChart.Height.get -> int
+XLibur.Excel.IXLChart.Height.set -> void
+XLibur.Excel.IXLChart.Left.get -> int
+XLibur.Excel.IXLChart.Left.set -> void
+XLibur.Excel.IXLChart.Legend.get -> XLibur.Excel.IXLChartLegend!
 XLibur.Excel.IXLChart.SecondaryChartType.get -> XLibur.Excel.XLChartType?
 XLibur.Excel.IXLChart.SecondaryChartType.set -> void
 XLibur.Excel.IXLChart.SecondarySeries.get -> XLibur.Excel.IXLChartSeriesCollection!
+XLibur.Excel.IXLChart.SecondaryValueAxis.get -> XLibur.Excel.IXLChartAxis!
 XLibur.Excel.IXLChart.SecondPosition.get -> XLibur.Excel.IXLDrawingPosition!
 XLibur.Excel.IXLChart.Series.get -> XLibur.Excel.IXLChartSeriesCollection!
 XLibur.Excel.IXLChart.SetTitle(string? title) -> XLibur.Excel.IXLChart!
 XLibur.Excel.IXLChart.Title.get -> string?
 XLibur.Excel.IXLChart.Title.set -> void
+XLibur.Excel.IXLChart.Top.get -> int
+XLibur.Excel.IXLChart.Top.set -> void
+XLibur.Excel.IXLChart.ValueAxis.get -> XLibur.Excel.IXLChartAxis!
+XLibur.Excel.IXLChart.Width.get -> int
+XLibur.Excel.IXLChart.Width.set -> void
 XLibur.Excel.IXLChart.Worksheet.get -> XLibur.Excel.IXLWorksheet!
+XLibur.Excel.IXLChartAxis
+XLibur.Excel.IXLChartAxis.LogBase.get -> double
+XLibur.Excel.IXLChartAxis.LogBase.set -> void
+XLibur.Excel.IXLChartAxis.LogScale.get -> bool
+XLibur.Excel.IXLChartAxis.LogScale.set -> void
+XLibur.Excel.IXLChartAxis.MajorGridlines.get -> bool
+XLibur.Excel.IXLChartAxis.MajorGridlines.set -> void
+XLibur.Excel.IXLChartAxis.MajorUnit.get -> double?
+XLibur.Excel.IXLChartAxis.MajorUnit.set -> void
+XLibur.Excel.IXLChartAxis.Max.get -> double?
+XLibur.Excel.IXLChartAxis.Max.set -> void
+XLibur.Excel.IXLChartAxis.Min.get -> double?
+XLibur.Excel.IXLChartAxis.Min.set -> void
+XLibur.Excel.IXLChartAxis.MinorUnit.get -> double?
+XLibur.Excel.IXLChartAxis.MinorUnit.set -> void
+XLibur.Excel.IXLChartAxis.NumberFormat.get -> string?
+XLibur.Excel.IXLChartAxis.NumberFormat.set -> void
+XLibur.Excel.IXLChartAxis.Orientation.get -> XLibur.Excel.XLAxisOrientation
+XLibur.Excel.IXLChartAxis.Orientation.set -> void
+XLibur.Excel.IXLChartAxis.Title.get -> string?
+XLibur.Excel.IXLChartAxis.Title.set -> void
+XLibur.Excel.IXLChartAxis.Visible.get -> bool
+XLibur.Excel.IXLChartAxis.Visible.set -> void
+XLibur.Excel.IXLChartLegend
+XLibur.Excel.IXLChartLegend.Overlay.get -> bool
+XLibur.Excel.IXLChartLegend.Overlay.set -> void
+XLibur.Excel.IXLChartLegend.Position.get -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.IXLChartLegend.Position.set -> void
+XLibur.Excel.IXLChartLegend.Visible.get -> bool
+XLibur.Excel.IXLChartLegend.Visible.set -> void
 XLibur.Excel.IXLCharts.Add(XLibur.Excel.XLChartType chartType) -> XLibur.Excel.IXLChart!
 XLibur.Excel.IXLCharts.Count.get -> int
 XLibur.Excel.IXLChartSeries
 XLibur.Excel.IXLChartSeries.CategoryReferences.get -> string?
 XLibur.Excel.IXLChartSeries.CategoryReferences.set -> void
-XLibur.Excel.IXLChartSeries.Index.get -> uint
-XLibur.Excel.IXLChartSeries.Name.get -> string!
-XLibur.Excel.IXLChartSeries.Name.set -> void
-XLibur.Excel.IXLChartSeries.Order.get -> uint
-XLibur.Excel.IXLChartSeries.ValueReferences.get -> string!
-XLibur.Excel.IXLChartSeries.ValueReferences.set -> void
-XLibur.Excel.IXLChartSeriesCollection
-XLibur.Excel.IXLChartSeriesCollection.Add(string! name, string! valueReferences, string? categoryReferences = null) -> XLibur.Excel.IXLChartSeries!
-XLibur.Excel.IXLChartSeriesCollection.Count.get -> int
-XLibur.Excel.IXLWorksheet.Charts.get -> XLibur.Excel.IXLCharts!
-XLibur.Excel.XLChartType.BoxWhisker = 73 -> XLibur.Excel.XLChartType
-XLibur.Excel.XLChartType.Funnel = 74 -> XLibur.Excel.XLChartType
-XLibur.Excel.XLChartType.Sunburst = 75 -> XLibur.Excel.XLChartType
-XLibur.Excel.XLChartType.Treemap = 76 -> XLibur.Excel.XLChartType
-XLibur.Excel.XLChartType.Waterfall = 77 -> XLibur.Excel.XLChartType
-*REMOVED*XLibur.Excel.IXLCFDataBarMax.HighestValue() -> void
-*REMOVED*XLibur.Excel.IXLCFDataBarMax.Maximum(XLibur.Excel.XLCFContentType type, double value) -> void
-*REMOVED*XLibur.Excel.IXLCFDataBarMax.Maximum(XLibur.Excel.XLCFContentType type, string! value) -> void
-XLibur.Excel.IXLCFDataBarMax.HighestValue() -> XLibur.Excel.IXLConditionalFormat!
-XLibur.Excel.IXLCFDataBarMax.Maximum(XLibur.Excel.XLCFContentType type, double value) -> XLibur.Excel.IXLConditionalFormat!
-XLibur.Excel.IXLCFDataBarMax.Maximum(XLibur.Excel.XLCFContentType type, string! value) -> XLibur.Excel.IXLConditionalFormat!
-XLibur.Excel.IXLConditionalFormat.BarAxisColor.get -> XLibur.Excel.XLColor!
-XLibur.Excel.IXLConditionalFormat.BarAxisColor.set -> void
-XLibur.Excel.IXLConditionalFormat.BarAxisPosition.get -> XLibur.Excel.XLDataBarAxisPosition
-XLibur.Excel.IXLConditionalFormat.BarAxisPosition.set -> void
-XLibur.Excel.IXLConditionalFormat.Gradient.set -> void
-XLibur.Excel.IXLConditionalFormat.ShowBarOnly.set -> void
-XLibur.Excel.XLDataBarAxisPosition
-XLibur.Excel.XLDataBarAxisPosition.Automatic = 0 -> XLibur.Excel.XLDataBarAxisPosition
-XLibur.Excel.XLDataBarAxisPosition.Middle = 1 -> XLibur.Excel.XLDataBarAxisPosition
-XLibur.Excel.XLDataBarAxisPosition.None = 2 -> XLibur.Excel.XLDataBarAxisPosition
-XLibur.Graphics.IXLFontEngine
-XLibur.Graphics.IXLFontEngine.GetDescent(XLibur.Excel.IXLFontBase! font, double dpiY) -> double
-XLibur.Graphics.IXLFontEngine.GetGlyphBox(System.ReadOnlySpan<int> graphemeCluster, XLibur.Excel.IXLFontBase! font, XLibur.Graphics.Dpi dpi) -> XLibur.Graphics.GlyphBox
-XLibur.Graphics.IXLFontEngine.GetMaxDigitWidth(XLibur.Excel.IXLFontBase! font, double dpiX) -> double
-XLibur.Graphics.IXLFontEngine.GetTextHeight(XLibur.Excel.IXLFontBase! font, double dpiY) -> double
-XLibur.Graphics.IXLFontEngine.GetTextWidth(string! text, XLibur.Excel.IXLFontBase! font, double dpiX) -> double
-XLibur.Graphics.DefaultGraphicEngine.DefaultGraphicEngine(XLibur.Graphics.IXLFontEngine! fontEngine) -> void
-*REMOVED*XLibur.Graphics.DefaultGraphicEngine.DefaultGraphicEngine(string! fallbackFont) -> void
-*REMOVED*static XLibur.Graphics.DefaultGraphicEngine.Instance.get -> System.Lazy<XLibur.Graphics.DefaultGraphicEngine!>!
-*REMOVED*static XLibur.Graphics.DefaultGraphicEngine.CreateOnlyWithFonts(System.IO.Stream! fallbackFontStream, params System.IO.Stream![]! fontStreams) -> XLibur.Graphics.IXLGraphicEngine!
-*REMOVED*static XLibur.Graphics.DefaultGraphicEngine.CreateWithFontsAndSystemFonts(System.IO.Stream! fallbackFontStream, params System.IO.Stream![]! fontStreams) -> XLibur.Graphics.IXLGraphicEngine!
-XLibur.Excel.LoadOptions.FontEngine.get -> XLibur.Graphics.IXLFontEngine?
-XLibur.Excel.LoadOptions.FontEngine.set -> void
-static XLibur.Excel.LoadOptions.DefaultFontEngine.get -> XLibur.Graphics.IXLFontEngine?
-static XLibur.Excel.LoadOptions.DefaultFontEngine.set -> void
-XLibur.Excel.IXLWorksheet.EnumerateUsedCells() -> XLibur.Excel.XLUsedCellEnumerable
-XLibur.Excel.XLUsedCell
-XLibur.Excel.XLUsedCell.Column.get -> int
-XLibur.Excel.XLUsedCell.Row.get -> int
-XLibur.Excel.XLUsedCell.Value.get -> XLibur.Excel.XLCellValue
-XLibur.Excel.XLUsedCell.XLUsedCell() -> void
-XLibur.Excel.XLUsedCellEnumerable
-XLibur.Excel.XLUsedCellEnumerable.GetEnumerator() -> XLibur.Excel.XLUsedCellEnumerator
-XLibur.Excel.XLUsedCellEnumerable.XLUsedCellEnumerable() -> void
-XLibur.Excel.XLUsedCellEnumerator
-XLibur.Excel.XLUsedCellEnumerator.Current.get -> XLibur.Excel.XLUsedCell
-XLibur.Excel.XLUsedCellEnumerator.Dispose() -> void
-XLibur.Excel.XLUsedCellEnumerator.MoveNext() -> bool
-XLibur.Excel.XLUsedCellEnumerator.XLUsedCellEnumerator() -> void
-XLibur.Excel.Drawings.IXLPicture.Group.get -> XLibur.Excel.Drawings.IXLPictureGroup?
-XLibur.Excel.Drawings.IXLPicture.IsInGroup.get -> bool
-XLibur.Excel.Drawings.IXLPictureGroup
-XLibur.Excel.Drawings.IXLPictureGroup.Add(System.IO.Stream! stream) -> XLibur.Excel.Drawings.IXLPicture!
-XLibur.Excel.Drawings.IXLPictureGroup.Add(System.IO.Stream! stream, string! name) -> XLibur.Excel.Drawings.IXLPicture!
-XLibur.Excel.Drawings.IXLPictureGroup.Pictures.get -> System.Collections.Generic.IEnumerable<XLibur.Excel.Drawings.IXLPicture!>!
-XLibur.Excel.Drawings.IXLPictureGroup.Remove(XLibur.Excel.Drawings.IXLPicture! picture) -> void
-XLibur.Excel.Drawings.IXLPictureGroup.Worksheet.get -> XLibur.Excel.IXLWorksheet!
-XLibur.Excel.Drawings.IXLPictures.Group(params XLibur.Excel.Drawings.IXLPicture![]! pictures) -> XLibur.Excel.Drawings.IXLPictureGroup!
-XLibur.Excel.IXLWorksheet.PictureGroups.get -> System.Collections.Generic.IEnumerable<XLibur.Excel.Drawings.IXLPictureGroup!>!
-XLibur.Excel.IXLSheetView.PaneTopLeftCellAddress.get -> XLibur.Excel.IXLAddress?
-XLibur.Excel.IXLSheetView.PaneTopLeftCellAddress.set -> void
-XLibur.Excel.IXLWorksheet.SetActiveCell(string! address) -> XLibur.Excel.IXLWorksheet!
-XLibur.Excel.IXLWorksheet.SetActiveCell(XLibur.Excel.IXLCell! cell) -> XLibur.Excel.IXLWorksheet!
-XLibur.Excel.IXLWorksheet.FocusCell(string! address) -> XLibur.Excel.IXLWorksheet!
-XLibur.Excel.IXLWorksheet.FocusCell(XLibur.Excel.IXLCell! cell) -> XLibur.Excel.IXLWorksheet!
-XLibur.Excel.IXLCell.Focus() -> XLibur.Excel.IXLCell!
-~override XLibur.Excel.XLAlignmentKey.Equals(object obj) -> bool
-override XLibur.Excel.XLAlignmentKey.GetHashCode() -> int
-XLibur.Excel.XLAlignmentKey.Equals(XLibur.Excel.XLAlignmentKey other) -> bool
-static XLibur.Excel.XLAlignmentKey.operator ==(XLibur.Excel.XLAlignmentKey left, XLibur.Excel.XLAlignmentKey right) -> bool
-static XLibur.Excel.XLAlignmentKey.operator !=(XLibur.Excel.XLAlignmentKey left, XLibur.Excel.XLAlignmentKey right) -> bool
-static XLibur.AttributeExtensions.GetMethod<T>(this T instance, System.Linq.Expressions.Expression<System.Func<T, object!>!>! methodSelector) -> System.Reflection.MethodInfo!
-static XLibur.AttributeExtensions.GetMethod<T>(this T instance, System.Linq.Expressions.Expression<System.Action<T>!>! methodSelector) -> System.Reflection.MethodInfo!
-XLibur.Excel.XLError.SpillRange = 7 -> XLibur.Excel.XLError
+XLibur.Excel.IXLChartSeries.DataLabels.get -> XLibur.Excel.IXLDataLabels!
 XLibur.Excel.IXLChartSeries.FillColor.get -> XLibur.Excel.XLColor?
 XLibur.Excel.IXLChartSeries.FillColor.set -> void
+XLibur.Excel.IXLChartSeries.Index.get -> uint
 XLibur.Excel.IXLChartSeries.LineColor.get -> XLibur.Excel.XLColor?
 XLibur.Excel.IXLChartSeries.LineColor.set -> void
 XLibur.Excel.IXLChartSeries.LineWidthPt.get -> double?
@@ -116,24 +121,24 @@ XLibur.Excel.IXLChartSeries.MarkerSize.get -> double?
 XLibur.Excel.IXLChartSeries.MarkerSize.set -> void
 XLibur.Excel.IXLChartSeries.MarkerStyle.get -> XLibur.Excel.XLMarkerStyle
 XLibur.Excel.IXLChartSeries.MarkerStyle.set -> void
+XLibur.Excel.IXLChartSeries.Name.get -> string!
+XLibur.Excel.IXLChartSeries.Name.set -> void
+XLibur.Excel.IXLChartSeries.Order.get -> uint
 XLibur.Excel.IXLChartSeries.Smooth.get -> bool
 XLibur.Excel.IXLChartSeries.Smooth.set -> void
 XLibur.Excel.IXLChartSeries.UseSecondaryAxis.get -> bool
 XLibur.Excel.IXLChartSeries.UseSecondaryAxis.set -> void
-XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.Auto = 0 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.None = 1 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.Circle = 2 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.Dash = 3 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.Diamond = 4 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.Dot = 5 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.Plus = 6 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.Square = 7 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.Star = 8 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.Triangle = 9 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.XLMarkerStyle.X = 10 -> XLibur.Excel.XLMarkerStyle
-XLibur.Excel.IXLChart.DataLabels.get -> XLibur.Excel.IXLDataLabels!
-XLibur.Excel.IXLChartSeries.DataLabels.get -> XLibur.Excel.IXLDataLabels!
+XLibur.Excel.IXLChartSeries.ValueReferences.get -> string!
+XLibur.Excel.IXLChartSeries.ValueReferences.set -> void
+XLibur.Excel.IXLChartSeriesCollection
+XLibur.Excel.IXLChartSeriesCollection.Add(string! name, string! valueReferences, string? categoryReferences = null) -> XLibur.Excel.IXLChartSeries!
+XLibur.Excel.IXLChartSeriesCollection.Count.get -> int
+XLibur.Excel.IXLConditionalFormat.BarAxisColor.get -> XLibur.Excel.XLColor!
+XLibur.Excel.IXLConditionalFormat.BarAxisColor.set -> void
+XLibur.Excel.IXLConditionalFormat.BarAxisPosition.get -> XLibur.Excel.XLDataBarAxisPosition
+XLibur.Excel.IXLConditionalFormat.BarAxisPosition.set -> void
+XLibur.Excel.IXLConditionalFormat.Gradient.set -> void
+XLibur.Excel.IXLConditionalFormat.ShowBarOnly.set -> void
 XLibur.Excel.IXLDataLabels
 XLibur.Excel.IXLDataLabels.NumberFormat.get -> string?
 XLibur.Excel.IXLDataLabels.NumberFormat.set -> void
@@ -147,88 +152,112 @@ XLibur.Excel.IXLDataLabels.ShowSeriesName.get -> bool
 XLibur.Excel.IXLDataLabels.ShowSeriesName.set -> void
 XLibur.Excel.IXLDataLabels.ShowValue.get -> bool
 XLibur.Excel.IXLDataLabels.ShowValue.set -> void
-XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.XLDataLabelPosition.Auto = 0 -> XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.XLDataLabelPosition.Center = 1 -> XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.XLDataLabelPosition.InsideEnd = 2 -> XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.XLDataLabelPosition.InsideBase = 3 -> XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.XLDataLabelPosition.OutsideEnd = 4 -> XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.XLDataLabelPosition.BestFit = 5 -> XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.XLDataLabelPosition.Left = 6 -> XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.XLDataLabelPosition.Right = 7 -> XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.XLDataLabelPosition.Above = 8 -> XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.XLDataLabelPosition.Below = 9 -> XLibur.Excel.XLDataLabelPosition
-XLibur.Excel.IXLChart.Legend.get -> XLibur.Excel.IXLChartLegend!
-XLibur.Excel.IXLChart.CategoryAxis.get -> XLibur.Excel.IXLChartAxis!
-XLibur.Excel.IXLChart.ValueAxis.get -> XLibur.Excel.IXLChartAxis!
-XLibur.Excel.IXLChart.SecondaryValueAxis.get -> XLibur.Excel.IXLChartAxis!
-XLibur.Excel.IXLChartLegend
-XLibur.Excel.IXLChartLegend.Visible.get -> bool
-XLibur.Excel.IXLChartLegend.Visible.set -> void
-XLibur.Excel.IXLChartLegend.Position.get -> XLibur.Excel.XLLegendPosition
-XLibur.Excel.IXLChartLegend.Position.set -> void
-XLibur.Excel.IXLChartLegend.Overlay.get -> bool
-XLibur.Excel.IXLChartLegend.Overlay.set -> void
-XLibur.Excel.XLLegendPosition
-XLibur.Excel.XLLegendPosition.Right = 0 -> XLibur.Excel.XLLegendPosition
-XLibur.Excel.XLLegendPosition.Bottom = 1 -> XLibur.Excel.XLLegendPosition
-XLibur.Excel.XLLegendPosition.Left = 2 -> XLibur.Excel.XLLegendPosition
-XLibur.Excel.XLLegendPosition.Top = 3 -> XLibur.Excel.XLLegendPosition
-XLibur.Excel.XLLegendPosition.TopRight = 4 -> XLibur.Excel.XLLegendPosition
-XLibur.Excel.IXLChartAxis
-XLibur.Excel.IXLChartAxis.Title.get -> string?
-XLibur.Excel.IXLChartAxis.Title.set -> void
-XLibur.Excel.IXLChartAxis.NumberFormat.get -> string?
-XLibur.Excel.IXLChartAxis.NumberFormat.set -> void
-XLibur.Excel.IXLChartAxis.Min.get -> double?
-XLibur.Excel.IXLChartAxis.Min.set -> void
-XLibur.Excel.IXLChartAxis.Max.get -> double?
-XLibur.Excel.IXLChartAxis.Max.set -> void
-XLibur.Excel.IXLChartAxis.MajorUnit.get -> double?
-XLibur.Excel.IXLChartAxis.MajorUnit.set -> void
-XLibur.Excel.IXLChartAxis.MinorUnit.get -> double?
-XLibur.Excel.IXLChartAxis.MinorUnit.set -> void
-XLibur.Excel.IXLChartAxis.Visible.get -> bool
-XLibur.Excel.IXLChartAxis.Visible.set -> void
-XLibur.Excel.IXLChartAxis.MajorGridlines.get -> bool
-XLibur.Excel.IXLChartAxis.MajorGridlines.set -> void
-XLibur.Excel.IXLChartAxis.Orientation.get -> XLibur.Excel.XLAxisOrientation
-XLibur.Excel.IXLChartAxis.Orientation.set -> void
-XLibur.Excel.IXLChartAxis.LogScale.get -> bool
-XLibur.Excel.IXLChartAxis.LogScale.set -> void
-XLibur.Excel.IXLChartAxis.LogBase.get -> double
-XLibur.Excel.IXLChartAxis.LogBase.set -> void
-XLibur.Excel.XLAxisOrientation
-XLibur.Excel.XLAxisOrientation.MinMax = 0 -> XLibur.Excel.XLAxisOrientation
-XLibur.Excel.XLAxisOrientation.MaxMin = 1 -> XLibur.Excel.XLAxisOrientation
-XLibur.Excel.IXLChart.Anchor.get -> XLibur.Excel.XLDrawingAnchor
-XLibur.Excel.IXLChart.Anchor.set -> void
-XLibur.Excel.IXLChart.Width.get -> int
-XLibur.Excel.IXLChart.Width.set -> void
-XLibur.Excel.IXLChart.Height.get -> int
-XLibur.Excel.IXLChart.Height.set -> void
-XLibur.Excel.IXLChart.Left.get -> int
-XLibur.Excel.IXLChart.Left.set -> void
-XLibur.Excel.IXLChart.Top.get -> int
-XLibur.Excel.IXLChart.Top.set -> void
-*REMOVED*XLibur.Excel.XLColorType.Color = 0 -> XLibur.Excel.XLColorType
-*REMOVED*XLibur.Excel.XLColorType.Theme = 1 -> XLibur.Excel.XLColorType
-*REMOVED*XLibur.Excel.XLColorType.Indexed = 2 -> XLibur.Excel.XLColorType
-XLibur.Excel.XLColorType.Automatic = 0 -> XLibur.Excel.XLColorType
-XLibur.Excel.XLColorType.Color = 1 -> XLibur.Excel.XLColorType
-XLibur.Excel.XLColorType.Theme = 2 -> XLibur.Excel.XLColorType
-XLibur.Excel.XLColorType.Indexed = 3 -> XLibur.Excel.XLColorType
-XLibur.Excel.XLColor.IsAutomatic.get -> bool
-static XLibur.Excel.XLColor.Automatic.get -> XLibur.Excel.XLColor!
-XLibur.Excel.Exceptions.XLEncryptionException
-XLibur.Excel.Exceptions.XLEncryptionException.XLEncryptionException() -> void
-XLibur.Excel.Exceptions.XLEncryptionException.XLEncryptionException(string! message) -> void
-XLibur.Excel.Exceptions.XLEncryptionException.XLEncryptionException(string! message, System.Exception! inner) -> void
-XLibur.Excel.Exceptions.XLInvalidPasswordException
-XLibur.Excel.Exceptions.XLInvalidPasswordException.XLInvalidPasswordException() -> void
-XLibur.Excel.Exceptions.XLInvalidPasswordException.XLInvalidPasswordException(string! message) -> void
-XLibur.Excel.Exceptions.XLInvalidPasswordException.XLInvalidPasswordException(string! message, System.Exception! inner) -> void
+XLibur.Excel.IXLPerson
+XLibur.Excel.IXLPerson.DisplayName.get -> string!
+XLibur.Excel.IXLPerson.Id.get -> System.Guid
+XLibur.Excel.IXLPerson.ProviderId.get -> string?
+XLibur.Excel.IXLPerson.UserId.get -> string?
+XLibur.Excel.IXLPersons
+XLibur.Excel.IXLPersons.Add(string! displayName, string? userId, string? providerId) -> XLibur.Excel.IXLPerson!
+XLibur.Excel.IXLPersons.Add(string! displayName) -> XLibur.Excel.IXLPerson!
+XLibur.Excel.IXLPersons.Count.get -> int
+XLibur.Excel.IXLPersons.Get(System.Guid id) -> XLibur.Excel.IXLPerson?
+XLibur.Excel.IXLPersons.GetByDisplayName(string! displayName) -> XLibur.Excel.IXLPerson?
+XLibur.Excel.IXLPersons.Remove(System.Guid id) -> bool
+XLibur.Excel.IXLSheetView.PaneTopLeftCellAddress.get -> XLibur.Excel.IXLAddress?
+XLibur.Excel.IXLSheetView.PaneTopLeftCellAddress.set -> void
+XLibur.Excel.IXLThreadedComment
+XLibur.Excel.IXLThreadedComment.AddReply(XLibur.Excel.IXLPerson! author, string! text) -> XLibur.Excel.IXLThreadedComment!
+XLibur.Excel.IXLThreadedComment.Author.get -> XLibur.Excel.IXLPerson!
+XLibur.Excel.IXLThreadedComment.CreatedUtc.get -> System.DateTime
+XLibur.Excel.IXLThreadedComment.Delete() -> void
+XLibur.Excel.IXLThreadedComment.Id.get -> System.Guid
+XLibur.Excel.IXLThreadedComment.Parent.get -> XLibur.Excel.IXLThreadedComment?
+XLibur.Excel.IXLThreadedComment.Replies.get -> System.Collections.Generic.IReadOnlyList<XLibur.Excel.IXLThreadedComment!>!
+XLibur.Excel.IXLThreadedComment.Resolved.get -> bool
+XLibur.Excel.IXLThreadedComment.Resolved.set -> void
+XLibur.Excel.IXLThreadedComment.Text.get -> string!
+XLibur.Excel.IXLThreadedComment.Text.set -> void
+XLibur.Excel.IXLWorkbook.Persons.get -> XLibur.Excel.IXLPersons!
+XLibur.Excel.IXLWorksheet.Charts.get -> XLibur.Excel.IXLCharts!
+XLibur.Excel.IXLWorksheet.EnumerateUsedCells() -> XLibur.Excel.XLUsedCellEnumerable
+XLibur.Excel.IXLWorksheet.FocusCell(string! address) -> XLibur.Excel.IXLWorksheet!
+XLibur.Excel.IXLWorksheet.FocusCell(XLibur.Excel.IXLCell! cell) -> XLibur.Excel.IXLWorksheet!
+XLibur.Excel.IXLWorksheet.PictureGroups.get -> System.Collections.Generic.IEnumerable<XLibur.Excel.Drawings.IXLPictureGroup!>!
+XLibur.Excel.IXLWorksheet.SetActiveCell(string! address) -> XLibur.Excel.IXLWorksheet!
+XLibur.Excel.IXLWorksheet.SetActiveCell(XLibur.Excel.IXLCell! cell) -> XLibur.Excel.IXLWorksheet!
+XLibur.Excel.LoadOptions.FontEngine.get -> XLibur.Graphics.IXLFontEngine?
+XLibur.Excel.LoadOptions.FontEngine.set -> void
 XLibur.Excel.LoadOptions.Password.get -> string?
 XLibur.Excel.LoadOptions.Password.set -> void
 XLibur.Excel.SaveOptions.Password.get -> string?
 XLibur.Excel.SaveOptions.Password.set -> void
+XLibur.Excel.XLAlignmentKey.Equals(XLibur.Excel.XLAlignmentKey other) -> bool
+XLibur.Excel.XLAxisOrientation
+XLibur.Excel.XLAxisOrientation.MaxMin = 1 -> XLibur.Excel.XLAxisOrientation
+XLibur.Excel.XLAxisOrientation.MinMax = 0 -> XLibur.Excel.XLAxisOrientation
+XLibur.Excel.XLChartType.BoxWhisker = 73 -> XLibur.Excel.XLChartType
+XLibur.Excel.XLChartType.Funnel = 74 -> XLibur.Excel.XLChartType
+XLibur.Excel.XLChartType.Sunburst = 75 -> XLibur.Excel.XLChartType
+XLibur.Excel.XLChartType.Treemap = 76 -> XLibur.Excel.XLChartType
+XLibur.Excel.XLChartType.Waterfall = 77 -> XLibur.Excel.XLChartType
+XLibur.Excel.XLColor.IsAutomatic.get -> bool
+XLibur.Excel.XLColorType.Automatic = 0 -> XLibur.Excel.XLColorType
+XLibur.Excel.XLColorType.Color = 1 -> XLibur.Excel.XLColorType
+XLibur.Excel.XLColorType.Indexed = 3 -> XLibur.Excel.XLColorType
+XLibur.Excel.XLColorType.Theme = 2 -> XLibur.Excel.XLColorType
+XLibur.Excel.XLDataBarAxisPosition
+XLibur.Excel.XLDataBarAxisPosition.Automatic = 0 -> XLibur.Excel.XLDataBarAxisPosition
+XLibur.Excel.XLDataBarAxisPosition.Middle = 1 -> XLibur.Excel.XLDataBarAxisPosition
+XLibur.Excel.XLDataBarAxisPosition.None = 2 -> XLibur.Excel.XLDataBarAxisPosition
+XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Above = 8 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Auto = 0 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Below = 9 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.BestFit = 5 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Center = 1 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.InsideBase = 3 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.InsideEnd = 2 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Left = 6 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.OutsideEnd = 4 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLDataLabelPosition.Right = 7 -> XLibur.Excel.XLDataLabelPosition
+XLibur.Excel.XLError.SpillRange = 7 -> XLibur.Excel.XLError
+XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLLegendPosition.Bottom = 1 -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLLegendPosition.Left = 2 -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLLegendPosition.Right = 0 -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLLegendPosition.Top = 3 -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLLegendPosition.TopRight = 4 -> XLibur.Excel.XLLegendPosition
+XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Auto = 0 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Circle = 2 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Dash = 3 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Diamond = 4 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Dot = 5 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.None = 1 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Plus = 6 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Square = 7 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Star = 8 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.Triangle = 9 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLMarkerStyle.X = 10 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLUsedCell
+XLibur.Excel.XLUsedCell.Column.get -> int
+XLibur.Excel.XLUsedCell.Row.get -> int
+XLibur.Excel.XLUsedCell.Value.get -> XLibur.Excel.XLCellValue
+XLibur.Excel.XLUsedCell.XLUsedCell() -> void
+XLibur.Excel.XLUsedCellEnumerable
+XLibur.Excel.XLUsedCellEnumerable.GetEnumerator() -> XLibur.Excel.XLUsedCellEnumerator
+XLibur.Excel.XLUsedCellEnumerable.XLUsedCellEnumerable() -> void
+XLibur.Excel.XLUsedCellEnumerator
+XLibur.Excel.XLUsedCellEnumerator.Current.get -> XLibur.Excel.XLUsedCell
+XLibur.Excel.XLUsedCellEnumerator.Dispose() -> void
+XLibur.Excel.XLUsedCellEnumerator.MoveNext() -> bool
+XLibur.Excel.XLUsedCellEnumerator.XLUsedCellEnumerator() -> void
+XLibur.Excel.XLWorkbook.Persons.get -> XLibur.Excel.IXLPersons!
+XLibur.Graphics.DefaultGraphicEngine.DefaultGraphicEngine(XLibur.Graphics.IXLFontEngine! fontEngine) -> void
+XLibur.Graphics.IXLFontEngine
+XLibur.Graphics.IXLFontEngine.GetDescent(XLibur.Excel.IXLFontBase! font, double dpiY) -> double
+XLibur.Graphics.IXLFontEngine.GetGlyphBox(System.ReadOnlySpan<int> graphemeCluster, XLibur.Excel.IXLFontBase! font, XLibur.Graphics.Dpi dpi) -> XLibur.Graphics.GlyphBox
+XLibur.Graphics.IXLFontEngine.GetMaxDigitWidth(XLibur.Excel.IXLFontBase! font, double dpiX) -> double
+XLibur.Graphics.IXLFontEngine.GetTextHeight(XLibur.Excel.IXLFontBase! font, double dpiY) -> double
+XLibur.Graphics.IXLFontEngine.GetTextWidth(string! text, XLibur.Excel.IXLFontBase! font, double dpiX) -> double

--- a/docs/round-trip-fidelity.md
+++ b/docs/round-trip-fidelity.md
@@ -1,0 +1,100 @@
+# Round-trip fidelity
+
+What survives a load → save round trip for content XLibur has no object model for.
+
+Every claim here is backed by a test in `XLibur.Tests/Excel/RoundTripFidelityTests.cs`. If someone
+later changes the save path to rebuild packages from scratch, those tests fail rather than quietly
+dropping a user's chartsheets.
+
+## The mechanism
+
+XLibur does not build a new package on save. It reopens the package it loaded and rewrites only the
+parts it models:
+
+```csharp
+// XLWorkbook_Save.cs
+var package = File.Exists(filePath)
+    ? SpreadsheetDocument.Open(filePath, true)
+    : SpreadsheetDocument.Create(filePath, spreadsheetDocumentType);
+```
+
+`SaveAs` to a new path or stream copies the original package there first and then does the same
+thing. So the default for any part XLibur does not understand is **survival**, not loss — the
+opposite of what you would expect from a library that reads into a model and writes back out.
+
+Two consequences:
+
+- Preservation is free and automatic. There is nothing to opt into.
+- Preservation requires an original package. A workbook created with `new XLWorkbook()` has nothing
+  to carry forward, which is the hard boundary of everything below.
+
+## Findings
+
+| Content | Parts survive | Sheet references survive | Modelled | Notes |
+|---|---|---|---|---|
+| Chartsheets | ✅ | ✅ | ❌ | Kept as `XLWorkbook.UnsupportedSheet` |
+| Dialog / macro sheets | ✅ | ✅ | ❌ | Same path as chartsheets |
+| Form controls | ✅ | ✅ | ❌ | `<controls>` incl. `mc:AlternateContent` and anchors |
+| ActiveX | ✅ | ✅ | ❌ | Both `activeX1.xml` and `activeX1.bin` |
+| Timelines | ✅ | n/a | ❌ | `timelines/` and `timelineCaches/` |
+| Custom XML | ✅ | n/a | ❌ | `customXml/item*.xml` and props |
+| Slicers | ❓ | ❓ | ❌ | **Untested** — see gaps below |
+| Threaded comments | ✅ | ✅ | ✅ | Modelled as of spec 09 |
+
+### Chartsheets are preserved, not dropped
+
+Spec 09 recorded that chartsheets "land in `XLWorkbook.UnsupportedSheet` and are **dropped on
+save**". That is not what happens. `WorkbookPartWriter.GenerateContent` reorders the sheets it does
+model *around* the unsupported ones rather than rewriting the `<sheets>` list from scratch:
+
+```csharp
+var totalSheets = sheetElements.Count() + xlWorkbook.UnsupportedSheets.Count;
+```
+
+so the `<sheet name="Chart" sheetId="3" r:id="rId3"/>` entry stays, the `xl/chartsheets/sheet1.xml`
+part is never touched, and the file reopens intact in Excel and in XLibur.
+
+The real limitation is narrower and worth stating plainly: chartsheets are **preserved but not
+manipulable**. They are not `IXLWorksheet`, so `wb.Worksheets` does not include them and there is no
+API to read or change one. Preservation only breaks if the sheet order is changed such that the
+reorder logic mismatches, which is a separate concern from dropping content.
+
+**Do / can't-do conclusion for chartsheet pass-through: already done, no work required.** Adding a
+real chartsheet model would be a feature, not a fidelity fix.
+
+### Form controls and ActiveX keep their anchors
+
+Worth calling out because the worksheet part *is* regenerated from the model on every save, so this
+one is not free in the way an untouched part is. `WorksheetPartWriter` carries the `<controls>`
+element through verbatim, including the `mc:AlternateContent` wrapper and the `<anchor>` offsets
+inside `controlPr`. Surviving `activeX1.bin` would be worthless if the sheet stopped referencing it.
+
+### Comment VML is pruned surgically
+
+`DeleteExistingCommentsShapes` removes only shapes whose `type` matches the comment shapetype:
+
+```csharp
+.Where(e => e.Name.LocalName == "shape" &&
+            e.Attribute("type")?.Value == "#" + XLConstants.Comment.ShapeTypeId)
+```
+
+Form-control shapes in the same `vmlDrawing1.vml` are left alone, and `RemoveEmptyVmlPart` only
+deletes the part when nothing at all is left in it.
+
+## Gaps
+
+- **Slicers are unverified.** The test suite has no fixture containing `xl/slicers/` or
+  `xl/slicerCaches/`. The same mechanism should carry them through, but "should" is not "does" and
+  this doc does not claim otherwise. Closing this needs an Excel-authored file with a slicer added
+  to `XLibur.Tests/Resource/`.
+- **Nothing is preserved for workbooks built from scratch**, by construction.
+- **Preservation is not manipulation.** Everything in the table above is opaque: it round-trips, but
+  there is no API to inspect or edit it, and no guarantee it stays consistent if you delete the
+  worksheet or pivot table it depends on.
+
+## Threaded comments
+
+As of spec 09 threaded comments are modelled rather than preserved, so they are the exception to
+this document. See `XLibur/Excel/Comments/Threaded/`. The one piece still handled by preservation is
+`<mentions>`, whose raw XML is round-tripped on unmodified comments and dropped when the comment's
+text changes, because a mention's `startIndex`/`length` index into the text it was written against.

--- a/docs/specs/09-threaded-comments-roundtrip.md
+++ b/docs/specs/09-threaded-comments-roundtrip.md
@@ -3,7 +3,7 @@
 **Area:** Feature + Compatibility
 **Effort:** M (1–2 weeks)
 **Dependencies:** None.
-**Status:** Proposed
+**Status:** Implemented — see [Implementation notes](#implementation-notes)
 
 ## Summary
 
@@ -89,3 +89,44 @@ New `ThreadedCommentPartWriter` + `PersonPartWriter` in `XLibur/Excel/IO/`:
 
 - Excel is picky about person/thread GUID and relationship wiring — the manual open-in-Excel check is the gate, automate reopen-via-XLibur for CI.
 - The legacy-fallback pairing is underdocumented; copy exactly what current Excel emits (author a sample file, inspect parts, mirror it).
+
+## Implementation notes
+
+All six tasks landed. Full suite green (6650 tests, 0 failures) across net8.0/net9.0/net10.0.
+
+### Manual verification (acceptance criteria 2 and 3)
+
+Four workbooks were generated and opened in Excel 365 — all four opened cleanly with no repair
+prompt: threads created from scratch via the API (including replies from multiple authors, a
+resolved thread and a non-ASCII display name, across two sheets); an Excel-authored file
+round-tripped unchanged; the same file with its root text edited and a reply appended; and a sheet
+mixing a legacy note with a thread.
+
+### Deviations from the design above
+
+1. **Storage: misc slice, not a side dictionary.** The design recommended a per-worksheet side
+   dictionary keyed by `Point`. It went into `XLMiscSliceContent` instead, because row/column
+   shifting, `Swap` and area-clear all iterate `XLCellsCollection._slices` — a side dictionary would
+   have needed every one of those reimplemented by hand. The slice is sparse, so the cost is 8 bytes
+   per cell that already holds misc content. All 20 editing-semantics tests passed on the first run
+   with no additional code, which is the payoff.
+2. **The fallback note omits `shapeId`.** Excel writes `shapeId="0"` on a thread's fallback comment,
+   but the schema the OpenXML SDK validates against does not declare the attribute, so every
+   `validate: true` save failed with it present. It is optional and Excel ignores it; the pairing is
+   carried by the `tc={rootId}` author and the `xr:uid`.
+3. **`done` is written only on the thread root**, matching Excel, so `Resolved` reads through from a
+   reply but throws when set on one.
+
+### Correction to the current-state analysis
+
+Two claims in this spec turned out not to match the code:
+
+- **Threaded comment parts were already surviving a round trip.** Saving reopens the original package
+  and rewrites only modelled parts, so `threadedComments/` and `persons/` were carried through — but
+  `comments1.xml` was regenerated without the `tc={rootId}` author or `xr:uid`, so the result was an
+  *inconsistent pairing* rather than a clean downgrade to a note.
+- **Chartsheets are not dropped on save.** `WorkbookPartWriter` reorders modelled sheets around the
+  unsupported ones rather than rewriting the `<sheets>` list, so both the `<sheet>` entry and the
+  part survive. Task 6 therefore found no pass-through work to do; its deliverable is
+  `docs/round-trip-fidelity.md` plus regression tests locking the behaviour in. Slicers remain
+  unverified — the repo has no fixture containing `xl/slicers/`.


### PR DESCRIPTION
## Summary

Implements [spec 09](docs/specs/09-threaded-comments-roundtrip.md): threaded comments (Office 365 reply-style comments) get a first-class model and a full round trip, replacing a reader that flattened every thread into a legacy note's text.

The bug was worse than the spec recorded. Because saving reopens the original package rather than rebuilding it, `threadedComments/` and `persons/` already survived a round trip — but `comments1.xml` was regenerated without the `tc={rootId}` author or the `xr:uid`, so the result was an **inconsistent pairing** rather than a clean downgrade to a note: Excel 365 still showed the thread while the fallback note beside it no longer pointed at anything.

## Changes

**Model** — new `XLibur/Excel/Comments/Threaded/`: `IXLThreadedComment`, `IXLPerson`, `IXLPersons`, reachable through `IXLCell.GetThreadedComment()` / `CreateThreadedComment()` / `HasThreadedComment` and `IXLWorkbook.Persons`. A cell carries either a note or a thread, never both — creating one over the other throws rather than silently discarding it.

**Storage** — threads live in `XLMiscSliceContent` beside legacy notes, not in a side table. Row/column shifting, `Swap` and area-clear all iterate `XLCellsCollection._slices`, so anywhere else would have meant reimplementing each by hand. The slice is sparse, so the cost is 8 bytes per cell that already holds misc content. All 20 editing-semantics tests passed on the first run with no extra code.

**Reader** — loads persons once at workbook level, builds roots and replies ordered by `dT`, pins timestamps to UTC (Excel writes no designator), and takes the paired fallback note off the cell, keeping it only for its shape geometry.

**Writers** — `PersonPartWriter` and `ThreadedCommentPartWriter`, plus a shared `CommentWriteSource` feeding both `CommentPartWriter` and `VmlDrawingPartWriter`. The fallback note and its VML shape are regenerated from the thread on every save, so the two cannot drift apart after an edit. Mentions round-trip as raw XML and are dropped when the text changes, since their offsets index into the text they were written against.

## Commits

1. `feat(comments): model threaded comments and round-trip them`
2. `docs(fidelity): audit what survives a load/save round trip`
3. `fix(comments): close four defects found in review`

## Review fixes (commit 3)

Four defects found in review, each reproduced by a test that failed before the change:

- **A thread's cell back-reference went stale.** Shifting rows or columns moves the thread's entry within the misc slice without telling the thread, so `Delete()` cleared the address it *used to* be at and left it at its new one. Rather than teach six generic `Slice<TElement>` paths about one element type, the back-reference is dropped: a thread now holds its `XLWorksheet`, which shifting never changes, and `Delete()` finds itself by identity. `Rehome`, which was never called from anywhere, went with it.
- **Removing a person orphaned their comments.** `ThreadedCommentPartWriter` emitted a `personId` with no matching `<person>` — a dangling reference Excel cannot resolve, and a contradiction of what `IXLPersons.Remove` documents. `person.xml` is now written from the workbook list unioned with every author a thread still references.
- **`XLPersons.Map` merged distinct provider-less people** sharing a display name, so a cross-workbook copy could reattribute one person's comments to another. Identity matching now requires a `userId` or `providerId`; matching on a real provider identity is unchanged.
- **`ParseThreadedCommentDate` returned a bare `default`** for a comment with no `dT`, handing back an `Unspecified` `DateTime` from a property documented as UTC.

One review suggestion was **not** applied: annotating a test helper's return as `ZipArchiveEntry?`. The premise is right, but `<Nullable>enable</Nullable>` is set only in `XLibur.csproj`, so in the test project the annotation only earns a CS8632 (verified by building it). A comment records why.

## Related Issues

Implements `docs/specs/09-threaded-comments-roundtrip.md`. Supersedes the flattened-text behaviour asserted by the #2344 regression test, which is updated to assert the thread.

## Testing

- [x] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually

**6655 tests, 0 failures.** All target frameworks build clean. 49 new tests: 16 load/round-trip, 20 editing semantics (shifting, swap, clear, copy within and across workbooks), 8 fidelity, 5 review regressions.

**Manual Excel 365 verification** (acceptance criteria 2 and 3) — four workbooks generated and opened, all cleanly with no repair prompt:

| File | Covers |
|---|---|
| Created from scratch | Threads via API: replies from multiple authors, a resolved thread, a non-ASCII display name, two sheets |
| Round-tripped unchanged | Excel-authored file loaded and saved |
| Round-tripped edited | Root text rewritten and a reply appended through the API |
| Mixed | A legacy note and a thread on the same sheet, sharing the comments and VML parts |

That check ran against commit 1. The commit 3 fixes do not change the bytes written for any of those four scenarios — none removes a person, none maps a provider-less person across workbooks, and none has a comment without a `dT` — so the verification still stands.

## Known gaps

- **Excel 2016 fallback rendering is inferred, not tested** — no old Excel available. The structure written matches what Excel emits.
- **Slicers remain unverified** — the repo has no fixture containing `xl/slicers/`. `docs/round-trip-fidelity.md` says so rather than assuming they pass through.
- **`XLComment.Delete()` has the same stale-cell weakness** the thread fix removed: it holds `_cell` and clears whatever address it was created at. That predates this branch and is left for separate work.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced (`TreatWarningsAsErrors` clean; new public API added to `PublicAPI.Unshipped.txt`)
- [x] PR targets the `main` branch
