### PR TITLE
chore: remove nested block in CopyingRowsAndColumns (S1199)

### DIFF
--- a/XLibur.Examples/Misc/CopyingRowsAndColumns.cs
+++ b/XLibur.Examples/Misc/CopyingRowsAndColumns.cs
@@ -57,16 +57,14 @@ public class CopyingRowsAndColumns : IXLExample
     private static void CopyRowAsRange(IXLWorksheet originalSheet, int originalRowNumber, IXLWorksheet destSheet,
         int destRowNumber)
     {
-        {
-            var destinationRow = destSheet.Row(destRowNumber);
-            destinationRow.Clear();
+        var destinationRow = destSheet.Row(destRowNumber);
+        destinationRow.Clear();
 
-            var originalRow = originalSheet.Row(originalRowNumber);
-            var columnNumber = originalRow.LastCellUsed(XLCellsUsedOptions.All).Address.ColumnNumber;
+        var originalRow = originalSheet.Row(originalRowNumber);
+        var columnNumber = originalRow.LastCellUsed(XLCellsUsedOptions.All).Address.ColumnNumber;
 
-            var originalRange = originalSheet.Range(originalRowNumber, 1, originalRowNumber, columnNumber);
-            var destRange = destSheet.Range(destRowNumber, 1, destRowNumber, columnNumber);
-            originalRange.CopyTo(destRange);
-        }
+        var originalRange = originalSheet.Range(originalRowNumber, 1, originalRowNumber, columnNumber);
+        var destRange = destSheet.Range(destRowNumber, 1, destRowNumber, columnNumber);
+        originalRange.CopyTo(destRange);
     }
 }


### PR DESCRIPTION
## Summary

- Remove an unnecessary nested code block in `CopyRowAsRange` that triggered SonarCloud S1199 ("Nested code blocks should not be used").

## Changes

- `XLibur.Examples/Misc/CopyingRowsAndColumns.cs`: unwrap the redundant braces in `CopyRowAsRange`

## Related Issues

- SonarCloud S1199: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=XLibur_XLibur&open=AZzs6xZenvODKcpvTlFD

## Testing

- [ ] Added or updated unit tests
- [ ] All existing tests pass
- [ ] Tested manually (describe below if applicable)

No behavior change; example-only cleanup.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch