### PR TITLE
feat(streaming): forward-only write API for large workbooks (spec 01)

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -351,9 +351,16 @@ formatted into a reusable `char[]` buffer, so the loop allocates nothing per cel
 `XLWorkbook` materialises the whole workbook before saving, so the in-memory model
 — not the serializer — is the ceiling on export size. `XLStreamingWorkbook` is a
 separate, append-only writer for that case: rows are serialised into the package as
-they arrive, so memory does not grow with row count.
+they arrive, so nothing is retained per row.
 
-```
+Memory is flat in the number of *rows*, but not unconditionally flat. Under the
+default `SharedStrings` mode each distinct string is held until `Finish()`, so cost
+tracks the *cardinality of distinct text values* — a million rows of repeating
+labels is cheap, a million distinct ones is not. `XLStreamingStringStorage.Inline`
+removes that term entirely at the cost of a larger file. Measured at 1M × 10 with
+every row carrying a distinct string: 108 MB shared, 14 MB inline.
+
+```text
 XLStreamingWorkbook ──> StreamingPackageWriter ──> ZipArchive (Create mode)
    │                          │
    │  XLStreamingWorksheet ───┘  one part at a time, streamed

--- a/Architecture.md
+++ b/Architecture.md
@@ -336,19 +336,60 @@ SaveAs(path) / Save()
 
 **Streaming `<sheetData>` with raw `XmlWriter`:**
 
-`SheetDataWriter.StreamSheetData(...)` is the performance-critical hot path. It
-bypasses the OpenXML SDK's `OpenXmlPartWriter` by extracting the underlying
-`XmlWriter` via reflection and writing `<row>` / `<c>` elements directly:
+`SheetDataWriter.StreamSheetData(...)` is the performance-critical hot path.
+`WorksheetPartWriter` builds a detached OpenXML DOM for everything *except*
+`<sheetData>`, then re-emits it through its own `XmlWriter` over the part stream,
+splicing in the streaming writer where `<sheetData>` belongs. Walking the source
+DOM by top-level child this way avoids `OpenXmlPartWriter`'s element-wrapping
+ceremony in the hot path without reaching into its private state via reflection.
 
-```csharp
-// Steal the XmlWriter from OpenXmlPartWriter for raw streaming
-var xml = (XmlWriter)XmlWriterFieldInfo.GetValue(writer)!;
-xml.WriteStartElement("sheetData", Main2006SsNs);
+This avoids creating OpenXML DOM objects for every cell. Cell references are
+formatted into a reusable `char[]` buffer, so the loop allocates nothing per cell.
+
+### Forward-Only Writing (`XLibur.Excel.Streaming`)
+
+`XLWorkbook` materialises the whole workbook before saving, so the in-memory model
+— not the serializer — is the ceiling on export size. `XLStreamingWorkbook` is a
+separate, append-only writer for that case: rows are serialised into the package as
+they arrive, so memory does not grow with row count.
+
+```
+XLStreamingWorkbook ──> StreamingPackageWriter ──> ZipArchive (Create mode)
+   │                          │
+   │  XLStreamingWorksheet ───┘  one part at a time, streamed
+   │  XLStreamingRow            (ref struct; no per-row allocation)
+   │
+   ├─ StreamingStyleTable       XLStyleValue → cellXf index, intern order
+   └─ StreamingSharedStringTable  dense ids, no refcounting
 ```
 
-This avoids the overhead of creating OpenXML DOM objects for every cell and
-enables streaming writes with minimal allocations. Cell references are formatted
-into a reusable `char[]` buffer.
+Three things distinguish it from the normal save path:
+
+1. **It owns its zip.** `System.IO.Packaging` opens packages read/write, which is
+   `ZipArchiveMode.Update`, and that buffers every part's *uncompressed* bytes
+   until the archive closes — the memory ceiling this API exists to remove. So the
+   OPC package (content types, relationships, workbook, worksheets, styles, shared
+   strings) is assembled directly over `ZipArchiveMode.Create`. Consequences: the
+   output stream need not be seekable, `CompressionLevel` is available, and
+   `[Content_Types].xml` is written last since nothing can be revisited.
+
+2. **Style and string ids are inputs, not outputs.** A cell's style id is fixed
+   when the cell is written, long before the styles part exists. So
+   `WorkbookStylesPartWriter.GenerateStreamingContent` emits one `cellXf` per
+   interned style *in intern order*, with no dedup and no remap — index *i* is the
+   *i*-th style by construction. Shared strings are dense for the same reason,
+   unlike the refcounted `SharedStringTable`, whose gaps need an `SstMap` remap.
+
+3. **Only the leaves are shared with `SheetDataWriter`.** `CellXmlWriter` holds the
+   row/cell XML primitives both writers use. The enumeration itself is *not*
+   abstracted: `SheetDataWriter`'s loop is a single pass over a struct slice
+   enumerator with no per-cell allocation, and routing it through a row/cell
+   interface wide enough for the streaming side would cost a virtual call per cell.
+
+Value-driven style rules (a date needs number format 14/22, a duration 46, a
+quote-prefixed or multi-line text value needs style flags) live in
+`XLValueStyleRules`, shared between the cell setter and the streaming writer so a
+streamed date round-trips as a date rather than as a number.
 
 ---
 
@@ -638,7 +679,7 @@ XLibur/
     ├── Exceptions/            — Domain-specific exceptions
     ├── Hyperlinks/            — Cell/range hyperlinks
     ├── InsertData/            — Bulk data insertion helpers
-    ├── IO/                    — 42 reader/writer files (the full IO layer)
+    ├── IO/                    — 43 reader/writer files (the full IO layer)
     ├── Misc/                  — Helper types
     ├── PageSetup/             — Print settings, margins, headers/footers
     ├── Patterns/              — Pattern matching utilities
@@ -650,6 +691,7 @@ XLibur/
     ├── RichText/              — XLImmutableRichText, rich text formatting
     ├── Rows/                  — XLRow, XLRows
     ├── Sparkline/             — Sparkline support
+    ├── Streaming/             — XLStreamingWorkbook, forward-only write path
     ├── Style/                 — XLStyleValue, keys, deferred styles, colors
     │   └── Colors/            — XLColor, theme colors, indexed colors
     └── Tables/                — XLTable, structured references, table fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,11 @@
 
 #### Writing large files
 
-- **Streaming write API (`XLStreamingWorkbook`)**: a forward-only writer for exports too large to hold in memory. Rows are serialised straight into the file as they are appended, so memory stays flat regardless of row count — a million rows by ten columns costs about 108 MB of peak managed heap, against roughly 1.3 GB extrapolated for the same data through `XLWorkbook`. On the 50K-row benchmark it is also 1.6× faster than `XLWorkbook` and allocates a fifth as much.
+- **Streaming write API (`XLStreamingWorkbook`)**: a forward-only writer for exports too large to hold in memory. Rows are serialised straight into the file as they are appended, so nothing is retained per row — a million rows by ten columns costs about 108 MB of peak managed heap, where `XLWorkbook` needs roughly that much for a *tenth* as many rows. On the 50K-row benchmark it is also 1.6× faster than `XLWorkbook` and allocates a fifth as much.
 
   ```csharp
+  using XLibur.Excel.Streaming;
+
   using var workbook = XLStreamingWorkbook.Create("Large.xlsx");
   var sheet = workbook.AddWorksheet("Data");
   sheet.FreezeRows(1);
@@ -47,7 +49,7 @@
 
   The trade is that it is append-only: rows go in ascending order, one worksheet at a time, nothing can be read back or revised, and formulas are stored verbatim rather than evaluated. Streamed sheets support column widths, freeze panes, an autofilter range, row and per-cell styles, and formulas with cached values. Anything beyond that — tables, merges, conditional formats, pivot tables, drawings — still needs `XLWorkbook`.
 
-  Distinct strings accumulate in a shared string table until `Finish()`, the one part of a streaming write proportional to the data. `XLStreamingStringStorage.Inline` removes that at the cost of a larger file, and takes the million-row case from 108 MB to 14 MB.
+  Memory is flat in the number of rows, but not unconditionally flat: under the default `SharedStrings` mode each distinct string is held until `Finish()`, so cost tracks how many *distinct* text values there are rather than how many rows. A million rows of repeating labels is cheap; a million distinct ones is not. `XLStreamingStringStorage.Inline` removes that term entirely at the cost of a larger file, and takes the worst case — every row carrying a distinct string — from 108 MB to 14 MB.
 
   Because the writer assembles the package itself rather than going through `System.IO.Packaging`, the destination stream does not have to be seekable — a workbook can be written straight to an HTTP response, which `XLWorkbook.SaveAs` cannot do. ([#263](https://github.com/XLibur/XLibur/pull/263) by [@jafin](https://github.com/jafin))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,9 @@
 
   Distinct strings accumulate in a shared string table until `Finish()`, the one part of a streaming write proportional to the data. `XLStreamingStringStorage.Inline` removes that at the cost of a larger file, and takes the million-row case from 108 MB to 14 MB.
 
-  Because the writer assembles the package itself rather than going through `System.IO.Packaging`, the destination stream does not have to be seekable — a workbook can be written straight to an HTTP response, which `XLWorkbook.SaveAs` cannot do.
+  Because the writer assembles the package itself rather than going through `System.IO.Packaging`, the destination stream does not have to be seekable — a workbook can be written straight to an HTTP response, which `XLWorkbook.SaveAs` cannot do. ([#263](https://github.com/XLibur/XLibur/pull/263) by [@jafin](https://github.com/jafin))
 
-- **`SaveOptions.CompressionLevel`**: choose how hard the package is compressed on an ordinary save. `CompressionLevel.Fastest` trades a larger file for a quicker save, `NoCompression` skips it entirely. Applies to parts the save creates; re-saving a workbook loaded from an existing file leaves its existing parts alone. `XLStreamingOptions.CompressionLevel` does the same for streamed writes, where `Fastest` is about 1.7× quicker than the default.
+- **`SaveOptions.CompressionLevel`**: choose how hard the package is compressed on an ordinary save. `CompressionLevel.Fastest` trades a larger file for a quicker save, `NoCompression` skips it entirely. Applies to parts the save creates; re-saving a workbook loaded from an existing file leaves its existing parts alone. `XLStreamingOptions.CompressionLevel` does the same for streamed writes, where `Fastest` is about 1.7× quicker than the default. ([#263](https://github.com/XLibur/XLibur/pull/263) by [@jafin](https://github.com/jafin))
 
 #### Formula functions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,30 @@
 
 ### ✨ New Features
 
+#### Writing large files
+
+- **Streaming write API (`XLStreamingWorkbook`)**: a forward-only writer for exports too large to hold in memory. Rows are serialised straight into the file as they are appended, so memory stays flat regardless of row count — a million rows by ten columns costs about 108 MB of peak managed heap, against roughly 1.3 GB extrapolated for the same data through `XLWorkbook`. On the 50K-row benchmark it is also 1.6× faster than `XLWorkbook` and allocates a fifth as much.
+
+  ```csharp
+  using var workbook = XLStreamingWorkbook.Create("Large.xlsx");
+  var sheet = workbook.AddWorksheet("Data");
+  sheet.FreezeRows(1);
+  sheet.AppendRow("Name", "Amount");
+
+  for (var i = 0; i < 1_000_000; i++)
+      sheet.AppendRow($"Item {i}", i * 1.5);
+
+  workbook.Finish();   // required — disposing without it abandons the write
+  ```
+
+  The trade is that it is append-only: rows go in ascending order, one worksheet at a time, nothing can be read back or revised, and formulas are stored verbatim rather than evaluated. Streamed sheets support column widths, freeze panes, an autofilter range, row and per-cell styles, and formulas with cached values. Anything beyond that — tables, merges, conditional formats, pivot tables, drawings — still needs `XLWorkbook`.
+
+  Distinct strings accumulate in a shared string table until `Finish()`, the one part of a streaming write proportional to the data. `XLStreamingStringStorage.Inline` removes that at the cost of a larger file, and takes the million-row case from 108 MB to 14 MB.
+
+  Because the writer assembles the package itself rather than going through `System.IO.Packaging`, the destination stream does not have to be seekable — a workbook can be written straight to an HTTP response, which `XLWorkbook.SaveAs` cannot do.
+
+- **`SaveOptions.CompressionLevel`**: choose how hard the package is compressed on an ordinary save. `CompressionLevel.Fastest` trades a larger file for a quicker save, `NoCompression` skips it entirely. Applies to parts the save creates; re-saving a workbook loaded from an existing file leaves its existing parts alone. `XLStreamingOptions.CompressionLevel` does the same for streamed writes, where `Fastest` is about 1.7× quicker than the default.
+
 #### Formula functions
 
 - **Regression and descriptive statistics — 23 functions**: `LINEST`, `LOGEST`, `TREND`, `GROWTH`, `FREQUENCY`, `FORECAST`, `FORECAST.LINEAR`, `CORREL`, `PEARSON`, `COVARIANCE.P`, `COVARIANCE.S`, `COVAR`, `SLOPE`, `INTERCEPT`, `RSQ`, `STEYX`, `SKEW`, `SKEW.P`, `KURT`, `PROB`, `TRIMMEAN`, `HARMEAN` and `AVEDEV`. The five array-returning ones spill.

--- a/XLibur.Benchmarks/Program.cs
+++ b/XLibur.Benchmarks/Program.cs
@@ -11,12 +11,15 @@ SixLaborsV1FontBootstrap.Register();
 if (args.Length > 0 && args[0].Equals("profile", StringComparison.OrdinalIgnoreCase))
 {
     // "profile alloc" is a fast, GC-exact allocation report for the save path, split into
-    // create/save phases; "profile create" breaks the create phase down per API call.
-    // The other modes attach dotMemory and target the load path.
+    // create/save phases; "profile create" breaks the create phase down per API call;
+    // "profile streaming [rows]" reports peak heap for the forward-only writer against the
+    // in-memory model. The other modes attach dotMemory and target the load path.
     if (args.Length > 1 && args[1].Equals("alloc", StringComparison.OrdinalIgnoreCase))
         SaveAllocationProfile.Run();
     else if (args.Length > 1 && args[1].Equals("create", StringComparison.OrdinalIgnoreCase))
         CreatePhaseProbe.Run();
+    else if (args.Length > 1 && args[1].Equals("streaming", StringComparison.OrdinalIgnoreCase))
+        StreamingMemoryProfile.Run(args);
     else
         MemoryProfile.Run(args);
 

--- a/XLibur.Benchmarks/StreamingWriteBenchmarks.cs
+++ b/XLibur.Benchmarks/StreamingWriteBenchmarks.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.IO.Compression;
 using BenchmarkDotNet.Attributes;
@@ -144,7 +144,12 @@ public static class StreamingMemoryProfile
                 }
 
                 peak = Math.Max(peak, GC.GetTotalMemory(forceFullCollection: false));
+
+                // Finish() serialises the shared string table, which under SharedStrings is the
+                // largest live structure of the whole write - sampling before it would report a
+                // peak that excludes the most expensive moment.
                 workbook.Finish();
+                peak = Math.Max(peak, GC.GetTotalMemory(forceFullCollection: false));
             }
 
             var elapsed = DateTime.UtcNow - start;

--- a/XLibur.Benchmarks/StreamingWriteBenchmarks.cs
+++ b/XLibur.Benchmarks/StreamingWriteBenchmarks.cs
@@ -1,0 +1,211 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using BenchmarkDotNet.Attributes;
+using XLibur.Excel;
+using XLibur.Excel.Streaming;
+using XLibur.Fonts.SixLabors.V1;
+
+namespace XLibur.Benchmarks;
+
+/// <summary>
+/// The forward-only writer on the same 50K x 3 workload as
+/// <see cref="XLiburWorkbookBenchmarks.CreateAndSave"/> and
+/// <see cref="OpenXmlWorkbookBenchmarks.CreateAndSave"/>, so the three are directly comparable
+/// in the joined summary: the in-memory model, the streaming writer, and the raw OpenXML SDK
+/// floor.
+/// </summary>
+/// <remarks>
+/// Peak memory is what this API is for, and 50K rows is far too small to show it - a workload
+/// that fits comfortably in memory cannot demonstrate bounded memory. That measurement lives in
+/// <see cref="StreamingMemoryProfile"/>, at a million rows.
+/// </remarks>
+[MemoryDiagnoser]
+[Config(typeof(JoinSummaryConfig))]
+public class StreamingWriteBenchmarks
+{
+    private const int RowCount = 50_000;
+
+    private BenchmarkData _data = null;
+    private string[] _strings = null;
+    private double[] _numbers = null;
+    private DateTime[] _dates = null;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        SixLaborsV1FontBootstrap.Register();
+        _data = BenchmarkData.Create(RowCount);
+        _strings = _data.Strings;
+        _numbers = _data.Numbers;
+        _dates = _data.Dates;
+    }
+
+    [Benchmark(Baseline = true)]
+    public void StreamingWrite() => Write(new XLStreamingOptions());
+
+    [Benchmark]
+    public void StreamingWriteInlineStrings() =>
+        Write(new XLStreamingOptions { StringStorage = XLStreamingStringStorage.Inline });
+
+    [Benchmark]
+    public void StreamingWriteFastestCompression() =>
+        Write(new XLStreamingOptions { CompressionLevel = CompressionLevel.Fastest });
+
+    private void Write(XLStreamingOptions options)
+    {
+        using var stream = new MemoryStream();
+        using var workbook = XLStreamingWorkbook.Create(stream, options);
+
+        var sheet = workbook.AddWorksheet("Data");
+        sheet.AppendRow("Name", "Amount", "Date");
+
+        for (var i = 0; i < RowCount; i++)
+            sheet.AppendRow(_strings[i], _numbers[i], _dates[i]);
+
+        using (var row = sheet.AddRow())
+        {
+            row.Cell("Total");
+            row.Formula($"SUM(B2:B{RowCount + 1})");
+        }
+
+        workbook.Finish();
+    }
+}
+
+/// <summary>
+/// The acceptance measurement for the streaming writer: a million rows of ten columns, written
+/// to disk, reporting peak managed heap alongside what the in-memory model costs for the same
+/// data.
+/// </summary>
+/// <remarks>
+/// Run with: <c>dotnet run -c Release -- profile streaming [rowCount]</c>.
+/// Not a BenchmarkDotNet benchmark - peak heap over one long run is the quantity of interest,
+/// not a distribution over many short ones, and running the in-memory comparison under BDN
+/// would mean holding a multi-gigabyte workbook through the warmup iterations too.
+/// </remarks>
+public static class StreamingMemoryProfile
+{
+    private const int DefaultRowCount = 1_000_000;
+    private const int ColumnCount = 10;
+
+    public static void Run(string[] args)
+    {
+        SixLaborsV1FontBootstrap.Register();
+
+        var rowCount = args.Length > 2 && int.TryParse(args[2], out var parsed) ? parsed : DefaultRowCount;
+        Console.WriteLine($"Streaming write: {rowCount:N0} rows x {ColumnCount} cols");
+        Console.WriteLine();
+
+        MeasureStreaming(rowCount, new XLStreamingOptions(), "XLStreamingWorkbook (shared strings)");
+
+        // Every row here carries a distinct string, which is the worst case for the shared
+        // string table and the one case where a streaming write is not flat in memory. Inline
+        // storage is the documented escape hatch; measuring both makes the trade concrete.
+        MeasureStreaming(rowCount,
+            new XLStreamingOptions { StringStorage = XLStreamingStringStorage.Inline },
+            "XLStreamingWorkbook (inline strings)");
+
+        // The in-memory comparison is run at a tenth of the size: XLWorkbook needs roughly a
+        // gigabyte per 400K rows at this width, so the full run would page or die on most
+        // machines - which is the entire point of the exercise.
+        var comparisonRows = Math.Max(1, rowCount / 10);
+        Console.WriteLine();
+        Console.WriteLine($"For comparison, XLWorkbook at {comparisonRows:N0} rows (a tenth of the size):");
+        MeasureInMemory(comparisonRows);
+    }
+
+    private static void MeasureStreaming(int rowCount, XLStreamingOptions options, string label)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"xlibur-streaming-profile-{Guid.NewGuid():N}.xlsx");
+        try
+        {
+            ForceGc();
+            var baseline = GC.GetTotalMemory(forceFullCollection: true);
+            var start = DateTime.UtcNow;
+
+            long peak;
+            using (var workbook = XLStreamingWorkbook.Create(path, options))
+            {
+                var sheet = workbook.AddWorksheet("Data");
+                var values = new XLCellValue[ColumnCount];
+
+                peak = baseline;
+                for (var r = 0; r < rowCount; r++)
+                {
+                    values[0] = $"Item {r}";
+                    for (var c = 1; c < ColumnCount; c++)
+                        values[c] = r * ColumnCount + c;
+
+                    sheet.AppendRow(values, null);
+
+                    if (r % 100_000 == 0)
+                        peak = Math.Max(peak, GC.GetTotalMemory(forceFullCollection: false));
+                }
+
+                peak = Math.Max(peak, GC.GetTotalMemory(forceFullCollection: false));
+                workbook.Finish();
+            }
+
+            var elapsed = DateTime.UtcNow - start;
+            var fileSize = new FileInfo(path).Length;
+
+            Report(label, peak - baseline, elapsed, fileSize);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static void MeasureInMemory(int rowCount)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"xlibur-inmemory-profile-{Guid.NewGuid():N}.xlsx");
+        try
+        {
+            ForceGc();
+            var baseline = GC.GetTotalMemory(forceFullCollection: true);
+            var start = DateTime.UtcNow;
+
+            long peak;
+            using (var workbook = new XLWorkbook())
+            {
+                var sheet = workbook.AddWorksheet("Data");
+                for (var r = 0; r < rowCount; r++)
+                {
+                    sheet.Cell(r + 1, 1).Value = $"Item {r}";
+                    for (var c = 1; c < ColumnCount; c++)
+                        sheet.Cell(r + 1, c + 1).Value = r * ColumnCount + c;
+                }
+
+                peak = GC.GetTotalMemory(forceFullCollection: false);
+                workbook.SaveAs(path);
+                peak = Math.Max(peak, GC.GetTotalMemory(forceFullCollection: false));
+            }
+
+            var elapsed = DateTime.UtcNow - start;
+            var fileSize = new FileInfo(path).Length;
+
+            Report("XLWorkbook", peak - baseline, elapsed, fileSize);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static void Report(string label, long peakBytes, TimeSpan elapsed, long fileSize)
+    {
+        Console.WriteLine($"  {label}");
+        Console.WriteLine($"    peak managed heap : {peakBytes / 1024.0 / 1024.0,8:F1} MB");
+        Console.WriteLine($"    elapsed           : {elapsed.TotalSeconds,8:F2} s");
+        Console.WriteLine($"    file size         : {fileSize / 1024.0 / 1024.0,8:F1} MB");
+    }
+
+    private static void ForceGc()
+    {
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+    }
+}

--- a/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
+++ b/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -66,6 +66,85 @@ public class StreamingWriteTests
         await Assert.That(ws.Cell("B2").FormulaA1).IsEqualTo("A1&\"x\"");
         await Assert.That(ws.Cell("B2").CachedValue).IsEqualTo((XLCellValue)"2x");
         await Assert.That(ws.Cell("C2").FormulaA1).IsEqualTo("A1>B1");
+    }
+
+    /// <summary>
+    /// A cached date is stored as a serial number just like a literal one, so it needs the same
+    /// number format or it reads back as a plain number.
+    /// </summary>
+    [Test]
+    public async Task FormulaCachedDatesAndDurationsRoundTripAsSuchTypes()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Cached");
+            using (var row = sheet.AddRow())
+            {
+                row.Formula("TODAY()", cachedValue: new DateTime(2026, 7, 27));
+                row.Formula("NOW()", cachedValue: new DateTime(2026, 7, 27, 13, 45, 0));
+                row.Formula("B1-A1", cachedValue: new TimeSpan(3, 30, 0));
+                row.Formula("1+1", cachedValue: 2.0);
+            }
+
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        var ws = loaded.Worksheet("Cached");
+
+        await Assert.That(ws.Cell("A1").CachedValue.Type).IsEqualTo(XLDataType.DateTime);
+        await Assert.That(ws.Cell("A1").CachedValue.GetDateTime()).IsEqualTo(new DateTime(2026, 7, 27));
+        await Assert.That(ws.Cell("B1").CachedValue.GetDateTime())
+            .IsEqualTo(new DateTime(2026, 7, 27, 13, 45, 0));
+        await Assert.That(ws.Cell("C1").CachedValue.Type).IsEqualTo(XLDataType.TimeSpan);
+        await Assert.That(ws.Cell("C1").CachedValue.GetTimeSpan()).IsEqualTo(new TimeSpan(3, 30, 0));
+
+        // A numeric cached value must not pick up a date format.
+        await Assert.That(ws.Cell("D1").CachedValue.Type).IsEqualTo(XLDataType.Number);
+    }
+
+    /// <summary>
+    /// A formula's computed text is the value itself, not something a user typed, so a leading
+    /// apostrophe must survive rather than being absorbed into a quote-prefix style.
+    /// </summary>
+    [Test]
+    public async Task FormulaCachedTextKeepsALeadingApostrophe()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Quoted");
+            sheet.AddRow().Formula("CHAR(39)&\"x\"", cachedValue: "'x");
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        await Assert.That(loaded.Worksheet("Quoted").Cell("A1").CachedValue.GetText()).IsEqualTo("'x");
+    }
+
+    [Test]
+    public async Task SharedStringTableReportsReferenceAndUniqueCounts()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Counts");
+            for (var i = 0; i < 5; i++)
+                sheet.AppendRow("repeated", "also repeated", i);
+
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var sst = doc.WorkbookPart!.SharedStringTablePart!.SharedStringTable;
+
+        // 10 text cells referencing 2 distinct strings.
+        await Assert.That(sst.Count!.Value).IsEqualTo(10U);
+        await Assert.That(sst.UniqueCount!.Value).IsEqualTo(2U);
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
+++ b/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
@@ -1,0 +1,638 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using XLibur.Excel;
+using XLibur.Excel.Streaming;
+
+namespace XLibur.Tests.Excel.Streaming;
+
+public class StreamingWriteTests
+{
+    #region Round-trip
+
+    [Test]
+    public async Task WritesEveryValueTypeSoItLoadsBack()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Data");
+            sheet.AppendRow("text", 42.5, true);
+            sheet.AppendRow(new DateTime(2026, 7, 27), new TimeSpan(1, 2, 3), XLError.DivisionByZero);
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        var ws = loaded.Worksheet("Data");
+
+        await Assert.That(ws.Cell("A1").Value).IsEqualTo((XLCellValue)"text");
+        await Assert.That(ws.Cell("B1").Value).IsEqualTo((XLCellValue)42.5);
+        await Assert.That(ws.Cell("C1").GetBoolean()).IsTrue();
+        await Assert.That(ws.Cell("A2").GetDateTime()).IsEqualTo(new DateTime(2026, 7, 27));
+        await Assert.That(ws.Cell("B2").GetTimeSpan()).IsEqualTo(new TimeSpan(1, 2, 3));
+        await Assert.That(ws.Cell("C2").Value).IsEqualTo((XLCellValue)XLError.DivisionByZero);
+    }
+
+    [Test]
+    public async Task PassesFormulaStringsThroughVerbatimWithCachedValues()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Calc");
+            sheet.AppendRow(2.0, 3.0);
+            using (var row = sheet.AddRow())
+            {
+                row.Formula("A1*B1", cachedValue: 6.0);
+                // The leading '=' a user would type is accepted and stripped.
+                row.Formula("=A1&\"x\"", cachedValue: "2x");
+                row.Formula("A1>B1");
+            }
+
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        var ws = loaded.Worksheet("Calc");
+
+        await Assert.That(ws.Cell("A2").FormulaA1).IsEqualTo("A1*B1");
+        await Assert.That(ws.Cell("A2").CachedValue).IsEqualTo((XLCellValue)6.0);
+        await Assert.That(ws.Cell("B2").FormulaA1).IsEqualTo("A1&\"x\"");
+        await Assert.That(ws.Cell("B2").CachedValue).IsEqualTo((XLCellValue)"2x");
+        await Assert.That(ws.Cell("C2").FormulaA1).IsEqualTo("A1>B1");
+    }
+
+    [Test]
+    public async Task RoundTripsRowAndCellStyles()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var header = wb.CreateStyle();
+            header.Font.Bold = true;
+
+            var money = wb.CreateStyle();
+            money.NumberFormat.Format = "#,##0.00";
+
+            var sheet = wb.AddWorksheet("Styled");
+            sheet.AppendRow(["Name", "Amount"], header);
+            using (var row = sheet.AddRow())
+            {
+                row.Cell("Widget");
+                row.Cell(1234.5, money);
+            }
+
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        var ws = loaded.Worksheet("Styled");
+
+        await Assert.That(ws.Cell("A1").Style.Font.Bold).IsTrue();
+        await Assert.That(ws.Cell("B1").Style.Font.Bold).IsTrue();
+        await Assert.That(ws.Cell("A2").Style.Font.Bold).IsFalse();
+        await Assert.That(ws.Cell("B2").Style.NumberFormat.Format).IsEqualTo("#,##0.00");
+    }
+
+    [Test]
+    public async Task DistinctStylesGetDistinctIdsInInternOrder()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Many");
+
+            // One style per row, each differing only in font size, to check that the id handed
+            // out while writing still selects the right cellXf once the styles part is written.
+            for (var i = 0; i < 20; i++)
+            {
+                var style = wb.CreateStyle();
+                style.Font.FontSize = 8 + i;
+                sheet.AppendRow([i], style);
+            }
+
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        var ws = loaded.Worksheet("Many");
+
+        for (var i = 0; i < 20; i++)
+            await Assert.That(ws.Cell(i + 1, 1).Style.Font.FontSize).IsEqualTo(8 + i);
+    }
+
+    [Test]
+    public async Task ReusesSharedStringsForRepeatedText()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Sst");
+            for (var i = 0; i < 50; i++)
+                sheet.AppendRow("repeated", "also repeated");
+
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using (var doc = SpreadsheetDocument.Open(ms, false))
+        {
+            var sst = doc.WorkbookPart!.SharedStringTablePart!.SharedStringTable;
+            await Assert.That(sst.Count()).IsEqualTo(2);
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        await Assert.That(loaded.Worksheet("Sst").Cell("A50").GetString()).IsEqualTo("repeated");
+    }
+
+    [Test]
+    public async Task InlineModeWritesNoSharedStringPart()
+    {
+        using var ms = new MemoryStream();
+        var options = new XLStreamingOptions { StringStorage = XLStreamingStringStorage.Inline };
+        using (var wb = XLStreamingWorkbook.Create(ms, options))
+        {
+            var sheet = wb.AddWorksheet("Inline");
+            sheet.AppendRow("alpha", "beta");
+            sheet.AppendRow("alpha", " leading space");
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using (var doc = SpreadsheetDocument.Open(ms, false))
+            await Assert.That(doc.WorkbookPart!.SharedStringTablePart).IsNull();
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        var ws = loaded.Worksheet("Inline");
+        await Assert.That(ws.Cell("A2").GetString()).IsEqualTo("alpha");
+        await Assert.That(ws.Cell("B2").GetString()).IsEqualTo(" leading space");
+    }
+
+    [Test]
+    public async Task SkippedRowsAndCellsLeaveGapsAtTheRightAddresses()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Gaps");
+            sheet.AppendRow("first");
+            sheet.SkipRows(3);
+            using (var row = sheet.AddRow())
+            {
+                row.Cell("a");
+                row.Skip(2);
+                row.Cell("d");
+                row.At(10).Cell("j");
+            }
+
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        var ws = loaded.Worksheet("Gaps");
+
+        await Assert.That(ws.Cell("A1").GetString()).IsEqualTo("first");
+        await Assert.That(ws.Cell("A5").GetString()).IsEqualTo("a");
+        await Assert.That(ws.Cell("B5").IsEmpty()).IsTrue();
+        await Assert.That(ws.Cell("D5").GetString()).IsEqualTo("d");
+        await Assert.That(ws.Cell("J5").GetString()).IsEqualTo("j");
+    }
+
+    [Test]
+    public async Task WritesMultipleWorksheetsInOrder()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            wb.AddWorksheet("First").AppendRow("one");
+            // The first sheet is completed implicitly by adding the second.
+            wb.AddWorksheet("Second").AppendRow("two");
+            wb.AddWorksheet("Third").AppendRow("three");
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+
+        await Assert.That(loaded.Worksheets.Count).IsEqualTo(3);
+        await Assert.That(loaded.Worksheets.Select(w => w.Name).ToArray())
+            .IsEquivalentTo(new[] { "First", "Second", "Third" });
+        await Assert.That(loaded.Worksheet("Second").Cell("A1").GetString()).IsEqualTo("two");
+    }
+
+    [Test]
+    public async Task WritesAnEmptyWorksheet()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            wb.AddWorksheet("Empty");
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        await Assert.That(loaded.Worksheet("Empty").LastCellUsed()).IsNull();
+    }
+
+    [Test]
+    public async Task WritesToAFilePath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"xlibur-streaming-{Guid.NewGuid():N}.xlsx");
+        try
+        {
+            using (var wb = XLStreamingWorkbook.Create(path))
+            {
+                wb.AddWorksheet("Sheet1").AppendRow("on disk");
+                wb.Finish();
+            }
+
+            using var loaded = new XLWorkbook(path);
+            await Assert.That(loaded.Worksheet("Sheet1").Cell("A1").GetString()).IsEqualTo("on disk");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    #endregion Round-trip
+
+    #region Sheet-level features
+
+    [Test]
+    public async Task RoundTripsColumnWidthsFreezePanesAndAutoFilter()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Layout");
+            sheet.Column(1).Width = 30;
+            sheet.Columns(2, 3).Hidden = true;
+            sheet.FreezeRows(1);
+            sheet.AutoFilterRange = "A1:C1";
+
+            sheet.AppendRow("Name", "Qty", "Note");
+            sheet.AppendRow("Widget", 1, "ok");
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        var ws = loaded.Worksheet("Layout");
+
+        await Assert.That(ws.Column(1).Width).IsEqualTo(30).Within(0.01);
+        await Assert.That(ws.Column(2).IsHidden).IsTrue();
+        await Assert.That(ws.Column(3).IsHidden).IsTrue();
+        await Assert.That(ws.SheetView.SplitRow).IsEqualTo(1);
+        await Assert.That(ws.AutoFilter.IsEnabled).IsTrue();
+    }
+
+    [Test]
+    public async Task RoundTripsRowHeightAndHiddenRows()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Rows");
+            sheet.AddRow(null, height: 40).Cell("tall");
+            sheet.AddRow(null, hidden: true).Cell("hidden");
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        var ws = loaded.Worksheet("Rows");
+
+        await Assert.That(ws.Row(1).Height).IsEqualTo(40).Within(0.01);
+        await Assert.That(ws.Row(2).IsHidden).IsTrue();
+    }
+
+    [Test]
+    public async Task FreezingBothAxesSetsBothSplits()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var sheet = wb.AddWorksheet("Panes");
+            sheet.FreezePanes(2, 1);
+            sheet.AppendRow("a", "b");
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        var view = loaded.Worksheet("Panes").SheetView;
+
+        await Assert.That(view.SplitRow).IsEqualTo(2);
+        await Assert.That(view.SplitColumn).IsEqualTo(1);
+    }
+
+    #endregion Sheet-level features
+
+    #region Package validity
+
+    [Test]
+    public async Task ProducesAPackageThatPassesOpenXmlValidation()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            var bold = wb.CreateStyle();
+            bold.Font.Bold = true;
+
+            var sheet = wb.AddWorksheet("Valid");
+            sheet.Column(1).Width = 25;
+            sheet.FreezeRows(1);
+            sheet.AutoFilterRange = "A1:C1";
+            sheet.AppendRow(["Name", "Qty", "When"], bold);
+            sheet.AppendRow("Widget", 3, new DateTime(2026, 1, 2));
+            using (var row = sheet.AddRow())
+            {
+                row.Cell("Total");
+                row.Formula("SUM(B2:B2)", cachedValue: 3.0);
+            }
+
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var errors = new OpenXmlValidator().Validate(doc).ToArray();
+        var message = string.Join("\r\n",
+            errors.Select(e => $"Part {e.Part?.Uri}, Path {e.Path?.XPath}: {e.Description}"));
+
+        await Assert.That(errors).IsEmpty().Because(message);
+    }
+
+    [Test]
+    public async Task ValidatesAnInlineStringPackage()
+    {
+        using var ms = new MemoryStream();
+        var options = new XLStreamingOptions { StringStorage = XLStreamingStringStorage.Inline };
+        using (var wb = XLStreamingWorkbook.Create(ms, options))
+        {
+            wb.AddWorksheet("Inline").AppendRow("alpha", 1, "beta");
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var errors = new OpenXmlValidator().Validate(doc).ToArray();
+
+        await Assert.That(errors).IsEmpty()
+            .Because(string.Join("\r\n", errors.Select(e => e.Description)));
+    }
+
+    #endregion Package validity
+
+    #region Memory
+
+    /// <summary>
+    /// The point of the whole API: resident memory must not grow with the number of rows.
+    /// </summary>
+    /// <remarks>
+    /// Runs at 100K x 10 rather than the spec's 1M x 10 so it stays a few seconds of CI time -
+    /// the 1M measurement lives in <c>StreamingWriteBenchmarks</c>. Scale is not what the test
+    /// proves anyway: what it proves is that the live heap after writing is flat, which fails
+    /// just as loudly at 100K if any per-row state is being retained. The equivalent
+    /// <see cref="XLWorkbook"/> would hold hundreds of MB of slices at this size.
+    ///
+    /// The bound is deliberately far above what is measured - retained growth is on the order of
+    /// tens of KB - so that JIT warmup on a cold CI agent cannot trip it, while still catching
+    /// the regression this guards against. Routing the package back through
+    /// <c>System.IO.Packaging</c>, which buffers every part uncompressed until close, put ~48 MB
+    /// on the heap at this size.
+    ///
+    /// Written to a temp file, not a MemoryStream, so the package itself is not counted as heap.
+    /// </remarks>
+    [Test]
+    public async Task StreamingAMillionCellsDoesNotGrowTheHeap()
+    {
+        const int rowCount = 100_000;
+        const int columnCount = 10;
+
+        var path = Path.Combine(Path.GetTempPath(), $"xlibur-streaming-mem-{Guid.NewGuid():N}.xlsx");
+        try
+        {
+            var baseline = GC.GetTotalMemory(forceFullCollection: true);
+            long liveAfterWrite;
+
+            using (var wb = XLStreamingWorkbook.Create(path))
+            {
+                var sheet = wb.AddWorksheet("Big");
+                var values = new XLCellValue[columnCount];
+
+                for (var r = 0; r < rowCount; r++)
+                {
+                    // A bounded set of distinct strings: an unbounded one would legitimately
+                    // grow the shared string dictionary, which is documented behaviour rather
+                    // than a leak.
+                    values[0] = $"row-kind-{r % 100}";
+                    for (var c = 1; c < columnCount; c++)
+                        values[c] = r * columnCount + c;
+
+                    sheet.AppendRow(values, null);
+                }
+
+                liveAfterWrite = GC.GetTotalMemory(forceFullCollection: true);
+                wb.Finish();
+            }
+
+            var growth = liveAfterWrite - baseline;
+            await Assert.That(growth).IsLessThan(16L * 1024 * 1024)
+                .Because($"streaming {rowCount:N0} x {columnCount} cells retained {growth / (1024 * 1024)} MB");
+
+            // ...and the file it produced is real.
+            using var loaded = new XLWorkbook(path);
+            var ws = loaded.Worksheet("Big");
+            await Assert.That(ws.Cell(rowCount, 1).GetString()).IsEqualTo($"row-kind-{(rowCount - 1) % 100}");
+            await Assert.That(ws.Cell(rowCount, columnCount).GetDouble())
+                .IsEqualTo((rowCount - 1) * columnCount + columnCount - 1);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// Owning the zip means the output is written strictly forwards, so it does not have to be
+    /// seekable - a workbook can go straight to a network stream. <see cref="XLWorkbook.SaveAs(Stream)"/>
+    /// cannot do this.
+    /// </summary>
+    [Test]
+    public async Task WritesToANonSeekableStream()
+    {
+        using var backing = new MemoryStream();
+        using (var forwardOnly = new ForwardOnlyStream(backing))
+        using (var wb = XLStreamingWorkbook.Create(forwardOnly))
+        {
+            wb.AddWorksheet("Piped").AppendRow("no seeking", 1);
+            wb.Finish();
+        }
+
+        backing.Position = 0;
+        using var loaded = new XLWorkbook(backing);
+        await Assert.That(loaded.Worksheet("Piped").Cell("A1").GetString()).IsEqualTo("no seeking");
+    }
+
+    [Test]
+    public async Task FastestCompressionProducesALargerFileThanOptimal()
+    {
+        var optimal = WriteSized(CompressionLevel.Optimal);
+        var fastest = WriteSized(CompressionLevel.Fastest);
+
+        await Assert.That(fastest).IsGreaterThan(optimal);
+
+        static long WriteSized(CompressionLevel level)
+        {
+            using var ms = new MemoryStream();
+            using (var wb = XLStreamingWorkbook.Create(ms, new XLStreamingOptions { CompressionLevel = level }))
+            {
+                var sheet = wb.AddWorksheet("Data");
+                for (var r = 0; r < 5_000; r++)
+                    sheet.AppendRow($"row {r}", r, r * 1.5, $"note for row {r}");
+
+                wb.Finish();
+            }
+
+            return ms.Length;
+        }
+    }
+
+    /// <summary>A write-only, non-seekable wrapper, standing in for a network stream.</summary>
+    private sealed class ForwardOnlyStream(Stream inner) : Stream
+    {
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => inner.Flush();
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+        public override void Write(ReadOnlySpan<byte> buffer) => inner.Write(buffer);
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
+    #endregion Memory
+
+    #region Misuse
+
+    [Test]
+    public async Task RejectsColumnConfigurationAfterTheFirstRow()
+    {
+        using var ms = new MemoryStream();
+        using var wb = XLStreamingWorkbook.Create(ms);
+        var sheet = wb.AddWorksheet("Late");
+        sheet.AppendRow("a");
+
+        await Assert.That(() => sheet.Column(1).Width = 10).Throws<InvalidOperationException>();
+        await Assert.That(() => sheet.FreezeRows(1)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task RejectsWritingToARowThatIsNoLongerOpen()
+    {
+        using var ms = new MemoryStream();
+        using var wb = XLStreamingWorkbook.Create(ms);
+        var sheet = wb.AddWorksheet("Stale");
+
+        var first = sheet.AddRow();
+        first.Cell("ok");
+        sheet.AddRow().Cell("second");
+
+        // A ref struct cannot be captured in a lambda, so the assertion is written out.
+        Exception caught = null;
+        try
+        {
+            first.Cell("too late");
+        }
+        catch (InvalidOperationException e)
+        {
+            caught = e;
+        }
+
+        await Assert.That(caught).IsNotNull();
+    }
+
+    [Test]
+    public async Task RejectsDuplicateSheetNames()
+    {
+        using var ms = new MemoryStream();
+        using var wb = XLStreamingWorkbook.Create(ms);
+        wb.AddWorksheet("Data");
+
+        await Assert.That(() => wb.AddWorksheet("data")).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task RejectsAddingWorksheetsAfterFinish()
+    {
+        using var ms = new MemoryStream();
+        using var wb = XLStreamingWorkbook.Create(ms);
+        wb.AddWorksheet("Data").AppendRow("a");
+        wb.Finish();
+
+        await Assert.That(() => wb.AddWorksheet("More")).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task FinishIsIdempotent()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = XLStreamingWorkbook.Create(ms))
+        {
+            wb.AddWorksheet("Data").AppendRow("a");
+            wb.Finish();
+            wb.Finish();
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        await Assert.That(loaded.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("a");
+    }
+
+    [Test]
+    public async Task RejectsWritingCellsToTheLeftOfThePosition()
+    {
+        using var ms = new MemoryStream();
+        using var wb = XLStreamingWorkbook.Create(ms);
+        var sheet = wb.AddWorksheet("Back");
+        var row = sheet.AddRow();
+        row.Cell("a").Cell("b").Cell("c");
+
+        Exception caught = null;
+        try
+        {
+            row.At(2);
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            caught = e;
+        }
+
+        await Assert.That(caught).IsNotNull();
+    }
+
+    #endregion Misuse
+}

--- a/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
+++ b/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
@@ -512,6 +512,38 @@ public class StreamingWriteTests
         }
     }
 
+    /// <summary>
+    /// The same knob on the ordinary save path, which reaches it through the SDK's
+    /// <c>OpenXmlPackage.CompressionOption</c> rather than by owning the zip.
+    /// </summary>
+    [Test]
+    public async Task SaveOptionsCompressionLevelChangesPackageSize()
+    {
+        var optimal = SaveSized(CompressionLevel.Optimal);
+        var none = SaveSized(CompressionLevel.NoCompression);
+
+        await Assert.That(none).IsGreaterThan(optimal);
+
+        static long SaveSized(CompressionLevel level)
+        {
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Data");
+                for (var r = 1; r <= 2_000; r++)
+                {
+                    ws.Cell(r, 1).Value = $"row {r}";
+                    ws.Cell(r, 2).Value = r;
+                    ws.Cell(r, 3).Value = $"note for row {r}";
+                }
+
+                wb.SaveAs(ms, new SaveOptions { CompressionLevel = level });
+            }
+
+            return ms.Length;
+        }
+    }
+
     /// <summary>A write-only, non-seekable wrapper, standing in for a network stream.</summary>
     private sealed class ForwardOnlyStream(Stream inner) : Stream
     {

--- a/XLibur/Excel/IO/CellXmlWriter.cs
+++ b/XLibur/Excel/IO/CellXmlWriter.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Xml;
+using XLibur.Extensions;
+using static XLibur.Excel.IO.OpenXmlConst;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Leaf-level <c>sheetData</c> XML primitives, shared by the two producers of that element:
+/// <see cref="SheetDataWriter"/>, which walks a fully materialised <see cref="XLWorksheet"/>,
+/// and the forward-only writer in <c>XLibur.Excel.Streaming</c>, whose enumeration is driven
+/// by the caller and has no slice storage to read from.
+/// </summary>
+/// <remarks>
+/// Only the leaves are shared. Neither producer's row/cell loop is expressed in terms of the
+/// other, deliberately: the worksheet loop is a single pass over a struct slice enumerator with
+/// no per-cell allocation, and routing it through a row/cell abstraction wide enough for the
+/// streaming side (formula, misc metadata, rich text, table-totals membership) would cost an
+/// interface dispatch per cell for no gain.
+/// </remarks>
+internal static class CellXmlWriter
+{
+    /// <summary>
+    /// Day offset between the 1900 and 1904 date systems used by Excel.
+    /// </summary>
+    internal const int Date1904OffsetDays = 1462;
+
+    /// <summary>
+    /// Enough to hold the longest cell reference (<c>XFD1048576</c>) as chars.
+    /// </summary>
+    internal const int CellRefBufferLength = 10;
+
+    /// <summary>
+    /// An array to convert data type for a formula cell. Key is <see cref="XLDataType"/>.
+    /// It saves some performance through direct indexation instead of switch.
+    /// </summary>
+    private static readonly string?[] FormulaDataType =
+    [
+        null, // blank
+        "b", // boolean
+        null, // number, default value, no need to save type
+        "str", // text, formula can only save this type, no inline or shared string
+        "e", // error
+        null, // datetime, saved as serialized date-time
+        null // timespan, saved as serialized date-time
+    ];
+
+    /// <summary>
+    /// An array to convert a data type for a cell that only contains a value. Key is <see cref="XLDataType"/>.
+    /// It saves some performance through direct indexation instead of switch.
+    /// </summary>
+    private static readonly string?[] ValueDataType =
+    [
+        null, // blank
+        "b", // boolean
+        null, // number, default value, no need to save type
+        "s", // text, the default is a shared string, but there also can be inline string depending on ShareString property
+        "e", // error
+        null, // datetime, saved as serialized date-time
+        null // timespan, saved as serialized date-time
+    ];
+
+    /// <summary>
+    /// The <c>t</c> attribute value for a formula cell whose cached value has the passed type,
+    /// or <c>null</c> when the default (number) applies and the attribute can be omitted.
+    /// </summary>
+    internal static string? GetFormulaCellType(XLDataType dataType) => FormulaDataType[(int)dataType];
+
+    /// <summary>
+    /// The <c>t</c> attribute value for a cell that only carries a value, or <c>null</c> when
+    /// the default (number) applies and the attribute can be omitted.
+    /// </summary>
+    internal static string? GetValueCellType(XLDataType dataType, bool shareString)
+    {
+        if (dataType == XLDataType.Text && !shareString)
+            return "inlineStr";
+        return ValueDataType[(int)dataType];
+    }
+
+    /// <summary>
+    /// Open a <c>&lt;row&gt;</c> element and write its <c>r</c> and (when known) <c>spans</c>
+    /// attributes. The element is left open so the caller can add its own attributes.
+    /// </summary>
+    internal static void WriteRowStart(XmlWriter w, int rowNumber, int maxColumn)
+    {
+        w.WriteStartElement("row", Main2006SsNs);
+
+        w.WriteStartAttribute("r");
+        w.WriteNumberValue(rowNumber);
+        w.WriteEndAttribute();
+
+        if (maxColumn > 0)
+        {
+            w.WriteStartAttribute("spans");
+            w.WriteString("1:");
+            w.WriteNumberValue(maxColumn);
+            w.WriteEndAttribute();
+        }
+    }
+
+    /// <summary>
+    /// Open a <c>&lt;c&gt;</c> element with its reference, style and type attributes. The
+    /// element is left open so the caller can add optional attributes and the value.
+    /// <c>reference</c> holds the cell reference as written by <c>Point.Format</c>, of which
+    /// <c>referenceLength</c> chars are used.
+    /// </summary>
+    internal static void WriteCellStart(XmlWriter w, char[] reference, int referenceLength, string? dataType,
+        uint styleId)
+    {
+        w.WriteStartElement("c", Main2006SsNs);
+
+        w.WriteStartAttribute("r");
+        w.WriteRaw(reference, 0, referenceLength);
+        w.WriteEndAttribute();
+
+        w.WriteAttribute("s", styleId);
+
+        if (dataType is not null)
+            w.WriteAttributeString("t", dataType);
+    }
+
+    /// <summary>
+    /// The optional cell attributes carried by the misc slice: phonetic flag and the cell and
+    /// value metadata indexes. Written straight after <see cref="WriteCellStart"/>.
+    /// </summary>
+    internal static void WriteCellMetaAttributes(XmlWriter w, bool hasPhonetic, uint? cellMetaIndex,
+        uint? valueMetaIndex)
+    {
+        if (hasPhonetic)
+            w.WriteAttributeString("ph", TrueValue);
+
+        if (cellMetaIndex is not null)
+            w.WriteAttribute("cm", cellMetaIndex.Value);
+
+        if (valueMetaIndex is not null)
+            w.WriteAttribute("vm", valueMetaIndex.Value);
+    }
+
+    /// <summary>
+    /// Write a <c>&lt;v&gt;</c> element holding a shared string index.
+    /// </summary>
+    internal static void WriteSharedStringValue(XmlWriter w, int sharedStringId)
+    {
+        w.WriteStartElement("v", Main2006SsNs);
+        w.WriteNumberValue(sharedStringId);
+        w.WriteEndElement();
+    }
+
+    /// <summary>
+    /// Write a <c>&lt;v&gt;</c> element holding verbatim text.
+    /// </summary>
+    internal static void WriteStringValue(XmlWriter w, string text)
+    {
+        w.WriteStartElement("v", Main2006SsNs);
+        w.WriteString(text);
+        w.WriteEndElement();
+    }
+
+    /// <summary>
+    /// Write a <c>&lt;v&gt;</c> element holding a number.
+    /// </summary>
+    internal static void WriteNumberValue(XmlWriter w, double value)
+    {
+        w.WriteStartElement("v", Main2006SsNs);
+        w.WriteNumberValue(value);
+        w.WriteEndElement();
+    }
+
+    /// <summary>
+    /// Write an <c>&lt;is&gt;&lt;t&gt;</c> inline string, preserving leading/trailing spaces
+    /// when needed.
+    /// </summary>
+    internal static void WriteInlineString(XmlWriter w, string text)
+    {
+        w.WriteStartElement("is", Main2006SsNs);
+        WriteTextElement(w, text);
+        w.WriteEndElement(); // is
+    }
+
+    /// <summary>
+    /// Write a <c>&lt;t&gt;</c> element, preserving leading/trailing spaces when needed.
+    /// </summary>
+    internal static void WriteTextElement(XmlWriter w, string text)
+    {
+        w.WriteStartElement("t", Main2006SsNs);
+        if (text.PreserveSpaces())
+            w.WritePreserveSpaceAttr();
+
+        w.WriteString(text);
+        w.WriteEndElement(); // t
+    }
+
+    /// <summary>
+    /// Write the <c>&lt;v&gt;</c> element for every value type except
+    /// <see cref="XLDataType.Blank"/> (which has no value element) and
+    /// <see cref="XLDataType.Text"/>, whose representation differs per caller: a shared string
+    /// index, an inline string, rich text, or - for a formula's cached value - verbatim text.
+    /// </summary>
+    internal static void WriteNonTextValue(XmlWriter w, XLCellValue cellValue, bool use1904DateSystem)
+    {
+        switch (cellValue.Type)
+        {
+            case XLDataType.TimeSpan:
+                WriteNumberValue(w, cellValue.GetUnifiedNumber());
+                break;
+            case XLDataType.Number:
+                WriteNumberValue(w, cellValue.GetNumber());
+                break;
+            case XLDataType.DateTime:
+                WriteNumberValue(w, ToSerialDateTime(cellValue.GetDateTime(), use1904DateSystem));
+                break;
+            case XLDataType.Boolean:
+                WriteStringValue(w, cellValue.GetBoolean() ? TrueValue : FalseValue);
+                break;
+            case XLDataType.Error:
+                WriteStringValue(w, cellValue.GetError().ToDisplayString());
+                break;
+            default:
+                throw new InvalidOperationException();
+        }
+    }
+
+    /// <summary>
+    /// Convert a date to its Excel serial number, shifting it into the 1904 date system when
+    /// the workbook uses one.
+    /// </summary>
+    internal static double ToSerialDateTime(DateTime date, bool use1904DateSystem)
+    {
+        if (use1904DateSystem)
+            date = date.AddDays(-Date1904OffsetDays);
+
+        return date.ToSerialDateTime();
+    }
+}

--- a/XLibur/Excel/IO/CellXmlWriter.cs
+++ b/XLibur/Excel/IO/CellXmlWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Xml;
 using XLibur.Extensions;
 using static XLibur.Excel.IO.OpenXmlConst;

--- a/XLibur/Excel/IO/SheetDataWriter.cs
+++ b/XLibur/Excel/IO/SheetDataWriter.cs
@@ -13,41 +13,6 @@ namespace XLibur.Excel.IO;
 
 internal static class SheetDataWriter
 {
-    /// <summary>
-    /// Day offset between the 1900 and 1904 date systems used by Excel.
-    /// </summary>
-    private const int Date1904OffsetDays = 1462;
-
-    /// <summary>
-    /// An array to convert data type for a formula cell. Key is <see cref="XLDataType"/>.
-    /// It saves some performance through direct indexation instead of switch.
-    /// </summary>
-    private static readonly string?[] FormulaDataType =
-    [
-        null, // blank
-        "b", // boolean
-        null, // number, default value, no need to save type
-        "str", // text, formula can only save this type, no inline or shared string
-        "e", // error
-        null, // datetime, saved as serialized date-time
-        null // timespan, saved as serialized date-time
-    ];
-
-    /// <summary>
-    /// An array to convert a data type for a cell that only contains a value. Key is <see cref="XLDataType"/>.
-    /// It saves some performance through direct indexation instead of switch.
-    /// </summary>
-    private static readonly string?[] ValueDataType =
-    [
-        null, // blank
-        "b", // boolean
-        null, // number, default value, no need to save type
-        "s", // text, the default is a shared string, but there also can be inline string depending on ShareString property
-        "e", // error
-        null, // datetime, saved as serialized date-time
-        null // timespan, saved as serialized date-time
-    ];
-
     internal static void StreamSheetData(XmlWriter xml, XLWorksheet xlWorksheet, SaveContext context,
         SaveOptions options)
     {
@@ -63,7 +28,7 @@ internal static class SheetDataWriter
         var cellCtx = new CellWriteContext
         {
             CellsCollection = xlWorksheet.Internals.CellsCollection,
-            CellRef = new char[10], // Buffer must be enough to hold span and rowNumber as strings
+            CellRef = new char[CellXmlWriter.CellRefBufferLength],
             SaveContext = context,
             SaveOptions = options,
             TableTotalCells = tableTotalCells,
@@ -261,7 +226,7 @@ internal static class SheetDataWriter
         // whose evaluation is unsupported).
         var cachedValue = cellsCollection.ValueSlice.GetCellValue(point);
         var cachedValueType = cachedValue.Type;
-        var dataType = cachedValueType != XLDataType.Blank ? FormulaDataType[(int)cachedValueType] : null;
+        var dataType = cachedValueType != XLDataType.Blank ? CellXmlWriter.GetFormulaCellType(cachedValueType) : null;
 
         Span<char> cellRefSpan = ctx.CellRef;
         var cellRefLen = point.Format(cellRefSpan);
@@ -348,25 +313,8 @@ internal static class SheetDataWriter
     private static void WriteStartFormulaCellDirect(XmlWriter w, char[] reference, int referenceLength,
         string? dataType, uint styleId, in XLMiscSliceContent misc, uint? cmIndex)
     {
-        w.WriteStartElement("c", Main2006SsNs);
-
-        w.WriteStartAttribute("r");
-        w.WriteRaw(reference, 0, referenceLength);
-        w.WriteEndAttribute();
-
-        w.WriteAttribute("s", styleId);
-
-        if (dataType is not null)
-            w.WriteAttributeString("t", dataType);
-
-        if (misc.HasPhonetic)
-            w.WriteAttributeString("ph", TrueValue);
-
-        if (cmIndex is not null)
-            w.WriteAttribute("cm", cmIndex.Value);
-
-        if (misc.ValueMetaIndex is not null)
-            w.WriteAttribute("vm", misc.ValueMetaIndex.Value);
+        CellXmlWriter.WriteCellStart(w, reference, referenceLength, dataType, styleId);
+        CellXmlWriter.WriteCellMetaAttributes(w, misc.HasPhonetic, cmIndex, misc.ValueMetaIndex);
     }
 
     /// <summary>
@@ -380,31 +328,11 @@ internal static class SheetDataWriter
             case XLDataType.Blank:
                 return;
             case XLDataType.Text:
-                WriteStringValue(w, cellValue.GetText());
-                break;
-            case XLDataType.TimeSpan:
-                WriteNumberValue(w, cellValue.GetUnifiedNumber());
-                break;
-            case XLDataType.Number:
-                WriteNumberValue(w, cellValue.GetNumber());
-                break;
-            case XLDataType.DateTime:
-                {
-                    var date = cellValue.GetDateTime();
-                    if (use1904DateSystem)
-                        date = date.AddDays(-Date1904OffsetDays);
-
-                    WriteNumberValue(w, date.ToSerialDateTime());
-                    break;
-                }
-            case XLDataType.Boolean:
-                WriteStringValue(w, cellValue.GetBoolean() ? TrueValue : FalseValue);
-                break;
-            case XLDataType.Error:
-                WriteStringValue(w, cellValue.GetError().ToDisplayString());
+                CellXmlWriter.WriteStringValue(w, cellValue.GetText());
                 break;
             default:
-                throw new InvalidOperationException();
+                CellXmlWriter.WriteNonTextValue(w, cellValue, use1904DateSystem);
+                break;
         }
     }
 
@@ -452,7 +380,7 @@ internal static class SheetDataWriter
             ref readonly var misc = ref cellsCollection.MiscSlice[point];
 
             WriteStartCellDirect(xml, ctx.CellRef, cellRefLen, "s", cellStyleId, in misc);
-            WriteValue(xml, sharedStringId);
+            CellXmlWriter.WriteSharedStringValue(xml, sharedStringId);
             xml.WriteEndElement(); // cell
         }
     }
@@ -462,7 +390,7 @@ internal static class SheetDataWriter
     {
         Span<char> cellRefSpan = ctx.CellRef;
         var cellRefLen = point.Format(cellRefSpan);
-        var dataType = GetCellValueTypeDirect(cellValue.Type, shareString);
+        var dataType = CellXmlWriter.GetValueCellType(cellValue.Type, shareString);
         ref readonly var misc = ref ctx.CellsCollection.MiscSlice[point];
 
         WriteStartCellDirect(xml, ctx.CellRef, cellRefLen, dataType, cellStyleId, in misc);
@@ -501,19 +429,7 @@ internal static class SheetDataWriter
 
     private static void WriteStartRow(XmlWriter w, XLRow? xlRow, int rowNumber, int maxColumn, SaveContext context)
     {
-        w.WriteStartElement("row", Main2006SsNs);
-
-        w.WriteStartAttribute("r");
-        w.WriteNumberValue(rowNumber);
-        w.WriteEndAttribute();
-
-        if (maxColumn > 0)
-        {
-            w.WriteStartAttribute("spans");
-            w.WriteString("1:");
-            w.WriteNumberValue(maxColumn);
-            w.WriteEndAttribute();
-        }
+        CellXmlWriter.WriteRowStart(w, rowNumber, maxColumn);
 
         if (xlRow is null)
             return;
@@ -594,42 +510,11 @@ internal static class SheetDataWriter
         xml.WriteEndElement(); // f
     }
 
-    private static void WriteValue(XmlWriter xml, int sharedStringId)
-    {
-        xml.WriteStartElement("v", Main2006SsNs);
-        xml.WriteNumberValue(sharedStringId);
-        xml.WriteEndElement();
-    }
-
-    private static string? GetCellValueTypeDirect(XLDataType dataType, bool shareString)
-    {
-        if (dataType == XLDataType.Text && !shareString)
-            return "inlineStr";
-        return ValueDataType[(int)dataType];
-    }
-
     private static void WriteStartCellDirect(XmlWriter w, char[] reference, int referenceLength, string? dataType,
         uint styleId, in XLMiscSliceContent misc)
     {
-        w.WriteStartElement("c", Main2006SsNs);
-
-        w.WriteStartAttribute("r");
-        w.WriteRaw(reference, 0, referenceLength);
-        w.WriteEndAttribute();
-
-        w.WriteAttribute("s", styleId);
-
-        if (dataType is not null)
-            w.WriteAttributeString("t", dataType);
-
-        if (misc.HasPhonetic)
-            w.WriteAttributeString("ph", TrueValue);
-
-        if (misc.CellMetaIndex is not null)
-            w.WriteAttribute("cm", misc.CellMetaIndex.Value);
-
-        if (misc.ValueMetaIndex is not null)
-            w.WriteAttribute("vm", misc.ValueMetaIndex.Value);
+        CellXmlWriter.WriteCellStart(w, reference, referenceLength, dataType, styleId);
+        CellXmlWriter.WriteCellMetaAttributes(w, misc.HasPhonetic, misc.CellMetaIndex, misc.ValueMetaIndex);
     }
 
     private static void WriteCellValueDirect(XmlWriter w, XLCellValue cellValue, bool shareString,
@@ -642,29 +527,9 @@ internal static class SheetDataWriter
             case XLDataType.Text:
                 WriteCellValueDirectText(w, cellValue, shareString, point, cellsCollection, context);
                 break;
-            case XLDataType.TimeSpan:
-                WriteNumberValue(w, cellValue.GetUnifiedNumber());
-                break;
-            case XLDataType.Number:
-                WriteNumberValue(w, cellValue.GetNumber());
-                break;
-            case XLDataType.DateTime:
-                {
-                    var date = cellValue.GetDateTime();
-                    if (use1904DateSystem)
-                        date = date.AddDays(-Date1904OffsetDays);
-
-                    WriteNumberValue(w, date.ToSerialDateTime());
-                    break;
-                }
-            case XLDataType.Boolean:
-                WriteStringValue(w, cellValue.GetBoolean() ? TrueValue : FalseValue);
-                break;
-            case XLDataType.Error:
-                WriteStringValue(w, cellValue.GetError().ToDisplayString());
-                break;
             default:
-                throw new InvalidOperationException();
+                CellXmlWriter.WriteNonTextValue(w, cellValue, use1904DateSystem);
+                break;
         }
     }
 
@@ -675,43 +540,20 @@ internal static class SheetDataWriter
         {
             var memorySstId = cellsCollection.ValueSlice.GetShareStringId(point);
             var sharedStringId = context.GetSharedStringId(memorySstId, point);
-            WriteValue(w, sharedStringId);
+            CellXmlWriter.WriteSharedStringValue(w, sharedStringId);
+            return;
         }
-        else
+
+        var richText = cellsCollection.ValueSlice.GetRichText(point);
+        if (richText is null)
         {
-            w.WriteStartElement("is", Main2006SsNs);
-            var richText = cellsCollection.ValueSlice.GetRichText(point);
-            if (richText is not null)
-            {
-                TextSerializer.WriteRichTextElements(w, richText, context);
-            }
-            else
-            {
-                var text = cellValue.GetText();
-                w.WriteStartElement("t", Main2006SsNs);
-                if (text.PreserveSpaces())
-                    w.WritePreserveSpaceAttr();
-
-                w.WriteString(text);
-                w.WriteEndElement();
-            }
-
-            w.WriteEndElement(); // is
+            CellXmlWriter.WriteInlineString(w, cellValue.GetText());
+            return;
         }
-    }
 
-    private static void WriteStringValue(XmlWriter w, string text)
-    {
-        w.WriteStartElement("v", Main2006SsNs);
-        w.WriteString(text);
-        w.WriteEndElement();
-    }
-
-    private static void WriteNumberValue(XmlWriter w, double value)
-    {
-        w.WriteStartElement("v", Main2006SsNs);
-        w.WriteNumberValue(value);
-        w.WriteEndElement();
+        w.WriteStartElement("is", Main2006SsNs);
+        TextSerializer.WriteRichTextElements(w, richText, context);
+        w.WriteEndElement(); // is
     }
 
     private struct RowWriterState

--- a/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
@@ -606,10 +606,10 @@ internal static class WorkbookStylesPartWriter
 
             if (foundOne) continue;
 
-            stylesheet.CellFormats!.AppendChild(BuildCellFormat(styleInfo));
+            stylesheet.CellFormats.AppendChild(BuildCellFormat(styleInfo));
         }
 
-        stylesheet.CellFormats!.Count = (uint)stylesheet.CellFormats!.ChildElements.Count;
+        stylesheet.CellFormats.Count = (uint)stylesheet.CellFormats.ChildElements.Count;
     }
 
     /// <summary>
@@ -667,11 +667,11 @@ internal static class WorkbookStylesPartWriter
             if (cellStyleFormat.ApplyProtection!.Value)
                 cellStyleFormat.AppendChild(GetProtection(styleInfo));
 
-            stylesheet.CellStyleFormats!.AppendChild(cellStyleFormat);
+            stylesheet.CellStyleFormats.AppendChild(cellStyleFormat);
         }
 
-        stylesheet.CellStyleFormats!.Count =
-            (uint)stylesheet.CellStyleFormats!.ChildElements.Count;
+        stylesheet.CellStyleFormats.Count =
+            (uint)stylesheet.CellStyleFormats.ChildElements.Count;
     }
 
     private static bool ApplyFill(StyleInfo styleInfo)

--- a/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
@@ -15,7 +15,7 @@ namespace XLibur.Excel.IO;
 
 internal static class WorkbookStylesPartWriter
 {
-    internal static void GenerateContent(WorkbookStylesPart workbookStylesPart, XLWorkbook workbook,
+    internal static void GenerateContent(Stylesheet stylesheet, XLWorkbook workbook,
         SaveContext context)
     {
         var defaultStyle = DefaultStyleValue;
@@ -23,10 +23,9 @@ internal static class WorkbookStylesPartWriter
         if (!context.SharedFonts.ContainsKey(defaultStyle.Font))
             context.SharedFonts.Add(defaultStyle.Font, new FontInfo { FontId = 0, Font = defaultStyle.Font });
 
-        workbookStylesPart.Stylesheet ??= new Stylesheet();
-        workbookStylesPart.Stylesheet!.CellStyles ??= new CellStyles();
+        stylesheet.CellStyles ??= new CellStyles();
 
-        var defaultFormatId = ResolveDefaultFormatId(workbookStylesPart);
+        var defaultFormatId = ResolveDefaultFormatId(stylesheet);
 
         context.SharedStyles.Add(defaultStyle,
             new StyleInfo
@@ -60,37 +59,132 @@ internal static class WorkbookStylesPartWriter
 
         var customNumberFormats = CollectCustomNumberFormats(xlStyles, pivotCustomFormats);
 
-        var allSharedNumberFormats = ResolveNumberFormats(workbookStylesPart, customNumberFormats, defaultFormatId);
+        var allSharedNumberFormats = ResolveNumberFormats(stylesheet, customNumberFormats, defaultFormatId);
         foreach (var nf in allSharedNumberFormats)
             context.SharedNumberFormats.Add(nf.Key, nf.Value);
 
-        ResolveFonts(workbookStylesPart, context);
-        var allSharedFills = ResolveFills(workbookStylesPart, sharedFills);
-        var allSharedBorders = ResolveBorders(workbookStylesPart, sharedBorders);
+        ResolveFonts(stylesheet, context);
+        var allSharedFills = ResolveFills(stylesheet, sharedFills);
+        var allSharedBorders = ResolveBorders(stylesheet, sharedBorders);
 
         BuildSharedStyleMappings(context, xlStyles, allSharedNumberFormats, allSharedFills, allSharedBorders);
 
-        ResolveCellStyleFormats(workbookStylesPart, context);
-        ResolveRest(workbookStylesPart, context);
+        ResolveCellStyleFormats(stylesheet, context);
+        ResolveRest(stylesheet, context);
 
-        if (!workbookStylesPart.Stylesheet!.CellStyles.Elements<CellStyle>().Any(c =>
+        if (!stylesheet.CellStyles.Elements<CellStyle>().Any(c =>
                 c.BuiltinId != null && c.BuiltinId.HasValue && c.BuiltinId.Value == 0U))
-            workbookStylesPart.Stylesheet!.CellStyles.AppendChild(new CellStyle
+            stylesheet.CellStyles.AppendChild(new CellStyle
             { Name = "Normal", FormatId = defaultFormatId, BuiltinId = 0U });
 
-        workbookStylesPart.Stylesheet!.CellStyles.Count = (uint)workbookStylesPart.Stylesheet!.CellStyles.ChildElements.Count;
+        stylesheet.CellStyles.Count = (uint)stylesheet.CellStyles.ChildElements.Count;
 
-        RemapStyleIds(workbookStylesPart, context);
+        RemapStyleIds(stylesheet, context);
 
-        AddDifferentialFormats(workbookStylesPart, workbook, context);
+        AddDifferentialFormats(stylesheet, workbook, context);
+    }
+
+    /// <summary>
+    /// Styles part for the forward-only streaming writer.
+    /// </summary>
+    /// <remarks>
+    /// The normal path collects the workbook's styles into a set, writes deduplicated
+    /// <c>cellXf</c>s and then reads the final ids back out. The streaming writer cannot work
+    /// that way: it hands a style id to a cell the moment that cell is written, long before the
+    /// styles part exists, and that sheet XML is already in the package by the time this runs.
+    /// So the ids are the input, not the output - one <c>cellXf</c> per style in exactly the
+    /// order the ids were handed out, no deduplication and no remap, which makes index i the
+    /// style at <paramref name="orderedStyles"/>[i] by construction.
+    /// <paramref name="orderedStyles"/>[0] must be the default style.
+    /// </remarks>
+    internal static void GenerateStreamingContent(Stylesheet stylesheet,
+        IReadOnlyList<XLStyleValue> orderedStyles, SaveContext context)
+    {
+        stylesheet.CellStyles ??= new CellStyles();
+
+        var defaultStyle = DefaultStyleValue;
+        if (!context.SharedFonts.ContainsKey(defaultStyle.Font))
+            context.SharedFonts.Add(defaultStyle.Font, new FontInfo { FontId = 0, Font = defaultStyle.Font });
+
+        uint fontCount = 1;
+        uint fillCount = 3;
+        uint borderCount = 1;
+
+        foreach (var style in orderedStyles)
+        {
+            if (!context.SharedFonts.ContainsKey(style.Font))
+                context.SharedFonts.Add(style.Font, new FontInfo { FontId = fontCount++, Font = style.Font });
+        }
+
+        var sharedFills = new Dictionary<XLFillValue, FillInfo>();
+        var sharedBorders = new Dictionary<XLBorderValue, BorderInfo>();
+        var customNumberFormats = new HashSet<XLNumberFormatValue>();
+        foreach (var style in orderedStyles)
+        {
+            if (!sharedFills.ContainsKey(style.Fill))
+                sharedFills.Add(style.Fill, new FillInfo { FillId = fillCount++, Fill = style.Fill });
+
+            if (!sharedBorders.ContainsKey(style.Border))
+                sharedBorders.Add(style.Border, new BorderInfo { BorderId = borderCount++, Border = style.Border });
+
+            if (style.NumberFormat.NumberFormatId == -1)
+                customNumberFormats.Add(style.NumberFormat);
+        }
+
+        var allSharedNumberFormats = ResolveNumberFormats(stylesheet, customNumberFormats, 0);
+        foreach (var nf in allSharedNumberFormats)
+            context.SharedNumberFormats.Add(nf.Key, nf.Value);
+
+        ResolveFonts(stylesheet, context);
+        var allSharedFills = ResolveFills(stylesheet, sharedFills);
+        var allSharedBorders = ResolveBorders(stylesheet, sharedBorders);
+
+        // A single cellStyleXf holding the default format; every cellXf points at it via FormatId 0.
+        stylesheet.CellStyleFormats ??= new CellStyleFormats();
+        stylesheet.CellStyleFormats.AppendChild(new CellFormat
+        {
+            NumberFormatId = 0,
+            FontId = 0,
+            FillId = 0,
+            BorderId = 0
+        });
+        stylesheet.CellStyleFormats.Count = (uint)stylesheet.CellStyleFormats.ChildElements.Count;
+
+        stylesheet.CellFormats ??= new CellFormats();
+        for (var styleId = 0; styleId < orderedStyles.Count; styleId++)
+        {
+            var style = orderedStyles[styleId];
+            var numberFormatId = style.NumberFormat.NumberFormatId >= 0
+                ? style.NumberFormat.NumberFormatId
+                : allSharedNumberFormats[style.NumberFormat].NumberFormatId;
+
+            var styleInfo = new StyleInfo
+            {
+                StyleId = (uint)styleId,
+                Style = style,
+                FontId = context.SharedFonts[style.Font].FontId,
+                FillId = allSharedFills[style.Fill].FillId,
+                BorderId = allSharedBorders[style.Border].BorderId,
+                NumberFormatId = numberFormatId,
+                IncludeQuotePrefix = style.IncludeQuotePrefix
+            };
+
+            context.SharedStyles[style] = styleInfo;
+            stylesheet.CellFormats.AppendChild(BuildCellFormat(styleInfo));
+        }
+
+        stylesheet.CellFormats.Count = (uint)stylesheet.CellFormats.ChildElements.Count;
+
+        stylesheet.CellStyles.AppendChild(new CellStyle { Name = "Normal", FormatId = 0U, BuiltinId = 0U });
+        stylesheet.CellStyles.Count = (uint)stylesheet.CellStyles.ChildElements.Count;
     }
 
     /// <summary>
     /// Determine the default workbook style by looking for the style with builtInId = 0.
     /// </summary>
-    private static uint ResolveDefaultFormatId(WorkbookStylesPart workbookStylesPart)
+    private static uint ResolveDefaultFormatId(Stylesheet stylesheet)
     {
-        var cellStyles = workbookStylesPart.Stylesheet!.CellStyles!;
+        var cellStyles = stylesheet.CellStyles!;
 
         if (cellStyles.Elements<CellStyle>()
             .Any(c => c.BuiltinId != null && c.BuiltinId.HasValue && c.BuiltinId.Value == 0))
@@ -208,13 +302,13 @@ internal static class WorkbookStylesPartWriter
     /// <summary>
     /// Match each shared style against the CellFormats in the part and assign the final style ID.
     /// </summary>
-    private static void RemapStyleIds(WorkbookStylesPart workbookStylesPart, SaveContext context)
+    private static void RemapStyleIds(Stylesheet stylesheet, SaveContext context)
     {
         var newSharedStyles = new Dictionary<XLStyleValue, StyleInfo>();
         foreach (var ss in context.SharedStyles)
         {
             var styleId = -1;
-            foreach (var openXmlElement in workbookStylesPart.Stylesheet!.CellFormats!)
+            foreach (var openXmlElement in stylesheet.CellFormats!)
             {
                 var f = (CellFormat)openXmlElement;
                 styleId++;
@@ -236,12 +330,12 @@ internal static class WorkbookStylesPartWriter
     /// <summary>
     /// Populates the differential formats that are currently in the file to the SaveContext
     /// </summary>
-    private static void AddDifferentialFormats(WorkbookStylesPart workbookStylesPart, XLWorkbook workbook,
+    private static void AddDifferentialFormats(Stylesheet stylesheet, XLWorkbook workbook,
         SaveContext context)
     {
-        workbookStylesPart.Stylesheet!.DifferentialFormats ??= new DifferentialFormats();
+        stylesheet.DifferentialFormats ??= new DifferentialFormats();
 
-        var differentialFormats = workbookStylesPart.Stylesheet!.DifferentialFormats;
+        var differentialFormats = stylesheet.DifferentialFormats;
         differentialFormats.RemoveAllChildren();
         FillDifferentialFormatsCollection(differentialFormats, context.DifferentialFormats);
 
@@ -255,7 +349,7 @@ internal static class WorkbookStylesPartWriter
 
         differentialFormats.Count = (uint)differentialFormats.ChildElements.Count;
         if (differentialFormats.Count == 0)
-            workbookStylesPart.Stylesheet!.DifferentialFormats = null;
+            stylesheet.DifferentialFormats = null;
     }
 
     private static void AddConditionalFormatDxfs(DifferentialFormats differentialFormats, XLWorksheet ws,
@@ -499,62 +593,71 @@ internal static class WorkbookStylesPartWriter
         context.DifferentialFormats.Add(style, differentialFormats.ChildElements.Count - 1);
     }
 
-    private static void ResolveRest(WorkbookStylesPart workbookStylesPart, SaveContext context)
+    private static void ResolveRest(Stylesheet stylesheet, SaveContext context)
     {
-        workbookStylesPart.Stylesheet!.CellFormats ??= new CellFormats();
+        stylesheet.CellFormats ??= new CellFormats();
 
         foreach (var styleInfo in context.SharedStyles.Values)
         {
             var info = styleInfo;
             var foundOne =
-                workbookStylesPart.Stylesheet!.CellFormats.Cast<CellFormat>()
+                stylesheet.CellFormats.Cast<CellFormat>()
                     .Any(f => CellFormatsAreEqual(f, info, compareAlignment: true));
 
             if (foundOne) continue;
 
-            var cellFormat = GetCellFormat(styleInfo);
-            cellFormat.FormatId = 0;
-            var alignment = new Alignment
-            {
-                Horizontal = styleInfo.Style.Alignment.Horizontal.ToOpenXml(),
-                Vertical = styleInfo.Style.Alignment.Vertical.ToOpenXml(),
-                Indent = (uint)styleInfo.Style.Alignment.Indent,
-                ReadingOrder = (uint)styleInfo.Style.Alignment.ReadingOrder,
-                WrapText = styleInfo.Style.Alignment.WrapText,
-                TextRotation = (uint)GetOpenXmlTextRotation(styleInfo.Style.Alignment),
-                ShrinkToFit = styleInfo.Style.Alignment.ShrinkToFit,
-                RelativeIndent = styleInfo.Style.Alignment.RelativeIndent,
-                JustifyLastLine = styleInfo.Style.Alignment.JustifyLastLine
-            };
-            cellFormat.AppendChild(alignment);
-
-            if (cellFormat.ApplyProtection!.Value)
-                cellFormat.AppendChild(GetProtection(styleInfo));
-
-            workbookStylesPart.Stylesheet!.CellFormats!.AppendChild(cellFormat);
+            stylesheet.CellFormats!.AppendChild(BuildCellFormat(styleInfo));
         }
 
-        workbookStylesPart.Stylesheet!.CellFormats!.Count = (uint)workbookStylesPart.Stylesheet!.CellFormats!.ChildElements.Count;
-
-        static int GetOpenXmlTextRotation(XLAlignmentValue alignment)
-        {
-            var textRotation = alignment.TextRotation;
-            return textRotation >= 0
-                ? textRotation
-                : 90 - textRotation;
-        }
+        stylesheet.CellFormats!.Count = (uint)stylesheet.CellFormats!.ChildElements.Count;
     }
 
-    private static void ResolveCellStyleFormats(WorkbookStylesPart workbookStylesPart,
+    /// <summary>
+    /// Build the <c>cellXf</c> for a style, including its alignment and (when applicable)
+    /// protection children.
+    /// </summary>
+    private static CellFormat BuildCellFormat(StyleInfo styleInfo)
+    {
+        var cellFormat = GetCellFormat(styleInfo);
+        cellFormat.FormatId = 0;
+        var alignment = new Alignment
+        {
+            Horizontal = styleInfo.Style.Alignment.Horizontal.ToOpenXml(),
+            Vertical = styleInfo.Style.Alignment.Vertical.ToOpenXml(),
+            Indent = (uint)styleInfo.Style.Alignment.Indent,
+            ReadingOrder = (uint)styleInfo.Style.Alignment.ReadingOrder,
+            WrapText = styleInfo.Style.Alignment.WrapText,
+            TextRotation = (uint)GetOpenXmlTextRotation(styleInfo.Style.Alignment),
+            ShrinkToFit = styleInfo.Style.Alignment.ShrinkToFit,
+            RelativeIndent = styleInfo.Style.Alignment.RelativeIndent,
+            JustifyLastLine = styleInfo.Style.Alignment.JustifyLastLine
+        };
+        cellFormat.AppendChild(alignment);
+
+        if (cellFormat.ApplyProtection!.Value)
+            cellFormat.AppendChild(GetProtection(styleInfo));
+
+        return cellFormat;
+    }
+
+    private static int GetOpenXmlTextRotation(XLAlignmentValue alignment)
+    {
+        var textRotation = alignment.TextRotation;
+        return textRotation >= 0
+            ? textRotation
+            : 90 - textRotation;
+    }
+
+    private static void ResolveCellStyleFormats(Stylesheet stylesheet,
         SaveContext context)
     {
-        workbookStylesPart.Stylesheet!.CellStyleFormats ??= new CellStyleFormats();
+        stylesheet.CellStyleFormats ??= new CellStyleFormats();
 
         foreach (var styleInfo in context.SharedStyles.Values)
         {
             var info = styleInfo;
             var foundOne =
-                workbookStylesPart.Stylesheet!.CellStyleFormats.Cast<CellFormat>()
+                stylesheet.CellStyleFormats.Cast<CellFormat>()
                     .Any(f => CellFormatsAreEqual(f, info, compareAlignment: false));
 
             if (foundOne) continue;
@@ -564,11 +667,11 @@ internal static class WorkbookStylesPartWriter
             if (cellStyleFormat.ApplyProtection!.Value)
                 cellStyleFormat.AppendChild(GetProtection(styleInfo));
 
-            workbookStylesPart.Stylesheet!.CellStyleFormats!.AppendChild(cellStyleFormat);
+            stylesheet.CellStyleFormats!.AppendChild(cellStyleFormat);
         }
 
-        workbookStylesPart.Stylesheet!.CellStyleFormats!.Count =
-            (uint)workbookStylesPart.Stylesheet!.CellStyleFormats!.ChildElements.Count;
+        stylesheet.CellStyleFormats!.Count =
+            (uint)stylesheet.CellStyleFormats!.ChildElements.Count;
     }
 
     private static bool ApplyFill(StyleInfo styleInfo)
@@ -666,17 +769,17 @@ internal static class WorkbookStylesPartWriter
         return a.Equals(xlAlignment.Key);
     }
 
-    private static Dictionary<XLBorderValue, BorderInfo> ResolveBorders(WorkbookStylesPart workbookStylesPart,
+    private static Dictionary<XLBorderValue, BorderInfo> ResolveBorders(Stylesheet stylesheet,
         Dictionary<XLBorderValue, BorderInfo> sharedBorders)
     {
-        workbookStylesPart.Stylesheet!.Borders ??= new Borders();
+        stylesheet.Borders ??= new Borders();
 
         var allSharedBorders = new Dictionary<XLBorderValue, BorderInfo>();
         foreach (var borderInfo in sharedBorders.Values)
         {
             var borderId = 0;
             var foundOne = false;
-            foreach (var openXmlElement in workbookStylesPart.Stylesheet!.Borders)
+            foreach (var openXmlElement in stylesheet.Borders)
             {
                 var f = (Border)openXmlElement;
                 if (BordersAreEqual(f, borderInfo.Border))
@@ -691,14 +794,14 @@ internal static class WorkbookStylesPartWriter
             if (!foundOne)
             {
                 var border = GetNewBorder(borderInfo);
-                workbookStylesPart.Stylesheet!.Borders.AppendChild(border);
+                stylesheet.Borders.AppendChild(border);
             }
 
             allSharedBorders.Add(borderInfo.Border,
                 borderInfo with { BorderId = (uint)borderId });
         }
 
-        workbookStylesPart.Stylesheet!.Borders.Count = (uint)workbookStylesPart.Stylesheet!.Borders.ChildElements.Count;
+        stylesheet.Borders.Count = (uint)stylesheet.Borders.ChildElements.Count;
         return allSharedBorders;
     }
 
@@ -804,12 +907,12 @@ internal static class WorkbookStylesPartWriter
         return convertedBorder.Equals(xlBorder.Key);
     }
 
-    private static Dictionary<XLFillValue, FillInfo> ResolveFills(WorkbookStylesPart workbookStylesPart,
+    private static Dictionary<XLFillValue, FillInfo> ResolveFills(Stylesheet stylesheet,
         Dictionary<XLFillValue, FillInfo> sharedFills)
     {
-        workbookStylesPart.Stylesheet!.Fills ??= new Fills();
+        stylesheet.Fills ??= new Fills();
 
-        var fills = workbookStylesPart.Stylesheet!.Fills;
+        var fills = stylesheet.Fills;
 
         // Pattern idx 0 and idx 1 are hardcoded to Excel with values None (0) and Gray125. Excel will ignore
         // values from the file. Every file has had these values inside to keep the first available idx at 2.
@@ -950,16 +1053,16 @@ internal static class WorkbookStylesPartWriter
         return nF.Key.Equals(xlFill.Key);
     }
 
-    private static void ResolveFonts(WorkbookStylesPart workbookStylesPart, SaveContext context)
+    private static void ResolveFonts(Stylesheet stylesheet, SaveContext context)
     {
-        workbookStylesPart.Stylesheet!.Fonts ??= new Fonts();
+        stylesheet.Fonts ??= new Fonts();
 
         var newFonts = new Dictionary<XLFontValue, FontInfo>();
         foreach (var fontInfo in context.SharedFonts.Values)
         {
             var fontId = 0;
             var foundOne = false;
-            foreach (var openXmlElement in workbookStylesPart.Stylesheet!.Fonts)
+            foreach (var openXmlElement in stylesheet.Fonts)
             {
                 var f = (Font)openXmlElement;
                 if (FontsAreEqual(f, fontInfo.Font))
@@ -974,7 +1077,7 @@ internal static class WorkbookStylesPartWriter
             if (!foundOne)
             {
                 var font = GetNewFont(fontInfo);
-                workbookStylesPart.Stylesheet!.Fonts.AppendChild(font);
+                stylesheet.Fonts.AppendChild(font);
             }
 
             newFonts.Add(fontInfo.Font, new FontInfo { Font = fontInfo.Font, FontId = (uint)fontId });
@@ -984,7 +1087,7 @@ internal static class WorkbookStylesPartWriter
         foreach (var kp in newFonts)
             context.SharedFonts.Add(kp.Key, kp.Value);
 
-        workbookStylesPart.Stylesheet!.Fonts.Count = (uint)workbookStylesPart.Stylesheet!.Fonts.ChildElements.Count;
+        stylesheet.Fonts.Count = (uint)stylesheet.Fonts.ChildElements.Count;
     }
 
     private static Font GetNewFont(FontInfo fontInfo, bool ignoreMod = true)
@@ -1054,14 +1157,14 @@ internal static class WorkbookStylesPartWriter
     }
 
     private static Dictionary<XLNumberFormatValue, NumberFormatInfo> ResolveNumberFormats(
-        WorkbookStylesPart workbookStylesPart,
+        Stylesheet stylesheet,
         HashSet<XLNumberFormatValue> customNumberFormats,
         uint defaultFormatId)
     {
-        if (workbookStylesPart.Stylesheet!.NumberingFormats == null)
+        if (stylesheet.NumberingFormats == null)
         {
-            workbookStylesPart.Stylesheet!.NumberingFormats = new NumberingFormats();
-            workbookStylesPart.Stylesheet!.NumberingFormats.AppendChild(new NumberingFormat
+            stylesheet.NumberingFormats = new NumberingFormats();
+            stylesheet.NumberingFormats.AppendChild(new NumberingFormat
             {
                 NumberFormatId = 0,
                 FormatCode = ""
@@ -1069,7 +1172,7 @@ internal static class WorkbookStylesPartWriter
         }
 
         var allSharedNumberFormats = new Dictionary<XLNumberFormatValue, NumberFormatInfo>();
-        var partNumberingFormats = workbookStylesPart.Stylesheet!.NumberingFormats;
+        var partNumberingFormats = stylesheet.NumberingFormats;
 
         // number format ids in the part can have holes in the sequence, and the first id can be greater than the last built-in style id.
         // In some cases, there are also existing number formats with id below the last built-in style id.
@@ -1082,7 +1185,7 @@ internal static class WorkbookStylesPartWriter
         foreach (var customNumberFormat in customNumberFormats.Where(nf => nf.NumberFormatId != defaultFormatId))
         {
             NumberingFormat? partNumberFormat = null;
-            foreach (var nf in workbookStylesPart.Stylesheet!.NumberingFormats.Cast<NumberingFormat>())
+            foreach (var nf in stylesheet.NumberingFormats.Cast<NumberingFormat>())
             {
                 if (!CustomNumberFormatsAreEqual(nf, customNumberFormat)) continue;
                 partNumberFormat = nf;
@@ -1096,7 +1199,7 @@ internal static class WorkbookStylesPartWriter
                     NumberFormatId = availableNumberFormatId++,
                     FormatCode = customNumberFormat.Format
                 };
-                workbookStylesPart.Stylesheet!.NumberingFormats.AppendChild(partNumberFormat);
+                stylesheet.NumberingFormats.AppendChild(partNumberFormat);
             }
 
             allSharedNumberFormats.Add(customNumberFormat,
@@ -1107,8 +1210,8 @@ internal static class WorkbookStylesPartWriter
                 });
         }
 
-        workbookStylesPart.Stylesheet!.NumberingFormats.Count =
-            (uint)workbookStylesPart.Stylesheet!.NumberingFormats.ChildElements.Count;
+        stylesheet.NumberingFormats.Count =
+            (uint)stylesheet.NumberingFormats.ChildElements.Count;
         return allSharedNumberFormats;
     }
 

--- a/XLibur/Excel/SaveOptions.cs
+++ b/XLibur/Excel/SaveOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace XLibur.Excel;
+﻿using System.IO.Compression;
+
+namespace XLibur.Excel;
 
 public class SaveOptions
 {
@@ -6,6 +8,17 @@ public class SaveOptions
     {
         ValidatePackage = false;
     }
+
+    /// <summary>
+    /// How hard to compress the parts written to the package. Defaults to
+    /// <see cref="CompressionLevel.Optimal"/>; <see cref="CompressionLevel.Fastest"/> trades a
+    /// larger file for a quicker save.
+    /// </summary>
+    /// <remarks>
+    /// Only applies to parts this save creates. Re-saving a workbook that was loaded from an
+    /// existing file leaves the parts it already had at whatever level they were written with.
+    /// </remarks>
+    public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Optimal;
 
     public bool ConsolidateConditionalFormatRanges { get; set; } = true;
 

--- a/XLibur/Excel/Streaming/StreamingPackageWriter.cs
+++ b/XLibur/Excel/Streaming/StreamingPackageWriter.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Xml;
+
+namespace XLibur.Excel.Streaming;
+
+/// <summary>
+/// Writes the OPC package of a streaming workbook straight into a zip, one part at a time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The OpenXML SDK's packaging layer cannot be used here. <c>System.IO.Packaging</c> opens a
+/// package for read/write, which maps to <see cref="ZipArchiveMode.Update"/>, and that mode
+/// holds every entry's <em>uncompressed</em> bytes in memory until the archive is closed - about
+/// half a gigabyte for a million-row sheet, which is precisely what this API exists to avoid.
+/// Opening the package write-only does give <see cref="ZipArchiveMode.Create"/>, but the SDK
+/// enumerates parts as it works and fails on a write-only container.
+/// </para>
+/// <para>
+/// So the package is assembled by hand over <see cref="ZipArchiveMode.Create"/>, which writes
+/// each entry through to the output as it is produced and retains only the central directory.
+/// The parts involved are few and simple - content types, two relationship parts, the workbook,
+/// the worksheets, the styles and the shared strings - and the shape of an .xlsx package is
+/// fixed. A side benefit is that the output stream need not be seekable, so a workbook can be
+/// written directly to a network stream.
+/// </para>
+/// <para>
+/// One consequence of never seeking: <c>[Content_Types].xml</c> is written last, once the set of
+/// worksheets is known, rather than as the first entry. Readers resolve parts through the zip
+/// central directory, so its position in the archive does not matter.
+/// </para>
+/// </remarks>
+internal sealed class StreamingPackageWriter : IDisposable
+{
+    internal const string ContentTypesNs = "http://schemas.openxmlformats.org/package/2006/content-types";
+    internal const string PackageRelationshipsNs = "http://schemas.openxmlformats.org/package/2006/relationships";
+
+    private readonly ZipArchive _archive;
+    private readonly CompressionLevel _compressionLevel;
+    private bool _disposed;
+
+    internal StreamingPackageWriter(Stream output, bool leaveOpen, CompressionLevel compressionLevel)
+    {
+        _archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen);
+        _compressionLevel = compressionLevel;
+    }
+
+    /// <summary>
+    /// Start a part. The returned writer owns the entry: disposing it closes both the writer and
+    /// the entry, and no other part may be started until it has been.
+    /// </summary>
+    internal XmlWriter CreatePart(string entryName)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var entry = _archive.CreateEntry(entryName, _compressionLevel);
+        var settings = new XmlWriterSettings
+        {
+            CloseOutput = true,
+            Encoding = XLHelper.NoBomUTF8
+        };
+
+        return XmlWriter.Create(entry.Open(), settings);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _archive.Dispose();
+    }
+}

--- a/XLibur/Excel/Streaming/StreamingPackageWriter.cs
+++ b/XLibur/Excel/Streaming/StreamingPackageWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.IO.Compression;
 using System.Xml;

--- a/XLibur/Excel/Streaming/StreamingSharedStringTable.cs
+++ b/XLibur/Excel/Streaming/StreamingSharedStringTable.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml;
+using XLibur.Excel.IO;
+using XLibur.Utils;
+using static XLibur.Excel.IO.OpenXmlConst;
+
+namespace XLibur.Excel.Streaming;
+
+/// <summary>
+/// The shared string table of a streaming write: an append-only, insertion-ordered dictionary
+/// of distinct strings.
+/// </summary>
+/// <remarks>
+/// Deliberately not <see cref="SharedStringTable"/>. That one is reference counted, so ids can
+/// be freed and reused, which leaves gaps that the normal save path closes with a remap
+/// (<c>SaveContext.SstMap</c>) after the sheets are in memory. A streaming write cannot remap
+/// anything - the index goes into cell XML that is on disk before the table is written - so ids
+/// here are handed out densely and never released, and the part is emitted in that same order.
+/// </remarks>
+internal sealed class StreamingSharedStringTable
+{
+    private readonly Dictionary<string, int> _ids = new(System.StringComparer.Ordinal);
+    private readonly List<string> _texts = [];
+
+    internal int Count => _texts.Count;
+
+    /// <summary>
+    /// The index of a text, adding it to the table if this is its first use.
+    /// </summary>
+    internal int GetOrAdd(string text)
+    {
+        if (_ids.TryGetValue(text, out var id))
+            return id;
+
+        id = _texts.Count;
+        _texts.Add(text);
+        _ids.Add(text, id);
+        return id;
+    }
+
+    internal void Write(XmlWriter xml)
+    {
+        xml.WriteStartDocument();
+        xml.WriteStartElement("x", "sst", Main2006SsNs);
+        xml.WriteAttributeString("count", _texts.Count.ToString(CultureInfo.InvariantCulture));
+        xml.WriteAttributeString("uniqueCount", _texts.Count.ToString(CultureInfo.InvariantCulture));
+
+        foreach (var text in _texts)
+        {
+            xml.WriteStartElement("si", Main2006SsNs);
+            CellXmlWriter.WriteTextElement(xml, XmlEncoder.EncodeString(text));
+            xml.WriteEndElement(); // si
+        }
+
+        xml.WriteEndElement(); // sst
+        xml.WriteEndDocument();
+    }
+}

--- a/XLibur/Excel/Streaming/StreamingSharedStringTable.cs
+++ b/XLibur/Excel/Streaming/StreamingSharedStringTable.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Xml;
 using XLibur.Excel.IO;
@@ -23,6 +23,12 @@ internal sealed class StreamingSharedStringTable
     private readonly Dictionary<string, int> _ids = new(System.StringComparer.Ordinal);
     private readonly List<string> _texts = [];
 
+    /// <summary>
+    /// Total number of cells that referenced the table, which is what the <c>count</c> attribute
+    /// reports - as against <see cref="Count"/>, the number of <c>si</c> entries.
+    /// </summary>
+    private int _referenceCount;
+
     internal int Count => _texts.Count;
 
     /// <summary>
@@ -30,6 +36,8 @@ internal sealed class StreamingSharedStringTable
     /// </summary>
     internal int GetOrAdd(string text)
     {
+        _referenceCount++;
+
         if (_ids.TryGetValue(text, out var id))
             return id;
 
@@ -43,7 +51,8 @@ internal sealed class StreamingSharedStringTable
     {
         xml.WriteStartDocument();
         xml.WriteStartElement("x", "sst", Main2006SsNs);
-        xml.WriteAttributeString("count", _texts.Count.ToString(CultureInfo.InvariantCulture));
+        // count is how many cells point at the table; uniqueCount is how many entries it holds.
+        xml.WriteAttributeString("count", _referenceCount.ToString(CultureInfo.InvariantCulture));
         xml.WriteAttributeString("uniqueCount", _texts.Count.ToString(CultureInfo.InvariantCulture));
 
         foreach (var text in _texts)

--- a/XLibur/Excel/Streaming/StreamingStyleTable.cs
+++ b/XLibur/Excel/Streaming/StreamingStyleTable.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace XLibur.Excel.Streaming;
+
+/// <summary>
+/// Interns the styles used by a streaming write, handing out the cell style id at the moment
+/// a style is first used.
+/// </summary>
+/// <remarks>
+/// The id has to be final immediately: it is written into cell XML that is in the package long
+/// before the styles part exists. So the order styles are interned in <em>is</em> the
+/// <c>cellXfs</c> order, and <c>WorkbookStylesPartWriter.GenerateStreamingContent</c> emits one
+/// <c>cellXf</c> per entry of <see cref="OrderedStyles"/>, in order, at the end of the write.
+/// </remarks>
+internal sealed class StreamingStyleTable
+{
+    private readonly Dictionary<XLStyleValue, uint> _ids = [];
+    private readonly List<XLStyleValue> _ordered = [];
+
+    internal StreamingStyleTable()
+    {
+        // Id 0 must be the default style: it is what every cell written without an explicit
+        // style refers to, and what Excel treats as the workbook default.
+        GetOrAdd(XLStyleValue.Default);
+    }
+
+    internal IReadOnlyList<XLStyleValue> OrderedStyles => _ordered;
+
+    /// <summary>
+    /// The cell style id for a style, or 0 when <paramref name="style"/> is <c>null</c>.
+    /// </summary>
+    internal uint GetOrAdd(IXLStyle? style)
+    {
+        if (style is null)
+            return 0;
+
+        var key = XLStyle.GenerateKey(style);
+        return GetOrAdd(XLStyleValue.FromKey(ref key));
+    }
+
+    internal uint GetOrAdd(XLStyleValue value)
+    {
+        if (_ids.TryGetValue(value, out var id))
+            return id;
+
+        id = (uint)_ordered.Count;
+        _ordered.Add(value);
+        _ids.Add(value, id);
+        return id;
+    }
+}

--- a/XLibur/Excel/Streaming/StreamingStyleTable.cs
+++ b/XLibur/Excel/Streaming/StreamingStyleTable.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XLibur.Excel.Streaming;
 

--- a/XLibur/Excel/Streaming/XLStreamingColumn.cs
+++ b/XLibur/Excel/Streaming/XLStreamingColumn.cs
@@ -1,0 +1,44 @@
+namespace XLibur.Excel.Streaming;
+
+/// <summary>
+/// Presentation settings for a column (or a range of columns) of a streamed worksheet, as
+/// returned by <see cref="XLStreamingWorksheet.Column"/> and
+/// <see cref="XLStreamingWorksheet.Columns"/>.
+/// </summary>
+/// <remarks>
+/// Columns are written before <c>sheetData</c>, so these must be set before the first row is
+/// appended to the sheet.
+/// </remarks>
+public sealed class XLStreamingColumn
+{
+    internal XLStreamingColumn(int firstColumn, int lastColumn)
+    {
+        FirstColumn = firstColumn;
+        LastColumn = lastColumn;
+    }
+
+    /// <summary>First column this applies to, 1-based.</summary>
+    public int FirstColumn { get; }
+
+    /// <summary>Last column this applies to, 1-based and inclusive.</summary>
+    public int LastColumn { get; }
+
+    /// <summary>
+    /// Column width in Excel's character units, or <c>null</c> to leave the default width.
+    /// </summary>
+    public double? Width { get; set; }
+
+    /// <summary>Whether the column is hidden.</summary>
+    public bool Hidden { get; set; }
+
+    /// <summary>Outline (grouping) level, 0 for none.</summary>
+    public int OutlineLevel { get; set; }
+
+    /// <summary>Whether the outline group the column belongs to is collapsed.</summary>
+    public bool Collapsed { get; set; }
+
+    /// <summary>
+    /// Style applied to cells in the column that carry no style of their own.
+    /// </summary>
+    public IXLStyle? Style { get; set; }
+}

--- a/XLibur/Excel/Streaming/XLStreamingColumn.cs
+++ b/XLibur/Excel/Streaming/XLStreamingColumn.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel.Streaming;
+﻿namespace XLibur.Excel.Streaming;
 
 /// <summary>
 /// Presentation settings for a column (or a range of columns) of a streamed worksheet, as

--- a/XLibur/Excel/Streaming/XLStreamingOptions.cs
+++ b/XLibur/Excel/Streaming/XLStreamingOptions.cs
@@ -1,0 +1,56 @@
+using System.IO.Compression;
+
+namespace XLibur.Excel.Streaming;
+
+/// <summary>
+/// How the streaming writer stores text values.
+/// </summary>
+public enum XLStreamingStringStorage
+{
+    /// <summary>
+    /// Text is written to the workbook-wide shared string table and cells reference it by
+    /// index. Produces the smallest file when text repeats, which is the usual case for an
+    /// export. The dictionary of distinct strings is held in memory until
+    /// <see cref="XLStreamingWorkbook.Finish"/>, so it is the one part of a streaming write
+    /// whose cost grows with the data.
+    /// </summary>
+    SharedStrings = 0,
+
+    /// <summary>
+    /// Text is written into the cell as an inline string. Uses no memory beyond the current
+    /// row at the cost of a larger file when text repeats. Choose this when the number of
+    /// distinct strings is large enough that the shared string dictionary would not fit.
+    /// </summary>
+    Inline = 1
+}
+
+/// <summary>
+/// Options for <see cref="XLStreamingWorkbook.Create(System.IO.Stream, XLStreamingOptions?)"/>.
+/// </summary>
+public sealed class XLStreamingOptions
+{
+    /// <summary>
+    /// How text values are stored. Defaults to
+    /// <see cref="XLStreamingStringStorage.SharedStrings"/>.
+    /// </summary>
+    public XLStreamingStringStorage StringStorage { get; set; } = XLStreamingStringStorage.SharedStrings;
+
+    /// <summary>
+    /// Write dates against the 1904 date system rather than the 1900 one. Defaults to
+    /// <c>false</c>, matching <see cref="XLWorkbook"/>.
+    /// </summary>
+    public bool Use1904DateSystem { get; set; }
+
+    /// <summary>
+    /// How hard to compress the package. Defaults to
+    /// <see cref="System.IO.Compression.CompressionLevel.Optimal"/>;
+    /// <see cref="System.IO.Compression.CompressionLevel.Fastest"/> trades a noticeably larger
+    /// file for a faster write, which is often the right call for a large export.
+    /// </summary>
+    /// <remarks>
+    /// Available here and not on <see cref="SaveOptions"/> because the streaming writer owns its
+    /// zip, whereas <see cref="XLWorkbook"/> goes through <c>System.IO.Packaging</c>, which does
+    /// not expose the setting.
+    /// </remarks>
+    public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Optimal;
+}

--- a/XLibur/Excel/Streaming/XLStreamingOptions.cs
+++ b/XLibur/Excel/Streaming/XLStreamingOptions.cs
@@ -1,4 +1,4 @@
-using System.IO.Compression;
+﻿using System.IO.Compression;
 
 namespace XLibur.Excel.Streaming;
 
@@ -48,9 +48,10 @@ public sealed class XLStreamingOptions
     /// file for a faster write, which is often the right call for a large export.
     /// </summary>
     /// <remarks>
-    /// Available here and not on <see cref="SaveOptions"/> because the streaming writer owns its
-    /// zip, whereas <see cref="XLWorkbook"/> goes through <c>System.IO.Packaging</c>, which does
-    /// not expose the setting.
+    /// <see cref="SaveOptions.CompressionLevel"/> is the equivalent for an ordinary save. The two
+    /// reach it differently: the streaming writer configures its own zip, while
+    /// <see cref="XLWorkbook"/> passes the setting through <c>System.IO.Packaging</c>, which
+    /// applies it only to parts that save creates.
     /// </remarks>
     public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Optimal;
 }

--- a/XLibur/Excel/Streaming/XLStreamingRow.cs
+++ b/XLibur/Excel/Streaming/XLStreamingRow.cs
@@ -1,0 +1,94 @@
+namespace XLibur.Excel.Streaming;
+
+/// <summary>
+/// The row currently being written by an <see cref="XLStreamingWorksheet"/>. Cells are written
+/// left to right as they are added; the row cannot be revisited once it is closed.
+/// </summary>
+/// <remarks>
+/// A <c>ref struct</c> so that a row cannot outlive the sheet write it belongs to, and so
+/// building a row allocates nothing. Closing the row with <c>using</c> is optional - the row is
+/// also closed when the next row starts or the worksheet completes - but it makes the row's
+/// extent obvious at the call site.
+/// </remarks>
+/// <example>
+/// <code>
+/// using (var row = sheet.AddRow())
+/// {
+///     row.Cell("Widget");
+///     row.Cell(12, highlight);
+///     row.Skip(1);
+///     row.Formula("B2*2", cachedValue: 24);
+/// }
+/// </code>
+/// </example>
+public readonly ref struct XLStreamingRow
+{
+    private readonly XLStreamingWorksheet _worksheet;
+
+    internal XLStreamingRow(XLStreamingWorksheet worksheet, int rowNumber)
+    {
+        _worksheet = worksheet;
+        RowNumber = rowNumber;
+    }
+
+    /// <summary>The 1-based number of this row.</summary>
+    public int RowNumber { get; }
+
+    /// <summary>
+    /// Write a value into the next free column.
+    /// </summary>
+    public XLStreamingRow Cell(XLCellValue value)
+    {
+        _worksheet.WriteValueCell(RowNumber, value, null);
+        return this;
+    }
+
+    /// <summary>
+    /// Write a value into the next free column with its own style, overriding the row style.
+    /// </summary>
+    public XLStreamingRow Cell(XLCellValue value, IXLStyle? style)
+    {
+        _worksheet.WriteValueCell(RowNumber, value, style);
+        return this;
+    }
+
+    /// <summary>
+    /// Write a formula into the next free column. The formula string is stored verbatim - it is
+    /// never parsed or evaluated - and is accepted with or without a leading <c>=</c>.
+    /// </summary>
+    /// <remarks>
+    /// Without a <c>cachedValue</c> the cell has no result stored, so it shows as empty until
+    /// Excel recalculates the sheet. Supply the value you already know to have it display
+    /// immediately.
+    /// </remarks>
+    public XLStreamingRow Formula(string formula, XLCellValue cachedValue = default, IXLStyle? style = null)
+    {
+        _worksheet.WriteFormulaCell(RowNumber, formula, cachedValue, style);
+        return this;
+    }
+
+    /// <summary>
+    /// Leave the next <paramref name="columnCount"/> columns empty.
+    /// </summary>
+    public XLStreamingRow Skip(int columnCount)
+    {
+        _worksheet.SkipCells(RowNumber, columnCount);
+        return this;
+    }
+
+    /// <summary>
+    /// Continue writing at a specific column, 1-based. The column must be at or after the next
+    /// free one, since cells are written left to right.
+    /// </summary>
+    public XLStreamingRow At(int columnNumber)
+    {
+        _worksheet.MoveToColumn(RowNumber, columnNumber);
+        return this;
+    }
+
+    /// <summary>
+    /// Close the row. Optional: the row also closes when the next row starts or the worksheet
+    /// completes.
+    /// </summary>
+    public void Dispose() => _worksheet.EndRow(RowNumber);
+}

--- a/XLibur/Excel/Streaming/XLStreamingRow.cs
+++ b/XLibur/Excel/Streaming/XLStreamingRow.cs
@@ -1,4 +1,4 @@
-namespace XLibur.Excel.Streaming;
+﻿namespace XLibur.Excel.Streaming;
 
 /// <summary>
 /// The row currently being written by an <see cref="XLStreamingWorksheet"/>. Cells are written

--- a/XLibur/Excel/Streaming/XLStreamingWorkbook.cs
+++ b/XLibur/Excel/Streaming/XLStreamingWorkbook.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;

--- a/XLibur/Excel/Streaming/XLStreamingWorkbook.cs
+++ b/XLibur/Excel/Streaming/XLStreamingWorkbook.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+using DocumentFormat.OpenXml.Spreadsheet;
+using XLibur.Excel.IO;
+using XLibur.Extensions;
+using static XLibur.Excel.IO.OpenXmlConst;
+using static XLibur.Excel.Streaming.StreamingPackageWriter;
+using static XLibur.Excel.XLWorkbook;
+
+namespace XLibur.Excel.Streaming;
+
+/// <summary>
+/// A forward-only writer for .xlsx workbooks that are too large to hold in memory.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Rows are serialised straight into the package as they are appended, so peak memory does not
+/// grow with the number of rows. In exchange the writer is append-only: rows go in ascending
+/// order, one worksheet is written at a time, nothing can be read back or revised, and formulas
+/// are passed through verbatim rather than evaluated. Use <see cref="XLWorkbook"/> when any of
+/// that matters.
+/// </para>
+/// <para>
+/// Two things are still proportional to the data rather than constant. Distinct <em>strings</em>
+/// are held until <see cref="Finish"/> under
+/// <see cref="XLStreamingStringStorage.SharedStrings"/> - switch to
+/// <see cref="XLStreamingStringStorage.Inline"/> if that set is unbounded. Distinct
+/// <em>styles</em> are held too, but their number is bounded by how many distinct formats the
+/// caller actually uses, not by row count.
+/// </para>
+/// <para>
+/// <see cref="Finish"/> must be called to produce a readable file: it writes the shared strings,
+/// the styles, the workbook part and the package plumbing, none of which are known until the
+/// last row is in. Disposing without finishing abandons the write and leaves an incomplete
+/// package.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// using var wb = XLStreamingWorkbook.Create(stream);
+/// var sheet = wb.AddWorksheet("Data");
+/// sheet.FreezeRows(1);
+/// sheet.AppendRow("Name", "Qty");
+/// for (var i = 0; i &lt; 1_000_000; i++)
+///     sheet.AppendRow($"Item {i}", i);
+/// wb.Finish();
+/// </code>
+/// </example>
+public sealed class XLStreamingWorkbook : IDisposable
+{
+    private const string OfficeDocumentRelType =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
+
+    private const string WorksheetRelType =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet";
+
+    private const string StylesRelType =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles";
+
+    private const string SharedStringsRelType =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings";
+
+    private const string WorkbookContentType =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml";
+
+    private const string WorksheetContentType =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml";
+
+    private const string StylesContentType =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml";
+
+    private const string SharedStringsContentType =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml";
+
+    private const string RelationshipsContentType =
+        "application/vnd.openxmlformats-package.relationships+xml";
+
+    private const string StylesPartName = "xl/styles.xml";
+    private const string SharedStringsPartName = "xl/sharedStrings.xml";
+    private const string WorkbookPartName = "xl/workbook.xml";
+
+    private readonly StreamingPackageWriter _package;
+    private readonly Stream? _ownedStream;
+    private readonly List<XLStreamingWorksheet> _worksheets = [];
+    private readonly HashSet<string> _sheetNames = new(StringComparer.OrdinalIgnoreCase);
+
+    private XLStreamingWorksheet? _openWorksheet;
+    private bool _finished;
+    private bool _disposed;
+
+    private XLStreamingWorkbook(Stream output, Stream? ownedStream, XLStreamingOptions options)
+    {
+        _ownedStream = ownedStream;
+        _package = new StreamingPackageWriter(output, leaveOpen: ownedStream is null, options.CompressionLevel);
+        Options = options;
+        SharedStrings = new StreamingSharedStringTable();
+        Styles = new StreamingStyleTable();
+    }
+
+    internal XLStreamingOptions Options { get; }
+
+    internal StreamingSharedStringTable SharedStrings { get; }
+
+    internal StreamingStyleTable Styles { get; }
+
+    /// <summary>
+    /// Start writing a workbook to a stream. The stream only has to be writable - it is never
+    /// read back or seeked - so a workbook can be written straight to a network stream. It is
+    /// left open when this workbook is disposed.
+    /// </summary>
+    public static XLStreamingWorkbook Create(Stream output) => Create(output, null);
+
+    /// <inheritdoc cref="Create(Stream)"/>
+    public static XLStreamingWorkbook Create(Stream output, XLStreamingOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+
+        return new XLStreamingWorkbook(output, null, options ?? new XLStreamingOptions());
+    }
+
+    /// <summary>
+    /// Start writing a workbook to a file, creating or overwriting it.
+    /// </summary>
+    public static XLStreamingWorkbook Create(string path) => Create(path, null);
+
+    /// <inheritdoc cref="Create(string)"/>
+    public static XLStreamingWorkbook Create(string path, XLStreamingOptions? options)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var directoryName = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directoryName))
+            Directory.CreateDirectory(directoryName);
+
+        var fileStream = File.Create(path);
+        try
+        {
+            return new XLStreamingWorkbook(fileStream, fileStream, options ?? new XLStreamingOptions());
+        }
+        catch
+        {
+            fileStream.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// A fresh, unattached style initialised to the workbook default. Configure it and pass it
+    /// to a row or a cell.
+    /// </summary>
+    /// <remarks>
+    /// The writer interns the style's value at the point of use, so one instance can be
+    /// reconfigured and handed to later rows without disturbing the rows already written.
+    /// </remarks>
+    public IXLStyle CreateStyle() => XLStyle.CreateEmptyStyle();
+
+    /// <summary>
+    /// Add a worksheet and make it the one being written. Any worksheet still open is completed
+    /// first - only one can be open at a time, because both write to the same package.
+    /// </summary>
+    public XLStreamingWorksheet AddWorksheet(string name)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ThrowIfFinished();
+
+        XLHelper.ValidateSheetName(name);
+        if (!_sheetNames.Add(name))
+            throw new ArgumentException($"A worksheet named '{name}' has already been added.", nameof(name));
+
+        _openWorksheet?.Complete();
+
+        var index = _worksheets.Count + 1;
+        var worksheet = new XLStreamingWorksheet(this, name, index);
+        _worksheets.Add(worksheet);
+        _openWorksheet = worksheet;
+        return worksheet;
+    }
+
+    /// <summary>
+    /// Complete the workbook: finish any open worksheet, then write the shared strings, the
+    /// styles, the workbook part and the package plumbing. Repeat calls do nothing. No rows can
+    /// be appended afterwards.
+    /// </summary>
+    public void Finish()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_finished)
+            return;
+
+        _openWorksheet?.Complete();
+        _openWorksheet = null;
+
+        // Every worksheet has to be closed before the shared strings and styles are written:
+        // both are still accumulating entries while rows are being appended.
+        foreach (var worksheet in _worksheets)
+            worksheet.Complete();
+
+        var writeSharedStrings = Options.StringStorage == XLStreamingStringStorage.SharedStrings &&
+                                 SharedStrings.Count > 0;
+
+        if (writeSharedStrings)
+        {
+            using var xml = _package.CreatePart(SharedStringsPartName);
+            SharedStrings.Write(xml);
+        }
+
+        WriteStylesPart();
+        WriteWorkbookPart();
+        WriteWorkbookRelationships(writeSharedStrings);
+        WritePackageRelationships();
+        WriteContentTypes(writeSharedStrings);
+
+        _finished = true;
+    }
+
+    internal XmlWriter CreatePart(string entryName) => _package.CreatePart(entryName);
+
+    private void WriteStylesPart()
+    {
+        var stylesheet = new Stylesheet();
+        WorkbookStylesPartWriter.GenerateStreamingContent(stylesheet, Styles.OrderedStyles, new SaveContext());
+
+        using var xml = _package.CreatePart(StylesPartName);
+        xml.WriteStartDocument(true);
+        stylesheet.WriteTo(xml);
+        xml.WriteEndDocument();
+    }
+
+    private void WriteWorkbookPart()
+    {
+        using var xml = _package.CreatePart(WorkbookPartName);
+
+        xml.WriteStartDocument(true);
+        xml.WriteStartElement("workbook", Main2006SsNs);
+        xml.WriteAttributeString("xmlns", "r", null, RelationshipsNs);
+
+        if (Options.Use1904DateSystem)
+        {
+            xml.WriteStartElement("workbookPr", Main2006SsNs);
+            xml.WriteAttributeString("date1904", TrueValue);
+            xml.WriteEndElement();
+        }
+
+        xml.WriteStartElement("sheets", Main2006SsNs);
+        foreach (var worksheet in _worksheets)
+        {
+            xml.WriteStartElement("sheet", Main2006SsNs);
+            xml.WriteAttributeString("name", worksheet.Name);
+            xml.WriteAttribute("sheetId", (uint)worksheet.Index);
+            xml.WriteAttributeString("id", RelationshipsNs, WorksheetRelationshipId(worksheet.Index));
+            xml.WriteEndElement(); // sheet
+        }
+
+        xml.WriteEndElement(); // sheets
+        xml.WriteEndElement(); // workbook
+        xml.WriteEndDocument();
+    }
+
+    private void WriteWorkbookRelationships(bool writeSharedStrings)
+    {
+        using var xml = _package.CreatePart("xl/_rels/workbook.xml.rels");
+
+        xml.WriteStartDocument(true);
+        xml.WriteStartElement("Relationships", PackageRelationshipsNs);
+
+        foreach (var worksheet in _worksheets)
+        {
+            WriteRelationship(xml, WorksheetRelationshipId(worksheet.Index), WorksheetRelType,
+                XLStreamingWorksheet.EntryName(worksheet.Index)["xl/".Length..]);
+        }
+
+        var nextId = _worksheets.Count + 1;
+        WriteRelationship(xml, $"rId{nextId}", StylesRelType, "styles.xml");
+
+        if (writeSharedStrings)
+            WriteRelationship(xml, $"rId{nextId + 1}", SharedStringsRelType, "sharedStrings.xml");
+
+        xml.WriteEndElement(); // Relationships
+        xml.WriteEndDocument();
+    }
+
+    private void WritePackageRelationships()
+    {
+        using var xml = _package.CreatePart("_rels/.rels");
+
+        xml.WriteStartDocument(true);
+        xml.WriteStartElement("Relationships", PackageRelationshipsNs);
+        WriteRelationship(xml, "rId1", OfficeDocumentRelType, WorkbookPartName);
+        xml.WriteEndElement();
+        xml.WriteEndDocument();
+    }
+
+    private void WriteContentTypes(bool writeSharedStrings)
+    {
+        using var xml = _package.CreatePart("[Content_Types].xml");
+
+        xml.WriteStartDocument(true);
+        xml.WriteStartElement("Types", ContentTypesNs);
+
+        xml.WriteStartElement("Default", ContentTypesNs);
+        xml.WriteAttributeString("Extension", "rels");
+        xml.WriteAttributeString("ContentType", RelationshipsContentType);
+        xml.WriteEndElement();
+
+        WriteContentTypeOverride(xml, "/" + WorkbookPartName, WorkbookContentType);
+
+        foreach (var worksheet in _worksheets)
+        {
+            WriteContentTypeOverride(xml, "/" + XLStreamingWorksheet.EntryName(worksheet.Index),
+                WorksheetContentType);
+        }
+
+        WriteContentTypeOverride(xml, "/" + StylesPartName, StylesContentType);
+
+        if (writeSharedStrings)
+            WriteContentTypeOverride(xml, "/" + SharedStringsPartName, SharedStringsContentType);
+
+        xml.WriteEndElement(); // Types
+        xml.WriteEndDocument();
+    }
+
+    private static void WriteContentTypeOverride(XmlWriter xml, string partName, string contentType)
+    {
+        xml.WriteStartElement("Override", ContentTypesNs);
+        xml.WriteAttributeString("PartName", partName);
+        xml.WriteAttributeString("ContentType", contentType);
+        xml.WriteEndElement();
+    }
+
+    private static void WriteRelationship(XmlWriter xml, string id, string type, string target)
+    {
+        xml.WriteStartElement("Relationship", PackageRelationshipsNs);
+        xml.WriteAttributeString("Id", id);
+        xml.WriteAttributeString("Type", type);
+        xml.WriteAttributeString("Target", target);
+        xml.WriteEndElement();
+    }
+
+    private static string WorksheetRelationshipId(int index) => $"rId{index}";
+
+    private void ThrowIfFinished()
+    {
+        if (_finished)
+            throw new InvalidOperationException(
+                $"The workbook has been finished. Create a new {nameof(XLStreamingWorkbook)} to write more.");
+    }
+
+    /// <summary>
+    /// Release the package. <see cref="Finish"/> is <em>not</em> called implicitly: disposing a
+    /// workbook that was never finished abandons the write, because a package without its
+    /// workbook part cannot be opened.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _package.Dispose();
+        _ownedStream?.Dispose();
+    }
+}

--- a/XLibur/Excel/Streaming/XLStreamingWorksheet.cs
+++ b/XLibur/Excel/Streaming/XLStreamingWorksheet.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Xml;
 using XLibur.Excel.Coordinates;
@@ -292,7 +292,16 @@ public sealed class XLStreamingWorksheet
 
         var xml = RequireOpenRow(rowNumber);
         var column = _nextColumnNumber++;
-        var styleId = style is null ? _openRowStyleId : _workbook.Styles.GetOrAdd(ResolveStyleValue(style));
+
+        // A cached date or duration needs the same number format a literal one would, or it
+        // reads back as a plain number. Only that rule applies here: the text adjustments are
+        // about how a user typed a literal, and stripping a leading apostrophe from a formula's
+        // computed result would corrupt the cached value.
+        var styleValue = ResolveStyleValue(style);
+        var adjusted = AdjustStyleForNumberFormat(styleValue, cachedValue);
+        var styleId = ReferenceEquals(adjusted, styleValue) && style is null
+            ? _openRowStyleId
+            : _workbook.Styles.GetOrAdd(adjusted);
 
         // Formulas are stored without the leading '=' that a user typically writes.
         if (formula[0] == '=')
@@ -376,14 +385,8 @@ public sealed class XLStreamingWorksheet
         switch (value.Type)
         {
             case XLDataType.DateTime:
-                return XLValueStyleRules.HasGeneralNumberFormat(styleValue)
-                    ? XLValueStyleRules.WithDateTimeFormat(styleValue, value.GetUnifiedNumber() % 1 == 0)
-                    : styleValue;
-
             case XLDataType.TimeSpan:
-                return XLValueStyleRules.HasGeneralNumberFormat(styleValue)
-                    ? XLValueStyleRules.WithDurationFormat(styleValue)
-                    : styleValue;
+                return AdjustStyleForNumberFormat(styleValue, value);
 
             case XLDataType.Text:
                 {
@@ -398,6 +401,24 @@ public sealed class XLStreamingWorksheet
             default:
                 return styleValue;
         }
+    }
+
+    /// <summary>
+    /// Give a date or duration the number format that identifies it as one, when the style
+    /// leaves the format at General. Everything else is returned untouched.
+    /// </summary>
+    private static XLStyleValue AdjustStyleForNumberFormat(XLStyleValue styleValue, XLCellValue value)
+    {
+        if (!XLValueStyleRules.HasGeneralNumberFormat(styleValue))
+            return styleValue;
+
+        return value.Type switch
+        {
+            XLDataType.DateTime => XLValueStyleRules.WithDateTimeFormat(
+                styleValue, value.GetUnifiedNumber() % 1 == 0),
+            XLDataType.TimeSpan => XLValueStyleRules.WithDurationFormat(styleValue),
+            _ => styleValue
+        };
     }
 
     private void WriteCellStart(XmlWriter xml, int rowNumber, int columnNumber, string? dataType, uint styleId)

--- a/XLibur/Excel/Streaming/XLStreamingWorksheet.cs
+++ b/XLibur/Excel/Streaming/XLStreamingWorksheet.cs
@@ -1,0 +1,554 @@
+using System;
+using System.Collections.Generic;
+using System.Xml;
+using XLibur.Excel.Coordinates;
+using XLibur.Excel.IO;
+using XLibur.Extensions;
+using static XLibur.Excel.IO.OpenXmlConst;
+
+namespace XLibur.Excel.Streaming;
+
+/// <summary>
+/// A worksheet being written by an <see cref="XLStreamingWorkbook"/>. Rows are appended in
+/// ascending order and serialised immediately; nothing already written can be revisited.
+/// </summary>
+public sealed class XLStreamingWorksheet
+{
+    private readonly XLStreamingWorkbook _workbook;
+    private readonly char[] _cellRef = new char[CellXmlWriter.CellRefBufferLength];
+    private readonly Dictionary<(int First, int Last), XLStreamingColumn> _columns = [];
+
+    private XmlWriter? _xml;
+    private bool _started;
+    private bool _completed;
+
+    private int _nextRowNumber = 1;
+    private int _openRowNumber;
+    private uint _openRowStyleId;
+    private XLStyleValue _openRowStyleValue = XLStyleValue.Default;
+    private int _nextColumnNumber = 1;
+
+    private int _freezeRows;
+    private int _freezeColumns;
+
+    internal XLStreamingWorksheet(XLStreamingWorkbook workbook, string name, int index)
+    {
+        _workbook = workbook;
+        Name = name;
+        Index = index;
+    }
+
+    /// <summary>
+    /// The zip entry a worksheet's XML lives in. Sheets are numbered from 1 in the order they
+    /// were added, which is also their <c>sheetId</c> and the ordinal in their relationship id.
+    /// </summary>
+    internal static string EntryName(int index) => $"xl/worksheets/sheet{index}.xml";
+
+    /// <summary>The sheet name, as it appears on the tab.</summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Range the autofilter dropdowns cover, e.g. <c>"A1:D1"</c>, or <c>null</c> for none.
+    /// Written after the rows, so it may be set at any point before <see cref="Complete"/>.
+    /// </summary>
+    public string? AutoFilterRange { get; set; }
+
+    /// <summary>
+    /// Number of the row that will be written by the next <see cref="AddRow()"/> or
+    /// <see cref="AppendRow(XLCellValue[])"/>, 1-based.
+    /// </summary>
+    public int NextRowNumber => _nextRowNumber;
+
+    /// <summary>1-based position of the sheet, used for its part name, id and relationship.</summary>
+    internal int Index { get; }
+
+    #region Layout - must be set before the first row
+
+    /// <summary>
+    /// Presentation settings for a single column, 1-based. Must be called before the first row
+    /// is appended, because columns are written ahead of the rows.
+    /// </summary>
+    public XLStreamingColumn Column(int columnNumber) => Columns(columnNumber, columnNumber);
+
+    /// <summary>
+    /// Presentation settings for an inclusive range of columns, 1-based. Ranges must not
+    /// overlap. Must be called before the first row is appended.
+    /// </summary>
+    public XLStreamingColumn Columns(int firstColumn, int lastColumn)
+    {
+        ThrowIfStarted(nameof(Columns));
+        if (firstColumn < 1 || firstColumn > XLHelper.MaxColumnNumber)
+            throw new ArgumentOutOfRangeException(nameof(firstColumn));
+        if (lastColumn < firstColumn || lastColumn > XLHelper.MaxColumnNumber)
+            throw new ArgumentOutOfRangeException(nameof(lastColumn));
+
+        var key = (firstColumn, lastColumn);
+        if (!_columns.TryGetValue(key, out var column))
+        {
+            column = new XLStreamingColumn(firstColumn, lastColumn);
+            _columns.Add(key, column);
+        }
+
+        return column;
+    }
+
+    /// <summary>
+    /// Freeze the top <paramref name="rowCount"/> rows so they stay visible while scrolling.
+    /// Must be called before the first row is appended.
+    /// </summary>
+    public void FreezeRows(int rowCount) => FreezePanes(rowCount, _freezeColumns);
+
+    /// <summary>
+    /// Freeze the leftmost <paramref name="columnCount"/> columns. Must be called before the
+    /// first row is appended.
+    /// </summary>
+    public void FreezeColumns(int columnCount) => FreezePanes(_freezeRows, columnCount);
+
+    /// <summary>
+    /// Freeze the top <paramref name="rowCount"/> rows and leftmost
+    /// <paramref name="columnCount"/> columns. Must be called before the first row is appended.
+    /// </summary>
+    public void FreezePanes(int rowCount, int columnCount)
+    {
+        ThrowIfStarted(nameof(FreezePanes));
+        ArgumentOutOfRangeException.ThrowIfNegative(rowCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(columnCount);
+
+        _freezeRows = rowCount;
+        _freezeColumns = columnCount;
+    }
+
+    #endregion Layout
+
+    #region Rows
+
+    /// <summary>
+    /// Open a row for cell-by-cell writing. The row is closed by disposing the returned value,
+    /// or implicitly when the next row starts or the sheet completes.
+    /// </summary>
+    public XLStreamingRow AddRow() => AddRow(null);
+
+    /// <summary>
+    /// Open a row for cell-by-cell writing, with row-level formatting. <paramref name="style"/>
+    /// applies to cells in the row that carry no style of their own.
+    /// </summary>
+    public XLStreamingRow AddRow(IXLStyle? style, double? height = null, bool hidden = false)
+    {
+        ThrowIfCompleted();
+        EnsureStarted();
+        EndOpenRow();
+
+        var xml = _xml!;
+        var rowNumber = _nextRowNumber;
+
+        if (style is null)
+        {
+            _openRowStyleValue = XLStyleValue.Default;
+            _openRowStyleId = 0;
+        }
+        else
+        {
+            var key = XLStyle.GenerateKey(style);
+            _openRowStyleValue = XLStyleValue.FromKey(ref key);
+            _openRowStyleId = _workbook.Styles.GetOrAdd(_openRowStyleValue);
+        }
+
+        CellXmlWriter.WriteRowStart(xml, rowNumber, 0);
+
+        if (height is not null)
+        {
+            xml.WriteAttribute("ht", height.Value.SaveRound());
+            xml.WriteAttributeString("customHeight", TrueValue);
+        }
+
+        if (hidden)
+            xml.WriteAttributeString("hidden", TrueValue);
+
+        if (_openRowStyleId != 0)
+        {
+            xml.WriteAttribute("s", _openRowStyleId);
+            xml.WriteAttributeString("customFormat", TrueValue);
+        }
+
+        _openRowNumber = rowNumber;
+        _nextRowNumber = rowNumber + 1;
+        _nextColumnNumber = 1;
+
+        return new XLStreamingRow(this, rowNumber);
+    }
+
+    /// <summary>
+    /// Append a row of values, starting at column A.
+    /// </summary>
+    public void AppendRow(params XLCellValue[] values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        AppendRow(values.AsSpan(), null);
+    }
+
+    /// <summary>
+    /// Append a row of values, starting at column A, with an optional row-level style.
+    /// </summary>
+    public void AppendRow(ReadOnlySpan<XLCellValue> values, IXLStyle? style = null)
+    {
+        var row = AddRow(style);
+        foreach (var value in values)
+            row.Cell(value);
+
+        EndOpenRow();
+    }
+
+    /// <summary>
+    /// Leave <paramref name="count"/> rows empty. Skipped rows take no space in the file.
+    /// </summary>
+    public void SkipRows(int count)
+    {
+        ThrowIfCompleted();
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        EndOpenRow();
+        _nextRowNumber += count;
+    }
+
+    /// <summary>
+    /// Finish the worksheet and close its part. Repeat calls do nothing. Called automatically
+    /// when another worksheet is added or the workbook is finished.
+    /// </summary>
+    public void Complete()
+    {
+        if (_completed)
+            return;
+
+        EnsureStarted();
+        EndOpenRow();
+
+        _xml!.WriteEndElement(); // sheetData
+
+        if (!string.IsNullOrEmpty(AutoFilterRange))
+        {
+            _xml.WriteStartElement("autoFilter", Main2006SsNs);
+            _xml.WriteAttributeString("ref", AutoFilterRange);
+            _xml.WriteEndElement();
+        }
+
+        _xml.WriteEndElement(); // worksheet
+        _xml.WriteEndDocument();
+        _xml.Dispose();
+        _xml = null;
+        _completed = true;
+    }
+
+    #endregion Rows
+
+    #region Cell writing, driven by XLStreamingRow
+
+    internal void WriteValueCell(int rowNumber, XLCellValue value, IXLStyle? style)
+    {
+        var xml = RequireOpenRow(rowNumber);
+        var column = _nextColumnNumber++;
+
+        // A date, a duration and a number are all stored as a serial number, so only the number
+        // format distinguishes them on the way back in; likewise a leading apostrophe and a line
+        // break are carried by the style, not the value. Same rules the cell setter applies.
+        var styleValue = ResolveStyleValue(style);
+        var adjusted = AdjustStyleForValue(styleValue, ref value);
+        var styleId = ReferenceEquals(adjusted, styleValue) && style is null
+            ? _openRowStyleId
+            : _workbook.Styles.GetOrAdd(adjusted);
+
+        if (value.Type == XLDataType.Blank)
+        {
+            // A blank cell is only worth writing when it carries formatting the row does not.
+            if (styleId == _openRowStyleId)
+                return;
+
+            WriteCellStart(xml, rowNumber, column, null, styleId);
+            xml.WriteEndElement(); // c
+            return;
+        }
+
+        var shareStrings = _workbook.Options.StringStorage == XLStreamingStringStorage.SharedStrings;
+        WriteCellStart(xml, rowNumber, column, CellXmlWriter.GetValueCellType(value.Type, shareStrings), styleId);
+
+        if (value.Type == XLDataType.Text)
+        {
+            var text = value.GetText();
+            if (shareStrings)
+                CellXmlWriter.WriteSharedStringValue(xml, _workbook.SharedStrings.GetOrAdd(text));
+            else
+                CellXmlWriter.WriteInlineString(xml, text);
+        }
+        else
+        {
+            CellXmlWriter.WriteNonTextValue(xml, value, _workbook.Options.Use1904DateSystem);
+        }
+
+        xml.WriteEndElement(); // c
+    }
+
+    internal void WriteFormulaCell(int rowNumber, string formula, XLCellValue cachedValue, IXLStyle? style)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(formula);
+
+        var xml = RequireOpenRow(rowNumber);
+        var column = _nextColumnNumber++;
+        var styleId = style is null ? _openRowStyleId : _workbook.Styles.GetOrAdd(ResolveStyleValue(style));
+
+        // Formulas are stored without the leading '=' that a user typically writes.
+        if (formula[0] == '=')
+            formula = formula[1..];
+
+        var dataType = cachedValue.Type != XLDataType.Blank
+            ? CellXmlWriter.GetFormulaCellType(cachedValue.Type)
+            : null;
+
+        WriteCellStart(xml, rowNumber, column, dataType, styleId);
+
+        xml.WriteStartElement("f", Main2006SsNs);
+        xml.WriteString(formula);
+        xml.WriteEndElement(); // f
+
+        switch (cachedValue.Type)
+        {
+            case XLDataType.Blank:
+                break;
+            case XLDataType.Text:
+                CellXmlWriter.WriteStringValue(xml, cachedValue.GetText());
+                break;
+            default:
+                CellXmlWriter.WriteNonTextValue(xml, cachedValue, _workbook.Options.Use1904DateSystem);
+                break;
+        }
+
+        xml.WriteEndElement(); // c
+    }
+
+    internal void SkipCells(int rowNumber, int count)
+    {
+        RequireOpenRow(rowNumber);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        _nextColumnNumber += count;
+    }
+
+    internal void MoveToColumn(int rowNumber, int columnNumber)
+    {
+        RequireOpenRow(rowNumber);
+        if (columnNumber < _nextColumnNumber)
+        {
+            throw new ArgumentOutOfRangeException(nameof(columnNumber),
+                $"Cells are written left to right; column {columnNumber} is before the next free column " +
+                $"{_nextColumnNumber} of row {rowNumber}.");
+        }
+
+        _nextColumnNumber = columnNumber;
+    }
+
+    internal void EndRow(int rowNumber)
+    {
+        if (_openRowNumber == rowNumber)
+            EndOpenRow();
+    }
+
+    /// <summary>
+    /// The interned value of an explicit cell style, or the open row's style when there is none.
+    /// </summary>
+    /// <remarks>
+    /// Not cached against the last <see cref="IXLStyle"/> instance seen: a style handed out by
+    /// <see cref="XLStreamingWorkbook.CreateStyle"/> is documented as reusable, so the same
+    /// instance legitimately carries different values from one cell to the next.
+    /// </remarks>
+    private XLStyleValue ResolveStyleValue(IXLStyle? style)
+    {
+        if (style is null)
+            return _openRowStyleValue;
+
+        var key = XLStyle.GenerateKey(style);
+        return XLStyleValue.FromKey(ref key);
+    }
+
+    /// <summary>
+    /// Apply the value-driven style adjustments, and strip the quote prefix from text once it
+    /// has been captured in the style. Returns <paramref name="styleValue"/> unchanged when the
+    /// value needs nothing.
+    /// </summary>
+    private static XLStyleValue AdjustStyleForValue(XLStyleValue styleValue, ref XLCellValue value)
+    {
+        switch (value.Type)
+        {
+            case XLDataType.DateTime:
+                return XLValueStyleRules.HasGeneralNumberFormat(styleValue)
+                    ? XLValueStyleRules.WithDateTimeFormat(styleValue, value.GetUnifiedNumber() % 1 == 0)
+                    : styleValue;
+
+            case XLDataType.TimeSpan:
+                return XLValueStyleRules.HasGeneralNumberFormat(styleValue)
+                    ? XLValueStyleRules.WithDurationFormat(styleValue)
+                    : styleValue;
+
+            case XLDataType.Text:
+                {
+                    var text = value.GetText();
+                    var adjusted = XLValueStyleRules.AdjustForText(styleValue, text);
+                    if (text.Length > 0 && text[0] == '\'')
+                        value = text[1..];
+
+                    return adjusted ?? styleValue;
+                }
+
+            default:
+                return styleValue;
+        }
+    }
+
+    private void WriteCellStart(XmlWriter xml, int rowNumber, int columnNumber, string? dataType, uint styleId)
+    {
+        if (columnNumber > XLHelper.MaxColumnNumber)
+        {
+            throw new InvalidOperationException(
+                $"Row {rowNumber} of '{Name}' exceeds the {XLHelper.MaxColumnNumber} column limit.");
+        }
+
+        var length = new Point(rowNumber, columnNumber).Format(_cellRef);
+        CellXmlWriter.WriteCellStart(xml, _cellRef, length, dataType, styleId);
+    }
+
+    private XmlWriter RequireOpenRow(int rowNumber)
+    {
+        if (_openRowNumber != rowNumber || _xml is null)
+        {
+            throw new InvalidOperationException(
+                $"Row {rowNumber} of '{Name}' is no longer being written. A row can only be written to until " +
+                "the next row starts or the worksheet completes.");
+        }
+
+        return _xml;
+    }
+
+    private void EndOpenRow()
+    {
+        if (_openRowNumber == 0)
+            return;
+
+        _xml!.WriteEndElement(); // row
+        _openRowNumber = 0;
+        _openRowStyleId = 0;
+        _openRowStyleValue = XLStyleValue.Default;
+    }
+
+    #endregion Cell writing
+
+    #region Part header
+
+    /// <summary>
+    /// Open the part and write everything that precedes <c>sheetData</c>. Deferred to the first
+    /// row so the caller can still configure columns and panes after <c>AddWorksheet</c>.
+    /// </summary>
+    private void EnsureStarted()
+    {
+        if (_started)
+            return;
+
+        _started = true;
+        _xml = _workbook.CreatePart(EntryName(Index));
+
+        _xml.WriteStartDocument(true);
+        _xml.WriteStartElement("worksheet", Main2006SsNs);
+
+        WriteSheetViews(_xml);
+        WriteColumns(_xml);
+
+        _xml.WriteStartElement("sheetData", Main2006SsNs);
+    }
+
+    private void WriteSheetViews(XmlWriter xml)
+    {
+        xml.WriteStartElement("sheetViews", Main2006SsNs);
+        xml.WriteStartElement("sheetView", Main2006SsNs);
+        xml.WriteAttribute("workbookViewId", 0u);
+
+        if (_freezeRows > 0 || _freezeColumns > 0)
+        {
+            xml.WriteStartElement("pane", Main2006SsNs);
+
+            if (_freezeColumns > 0)
+                xml.WriteAttribute("xSplit", _freezeColumns);
+
+            if (_freezeRows > 0)
+                xml.WriteAttribute("ySplit", _freezeRows);
+
+            xml.WriteAttributeString("topLeftCell", new Point(_freezeRows + 1, _freezeColumns + 1).ToString());
+            xml.WriteAttributeString("activePane", ResolveActivePane());
+            xml.WriteAttributeString("state", "frozen");
+
+            xml.WriteEndElement(); // pane
+        }
+
+        xml.WriteEndElement(); // sheetView
+        xml.WriteEndElement(); // sheetViews
+    }
+
+    private string ResolveActivePane()
+    {
+        if (_freezeRows > 0 && _freezeColumns > 0)
+            return "bottomRight";
+
+        return _freezeRows > 0 ? "bottomLeft" : "topRight";
+    }
+
+    private void WriteColumns(XmlWriter xml)
+    {
+        if (_columns.Count == 0)
+            return;
+
+        var ordered = new List<XLStreamingColumn>(_columns.Values);
+        ordered.Sort(static (a, b) => a.FirstColumn.CompareTo(b.FirstColumn));
+
+        xml.WriteStartElement("cols", Main2006SsNs);
+        foreach (var column in ordered)
+        {
+            xml.WriteStartElement("col", Main2006SsNs);
+            xml.WriteAttribute("min", (uint)column.FirstColumn);
+            xml.WriteAttribute("max", (uint)column.LastColumn);
+
+            if (column.Width is not null)
+            {
+                xml.WriteAttribute("width", ColumnWriter.GetColumnWidth(column.Width.Value).SaveRound());
+                xml.WriteAttributeString("customWidth", TrueValue);
+            }
+
+            if (column.Style is not null)
+                xml.WriteAttribute("style", _workbook.Styles.GetOrAdd(column.Style));
+
+            if (column.Hidden)
+                xml.WriteAttributeString("hidden", TrueValue);
+
+            if (column.OutlineLevel > 0)
+                xml.WriteAttribute("outlineLevel", column.OutlineLevel);
+
+            if (column.Collapsed)
+                xml.WriteAttributeString("collapsed", TrueValue);
+
+            xml.WriteEndElement(); // col
+        }
+
+        xml.WriteEndElement(); // cols
+    }
+
+    private void ThrowIfStarted(string member)
+    {
+        if (_started)
+        {
+            throw new InvalidOperationException(
+                $"{member} affects XML written before the rows, so it must be set before the first row is " +
+                $"appended to '{Name}'.");
+        }
+    }
+
+    private void ThrowIfCompleted()
+    {
+        if (_completed)
+            throw new InvalidOperationException($"Worksheet '{Name}' has been completed.");
+    }
+
+    #endregion Part header
+}

--- a/XLibur/Excel/Style/XLValueStyleRules.cs
+++ b/XLibur/Excel/Style/XLValueStyleRules.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// The adjustments a cell's style needs so a value survives a round-trip through the file.
+/// </summary>
+/// <remarks>
+/// A worksheet cell stores a date, a duration and a number identically - as a serial number -
+/// so the number format is the only thing that tells a reader which it was. The same goes for a
+/// text value that starts with an apostrophe or spans several lines. Both writers depend on
+/// these rules: <see cref="XLWorksheet.GetStyleForValue"/> applies them when a value is assigned
+/// to a cell, and the streaming writer applies them as it serialises one.
+/// </remarks>
+internal static class XLValueStyleRules
+{
+    /// <summary>Built-in format <c>d/m/yyyy</c>, used for a date with no time part.</summary>
+    internal const int DateOnlyNumberFormatId = 14;
+
+    /// <summary>Built-in format <c>d/m/yyyy H:mm</c>, used for a date that carries a time.</summary>
+    internal const int DateTimeNumberFormatId = 22;
+
+    /// <summary>Built-in format <c>[h]:mm:ss</c>, used for an elapsed duration.</summary>
+    internal const int DurationNumberFormatId = 46;
+
+    /// <summary>
+    /// Whether the style leaves the number format at General, in which case a date or duration
+    /// written under it would read back as a plain number.
+    /// </summary>
+    internal static bool HasGeneralNumberFormat(XLStyleValue styleValue) =>
+        styleValue.NumberFormat.Format.Length == 0 && styleValue.NumberFormat.NumberFormatId == 0;
+
+    internal static XLStyleValue WithDateTimeFormat(XLStyleValue styleValue, bool onlyDatePart)
+    {
+        var numberFormat = styleValue.NumberFormat.WithNumberFormatId(
+            onlyDatePart ? DateOnlyNumberFormatId : DateTimeNumberFormatId);
+        return styleValue.WithNumberFormat(numberFormat);
+    }
+
+    internal static XLStyleValue WithDurationFormat(XLStyleValue styleValue)
+    {
+        var numberFormat = styleValue.NumberFormat.WithNumberFormatId(DurationNumberFormatId);
+        return styleValue.WithNumberFormat(numberFormat);
+    }
+
+    /// <summary>
+    /// The style a text value needs, or <c>null</c> when the passed one already suits it. A
+    /// leading apostrophe is Excel's marker for "treat this as text", carried by the quote
+    /// prefix flag rather than by the stored value; a multi-line value needs wrapping to be
+    /// legible.
+    /// </summary>
+    internal static XLStyleValue? AdjustForText(XLStyleValue styleValue, string text)
+    {
+        XLStyleValue? adjusted = null;
+
+        if (text.Length > 0 && text[0] == '\'')
+            adjusted = styleValue.WithIncludeQuotePrefix(true);
+
+        if (text.AsSpan().Contains(Environment.NewLine.AsSpan(), StringComparison.Ordinal))
+        {
+            adjusted ??= styleValue;
+            if (!adjusted.Alignment.WrapText)
+                adjusted = adjusted.WithAlignment(static alignment => alignment.WithWrapText(true));
+        }
+
+        return adjusted;
+    }
+}

--- a/XLibur/Excel/Style/XLValueStyleRules.cs
+++ b/XLibur/Excel/Style/XLValueStyleRules.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace XLibur.Excel;
 
@@ -51,18 +51,20 @@ internal static class XLValueStyleRules
     /// </summary>
     internal static XLStyleValue? AdjustForText(XLStyleValue styleValue, string text)
     {
-        XLStyleValue? adjusted = null;
+        var adjusted = styleValue;
 
         if (text.Length > 0 && text[0] == '\'')
-            adjusted = styleValue.WithIncludeQuotePrefix(true);
+            adjusted = adjusted.WithIncludeQuotePrefix(true);
 
-        if (text.AsSpan().Contains(Environment.NewLine.AsSpan(), StringComparison.Ordinal))
+        if (text.AsSpan().Contains(Environment.NewLine.AsSpan(), StringComparison.Ordinal) &&
+            !adjusted.Alignment.WrapText)
         {
-            adjusted ??= styleValue;
-            if (!adjusted.Alignment.WrapText)
-                adjusted = adjusted.WithAlignment(static alignment => alignment.WithWrapText(true));
+            adjusted = adjusted.WithAlignment(static alignment => alignment.WithWrapText(true));
         }
 
-        return adjusted;
+        // Style values are interned, so reference equality means nothing needed changing. Saying
+        // so with null keeps the caller from writing an explicit per-cell style that only
+        // restates what the row, column or worksheet already supplies.
+        return ReferenceEquals(adjusted, styleValue) ? null : adjusted;
     }
 }

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
+using System.IO.Packaging;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -59,10 +61,28 @@ public partial class XLWorkbook
                 package.ChangeDocumentType(spreadsheetDocumentType);
             }
 
+            package.CompressionOption = ToCompressionOption(options.CompressionLevel);
             CreateParts(package, options);
             if (options.ValidatePackage) Validate(package);
         }
     }
+
+    /// <summary>
+    /// Map the framework's compression level onto the packaging option the OpenXML SDK takes.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SaveOptions.CompressionLevel"/> is declared in terms of
+    /// <see cref="CompressionLevel"/> rather than <see cref="CompressionOption"/> so that it
+    /// reads the same as <c>XLStreamingOptions.CompressionLevel</c>, which writes its own zip
+    /// and so has no packaging layer to go through.
+    /// </remarks>
+    private static CompressionOption ToCompressionOption(CompressionLevel level) => level switch
+    {
+        CompressionLevel.NoCompression => CompressionOption.NotCompressed,
+        CompressionLevel.Fastest => CompressionOption.Fast,
+        CompressionLevel.SmallestSize => CompressionOption.Maximum,
+        _ => CompressionOption.Normal
+    };
 
     private void CreatePackage(Stream stream, bool newStream, SpreadsheetDocumentType spreadsheetDocumentType,
         SaveOptions options)
@@ -73,6 +93,7 @@ public partial class XLWorkbook
 
         using (package)
         {
+            package.CompressionOption = ToCompressionOption(options.CompressionLevel);
             CreateParts(package, options);
             if (options.ValidatePackage) Validate(package);
         }

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -303,7 +303,7 @@ public partial class XLWorkbook
                                  workbookPart.AddNewPart<WorkbookStylesPart>(
                                      context.RelIdGenerator.GetNext(RelType.Workbook));
         workbookStylesPart.Stylesheet ??= new Stylesheet();
-        WorkbookStylesPartWriter.GenerateContent(workbookStylesPart.Stylesheet!, this, context);
+        WorkbookStylesPartWriter.GenerateContent(workbookStylesPart.Stylesheet, this, context);
     }
 
     /// <summary>

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -281,7 +281,8 @@ public partial class XLWorkbook
         var workbookStylesPart = workbookPart.WorkbookStylesPart ??
                                  workbookPart.AddNewPart<WorkbookStylesPart>(
                                      context.RelIdGenerator.GetNext(RelType.Workbook));
-        WorkbookStylesPartWriter.GenerateContent(workbookStylesPart, this, context);
+        workbookStylesPart.Stylesheet ??= new Stylesheet();
+        WorkbookStylesPartWriter.GenerateContent(workbookStylesPart.Stylesheet!, this, context);
     }
 
     /// <summary>

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -1774,7 +1774,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
     {
         var onlyDatePart = value.GetUnifiedNumber() % 1 == 0;
         var styleValue = GetStyleValue(point);
-        if (styleValue.NumberFormat.Format.Length != 0 || styleValue.NumberFormat.NumberFormatId != 0)
+        if (!XLValueStyleRules.HasGeneralNumberFormat(styleValue))
             return null;
 
         if (onlyDatePart)
@@ -1782,8 +1782,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
             if (ReferenceEquals(styleValue, _cachedDateOnlySourceStyle))
                 return _cachedDateOnlyResultStyle;
 
-            var dateNumberFormat = styleValue.NumberFormat.WithNumberFormatId(14);
-            var result = styleValue.WithNumberFormat(dateNumberFormat);
+            var result = XLValueStyleRules.WithDateTimeFormat(styleValue, onlyDatePart: true);
             _cachedDateOnlySourceStyle = styleValue;
             _cachedDateOnlyResultStyle = result;
             return result;
@@ -1793,8 +1792,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
             if (ReferenceEquals(styleValue, _cachedDateTimeSourceStyle))
                 return _cachedDateTimeResultStyle;
 
-            var dateTimeNumberFormat = styleValue.NumberFormat.WithNumberFormatId(22);
-            var result = styleValue.WithNumberFormat(dateTimeNumberFormat);
+            var result = XLValueStyleRules.WithDateTimeFormat(styleValue, onlyDatePart: false);
             _cachedDateTimeSourceStyle = styleValue;
             _cachedDateTimeResultStyle = result;
             return result;
@@ -1804,14 +1802,13 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
     private XLStyleValue? GetStyleForTimeSpan(Point point)
     {
         var styleValue = GetStyleValue(point);
-        if (styleValue.NumberFormat.Format.Length != 0 || styleValue.NumberFormat.NumberFormatId != 0)
+        if (!XLValueStyleRules.HasGeneralNumberFormat(styleValue))
             return null;
 
         if (ReferenceEquals(styleValue, _cachedTimeSpanSourceStyle))
             return _cachedTimeSpanResultStyle;
 
-        var durationNumberFormat = styleValue.NumberFormat.WithNumberFormatId(46);
-        var result = styleValue.WithNumberFormat(durationNumberFormat);
+        var result = XLValueStyleRules.WithDurationFormat(styleValue);
         _cachedTimeSpanSourceStyle = styleValue;
         _cachedTimeSpanResultStyle = result;
         return result;
@@ -1820,24 +1817,15 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
     private XLStyleValue? GetStyleForText(XLCellValue value, Point point)
     {
         var text = value.GetText();
-        XLStyleValue? styleValue = null;
-        if (text.Length > 0 && text[0] == '\'')
+
+        // Reading the style out of the slice is the expensive part, so skip it entirely for the
+        // overwhelmingly common text value that needs no adjustment at all.
+        if ((text.Length == 0 || text[0] != '\'') &&
+            !text.AsSpan().Contains(Environment.NewLine.AsSpan(), StringComparison.Ordinal))
         {
-            styleValue = GetStyleValue(point);
-            styleValue = styleValue.WithIncludeQuotePrefix(true);
+            return null;
         }
 
-        var containsNewLine = text.AsSpan()
-            .Contains(Environment.NewLine.AsSpan(), StringComparison.Ordinal);
-        if (containsNewLine)
-        {
-            styleValue ??= GetStyleValue(point);
-            if (!styleValue.Alignment.WrapText)
-            {
-                styleValue = styleValue.WithAlignment(static alignment => alignment.WithWrapText(true));
-            }
-        }
-
-        return styleValue;
+        return XLValueStyleRules.AdjustForText(GetStyleValue(point), text);
     }
 }

--- a/XLibur/NUGET_README.md
+++ b/XLibur/NUGET_README.md
@@ -49,8 +49,13 @@ using (var workbook = new XLWorkbook())
 
 `XLWorkbook` builds the whole workbook in memory before saving, which puts a ceiling on how large
 an export can be. For those, `XLStreamingWorkbook` writes rows straight into the file as you append
-them, so memory stays flat no matter how many rows there are — a million rows by ten columns costs
-about 108 MB, or 14 MB with `Inline` string storage.
+them, so nothing is retained per row — a million rows by ten columns costs about 108 MB, or 14 MB
+with `Inline` string storage.
+
+Memory is flat in the number of rows, but not unconditionally flat: by default each *distinct*
+string is held until `Finish()`, so cost tracks how many distinct text values you write rather than
+how many rows. A million rows of repeating labels is cheap; a million distinct ones is not — see
+the note below on `Inline` storage.
 
 ```c#
 using XLibur.Excel.Streaming;

--- a/XLibur/NUGET_README.md
+++ b/XLibur/NUGET_README.md
@@ -15,6 +15,7 @@ Namespaces are changed to avoid conflicts with the original project.
 - Leverage later C# lang features.
 - Fix some outstanding bugs we wanted.
 - Improve memory usage, especially with formatted cells.
+- Add a streaming write API for exports too large to hold in memory (see below).
 
 ### Migration from ClosedXML
 
@@ -43,6 +44,41 @@ using (var workbook = new XLWorkbook())
     workbook.SaveAs("HelloWorld.xlsx");
 }
 ```
+
+### Writing very large files
+
+`XLWorkbook` builds the whole workbook in memory before saving, which puts a ceiling on how large
+an export can be. For those, `XLStreamingWorkbook` writes rows straight into the file as you append
+them, so memory stays flat no matter how many rows there are — a million rows by ten columns costs
+about 108 MB, or 14 MB with `Inline` string storage.
+
+```c#
+using XLibur.Excel.Streaming;
+
+using var workbook = XLStreamingWorkbook.Create("Large.xlsx");
+
+var sheet = workbook.AddWorksheet("Data");
+sheet.Column(1).Width = 30;
+sheet.FreezeRows(1);
+
+var header = workbook.CreateStyle();
+header.Font.Bold = true;
+sheet.AppendRow(["Name", "Amount"], header);
+
+for (var i = 0; i < 1_000_000; i++)
+    sheet.AppendRow($"Item {i}", i * 1.5);
+
+workbook.Finish();   // required: writes the strings, styles and workbook parts
+```
+
+The trade is that it is append-only: rows go in ascending order, one worksheet at a time, nothing
+can be read back or revised, and formulas are stored verbatim rather than evaluated. Use
+`XLWorkbook` whenever any of that matters.
+
+Two notes worth knowing. `Finish()` must be called — disposing without it abandons the write.
+And by default distinct strings accumulate in a shared string table until then, so if your data has
+an unbounded number of distinct strings, set
+`StringStorage = XLStreamingStringStorage.Inline` to keep memory flat at the cost of a larger file.
 
 ## Documentation
 

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -194,6 +194,8 @@ XLibur.Excel.LoadOptions.FontEngine.get -> XLibur.Graphics.IXLFontEngine?
 XLibur.Excel.LoadOptions.FontEngine.set -> void
 XLibur.Excel.LoadOptions.Password.get -> string?
 XLibur.Excel.LoadOptions.Password.set -> void
+XLibur.Excel.SaveOptions.CompressionLevel.get -> System.IO.Compression.CompressionLevel
+XLibur.Excel.SaveOptions.CompressionLevel.set -> void
 XLibur.Excel.SaveOptions.Password.get -> string?
 XLibur.Excel.SaveOptions.Password.set -> void
 XLibur.Excel.Streaming.XLStreamingColumn

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -21,6 +21,10 @@ static XLibur.Excel.XLAlignmentKey.operator !=(XLibur.Excel.XLAlignmentKey left,
 static XLibur.Excel.XLAlignmentKey.operator ==(XLibur.Excel.XLAlignmentKey left, XLibur.Excel.XLAlignmentKey right) -> bool
 static XLibur.Excel.XLCellValue.operator !=(XLibur.Excel.XLCellValue left, XLibur.Excel.XLCellValue right) -> bool
 static XLibur.Excel.XLCellValue.operator ==(XLibur.Excel.XLCellValue left, XLibur.Excel.XLCellValue right) -> bool
+static XLibur.Excel.Streaming.XLStreamingWorkbook.Create(System.IO.Stream! output) -> XLibur.Excel.Streaming.XLStreamingWorkbook!
+static XLibur.Excel.Streaming.XLStreamingWorkbook.Create(System.IO.Stream! output, XLibur.Excel.Streaming.XLStreamingOptions? options) -> XLibur.Excel.Streaming.XLStreamingWorkbook!
+static XLibur.Excel.Streaming.XLStreamingWorkbook.Create(string! path) -> XLibur.Excel.Streaming.XLStreamingWorkbook!
+static XLibur.Excel.Streaming.XLStreamingWorkbook.Create(string! path, XLibur.Excel.Streaming.XLStreamingOptions? options) -> XLibur.Excel.Streaming.XLStreamingWorkbook!
 static XLibur.Excel.XLColor.Automatic.get -> XLibur.Excel.XLColor!
 virtual XLibur.Excel.XLWorkbook.Dispose(bool disposing) -> void
 XLibur.Excel.Drawings.IXLPicture.Group.get -> XLibur.Excel.Drawings.IXLPictureGroup?
@@ -192,6 +196,60 @@ XLibur.Excel.LoadOptions.Password.get -> string?
 XLibur.Excel.LoadOptions.Password.set -> void
 XLibur.Excel.SaveOptions.Password.get -> string?
 XLibur.Excel.SaveOptions.Password.set -> void
+XLibur.Excel.Streaming.XLStreamingColumn
+XLibur.Excel.Streaming.XLStreamingColumn.Collapsed.get -> bool
+XLibur.Excel.Streaming.XLStreamingColumn.Collapsed.set -> void
+XLibur.Excel.Streaming.XLStreamingColumn.FirstColumn.get -> int
+XLibur.Excel.Streaming.XLStreamingColumn.Hidden.get -> bool
+XLibur.Excel.Streaming.XLStreamingColumn.Hidden.set -> void
+XLibur.Excel.Streaming.XLStreamingColumn.LastColumn.get -> int
+XLibur.Excel.Streaming.XLStreamingColumn.OutlineLevel.get -> int
+XLibur.Excel.Streaming.XLStreamingColumn.OutlineLevel.set -> void
+XLibur.Excel.Streaming.XLStreamingColumn.Style.get -> XLibur.Excel.IXLStyle?
+XLibur.Excel.Streaming.XLStreamingColumn.Style.set -> void
+XLibur.Excel.Streaming.XLStreamingColumn.Width.get -> double?
+XLibur.Excel.Streaming.XLStreamingColumn.Width.set -> void
+XLibur.Excel.Streaming.XLStreamingOptions
+XLibur.Excel.Streaming.XLStreamingOptions.CompressionLevel.get -> System.IO.Compression.CompressionLevel
+XLibur.Excel.Streaming.XLStreamingOptions.CompressionLevel.set -> void
+XLibur.Excel.Streaming.XLStreamingOptions.StringStorage.get -> XLibur.Excel.Streaming.XLStreamingStringStorage
+XLibur.Excel.Streaming.XLStreamingOptions.StringStorage.set -> void
+XLibur.Excel.Streaming.XLStreamingOptions.Use1904DateSystem.get -> bool
+XLibur.Excel.Streaming.XLStreamingOptions.Use1904DateSystem.set -> void
+XLibur.Excel.Streaming.XLStreamingOptions.XLStreamingOptions() -> void
+XLibur.Excel.Streaming.XLStreamingRow
+XLibur.Excel.Streaming.XLStreamingRow.At(int columnNumber) -> XLibur.Excel.Streaming.XLStreamingRow
+XLibur.Excel.Streaming.XLStreamingRow.Cell(XLibur.Excel.XLCellValue value) -> XLibur.Excel.Streaming.XLStreamingRow
+XLibur.Excel.Streaming.XLStreamingRow.Cell(XLibur.Excel.XLCellValue value, XLibur.Excel.IXLStyle? style) -> XLibur.Excel.Streaming.XLStreamingRow
+XLibur.Excel.Streaming.XLStreamingRow.Dispose() -> void
+XLibur.Excel.Streaming.XLStreamingRow.Formula(string! formula, XLibur.Excel.XLCellValue cachedValue = default(XLibur.Excel.XLCellValue), XLibur.Excel.IXLStyle? style = null) -> XLibur.Excel.Streaming.XLStreamingRow
+XLibur.Excel.Streaming.XLStreamingRow.RowNumber.get -> int
+XLibur.Excel.Streaming.XLStreamingRow.Skip(int columnCount) -> XLibur.Excel.Streaming.XLStreamingRow
+XLibur.Excel.Streaming.XLStreamingRow.XLStreamingRow() -> void
+XLibur.Excel.Streaming.XLStreamingStringStorage
+XLibur.Excel.Streaming.XLStreamingStringStorage.Inline = 1 -> XLibur.Excel.Streaming.XLStreamingStringStorage
+XLibur.Excel.Streaming.XLStreamingStringStorage.SharedStrings = 0 -> XLibur.Excel.Streaming.XLStreamingStringStorage
+XLibur.Excel.Streaming.XLStreamingWorkbook
+XLibur.Excel.Streaming.XLStreamingWorkbook.AddWorksheet(string! name) -> XLibur.Excel.Streaming.XLStreamingWorksheet!
+XLibur.Excel.Streaming.XLStreamingWorkbook.CreateStyle() -> XLibur.Excel.IXLStyle!
+XLibur.Excel.Streaming.XLStreamingWorkbook.Dispose() -> void
+XLibur.Excel.Streaming.XLStreamingWorkbook.Finish() -> void
+XLibur.Excel.Streaming.XLStreamingWorksheet
+XLibur.Excel.Streaming.XLStreamingWorksheet.AddRow() -> XLibur.Excel.Streaming.XLStreamingRow
+XLibur.Excel.Streaming.XLStreamingWorksheet.AddRow(XLibur.Excel.IXLStyle? style, double? height = null, bool hidden = false) -> XLibur.Excel.Streaming.XLStreamingRow
+XLibur.Excel.Streaming.XLStreamingWorksheet.AppendRow(System.ReadOnlySpan<XLibur.Excel.XLCellValue> values, XLibur.Excel.IXLStyle? style = null) -> void
+XLibur.Excel.Streaming.XLStreamingWorksheet.AppendRow(params XLibur.Excel.XLCellValue[]! values) -> void
+XLibur.Excel.Streaming.XLStreamingWorksheet.AutoFilterRange.get -> string?
+XLibur.Excel.Streaming.XLStreamingWorksheet.AutoFilterRange.set -> void
+XLibur.Excel.Streaming.XLStreamingWorksheet.Column(int columnNumber) -> XLibur.Excel.Streaming.XLStreamingColumn!
+XLibur.Excel.Streaming.XLStreamingWorksheet.Columns(int firstColumn, int lastColumn) -> XLibur.Excel.Streaming.XLStreamingColumn!
+XLibur.Excel.Streaming.XLStreamingWorksheet.Complete() -> void
+XLibur.Excel.Streaming.XLStreamingWorksheet.FreezeColumns(int columnCount) -> void
+XLibur.Excel.Streaming.XLStreamingWorksheet.FreezePanes(int rowCount, int columnCount) -> void
+XLibur.Excel.Streaming.XLStreamingWorksheet.FreezeRows(int rowCount) -> void
+XLibur.Excel.Streaming.XLStreamingWorksheet.Name.get -> string!
+XLibur.Excel.Streaming.XLStreamingWorksheet.NextRowNumber.get -> int
+XLibur.Excel.Streaming.XLStreamingWorksheet.SkipRows(int count) -> void
 XLibur.Excel.XLAlignmentKey.Equals(XLibur.Excel.XLAlignmentKey other) -> bool
 XLibur.Excel.XLAxisOrientation
 XLibur.Excel.XLAxisOrientation.MaxMin = 1 -> XLibur.Excel.XLAxisOrientation

--- a/docs-website/docs/getting-started.md
+++ b/docs-website/docs/getting-started.md
@@ -196,6 +196,10 @@ return File(
     "report.xlsx");
 ```
 
+For an export large enough that buffering it is the problem,
+[`XLStreamingWorkbook`](./streaming.md#writing-to-a-web-response) writes straight to the response
+body instead — no `MemoryStream` and no ceiling on size.
+
 ## Putting it together
 
 A small end-to-end example — build a report, save it, reopen it, and amend a cell:

--- a/docs-website/docs/importing-exporting.md
+++ b/docs-website/docs/importing-exporting.md
@@ -2,7 +2,7 @@
 id: importing-exporting
 title: Importing and Exporting Data
 sidebar_label: Importing and Exporting
-description: Bulk-load collections, DataTables, and DataSets into a workbook, and read data back out — including streaming to a web response.
+description: Bulk-load collections, DataTables, and DataSets into a workbook, and read data back out — including returning a generated file from a web response.
 ---
 
 # Importing and Exporting Data
@@ -295,6 +295,15 @@ back, or use `ToArray()` on a `MemoryStream` as above.
 :::
 
 ## Performance notes
+
+:::tip When memory is the limit, not speed
+Everything below makes an export cheaper *within* the in-memory model, where the whole workbook
+exists before it is written. Past a few hundred thousand rows that model is itself the ceiling.
+
+[`XLStreamingWorkbook`](./streaming.md) writes rows straight into the file as you append them, so
+memory stays flat — a million rows by ten columns costs around 108 MB against roughly a gigabyte.
+The trade is that it is append-only, with no reading back, no tables and no pivots.
+:::
 
 For large exports, a few habits make a substantial difference:
 

--- a/docs-website/docs/streaming.md
+++ b/docs-website/docs/streaming.md
@@ -1,0 +1,410 @@
+---
+id: streaming
+title: Streaming Writes for Large Files
+sidebar_label: Streaming Writes
+description: Write arbitrarily large .xlsx exports with flat memory using XLStreamingWorkbook — appending rows, styles, sheet layout, shared vs inline strings, and what the append-only model gives up.
+---
+
+# Streaming Writes for Large Files
+
+`XLWorkbook` builds the entire workbook in memory and writes it out at the end. That is what makes
+the rest of the API possible — you can read a cell back, edit it, insert a row above it — but it
+also means the largest file you can produce is bounded by how much memory you are willing to give
+it.
+
+`XLStreamingWorkbook` is the other trade. It serialises each row into the file the moment you
+append it and keeps nothing, so memory does not grow with the number of rows. In exchange it is
+append-only: rows go in ascending order, one worksheet at a time, and nothing already written can
+be read back or changed.
+
+| | `XLWorkbook` | `XLStreamingWorkbook` |
+|---|---|---|
+| Peak memory, 1M rows × 10 columns | Needs about as much for **100K** rows | **108 MB**, or **14 MB** with inline strings |
+| 50K rows × 3 columns | 250 ms, 67 MB allocated | **158 ms, 14 MB allocated** |
+| Read a cell back | Yes | No |
+| Edit what you wrote | Yes | No |
+| Formulas evaluated | Optional | No — stored verbatim |
+
+Reach for it when the output is a large, append-only export and memory is the constraint. For
+everything else — anything you need to read, revise, or decorate with tables and pivots — stay on
+[`XLWorkbook`](./importing-exporting.md).
+
+## A first export
+
+```csharp
+using XLibur.Excel.Streaming;
+
+using var workbook = XLStreamingWorkbook.Create("Orders.xlsx");
+
+var sheet = workbook.AddWorksheet("Orders");
+sheet.AppendRow("Order", "Customer", "Total");
+
+foreach (var order in GetOrders())
+    sheet.AppendRow(order.Reference, order.Customer, order.Total);
+
+workbook.Finish();
+```
+
+`Create` also takes a `Stream`:
+
+```csharp
+using var file = File.Create("Orders.xlsx");
+using var workbook = XLStreamingWorkbook.Create(file);
+```
+
+:::warning `Finish()` is not optional
+`Finish()` writes the shared strings, the styles and the workbook part — none of which can be
+known until the last row is in. A workbook that is disposed without it leaves an incomplete
+package that no reader can open.
+
+Disposal deliberately does **not** call it for you: if an exception were in flight, finishing
+would bury it behind a second failure. Treat `Finish()` as the last statement of the write.
+:::
+
+## Appending rows
+
+`AppendRow` is the short form. It takes values starting at column A:
+
+```csharp
+sheet.AppendRow("Widget", 12, 4.99, new DateTime(2026, 7, 27));
+```
+
+Values are `XLCellValue`, so strings, numbers, booleans, `DateTime`, `TimeSpan` and `XLError` all
+convert implicitly — the same value model as `IXLCell.Value`. Dates and durations pick up the
+number format that identifies them as such, exactly as they would on a normal cell, so they come
+back as dates rather than as serial numbers.
+
+To leave rows empty, skip them. Skipped rows cost nothing in the file:
+
+```csharp
+sheet.AppendRow("Section A");
+sheet.SkipRows(2);
+sheet.AppendRow("Section B");
+```
+
+`NextRowNumber` tells you where you are, which is useful for building a formula that refers to a
+range you have just written:
+
+```csharp
+var firstDataRow = sheet.NextRowNumber;
+foreach (var order in orders)
+    sheet.AppendRow(order.Reference, order.Total);
+
+var lastDataRow = sheet.NextRowNumber - 1;
+```
+
+## Building a row cell by cell
+
+`AddRow()` opens a row you fill in yourself. It is the only way to write a formula or give a
+single cell its own style, and it allocates nothing per row:
+
+```csharp
+using (var row = sheet.AddRow())
+{
+    row.Cell("Widget");
+    row.Cell(12, highlight);            // this cell only
+    row.Skip(1);                        // leave C empty
+    row.Formula("B2*1.2", cachedValue: 14.4);
+    row.At(10).Cell("note");            // jump to column J
+}
+```
+
+Calls chain, if you prefer:
+
+```csharp
+sheet.AddRow().Cell("Widget").Cell(12).Cell(4.99);
+```
+
+The `using` is optional — a row also closes when the next one starts or the sheet completes — but
+it makes the row's extent obvious and lets the compiler stop you using it afterwards. Writing to a
+row that is no longer the open one throws `InvalidOperationException` rather than corrupting the
+file.
+
+Rows themselves can carry height, visibility and a style:
+
+```csharp
+sheet.AddRow(header, height: 24).Cell("Quarterly Report");
+sheet.AddRow(style: null, hidden: true).Cell("internal");
+```
+
+### Formulas
+
+Formula text is stored **verbatim** — it is never parsed or evaluated. A leading `=` is accepted
+and stripped:
+
+```csharp
+row.Formula("SUM(B2:B100000)");             // stored as SUM(B2:B100000)
+row.Formula("=SUM(B2:B100000)");            // identical
+```
+
+Without a `cachedValue` the cell has no stored result, so it shows as empty until Excel
+recalculates the sheet — which it does on open. Supply the value when you already know it and the
+cell displays immediately:
+
+```csharp
+row.Formula($"SUM(B{firstDataRow}:B{lastDataRow})", cachedValue: runningTotal);
+```
+
+## Styles
+
+Styles come from `CreateStyle()`, which hands back a fresh `IXLStyle` you configure and pass to a
+row or a cell:
+
+```csharp
+var header = workbook.CreateStyle();
+header.Font.Bold = true;
+header.Fill.BackgroundColor = XLColor.LightGray;
+
+var money = workbook.CreateStyle();
+money.NumberFormat.Format = "#,##0.00";
+
+sheet.AppendRow(["Item", "Amount"], header);
+
+using (var row = sheet.AddRow())
+{
+    row.Cell("Widget");
+    row.Cell(1234.5, money);
+}
+```
+
+A row style applies to every cell in that row that does not specify its own.
+
+The writer interns a style's *value* at the moment you use it, so one instance can be reconfigured
+and handed to later rows without disturbing rows already written:
+
+```csharp
+var rowStyle = workbook.CreateStyle();
+
+foreach (var (item, isOverdue) in items)
+{
+    rowStyle.Font.FontColor = isOverdue ? XLColor.Red : XLColor.Black;
+    sheet.AppendRow([item.Name, item.DaysOpen], rowStyle);
+}
+```
+
+Distinct styles are held until `Finish()`, but their number is bounded by how many distinct formats
+you actually use — not by row count. A thousand rows sharing two styles costs two.
+
+## Sheet layout
+
+Column widths, freeze panes and an autofilter range are all supported:
+
+```csharp
+var sheet = workbook.AddWorksheet("Orders");
+
+sheet.Column(1).Width = 30;
+sheet.Columns(2, 4).Width = 14;
+sheet.Column(5).Hidden = true;
+
+sheet.FreezeRows(1);                 // keep the header visible
+sheet.AutoFilterRange = "A1:E1";
+
+sheet.AppendRow("Order", "Customer", "Date", "Total", "Internal");
+```
+
+`FreezeColumns` and `FreezePanes(rows, columns)` cover the other two cases.
+
+:::note Layout comes before the first row
+Columns and panes are written into the file *ahead of* the rows, so they have to be set before you
+append anything. Doing it afterwards throws `InvalidOperationException`, rather than silently
+producing a file that ignores them.
+
+`AutoFilterRange` is the exception — it is written after the rows, so it can be set at any point
+before the sheet completes. That is handy when the range depends on how many rows you ended up
+writing.
+:::
+
+## Several worksheets
+
+Only one sheet is open at a time, because both would be writing to the same package. Adding a
+worksheet completes the previous one automatically:
+
+```csharp
+var summary = workbook.AddWorksheet("Summary");
+summary.AppendRow("Region", "Total");
+// ...
+
+var detail = workbook.AddWorksheet("Detail");   // Summary is completed here
+detail.AppendRow("Order", "Amount");
+// ...
+
+workbook.Finish();                              // Detail is completed here
+```
+
+Sheets appear in the order you add them. You cannot go back to `summary` once `detail` has been
+added — if a summary depends on totals you only learn later, write it as a formula over the detail
+sheet and let Excel compute it, or make two passes over your data.
+
+## Strings and memory
+
+Memory is flat in the number of *rows*, but not unconditionally flat. By default text goes into a
+shared string table, which holds each **distinct** string until `Finish()`. So the cost tracks how
+many distinct text values you write rather than how many rows:
+
+```csharp
+// Cheap — a handful of distinct strings, however many rows
+sheet.AppendRow(status, region, productName);
+
+// Expensive — every row contributes a new string
+sheet.AppendRow($"Order {Guid.NewGuid()}", description);
+```
+
+When the number of distinct strings is genuinely unbounded, switch to inline storage. Each string
+is then written into its cell and nothing is retained:
+
+```csharp
+using var workbook = XLStreamingWorkbook.Create("Huge.xlsx", new XLStreamingOptions
+{
+    StringStorage = XLStreamingStringStorage.Inline,
+});
+```
+
+| Mode | Memory | File size | Use when |
+|---|---|---|---|
+| `SharedStrings` (default) | Grows with distinct strings | Smaller when text repeats | Text repeats — the usual export |
+| `Inline` | Flat | Larger when text repeats | Distinct strings are unbounded |
+
+On a million rows where every row carries a distinct string — the worst case — that is the
+difference between **108 MB and 14 MB**. Where text repeats, shared strings also produce a smaller
+file, so the default is usually right.
+
+## Writing to a web response
+
+The streaming writer never seeks backwards, so its destination only has to be writable. That means
+you can write straight to a response body, with neither a temporary file nor a `MemoryStream`
+holding the whole workbook:
+
+```csharp
+[HttpGet("export")]
+public async Task<IActionResult> Export()
+{
+    Response.ContentType =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    Response.Headers.ContentDisposition = "attachment; filename=orders.xlsx";
+
+    using (var workbook = XLStreamingWorkbook.Create(Response.Body))
+    {
+        var sheet = workbook.AddWorksheet("Orders");
+        sheet.AppendRow("Order", "Customer", "Total");
+
+        await foreach (var order in GetOrdersAsync())
+            sheet.AppendRow(order.Reference, order.Customer, order.Total);
+
+        workbook.Finish();
+    }
+
+    return new EmptyResult();
+}
+```
+
+`XLWorkbook.SaveAs` cannot do this: it goes through `System.IO.Packaging`, which needs a seekable
+stream and buffers the package regardless. See
+[Importing and Exporting](./importing-exporting.md#streams-uploads-and-web-responses) for the
+buffered equivalent.
+
+:::note The stream stays open
+`Create(Stream)` leaves the stream open when the workbook is disposed — the caller owns it. The
+`Create(string)` overload owns the file it opens and closes it for you.
+:::
+
+## Compression
+
+`CompressionLevel` trades file size against write time:
+
+```csharp
+using var workbook = XLStreamingWorkbook.Create("Fast.xlsx", new XLStreamingOptions
+{
+    CompressionLevel = CompressionLevel.Fastest,
+});
+```
+
+`Fastest` is roughly 1.7× quicker than the default `Optimal`, for a larger file — often the right
+call for a big export a user is waiting on. `SaveOptions.CompressionLevel` is the equivalent for an
+ordinary save.
+
+## What it cannot do
+
+The append-only model rules out anything that needs to revisit what was written:
+
+| Not supported | Use instead |
+|---|---|
+| Reading cells back, editing, inserting rows | `XLWorkbook` |
+| Formula evaluation | Store a `cachedValue`, or let Excel recalculate on open |
+| Tables, merged ranges, conditional formatting | `XLWorkbook` |
+| Pivot tables, charts, images, comments | `XLWorkbook` |
+| Data validation, hyperlinks, page setup | `XLWorkbook` |
+| Encryption ([`SaveOptions.Password`](./encryption.md)) | `XLWorkbook` |
+| Rows out of order, or a second pass over a sheet | Sort your data first |
+
+If you need a large export *and* one of these, the usual answer is to generate the bulk with the
+streaming writer and keep the decorated parts on a normal workbook in a separate file.
+
+## A worked example
+
+An export of arbitrary size, with a frozen and filtered header, formatted columns and a totals row
+computed by Excel:
+
+```csharp
+using System.IO.Compression;
+using XLibur.Excel;
+using XLibur.Excel.Streaming;
+
+using var workbook = XLStreamingWorkbook.Create("Orders.xlsx", new XLStreamingOptions
+{
+    CompressionLevel = CompressionLevel.Fastest,
+});
+
+var header = workbook.CreateStyle();
+header.Font.Bold = true;
+header.Fill.BackgroundColor = XLColor.LightGray;
+
+var money = workbook.CreateStyle();
+money.NumberFormat.Format = "#,##0.00";
+
+var date = workbook.CreateStyle();
+date.DateFormat.Format = "yyyy-MM-dd";
+
+var sheet = workbook.AddWorksheet("Orders");
+sheet.Column(1).Width = 16;
+sheet.Column(2).Width = 32;
+sheet.Column(3).Width = 12;
+sheet.Column(4).Width = 14;
+sheet.FreezeRows(1);
+sheet.AutoFilterRange = "A1:D1";
+
+sheet.AppendRow(["Order", "Customer", "Date", "Total"], header);
+
+var firstDataRow = sheet.NextRowNumber;
+var total = 0m;
+
+foreach (var order in GetOrders())
+{
+    using var row = sheet.AddRow();
+    row.Cell(order.Reference);
+    row.Cell(order.Customer);
+    row.Cell(order.Placed, date);
+    row.Cell((double)order.Total, money);
+
+    total += order.Total;
+}
+
+var lastDataRow = sheet.NextRowNumber - 1;
+
+using (var totals = sheet.AddRow(header))
+{
+    totals.Cell("Total");
+    totals.Skip(2);
+    totals.Formula($"SUM(D{firstDataRow}:D{lastDataRow})", cachedValue: (double)total, style: money);
+}
+
+workbook.Finish();
+```
+
+## Where to next
+
+- [Importing and Exporting](./importing-exporting.md#performance-notes) — bulk loading into a
+  normal workbook, and the performance habits that apply when you stay on `XLWorkbook`
+- [Workbook Settings](./workbook-settings.md#save-options) — `SaveOptions`, including
+  `CompressionLevel` for ordinary saves
+- [Styling](./styling.md) — the style model `CreateStyle()` returns
+- [Formulas](./formulas.md) — the formula syntax stored verbatim here

--- a/docs-website/docs/workbook-settings.md
+++ b/docs-website/docs/workbook-settings.md
@@ -241,6 +241,7 @@ var options = new SaveOptions
     ConsolidateDataValidationRanges = true,
     GenerateCalculationChain = true,
     FilterPrivacy = true,
+    CompressionLevel = CompressionLevel.Optimal,
 };
 
 workbook.SaveAs("Report.xlsx", options);
@@ -254,7 +255,17 @@ workbook.SaveAs("Report.xlsx", options);
 | `ConsolidateDataValidationRanges` | `true` | Same, for data validation |
 | `GenerateCalculationChain` | `true` | Write the calc chain part Excel uses to order recalculation |
 | `FilterPrivacy` | `null` | Set the privacy flag; `null` leaves it unchanged |
+| `CompressionLevel` | `Optimal` | How hard to compress the package — `Fastest` trades size for speed |
 | `Password` | `null` | Encrypt the saved file — see [Encryption](./encryption.md) |
+
+:::note `CompressionLevel` applies to new parts
+It is honoured for parts the save creates. Re-saving a workbook that was loaded from an existing
+file leaves that file's existing parts at whatever level they were originally written with, because
+those parts are updated rather than recreated. A workbook built from scratch is unaffected.
+
+[`XLStreamingOptions.CompressionLevel`](./streaming.md#compression) is the equivalent for a
+streaming write, where it applies to everything.
+:::
 
 The shorthand overloads cover the two common cases:
 

--- a/docs-website/sidebars.ts
+++ b/docs-website/sidebars.ts
@@ -14,6 +14,7 @@ const sidebars: SidebarsConfig = {
         'cells-and-ranges',
         'defined-names',
         'importing-exporting',
+        'streaming',
         'workbook-settings',
         'encryption',
       ],

--- a/docs/specs/01-streaming-write-api.md
+++ b/docs/specs/01-streaming-write-api.md
@@ -115,11 +115,11 @@ All five acceptance criteria met. Measured on net10.0 with
 
 | # | Criterion | Result |
 |---|---|---|
-| 1 | 1M × 10 under 150 MB peak managed heap | **107.9 MB** shared strings, **13.9 MB** inline ✅ |
-| 2 | Opens clean; `XLWorkbook.Load` round-trips values, styles, formulas | `OpenXmlValidator` clean, round-trip tests green ✅ |
+| 1 | 1M × 10 under 150 MB peak managed heap | **107.9 MB** shared strings, **14.0 MB** inline ✅ |
+| 2 | Opens clean; `XLWorkbook.Load` round-trips values, styles, formulas | `OpenXmlValidator` clean, round-trip tests green — **not verified in Excel itself** ⚠️ |
 | 3 | 50K scenario ≥ as fast as `CreateAndSave`, ≤ 25% of its allocations | **1.59× faster**, **20.1%** of allocations ✅ |
 | 4 | No public-API breaks; `PublicApiAnalyzers` additions only | Additions only ✅ |
-| 5 | Suite green; new tests in `XLibur.Tests/Excel/Streaming/` | 7432 tests, 25 new ✅ |
+| 5 | Suite green; new tests in `XLibur.Tests/Excel/Streaming/` | 7436 tests, 28 new ✅ |
 
 ### 50K × 3 workload
 
@@ -138,9 +138,14 @@ go through `System.IO.Packaging` at all.
 
 | Writer | Peak heap | Elapsed | File |
 |---|---|---|---|
-| `XLStreamingWorkbook`, shared strings | 107.9 MB | 10.6 s | 36.1 MB |
-| `XLStreamingWorkbook`, inline strings | 13.9 MB | 8.8 s | 35.5 MB |
-| `XLWorkbook` **at 100K × 10** (a tenth of the size) | 126.7 MB | 2.2 s | 3.5 MB |
+| `XLStreamingWorkbook`, shared strings | 107.9 MB | 10.3 s | 36.1 MB |
+| `XLStreamingWorkbook`, inline strings | 14.0 MB | 9.5 s | 35.5 MB |
+| `XLWorkbook` **at 100K × 10** (a tenth of the size) | ~100–130 MB | 2.2 s | 3.5 MB |
+
+The streaming figures are stable across runs. The `XLWorkbook` row is not — the harness samples
+`GC.GetTotalMemory` at two points rather than continuously, and it varied between 102.6 MB and
+126.7 MB over two runs, so treat it as an order-of-magnitude comparison rather than a measurement:
+it needs roughly what the streaming writer needs for *ten times* as many rows.
 
 Every row in this workload carries a distinct string, the worst case for the shared string
 table — the 108 MB is almost entirely that dictionary, and the inline figure is what the
@@ -156,6 +161,20 @@ the abstraction would have to be wide enough to carry formula, misc metadata, ri
 table-totals membership, none of which the streaming side has. Instead the *leaf* serializers
 (row start, cell start, value writers, type mapping) were extracted into `CellXmlWriter` and are
 shared by both producers. Same reuse, no change to the hot loop.
+
+The parity budget was measured against `main`, back to back on the same machine:
+
+| Benchmark | main | after | Δ |
+|---|---|---|---|
+| `CreateAndSave` time | 257.5 ms ± 5.11 | 253.5 ms ± 4.91 | −1.6% (bars overlap) |
+| `CreateAndSave` alloc | 67.46 MB | 67.46 MB | **0.00%** |
+| `CreateFormattedAndSave` time | 1157.8 ms ± 17.1 | 1040.3 ms ± 8.2 | −10.1% (bars separated) |
+| `CreateFormattedAndSave` alloc | 325.39 MB | 325.37 MB | −0.01% |
+
+Both inside the ≤2% time / 0% allocation budget, with time improving rather than degrading. The
+10% on `CreateFormattedAndSave` is incidental and unattributed — most likely the `Stylesheet`
+refactor hoisting ~40 `workbookStylesPart.Stylesheet!` accesses, many inside per-style loops, into
+a local, since that SDK property does a lazy root-element lookup per call. Not profiled to confirm.
 
 **Phase 2 — the package is written by hand, not through the OpenXML SDK.** Task P2.1 asked
 whether parts can be written incrementally under SDK 3.x. They can, and the spike confirmed it —

--- a/docs/specs/01-streaming-write-api.md
+++ b/docs/specs/01-streaming-write-api.md
@@ -3,7 +3,7 @@
 **Area:** Feature + Architecture + Performance (memory)
 **Effort:** L (2–4 weeks)
 **Dependencies:** None (but coordinate with Spec 03 — both touch `SheetDataWriter`)
-**Status:** Proposed
+**Status:** ✅ **Done** — see [Results](#results-2026-07-27) below.
 
 ## Summary
 
@@ -104,3 +104,122 @@ While in this area: expose `SaveOptions.CompressionLevel` if feasible via the SD
 
 - Architecture survey: `SheetDataWriter` has no seam; `ISlice` is a shift contract, not a data-source abstraction.
 - Benchmarks: `XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs`, results under `BenchmarkDotNet.Artifacts/results/`.
+
+## Results (2026-07-27)
+
+All five acceptance criteria met. Measured on net10.0 with
+`dotnet run -c Release --project XLibur.Benchmarks -f net10.0 -- profile streaming` and
+`-- --filter "*StreamingWriteBenchmarks*"`.
+
+### Acceptance criteria
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | 1M × 10 under 150 MB peak managed heap | **107.9 MB** shared strings, **13.9 MB** inline ✅ |
+| 2 | Opens clean; `XLWorkbook.Load` round-trips values, styles, formulas | `OpenXmlValidator` clean, round-trip tests green ✅ |
+| 3 | 50K scenario ≥ as fast as `CreateAndSave`, ≤ 25% of its allocations | **1.59× faster**, **20.1%** of allocations ✅ |
+| 4 | No public-API breaks; `PublicApiAnalyzers` additions only | Additions only ✅ |
+| 5 | Suite green; new tests in `XLibur.Tests/Excel/Streaming/` | 7432 tests, 25 new ✅ |
+
+### 50K × 3 workload
+
+| Writer | Mean | Allocated |
+|---|---|---|
+| `XLWorkbook.CreateAndSave` | 250.5 ms | 67.46 MB |
+| **`XLStreamingWorkbook`** | **157.9 ms** | **13.59 MB** |
+| `XLStreamingWorkbook`, inline strings | 144.3 ms | 8.70 MB |
+| `XLStreamingWorkbook`, `CompressionLevel.Fastest` | 91.9 ms | 17.00 MB |
+| Raw OpenXML SDK (practical floor for SDK-based libraries) | 205.2 ms | 142.26 MB |
+
+The streaming writer is faster and ~10× leaner than the raw SDK baseline, because it does not
+go through `System.IO.Packaging` at all.
+
+### 1M × 10, peak managed heap
+
+| Writer | Peak heap | Elapsed | File |
+|---|---|---|---|
+| `XLStreamingWorkbook`, shared strings | 107.9 MB | 10.6 s | 36.1 MB |
+| `XLStreamingWorkbook`, inline strings | 13.9 MB | 8.8 s | 35.5 MB |
+| `XLWorkbook` **at 100K × 10** (a tenth of the size) | 126.7 MB | 2.2 s | 3.5 MB |
+
+Every row in this workload carries a distinct string, the worst case for the shared string
+table — the 108 MB is almost entirely that dictionary, and the inline figure is what the
+documented escape hatch buys. Retained (post-collection) heap is ~30 KB at 400K rows either way.
+
+### What changed against the plan
+
+**Phase 1 — the `IXLSheetDataSource` seam was not built.** `StreamSheetData` is a single pass
+over a struct slice enumerator with no per-cell allocation, the product of specs 03 and 11. An
+`IEnumerable<XLRowData>` seam would add an interface dispatch per cell and a row object per row
+to the existing save path, missing this spec's own ≤2% time / 0% allocation parity budget — and
+the abstraction would have to be wide enough to carry formula, misc metadata, rich text and
+table-totals membership, none of which the streaming side has. Instead the *leaf* serializers
+(row start, cell start, value writers, type mapping) were extracted into `CellXmlWriter` and are
+shared by both producers. Same reuse, no change to the hot loop.
+
+**Phase 2 — the package is written by hand, not through the OpenXML SDK.** Task P2.1 asked
+whether parts can be written incrementally under SDK 3.x. They can, and the spike confirmed it —
+but only for *correctness*. Memory told a different story: `System.IO.Packaging` opens a package
+read/write, which maps to `ZipArchiveMode.Update`, and that mode buffers every part's
+**uncompressed** bytes until the archive closes. Measured 48 MB of live heap for 100K × 10,
+growing linearly — the exact failure the API exists to prevent, and the same ~96 MB hotspot
+[spec 03](03-save-path-allocations.md) flagged and deferred here. Opening the package write-only
+*does* select `ZipArchiveMode.Create`, but the SDK enumerates parts and throws
+`Cannot retrieve parts of writeonly container`.
+
+So `StreamingPackageWriter` assembles the OPC package directly over `ZipArchive` in Create mode.
+This is a different resolution than the spec's predicted fallback (staging sheet XML in temp
+files): temp files would not have helped, because the copy into the package would have been
+buffered just the same. Writing the zip ourselves also means no temp disk at all, and two
+capabilities fall out for free — the output need not be **seekable** (a workbook can be written
+straight to a network stream, which `XLWorkbook.SaveAs` cannot do) and `CompressionLevel` is
+directly available.
+
+**Two design points settled before implementation**, both because the spec's API sketch could
+not express what its own constraints promised:
+
+- The row builder `XLStreamingRow` was added alongside `AppendRow`. The sketched surface had no
+  way to write a **formula** (despite the stated "formula strings pass through verbatim"
+  constraint) or a **per-cell style**, and `AppendRow(params XLCellValue[])` allocates an array
+  per row, working against the memory goal.
+- Streamed worksheets support column widths, freeze panes and an autofilter range, not just a
+  name. All are O(1) memory and written around `sheetData`; without them a streamed export
+  cannot be a usable report.
+
+**Style and shared-string ids are inputs, not outputs.** A cell's style id is fixed the moment
+the cell is written, long before the styles part exists, and that XML is already in the package
+by then. `WorkbookStylesPartWriter.GenerateStreamingContent` therefore emits one `cellXf` per
+interned style in intern order, with no dedup and no remap, making index *i* the *i*-th style by
+construction. Shared strings are handed out densely for the same reason, so no `SstMap`
+translation is needed — unlike `SharedStringTable`, which is refcounted and leaves gaps.
+
+**Value-driven style rules are now shared.** A date, a duration and a number are all stored as a
+serial number, so only the number format distinguishes them on the way back in; a leading
+apostrophe and a line break are likewise carried by the style. `XLWorksheet` applied these rules
+on cell assignment. They moved to `XLValueStyleRules` so the cell setter and the streaming writer
+share one definition — found because a streamed `DateTime` initially round-tripped as a `double`.
+
+### Phase 3 — findings
+
+**`CompressionLevel`: implemented on both paths.** The SDK does expose
+`OpenXmlPackage.CompressionOption` (undocumented in the spec's survey), so
+`SaveOptions.CompressionLevel` now works for ordinary saves, mapping onto
+`System.IO.Packaging.CompressionOption`. It applies to parts a save creates; re-saving a loaded
+file leaves its existing parts at whatever level they were written with. The streaming writer
+takes `System.IO.Compression.CompressionLevel` directly. `Fastest` is 1.7× quicker than
+`Optimal` on the 50K workload for a ~25% larger file.
+
+**Async: not implemented, and deliberately so.** Split out rather than guessed at.
+
+- For `XLWorkbook.SaveAs`, it is blocked. `System.IO.Packaging` is entirely synchronous and the
+  SDK has no async save or package API — the only `*Async` methods in 3.4.1 are
+  `OpenXmlWriter.WriteStartElementAsync` and friends, which do not help since the package write
+  underneath them still blocks. A `SaveAsAsync` here could only be `Task.Run(() => SaveAs(...))`,
+  which does not free a thread, it just moves the blocked one — an anti-pattern in a library API.
+- For the streaming writer it *is* achievable, since we own the zip: `XmlWriterSettings.Async`
+  plus `ZipArchive` entry `WriteAsync`. But it would need an async twin of every write method
+  (`AppendRowAsync`, `Cell`…), roughly doubling a permanent public surface, for a workload that
+  is CPU-bound on deflate rather than I/O-bound. The benefit is confined to not holding a thread
+  while flushing to a slow sink — and the non-seekable-stream support already covers the main
+  scenario that motivates it (writing to an HTTP response). Worth a follow-on spec with a real
+  use case behind it, not speculative API surface now.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -10,7 +10,7 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 
 | # | Spec | Area | Effort | Status | Parallelizable? |
 |---|------|------|--------|--------|-----------------|
-| 01 | [Streaming write API](01-streaming-write-api.md) | Feature · Arch · Memory | L | Proposed | Phase 1 refactor first, then independent |
+| 01 | [Streaming write API](01-streaming-write-api.md) | Feature · Arch · Memory | L | ✅ **Done** (see Results) | Phase 1 refactor first, then independent |
 | 02 | [Load-path allocation elimination](02-load-path-allocations.md) | Perf (read) | M | ✅ **Done** (#175) | 3 independent sub-tasks |
 | 03 | [Save-path allocation reduction](03-save-path-allocations.md) | Perf (write) | M | In progress (see Results) | 7 small independent PRs |
 | 04 | [Demand-driven formula evaluation](04-demand-driven-formula-eval.md) | Perf · Arch | L | Proposed | Single owner (correctness-critical) |
@@ -40,11 +40,20 @@ one-cell/absolute anchored charts and every 3D or of-pie chart group. All fixed;
 Results sections. **Still open there:** the writer emits 3D pie/line/area and every surface type as
 their 2D group elements, so XLibur's own 3D charts round-trip as 2D.
 
+Spec 01 landed and resolved the packaging hotspot spec 03 had deferred to it. The blocker was not
+part *lifetime*, as 01 assumed, but part *buffering*: `System.IO.Packaging` opens a package
+read/write, which is `ZipArchiveMode.Update`, and that holds every part's uncompressed bytes until
+close. `XLStreamingWorkbook` therefore writes its OPC package straight over `ZipArchive` in Create
+mode. Two capabilities fall out of owning the zip: output no longer has to be **seekable**, and
+`CompressionLevel` became available — which also closed 01's Phase 3 for the *ordinary* save path,
+since the SDK does expose `OpenXmlPackage.CompressionOption`. Async remains unimplemented, with the
+reasons recorded in 01's Results.
+
 ## Why these ten (01–10)
 
 **Performance (specs 02, 03, 04, 05).** The write cell-loop and the sheetData parse have both had a round of tuning; what remains, in measured order: per-cell string allocations on load (`<v>` + attributes + SST DOM), the ~543 MB formatted save (number formatting, inherited-style resolution, StyleKey hashing), the full-workbook-recalc cliff when reading one dirty formula cell (can build a 176 MB dependency tree to answer one read), and O(all-ranges·log) work per single row insert. Specs 02–05 attack each with concrete targets.
 
-**Features (specs 01, 07, 08, 10).** The fork already leads upstream on charts, dynamic arrays, in-cell images, sparklines, WebP/SVG. The gaps that matter: no bounded-memory export path for huge files (01 — still open), ~250 missing formula functions with a clean registry to extend (07 — waves A–F now done; only the optional day-count-basis set A2 remains), no LET/LAMBDA (08 — still open, the one function family that needs engine work), and charts that couldn't be styled (10 — depth on the flagship differentiator, now done).
+**Features (specs 01, 07, 08, 10).** The fork already leads upstream on charts, dynamic arrays, in-cell images, sparklines, WebP/SVG. The gaps that matter: no bounded-memory export path for huge files (01 — now done: `XLStreamingWorkbook` writes 1M×10 in 108 MB, or 14 MB with inline strings), ~250 missing formula functions with a clean registry to extend (07 — waves A–F now done; only the optional day-count-basis set A2 remains), no LET/LAMBDA (08 — still open, the one function family that needs engine work), and charts that couldn't be styled (10 — depth on the flagship differentiator, now done).
 
 **Compatibility (specs 06, 09).** Both are now done. Password-encrypted files could not be opened or written at all — 06 added agile read/write and standard read (#245). Threaded comments were read lossily and downgraded on save — 09 gave them a real model and a write path (#258). 09's fidelity audit also **disproved its own premise**: chartsheets, form controls and slicers are *not* dropped on round-trip, because saving reopens the original package and rewrites only the parts XLibur models. See `docs/round-trip-fidelity.md`, which pins that behaviour with tests so a future rewrite cannot silently regress it.
 
@@ -58,13 +67,13 @@ Wave 1 (independent, start anytime):
   09 threaded comments ✅ done
   11 Tasks 1–4 ✅ done (−28.8% on the write benchmark; bulk styling −86% per cell)
 Wave 2 (after 03 lands, or coordinated):
-  01 streaming write (Phase 1 seam shared with 03's territory)
+  01 streaming write ✅ done (leaf serializers shared with 03's territory, not an enumeration seam)
   06 encryption ✅ done · 10 charts ✅ done (PRs 1–4: series formatting, data labels, legend/axes, reader gaps)
 Wave 3 (single-owner, correctness-critical — don't parallelize internally):
   04 demand-driven eval · 05 structural edits · 08 LET/LAMBDA (08 after or alongside 04)
 
-Remaining open work: 01 streaming write, 03 (finish), 04 demand-driven eval, 05 structural edits,
-08 LET/LAMBDA, plus the optional 07 wave A2 (day-count-basis financial functions).
+Remaining open work: 03 (finish), 04 demand-driven eval, 05 structural edits, 08 LET/LAMBDA,
+plus the optional 07 wave A2 (day-count-basis financial functions).
 ```
 
 **Read spec 02's Results section before starting 03** — it corrects 03's number-formatting task


### PR DESCRIPTION
Implements [spec 01](docs/specs/01-streaming-write-api.md): a forward-only writer for exports too large to hold in memory. All five acceptance criteria met.

## Results

| Criterion | Target | Measured |
|---|---|---|
| 1M × 10 peak managed heap | < 150 MB | **107.9 MB** (13.9 MB with inline strings) |
| Opens clean, round-trips values/styles/formulas | — | `OpenXmlValidator` clean + full `XLWorkbook` round-trip |
| vs `CreateAndSave` (50K × 3) | ≥ as fast, ≤ 25% alloc | **1.59× faster, 20.1% of allocations** |
| Public API | additions only | additions only |
| Tests | suite green | 7429 passed on net8.0 and net10.0 (25 new) |

50K × 3 workload:

| Writer | Mean | Allocated |
|---|---|---|
| `XLWorkbook.CreateAndSave` | 250.5 ms | 67.46 MB |
| **`XLStreamingWorkbook`** | **157.9 ms** | **13.59 MB** |
| …inline strings | 144.3 ms | 8.70 MB |
| …`CompressionLevel.Fastest` | 91.9 ms | 17.00 MB |
| Raw OpenXML SDK (floor for SDK-based libraries) | 205.2 ms | 142.26 MB |

## Usage

```csharp
using var workbook = XLStreamingWorkbook.Create("Large.xlsx");

var sheet = workbook.AddWorksheet("Data");
sheet.Column(1).Width = 30;
sheet.FreezeRows(1);

var header = workbook.CreateStyle();
header.Font.Bold = true;
sheet.AppendRow(["Name", "Amount"], header);

for (var i = 0; i < 1_000_000; i++)
    sheet.AppendRow($"Item {i}", i * 1.5);

using (var row = sheet.AddRow())
{
    row.Cell("Total");
    row.Formula($"SUM(B2:B{1_000_001})", cachedValue: 0d);
}

workbook.Finish();   // required — disposing without it abandons the write
```

Append-only: rows in ascending order, one worksheet at a time, no reading back, formulas stored verbatim rather than evaluated. Anything beyond cells, row/cell styles, column widths, freeze panes and an autofilter range still needs `XLWorkbook`.

## Where this departs from the spec

**Phase 1 — the `IXLSheetDataSource` seam was not built.** `StreamSheetData` is a single pass over a struct slice enumerator with no per-cell allocation, the product of specs 03 and 11. An `IEnumerable<XLRowData>` seam would add an interface dispatch per cell and a row object per row to the existing save path, missing this spec's own ≤2% time / 0% allocation parity budget — and the abstraction would have to carry formula, misc metadata, rich text and table-totals membership, none of which the streaming side has. Instead the *leaf* serializers moved into `CellXmlWriter`, shared by both producers. Measured against `main`, back to back:

| Benchmark | main | this branch | Δ |
|---|---|---|---|
| `CreateAndSave` time | 257.5 ms ± 5.11 | 253.5 ms ± 4.91 | −1.6% (bars overlap) |
| `CreateAndSave` alloc | 67.46 MB | 67.46 MB | **0.00%** |
| `CreateFormattedAndSave` time | 1157.8 ms ± 17.1 | 1040.3 ms ± 8.2 | −10.1% (bars separated) |
| `CreateFormattedAndSave` alloc | 325.39 MB | 325.37 MB | −0.01% |

The 10% is incidental and unattributed — most likely the `Stylesheet` refactor hoisting ~40 `workbookStylesPart.Stylesheet!` accesses, many inside per-style loops, into a local; that SDK property does a lazy root-element lookup per call. Not profiled to confirm.

**Phase 2 — the package is written by hand, not through the OpenXML SDK.** Task P2.1 asked whether parts can be written incrementally under SDK 3.x. They can — but the spike only established *correctness*. Memory told a different story: `System.IO.Packaging` opens packages read/write, which maps to `ZipArchiveMode.Update`, and that buffers every part's **uncompressed** bytes until close. Measured 48 MB of live heap at 100K × 10, growing linearly — the exact failure this API exists to prevent, and the same hotspot [spec 03](docs/specs/03-save-path-allocations.md) flagged and deferred here. Opening the package write-only *does* select `ZipArchiveMode.Create`, but the SDK enumerates parts and throws `Cannot retrieve parts of writeonly container`.

So `StreamingPackageWriter` assembles the OPC package directly over `ZipArchive`. This is a different resolution than the spec's predicted temp-file fallback: staging to temp files would not have helped, because the copy into the package would have been buffered just the same. Two capabilities fall out of owning the zip — output need not be **seekable** (a workbook can go straight to an HTTP response, which `XLWorkbook.SaveAs` cannot do), and **`CompressionLevel`** becomes available.

**API shape**, agreed before implementation, because the spec's sketch could not express what its own constraints promised: a row builder (`XLStreamingRow`) alongside `AppendRow`, since the sketched surface had no way to write a formula (despite the "formula strings pass through verbatim" constraint) or a per-cell style; and column widths, freeze panes and an autofilter range on streamed sheets, all O(1) memory, without which a streamed export is not a usable report.

## Also in here

- **`SaveOptions.CompressionLevel`** — spec Phase 3 assumed packaging blocked this. It doesn't: the SDK exposes `OpenXmlPackage.CompressionOption`. Verified the SDK's default is `Normal` and `Optimal` maps to `Normal`, so callers who don't set it get byte-identical output. Applies to parts a save creates; re-saving a loaded file leaves its existing parts alone.
- **`XLValueStyleRules`** — a streamed `DateTime` initially round-tripped as a `double`. The number format is the only thing distinguishing them in the file, and `XLWorksheet` applied that rule privately on cell assignment. Now shared between the cell setter and the streaming writer so the two cannot drift.
- **Async: not implemented, reasons recorded** in the spec. For `SaveAs` it is blocked — `System.IO.Packaging` is synchronous and the SDK has no async save, so `SaveAsAsync` could only be `Task.Run` over a blocking call, relocating a blocked thread rather than freeing one. For the streaming writer it is achievable but would roughly double a permanent public surface for a deflate-bound workload; non-seekable stream support already covers the scenario that usually motivates it.

## Reviewer notes

- **Please open a streamed file in real Excel before merging.** Criterion 2 names Excel; I verified `OpenXmlValidator` and a full `XLibur` round-trip, not Excel itself. Most likely place to bite: `[Content_Types].xml` is written last, since Create mode cannot seek back. Readers resolve through the zip central directory and the SDK's reader accepts it, but this is the one claim not machine-checked here.
- **We now own OPC packaging.** Content types, both relationship parts and the workbook part were the SDK's job before. New surface area, permanently ours.
- **Sheet-level features exist twice** — column widths, freeze panes and autofilter live in `ColumnWriter`/`SheetViewWriter` for the DOM path and again in `XLStreamingWorksheet`. `CellXmlWriter` and `XLValueStyleRules` prevent drift for cells and value-styling, but not for these.
- **`Dispose` without `Finish` silently leaves a corrupt package.** Deliberate — you cannot throw from `Dispose`, and finishing implicitly would mask an in-flight exception — but it is a footgun mitigated only by docs.
- **`WorkbookStylesPartWriter.GenerateContent` changed signature** (`WorkbookStylesPart` → `Stylesheet`). Internal only, no API break, but specs 03 and 05 both live in that file — merge-conflict surface for in-flight work.
- The CHANGELOG entry has no PR link; every other entry cites one. Worth adding this PR's number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a forward-only streaming API for creating large Excel workbooks with bounded memory usage.
  * Supports worksheet-at-a-time writing, row and cell streaming, formulas, styles, column settings, hidden rows/columns, freeze panes, and autofilters.
  * Added shared-string or inline-string storage options and configurable compression levels.
  * Added support for writing to file paths, regular streams, and non-seekable streams.

* **Documentation**
  * Added usage guidance, limitations, examples, and performance results for streaming exports.
  * Updated the changelog and architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->