### PR TITLE
perf: find comment threads through the misc slice, not a full-sheet cell scan

### DIFF
--- a/XLibur.Tests/Excel/Comments/ThreadedCommentSaveCostTests.cs
+++ b/XLibur.Tests/Excel/Comments/ThreadedCommentSaveCostTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+using XLibur.Excel.IO;
+
+namespace XLibur.Tests.Excel.Comments;
+
+/// <summary>
+/// The threaded-comment write path runs on every save of every workbook, including the
+/// overwhelming majority that have no threads at all. These tests pin down that it costs nothing
+/// on those workbooks — a scan that materialises an <c>XLCell</c> per used cell here is invisible
+/// in correctness tests but showed up as +23 MB on the 50K-row save benchmark.
+/// </summary>
+public class ThreadedCommentSaveCostTests
+{
+    private const int UsedCells = 20_000;
+
+    [Test]
+    public async Task Collecting_persons_does_not_materialise_a_cell_per_used_cell()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        for (var row = 1; row <= UsedCells; row++)
+            ws.Cell(row, 1).Value = row;
+
+        // Warm up so JIT and any first-call setup are outside the measured window.
+        PersonPartWriter.CollectReferencedPersons(wb);
+
+        var before = GC.GetTotalAllocatedBytes(precise: true);
+        var persons = PersonPartWriter.CollectReferencedPersons(wb);
+        var allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
+
+        await Assert.That(persons).IsEmpty();
+
+        // One XLCell wrapper per used cell is 48 bytes, so the scan this replaced allocated at
+        // least 960 KB here. Walking the misc slice allocates the empty result list and nothing
+        // per cell; the bound leaves room for that without leaving room for a per-cell wrapper.
+        await Assert.That(allocated).IsLessThan(64 * 1024);
+    }
+
+    [Test]
+    public async Task Threads_on_many_cells_round_trip_with_the_right_references()
+    {
+        using var ms = new MemoryStream();
+
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            var person = wb.Persons.Add("Ada Lovelace");
+
+            for (var row = 1; row <= UsedCells; row++)
+                ws.Cell(row, 1).Value = row;
+
+            // Spread across rows and columns so a row-major slice walk has to pair each thread
+            // with the point it actually sits on.
+            ws.Cell("A1").CreateThreadedComment(person, "first");
+            ws.Cell("C5").CreateThreadedComment(person, "middle");
+            ws.Cell("B20000").CreateThreadedComment(person, "last");
+
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        using var reloaded = new XLWorkbook(ms);
+        var sheet = reloaded.Worksheets.First();
+
+        await Assert.That(sheet.Cell("A1").GetThreadedComment()!.Text).IsEqualTo("first");
+        await Assert.That(sheet.Cell("C5").GetThreadedComment()!.Text).IsEqualTo("middle");
+        await Assert.That(sheet.Cell("B20000").GetThreadedComment()!.Text).IsEqualTo("last");
+        await Assert.That(reloaded.Persons.Count).IsEqualTo(1);
+        await Assert.That(reloaded.Persons.First().DisplayName).IsEqualTo("Ada Lovelace");
+    }
+}

--- a/XLibur/Excel/Cells/XLCellsCollection.cs
+++ b/XLibur/Excel/Cells/XLCellsCollection.cs
@@ -256,6 +256,28 @@ internal sealed class XLCellsCollection : IWorkbookListener
     }
 
     /// <summary>
+    /// Every comment thread in the sheet, paired with the point it sits on, in row-major order.
+    /// Scans the misc slice directly rather than materialising an <see cref="XLCell"/> per used
+    /// cell: the save path asks this of every sheet on every save, including the overwhelmingly
+    /// common case where no sheet has a thread at all.
+    /// </summary>
+    internal List<(Point Point, XLThreadedComment Thread)> GetThreadedComments()
+    {
+        var threads = new List<(Point, XLThreadedComment)>();
+        if (MiscSlice.IsEmpty)
+            return threads;
+
+        var enumerator = new Slice<XLMiscSliceContent>.Enumerator(MiscSlice, Area.Full);
+        while (enumerator.MoveNext())
+        {
+            if (enumerator.Current.ThreadedComment is { } thread)
+                threads.Add((enumerator.Point, thread));
+        }
+
+        return threads;
+    }
+
+    /// <summary>
     /// Points of all cells that carry an in-cell image, in row-major order. Scans the misc slice
     /// directly rather than materialising an <see cref="XLCell"/> per used cell.
     /// </summary>

--- a/XLibur/Excel/IO/PersonPartWriter.cs
+++ b/XLibur/Excel/IO/PersonPartWriter.cs
@@ -21,6 +21,12 @@ internal static class PersonPartWriter
     /// authored, and a <c>personId</c> with no matching <c>&lt;person&gt;</c> is a dangling
     /// reference Excel cannot resolve.
     /// </summary>
