### PR TITLE
fix: delete a note from where it is now, not where it was created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,10 @@
 
 - **`Series.Add(...)` on a chart loaded from a file throws instead of being discarded on save.** A loaded chart is patched, not regenerated, so a new series had nowhere to be written and vanished without a word. It now throws `NotSupportedException`, as `UseSecondaryAxis` already did. ([#230](https://github.com/XLibur/XLibur/pull/230) by [@jafin](https://github.com/jafin))
 
+#### Comments
+
+- **`IXLComment.Delete()` removes the note from where it is now, not where it was created** ([#259](https://github.com/XLibur/XLibur/issues/259)): a note remembered the cell it was constructed with, and inserting or deleting rows or columns moves the note without telling it. Deleting a note on `A5` after two rows were inserted above cleared `A5` — by then an empty cell — and left the note sitting on `A7`. The note is now confirmed to still be the one at the remembered address before that address is cleared, and located by identity when it is not. ([#268](https://github.com/XLibur/XLibur/pull/268) by [@jafin](https://github.com/jafin))
+
 ### 🗑️ Deprecations
 
 #### Colours and styles

--- a/XLibur.Tests/Excel/Comments/CommentsTests.cs
+++ b/XLibur.Tests/Excel/Comments/CommentsTests.cs
@@ -327,7 +327,8 @@ public partial class CommentsTests
     {
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");
-        ws.Cell("B2").GetComment().AddText("Note.");
+        var note = ws.Cell("B2").GetComment();
+        note.AddText("Note.");
 
         ws.Row(1).InsertRowsAbove(2);         // B2 -> B4
         ws.Column(1).InsertColumnsBefore(2);  // B4 -> D4
@@ -335,7 +336,7 @@ public partial class CommentsTests
         ws.Column(1).Delete();                // D3 -> C3
         await Assert.That(ws.Cell("C3").HasComment).IsTrue();
 
-        ws.Cell("C3").GetComment().Delete();
+        note.Delete();
 
         await Assert.That(ws.Cell("C3").HasComment).IsFalse();
         await Assert.That(ws.CellsUsed(XLCellsUsedOptions.Comments).Count()).IsEqualTo(0);

--- a/XLibur.Tests/Excel/Comments/CommentsTests.cs
+++ b/XLibur.Tests/Excel/Comments/CommentsTests.cs
@@ -322,6 +322,43 @@ public partial class CommentsTests
         await Assert.That(hasComment).IsTrue();
     }
 
+    [Test]
+    public async Task Deleting_a_note_that_has_been_shifted_clears_the_right_cell()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("B2").GetComment().AddText("Note.");
+
+        ws.Row(1).InsertRowsAbove(2);         // B2 -> B4
+        ws.Column(1).InsertColumnsBefore(2);  // B4 -> D4
+        ws.Row(1).Delete();                   // D4 -> D3
+        ws.Column(1).Delete();                // D3 -> C3
+        await Assert.That(ws.Cell("C3").HasComment).IsTrue();
+
+        ws.Cell("C3").GetComment().Delete();
+
+        await Assert.That(ws.Cell("C3").HasComment).IsFalse();
+        await Assert.That(ws.CellsUsed(XLCellsUsedOptions.Comments).Count()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Deleting_a_note_that_is_no_longer_on_the_sheet_leaves_the_cell_alone()
+    {
+        // A5's note goes with the deleted row and A6's note lands on A5, so deleting the note that
+        // is already gone must not take the one that replaced it.
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var deletedNote = ws.Cell("A5").GetComment();
+        deletedNote.AddText("Five.");
+        ws.Cell("A6").GetComment().AddText("Six.");
+
+        ws.Row(5).Delete();
+        deletedNote.Delete();
+
+        await Assert.That(ws.Cell("A5").HasComment).IsTrue();
+        await Assert.That(ws.Cell("A5").GetComment().Text).IsEqualTo("Six.");
+    }
+
     [GeneratedRegex(@"height:(\d+\.?\d*)pt")]
     private static partial Regex HeightPattern();
 }

--- a/XLibur/Excel/Cells/XLCellsCollection.cs
+++ b/XLibur/Excel/Cells/XLCellsCollection.cs
@@ -278,6 +278,46 @@ internal sealed class XLCellsCollection : IWorkbookListener
     }
 
     /// <summary>
+    /// The point of the cell that holds <paramref name="note"/>, or null when the note is no longer
+    /// on the sheet. Matches by identity rather than by an address the note remembers, because
+    /// shifting rows or columns moves the note's misc slice entry without telling the note. Walks
+    /// the misc slice rather than materialising an <see cref="XLCell"/> per used cell.
+    /// </summary>
+    internal Point? FindNote(XLComment note)
+    {
+        if (MiscSlice.IsEmpty)
+            return null;
+
+        var enumerator = new Slice<XLMiscSliceContent>.Enumerator(MiscSlice, Area.Full);
+        while (enumerator.MoveNext())
+        {
+            if (ReferenceEquals(enumerator.Current.Comment, note))
+                return enumerator.Point;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The point of the cell that holds <paramref name="thread"/>, or null when the thread is no
+    /// longer on the sheet. Matches by identity, for the same reason as <see cref="FindNote"/>.
+    /// </summary>
+    internal Point? FindThreadedComment(XLThreadedComment thread)
+    {
+        if (MiscSlice.IsEmpty)
+            return null;
+
+        var enumerator = new Slice<XLMiscSliceContent>.Enumerator(MiscSlice, Area.Full);
+        while (enumerator.MoveNext())
+        {
+            if (ReferenceEquals(enumerator.Current.ThreadedComment, thread))
+                return enumerator.Point;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Points of all cells that carry an in-cell image, in row-major order. Scans the misc slice
     /// directly rather than materialising an <see cref="XLCell"/> per used cell.
     /// </summary>

--- a/XLibur/Excel/Comments/Threaded/XLThreadedComment.cs
+++ b/XLibur/Excel/Comments/Threaded/XLThreadedComment.cs
@@ -121,16 +121,10 @@ internal sealed class XLThreadedComment : IXLThreadedComment
         }
 
         // Look the thread up by identity rather than trusting a remembered address: rows and columns
-        // may have shifted since it was created, which moves the slice entry silently. Threads are
-        // rare, so this only walks the handful of cells that have one.
-        foreach (var cell in Worksheet.Internals.CellsCollection.GetCells(c => c.HasThreadedComment))
-        {
-            if (ReferenceEquals(cell.SliceThreadedComment, this))
-            {
-                cell.SliceThreadedComment = null;
-                return;
-            }
-        }
+        // may have shifted since it was created, which moves the slice entry silently.
+        var cells = Worksheet.Internals.CellsCollection;
+        if (cells.FindThreadedComment(this) is { } point)
+            cells.GetCell(point).SliceThreadedComment = null;
     }
 
     internal XLThreadedComment Root => ParentInternal ?? this;

--- a/XLibur/Excel/Comments/XLComment.cs
+++ b/XLibur/Excel/Comments/XLComment.cs
@@ -5,7 +5,13 @@ namespace XLibur.Excel;
 
 internal sealed class XLComment : XLFormattedText<IXLComment>, IXLComment
 {
-    private XLCell _cell = null!;
+    /// <summary>
+    /// The cell the note was last known to sit on. Only a hint for <see cref="Delete"/>: shifting
+    /// rows or columns moves the note's entry within the misc slice without telling the note, so the
+    /// address can name a cell the note has since moved off. The worksheet behind the reference is
+    /// not a hint — a note never changes sheet, because copying builds a new one.
+    /// </summary>
+    private XLCell _lastKnownCell = null!;
 
     public XLComment(XLCell cell, IXLFontBase? defaultFont = null, int? shapeId = null)
         : base(defaultFont ?? XLFont.DefaultCommentFont)
@@ -44,7 +50,18 @@ internal sealed class XLComment : XLFormattedText<IXLComment>, IXLComment
 
     public void Delete()
     {
-        _cell.DeleteComment();
+        // Confirm the note is still the one living at the remembered address before clearing it: a
+        // shift may have moved this note elsewhere, or moved another note in. The sheet's notes are
+        // only walked when that hint has gone stale, so the common case stays a single slice read.
+        if (ReferenceEquals(_lastKnownCell.SliceComment, this))
+        {
+            _lastKnownCell.SliceComment = null;
+            return;
+        }
+
+        var cells = _lastKnownCell.Worksheet.Internals.CellsCollection;
+        if (cells.FindNote(this) is { } point)
+            cells.GetCell(point).SliceComment = null;
     }
 
     #endregion IXLComment Members
@@ -206,7 +223,7 @@ internal sealed class XLComment : XLFormattedText<IXLComment>, IXLComment
             .Protection.SetLocked(style.Protection.Locked)
             .Protection.SetLockText(style.Protection.LockText);
 
-        _cell = cell;
+        _lastKnownCell = cell;
         ShapeId = shapeId.Value;
     }
 }


### PR DESCRIPTION
Fixes #259.

## The bug

`XLComment` held the `XLCell` it was constructed with, and an `XLCell` is an address rather than a handle on the value it names. Shifting rows or columns moves the note's entry within `XLMiscSliceContent`; the `XLComment` object is never told, so `Delete()` cleared the address the note used to be at.

```csharp
ws.Cell("A5").GetComment().AddText("Note.");
ws.Row(1).InsertRowsAbove(2);        // the note is now on A7
ws.Cell("A7").GetComment().Delete();
ws.Cell("A7").HasComment;            // true — A5 was cleared instead
```

## The fix

This is the same defect #258 fixed on `XLThreadedComment`. That fix dropped the cell reference entirely and located the thread by identity, which is affordable because threads are rare. Notes are not, so the issue flagged the scan as the open question here.

The remembered cell is kept, but only as a hint. `Delete()` confirms the note is still the one living at that address before clearing it, and walks the sheet's notes only when the hint has gone stale — so a note that has never moved costs one slice read, and the scan is paid for by the shift, not by every delete. The identity check also covers the case the old code got wrong in the other direction: a note that a shift has already removed no longer takes the note that moved into its old address with it.

The walk goes through a new `XLCellsCollection.FindNote`, which enumerates the misc slice rather than materialising an `XLCell` per used cell. `XLThreadedComment.Delete` still had the `GetCells(c => c.HasThreadedComment)` form that #267 removed from the save path, so it moves to the matching `FindThreadedComment` — no behaviour change, one less instance of that pattern.

One incidental change: `Delete()` now clears the note alone rather than calling `XLCell.DeleteComment()`, which clears both kinds of annotation. A cell cannot hold both, so nothing observable changes.

Option 2 from the issue — notifying moved values from the slice — is not taken here. It is the better end state if a third kind of slice value ever needs to know where it lives, but it is a wider change than this bug needs, and the hint makes the scan cost a non-issue in the meantime.

## Tests

Two added in `XLibur.Tests/Excel/Comments/CommentsTests.cs`, alongside the threaded equivalent in `ThreadedCommentReviewTests.cs`:

- `Deleting_a_note_that_has_been_shifted_clears_the_right_cell` — a note pushed through `InsertRowsAbove`, `InsertColumnsBefore`, a row delete and a column delete, then deleted; the sheet is left with no notes at all. Fails on `main` at the first assertion.
- `Deleting_a_note_that_is_no_longer_on_the_sheet_leaves_the_cell_alone` — the collateral-damage case above.

Full suite: 11,603 passed, 4 skipped (pre-existing), 0 failed on net10.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed comment and note deletion after rows or columns are inserted, deleted, or shifted.
  - Deleting a moved note now removes it from its current cell instead of a stale location.
  - Deleting a note that is no longer present leaves replacement notes unchanged.
  - Improved threaded comment deletion to target the correct comment.

- **Tests**
  - Added coverage for shifted, removed, and threaded comment deletion scenarios.

- **Documentation**
  - Updated the changelog with the comment deletion fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->