### PR TITLE
fix(calc): suppress S1244 false positive in Statistical

### DIFF
--- a/XLibur/Excel/CalcEngine/Functions/Statistical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Statistical.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using XLibur.Excel.CalcEngine.Functions;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
+#pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility
+
 namespace XLibur.Excel.CalcEngine;
 
 internal static class Statistical


### PR DESCRIPTION
## Summary

Silences a SonarQube S1244 finding — *"Do not check floating point equality with exact values, use a range instead"* — in `XLibur/Excel/CalcEngine/Functions/Statistical.cs`.

It is a false positive, and following the rule's advice would introduce a bug.

## Why the rule is wrong here

The flagged line counts tied values for `RANK.AVG`:

```csharp
// RANK.AVG spreads the ranks a tied group occupies evenly across its members: a pair tied
// for third takes ranks three and four, so both are reported as 3.5.
var tied = numbers.Count(v => v == number);
return rank + (tied - 1) / 2.0;
```

Excel treats two values as tied only when they compare **exactly** equal. Replacing that with a tolerance range would pull distinct-but-nearby values into the same tie group and report the wrong average rank — so the suggested remediation changes behaviour away from Excel, which is the compatibility contract this whole namespace exists to honour.

## Changes

Adds the file-level pragma already used by the twenty other files that hit this rule for exactly the same reason:

```csharp
#pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility
```

Placement and comment text match the existing convention (after the usings, blank line either side, no `restore` — consistent with every current use), so this doesn't introduce a second mechanism for the same problem.

`Statistical.cs` contains no other exact float comparison, so a file-level pragma is proportionate rather than blanket cover.

## Testing

- Build clean, `TreatWarningsAsErrors` on.
- No behaviour change: the commit adds two lines, both comments/pragma.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