+    /// <remarks>
+    /// Every save calls this, for every sheet, to decide whether the person part is needed at all —
+    /// so it walks the misc slice rather than the cells collection. Materialising an
+    /// <see cref="XLCell"/> per used cell here cost 48 bytes × every cell in the workbook on saves
+    /// that had no threaded comments anywhere, which is nearly all of them.
+    /// </remarks>
     internal static List<XLPerson> CollectReferencedPersons(XLWorkbook workbook)
     {
         var persons = new List<XLPerson>();
@@ -34,9 +40,8 @@ internal static class PersonPartWriter
 
         foreach (var worksheet in workbook.WorksheetsInternal)
         {
-            foreach (var cell in worksheet.Internals.CellsCollection.GetCells(c => c.HasThreadedComment))
+            foreach (var (_, root) in worksheet.Internals.CellsCollection.GetThreadedComments())
             {
-                var root = cell.SliceThreadedComment!;
                 AddIfNew(persons, seen, root.AuthorInternal);
 
                 if (root.RepliesInternal is { } replies)

--- a/XLibur/Excel/IO/ThreadedCommentPartWriter.cs
+++ b/XLibur/Excel/IO/ThreadedCommentPartWriter.cs
@@ -32,10 +32,9 @@ internal static class ThreadedCommentPartWriter
         xml.WriteAttributeString("xmlns", "x", null, OpenXmlConst.Main2006SsNs);
 
         var refBuffer = new char[10];
-        foreach (var cell in worksheet.Internals.CellsCollection.GetCells(c => c.HasThreadedComment))
+        foreach (var (point, root) in worksheet.Internals.CellsCollection.GetThreadedComments())
         {
-            var root = cell.SliceThreadedComment!;
-            var reference = new string(refBuffer, 0, cell.SheetPoint.Format(refBuffer));
+            var reference = new string(refBuffer, 0, point.Format(refBuffer));
 
             WriteComment(xml, root, reference, root);
             if (root.RepliesInternal is { } replies)


### PR DESCRIPTION
## Summary

`GeneratePersonPart`, added by #258, runs on every save of every workbook to decide whether
`xl/persons/person.xml` is needed. It answered that with

```csharp
CellsCollection.GetCells(c => c.HasThreadedComment)
```

which materialises an `XLCell` wrapper for every used cell in every worksheet to read one bool.
At 48 bytes a wrapper that is 24 MB on a 500K-cell save, paid in full by the overwhelming
majority of workbooks, which contain no threads at all.

It regressed the save phase of the 50K-row benchmark by 19%. Bisected across 8 build/measure
points: good at `1d07c076` (117.6 MB), bad at `e45e03d6` (140.5 MB).

| Scenario | Save before | Save after |
|---|---:|---:|
| `CreateAndSave` | 41.9 MB | **34.9 MB** |
| `CreateFormattedAndSave` | 140.5 MB | **117.6 MB** |

`dotnet run -c Release --project XLibur.Benchmarks --framework net10.0 -- profile alloc`, two runs
per side, stable to ±0.2 MB. Both figures are back to exactly what #185 recorded (34.9 / 117.6),
so this is a restoration rather than a new win. Create phase (183.3 MB) and wall time are
unchanged.

## Changes

- Add `XLCellsCollection.GetThreadedComments()`, which walks the misc slice the way the existing
  `HasAnyThreadedComment` and `GetCellImagePoints` already do, returning each thread paired with
  its `Point`.
- Route `PersonPartWriter.CollectReferencedPersons` through it. This is the call site that runs
  unconditionally, and the whole of the regression.
- Route `ThreadedCommentPartWriter.GenerateContent` through it too. That one is gated behind
  `HasAnyThreadedComment`, so it was not part of the regression, but it paid the same
  per-used-cell cost to write a handful of comments.

No public API change. No CHANGELOG entry: #258 has not shipped, so the regression never reached a
release, and the existing "50% fewer allocations on save" bullet is true again.

## Related Issues

Regression introduced by #258. This is the fifth instance of the pattern
[spec 03](https://github.com/XLibur/XLibur/blob/main/docs/specs/03-save-path-allocations.md) removed from four other save
helpers — see its Results section, "Full-sheet `GetCells()` scans".

## Testing

- [x] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually — not applicable; no behaviour change, and threaded-comment round trips are
      covered by the existing suite from #258.

New `ThreadedCommentSaveCostTests`:

- `Collecting_persons_does_not_materialise_a_cell_per_used_cell` asserts that collecting persons
  on a 20,000-cell sheet with no threads allocates under 64 KB. Verified it fails against the
  previous implementation, where it reports **960,784 bytes** — 20,000 × 48, plus change. That is
  what confirmed the attribution.
- `Threads_on_many_cells_round_trip_with_the_right_references` puts threads on three cells spread
  across rows and columns of a 20,000-cell sheet and round-trips them, pinning the row-major point
  pairing the new walk does.

Full suite green on both TFMs: 11,601 passed, 4 skipped (all pre-existing).

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saving and reloading of threaded comments across multiple cells.
  * Preserved threaded comment text and author references during workbook round trips.
  * Reduced unnecessary processing when saving workbooks with many populated cells and few threaded comments.

* **Tests**
  * Added coverage for threaded comment persistence and save performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->