### PR TITLE
chore: use MemoryStream in chart test helpers (CA1859)

### DIFF
--- a/XLibur.Tests/Excel/Charts/ChartAnchorTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartAnchorTests.cs
@@ -31,7 +31,7 @@ public class ChartAnchorTests
         return ms;
     }
 
-    private static Xdr.WorksheetDrawing DrawingOf(Stream stream)
+    private static Xdr.WorksheetDrawing DrawingOf(MemoryStream stream)
     {
         stream.Position = 0;
         using var doc = SpreadsheetDocument.Open(stream, false);

--- a/XLibur.Tests/Excel/Charts/ChartDataLabelTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartDataLabelTests.cs
@@ -41,7 +41,7 @@ public class ChartDataLabelTests
         return ms;
     }
 
-    private static C.ChartSpace ChartSpaceOf(Stream stream)
+    private static C.ChartSpace ChartSpaceOf(MemoryStream stream)
     {
         stream.Position = 0;
         using var doc = SpreadsheetDocument.Open(stream, false);

--- a/XLibur.Tests/Excel/Charts/ChartLegendAndAxisTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartLegendAndAxisTests.cs
@@ -43,7 +43,7 @@ public class ChartLegendAndAxisTests
         return ms;
     }
 
-    private static C.ChartSpace ChartSpaceOf(Stream stream)
+    private static C.ChartSpace ChartSpaceOf(MemoryStream stream)
     {
         stream.Position = 0;
         using var doc = SpreadsheetDocument.Open(stream, false);

--- a/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartRoundTripPreservationTests.cs
@@ -162,7 +162,7 @@ public class ChartRoundTripPreservationTests
         return ms;
     }
 
-    private static string ReadChartXml(Stream stream)
+    private static string ReadChartXml(MemoryStream stream)
     {
         stream.Position = 0;
         using var doc = SpreadsheetDocument.Open(stream, false);

--- a/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
@@ -49,7 +49,7 @@ public class ChartSeriesFormattingTests
         return ms;
     }
 
-    private static C.ChartSpace ChartSpaceOf(Stream stream)
+    private static C.ChartSpace ChartSpaceOf(MemoryStream stream)
     {
         stream.Position = 0;
         using var doc = SpreadsheetDocument.Open(stream, false);


### PR DESCRIPTION
## Summary

- Narrow private chart-test helpers from `Stream` to `MemoryStream` (CA1859). Callers already pass `MemoryStream` from `SaveValidated` / workbook fixtures.

## Changes

- `ChartDataLabelTests.ChartSpaceOf`
- `ChartAnchorTests.DrawingOf`
- `ChartLegendAndAxisTests.ChartSpaceOf`
- `ChartSeriesFormattingTests.ChartSpaceOf`
- `ChartRoundTripPreservationTests.ReadChartXml`

## Related Issues

- SonarCloud CA1859: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZ-cSn8sBaRu4znBtB8s

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually (describe below if applicable)

Build of `XLibur.Tests` (net10.0) succeeded locally.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch