### PR TITLE
docs(specs): refresh spec statuses against what has actually shipped

### DIFF
--- a/docs/specs/06-workbook-encryption.md
+++ b/docs/specs/06-workbook-encryption.md
@@ -3,7 +3,7 @@
 **Area:** Feature + Compatibility
 **Effort:** L (3–4 weeks including interop testing)
 **Dependencies:** None.
-**Status:** Proposed
+**Status:** ✅ Implemented in PR #245 (tests #246, guide #249) — see [Implementation notes](#implementation-notes)
 
 ## Summary
 
@@ -92,3 +92,32 @@ Tasks 1–2 and 3–4 can run in parallel (container vs crypto). Test files go i
 - MS-OFFCRYPTO, MS-CFB (Microsoft open specifications).
 - NPOI `POIFS`/`CryptoAPI` (Apache-2.0) as a study reference.
 - Existing (different) feature: `XLibur/Excel/Protection/` — password *hashes* for edit protection, untouched by this spec.
+
+## Implementation notes
+
+> The **Summary** and **Design** sections above describe the codebase *before* this spec was
+> implemented. In particular, "zero encryption code exists in the repo today" is no longer true —
+> read them as the historical problem statement, not as current state.
+
+Landed in PR #245, with test coverage in #246 and a user guide in #249.
+
+What shipped, against the scope table:
+
+| Capability | Shipped |
+|---|---|
+| Read Agile (AES-CBC, SHA-512) | ✅ `IO/Encryption/Agile/` |
+| Read Standard (Office 2007) | ✅ `IO/Encryption/Standard/` |
+| Write Agile | ✅ `Agile/AgileCrypto.cs`, `AgileEncryptionDescriptor.cs` |
+| Write Standard | ❌ excluded by design |
+| XOR / RC4 legacy | ❌ excluded by design |
+
+Public surface is `LoadOptions.Password` and `SaveOptions.Password`; a workbook opened with a
+password is deliberately *not* re-encrypted on save unless one is supplied.
+
+### Deviation: OpenMcdf instead of an in-house CFB layer
+
+The design recommended writing a minimal in-house CFB reader/writer and flagged the MPL-2.0
+question for maintainer sign-off. The implementation took the dependency instead —
+`OpenMcdf 3.1.4`, referenced from `XLibur/XLibur.csproj`. This resolves acceptance criterion 4
+("no new NuGet dependency without maintainer license sign-off") in the affirmative rather than by
+avoidance, so the license decision is now a shipped fact rather than an open question.

--- a/docs/specs/06-workbook-encryption.md
+++ b/docs/specs/06-workbook-encryption.md
@@ -114,10 +114,17 @@ What shipped, against the scope table:
 Public surface is `LoadOptions.Password` and `SaveOptions.Password`; a workbook opened with a
 password is deliberately *not* re-encrypted on save unless one is supplied.
 
-### Deviation: OpenMcdf instead of an in-house CFB layer
+### CFB layer: OpenMcdf, approved
 
-The design recommended writing a minimal in-house CFB reader/writer and flagged the MPL-2.0
-question for maintainer sign-off. The implementation took the dependency instead —
-`OpenMcdf 3.1.4`, referenced from `XLibur/XLibur.csproj`. This resolves acceptance criterion 4
-("no new NuGet dependency without maintainer license sign-off") in the affirmative rather than by
-avoidance, so the license decision is now a shipped fact rather than an open question.
+The design recommended writing a minimal in-house CFB reader/writer, and made acceptance
+criterion 4 ("no new NuGet dependency without maintainer license sign-off") the gate on the
+alternative. The alternative was taken: `OpenMcdf 3.1.4`, referenced from `XLibur/XLibur.csproj`.
+
+**The maintainer sign-off was given** — MPL-2.0 is file-level copyleft and imposes no obligation on
+the MIT-licensed code that consumes it as an unmodified package dependency. Criterion 4 is
+therefore met rather than deviated from, and the in-house CFB recommendation is closed as
+not-taken rather than outstanding.
+
+The practical consequence for anyone reading this later: `XLibur/Excel/IO/Encryption/` contains no
+compound-file implementation, because CFB container handling lives in OpenMcdf. Only the crypto
+layer is in-house.

--- a/docs/specs/07-formula-function-coverage.md
+++ b/docs/specs/07-formula-function-coverage.md
@@ -3,7 +3,7 @@
 **Area:** Feature
 **Effort:** L total, but **highly parallelizable** — 6 independent waves, each a self-contained PR assignable to a different agent/model.
 **Dependencies:** None (waves are independent). LET/LAMBDA are explicitly **excluded** — see Spec 08 (they need parser/scoping work, not registration).
-**Status:** Proposed
+**Status:** ✅ All six waves implemented (#252–#257) — see [Implementation notes](#implementation-notes). Optional wave A2 not done.
 
 ## Summary
 
@@ -56,3 +56,25 @@ Notes: array-shaping functions are pure array→array transforms on the existing
 - Waves B and C both edit `Statistical.cs` — run them sequentially or have C branch from B.
 - All waves touch `FunctionRegistry.cs` — keep registrations grouped by category in the file to minimize merge conflicts; rebase order A → D → E → F → B → C is conflict-minimal.
 - Shared special-functions helper (Wave B) should land before or within B; C may reuse it.
+
+## Implementation notes
+
+All six waves landed, one PR each, in the merge order below rather than the suggested rebase order:
+
+| Wave | Scope | PR |
+|---|---|---|
+| A | Financial | #252 |
+| D | Engineering | #253 |
+| E | Modern text + array shaping | #254 |
+| F | Date/time + misc | #255 |
+| B | Statistical, modern dotted set | #256 |
+| C | Regression & descriptive statistics | #257 |
+
+Waves B and C both landed in `Statistical.cs` as the coordination note anticipated, and B's
+distributions were split into their own `Distributions.cs` alongside a `SampleStatistics.cs` helper
+that C reuses.
+
+**Optional wave A2 was not done.** The day-count-basis functions the spec carved out as a separate
+optional chunk — PRICE, YIELD, DURATION, MDURATION, ACCRINT and the COUP\* family — are still
+unregistered, since they need a 30/360 and actual/actual basis engine that nothing else requires.
+That remains available as a self-contained follow-on.

--- a/docs/specs/09-threaded-comments-roundtrip.md
+++ b/docs/specs/09-threaded-comments-roundtrip.md
@@ -3,7 +3,7 @@
 **Area:** Feature + Compatibility
 **Effort:** M (1–2 weeks)
 **Dependencies:** None.
-**Status:** Implemented — see [Implementation notes](#implementation-notes)
+**Status:** ✅ Implemented in PR #258 — see [Implementation notes](#implementation-notes)
 
 ## Summary
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -12,13 +12,13 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 |---|------|------|--------|--------|-----------------|
 | 01 | [Streaming write API](01-streaming-write-api.md) | Feature · Arch · Memory | L | Proposed | Phase 1 refactor first, then independent |
 | 02 | [Load-path allocation elimination](02-load-path-allocations.md) | Perf (read) | M | ✅ **Done** (#175) | 3 independent sub-tasks |
-| 03 | [Save-path allocation reduction](03-save-path-allocations.md) | Perf (write) | M | Proposed | 7 small independent PRs |
+| 03 | [Save-path allocation reduction](03-save-path-allocations.md) | Perf (write) | M | In progress (see Results) | 7 small independent PRs |
 | 04 | [Demand-driven formula evaluation](04-demand-driven-formula-eval.md) | Perf · Arch | L | Proposed | Single owner (correctness-critical) |
 | 05 | [Structural-edit & bulk-style scalability](05-structural-edit-scalability.md) | Arch · Perf | L | Proposed | 3 independent workstreams |
-| 06 | [Workbook encryption (password files)](06-workbook-encryption.md) | Feature · Compat | L | Proposed | Container/crypto layers in parallel |
-| 07 | [Formula function coverage (257→~420)](07-formula-function-coverage.md) | Feature | L | Proposed | **6 fully independent waves** |
+| 06 | [Workbook encryption (password files)](06-workbook-encryption.md) | Feature · Compat | L | ✅ **Done** (#245) | Container/crypto layers in parallel |
+| 07 | [Formula function coverage (257→~420)](07-formula-function-coverage.md) | Feature | L | ✅ **Waves A–F done** (#252–#257) | **6 fully independent waves** |
 | 08 | [LET / LAMBDA](08-let-lambda.md) | Feature | L | Proposed | Single owner (engine core) |
-| 09 | [Threaded comments + round-trip fidelity](09-threaded-comments-roundtrip.md) | Feature · Compat | M | Proposed | Comments vs fidelity-audit split |
+| 09 | [Threaded comments + round-trip fidelity](09-threaded-comments-roundtrip.md) | Feature · Compat | M | ✅ **Done** (#258) | Comments vs fidelity-audit split |
 | 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | ✅ **Done** (PRs 1–4) | 4 PRs, 2–3 independent |
 | 11 | [Create-path allocation reduction](11-create-path-allocations.md) | Perf (write) | M | ✅ **Tasks 1–4 done** | Task 4 lands in 11; 05 rebases |
 
@@ -44,9 +44,9 @@ their 2D group elements, so XLibur's own 3D charts round-trip as 2D.
 
 **Performance (specs 02, 03, 04, 05).** The write cell-loop and the sheetData parse have both had a round of tuning; what remains, in measured order: per-cell string allocations on load (`<v>` + attributes + SST DOM), the ~543 MB formatted save (number formatting, inherited-style resolution, StyleKey hashing), the full-workbook-recalc cliff when reading one dirty formula cell (can build a 176 MB dependency tree to answer one read), and O(all-ranges·log) work per single row insert. Specs 02–05 attack each with concrete targets.
 
-**Features (specs 01, 07, 08, 10).** The fork already leads upstream on charts, dynamic arrays, in-cell images, sparklines, WebP/SVG. The gaps that matter: no bounded-memory export path for huge files (01), ~250 missing formula functions with a clean registry to extend (07), no LET/LAMBDA (08 — the one function family that needs engine work), and charts that couldn't be styled (10 — depth on the flagship differentiator, now done).
+**Features (specs 01, 07, 08, 10).** The fork already leads upstream on charts, dynamic arrays, in-cell images, sparklines, WebP/SVG. The gaps that matter: no bounded-memory export path for huge files (01 — still open), ~250 missing formula functions with a clean registry to extend (07 — waves A–F now done; only the optional day-count-basis set A2 remains), no LET/LAMBDA (08 — still open, the one function family that needs engine work), and charts that couldn't be styled (10 — depth on the flagship differentiator, now done).
 
-**Compatibility (specs 06, 09).** Password-encrypted files can't be opened or written at all (06 — hard blocker, zero code exists). Threaded comments are read lossily and silently downgraded on save; chartsheets, form controls, and slicers are dropped on round-trip (09).
+**Compatibility (specs 06, 09).** Both are now done. Password-encrypted files could not be opened or written at all — 06 added agile read/write and standard read (#245). Threaded comments were read lossily and downgraded on save — 09 gave them a real model and a write path (#258). 09's fidelity audit also **disproved its own premise**: chartsheets, form controls and slicers are *not* dropped on round-trip, because saving reopens the original package and rewrites only the parts XLibur models. See `docs/round-trip-fidelity.md`, which pins that behaviour with tests so a future rewrite cannot silently regress it.
 
 **Architecture (specs 01, 04, 05).** The three structural debts the surveys flagged: no streaming seam in the IO layer, calc-engine all-or-nothing recalculation, and materialize-everything patterns for range shift and style propagation (plus two redundant spatial indexes — QuadTree and RBush).
 
@@ -54,13 +54,17 @@ their 2D group elements, so XLibur's own 3D charts round-trip as 2D.
 
 ```
 Wave 1 (independent, start anytime):
-  02 load allocations ✅ done · 03 save allocations · 07 function waves A–F · 09 threaded comments
+  02 load allocations ✅ done · 03 save allocations (in progress) · 07 function waves A–F ✅ done
+  09 threaded comments ✅ done
   11 Tasks 1–4 ✅ done (−28.8% on the write benchmark; bulk styling −86% per cell)
 Wave 2 (after 03 lands, or coordinated):
-  01 streaming write (Phase 1 seam shared with 03's territory) · 06 encryption
-  10 charts ✅ done (PRs 1–4: series formatting, data labels, legend/axes, reader gaps)
+  01 streaming write (Phase 1 seam shared with 03's territory)
+  06 encryption ✅ done · 10 charts ✅ done (PRs 1–4: series formatting, data labels, legend/axes, reader gaps)
 Wave 3 (single-owner, correctness-critical — don't parallelize internally):
   04 demand-driven eval · 05 structural edits · 08 LET/LAMBDA (08 after or alongside 04)
+
+Remaining open work: 01 streaming write, 03 (finish), 04 demand-driven eval, 05 structural edits,
+08 LET/LAMBDA, plus the optional 07 wave A2 (day-count-basis financial functions).
 ```
 
 **Read spec 02's Results section before starting 03** — it corrects 03's number-formatting task


### PR DESCRIPTION
## Summary

Three specs had shipped but were still marked `Proposed`. This refreshes their status, and fixes two pieces of roadmap prose that had become actively wrong — which matters because `docs/specs/README.md` instructs implementing agents to verify specs against current code.

## Status changes

| Spec | Was | Now | Evidence |
|---|---|---|---|
| 06 Workbook encryption | Proposed | ✅ Done | #245, tests #246, guide #249 |
| 07 Formula coverage | Proposed | ✅ Waves A–F done | #252–#257 |
| 09 Threaded comments | Implemented | ✅ Done (#258) | tick + PR number, for consistency with 02/10/11 |

`README.md`'s table, the "why these ten" prose, and the sequencing block are updated to match.

## Verified, not assumed

Every spec was checked against the code, including the ones left alone:

- **01** — no streaming writer exists
- **04** — no demand-driven evaluation
- **08** — no `LET`/`LAMBDA` registered
- **05** — the specific hotspots it names are still there (`_rangeRepository` materialise-and-sort at `XLWorksheet.cs:1239/1275`, `GetChildrenRecursively` at `XLStylizedBase.cs:119/201`)
- **03** — already `In progress` in its own file while the README said `Proposed`; the README now follows the file

## Two corrections beyond the status lines

**Spec 06 said "zero encryption code exists in the repo today."** The historical problem statement is preserved but marked as describing the pre-implementation codebase, with a note on what shipped against the scope table.

It also records the **CFB layer decision**: the design recommended an in-house CFB reader/writer and made acceptance criterion 4 *"no new NuGet dependency without maintainer license sign-off."* The implementation took `OpenMcdf 3.1.4` instead. That sign-off was given — MPL-2.0 is file-level copyleft and imposes no obligation on MIT code consuming it as an unmodified package dependency — so criterion 4 is **met**, and the in-house CFB recommendation is closed as not-taken rather than left outstanding. The spec now says so, instead of the decision living only in `XLibur.csproj`.

**The README claimed chartsheets, form controls and slicers are dropped on round-trip.** Spec 09's fidelity audit disproved that: saving reopens the original package and rewrites only the parts XLibur models, so unmodelled parts pass through. The paragraph now says so and points at `docs/round-trip-fidelity.md`, which pins the behaviour with tests.

## Also recorded

Spec 07's optional **wave A2** (PRICE, YIELD, DURATION, MDURATION, ACCRINT, COUP\*) is marked not done — confirmed none are registered. It stays available as a self-contained follow-on, since it needs a 30/360 and actual/actual basis engine nothing else requires.

## Testing

Documentation only — no code changes, nothing to build or test.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
