### PR TITLE
chore: scope the release tag globs to the core version stream

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -90,7 +90,9 @@ jobs:
           # sees none and drafts v0.0.1, which would publish NuGet packages below
           # the versions already out there — and NuGet versions cannot be reused.
           # Refuse anything that is not an increase over the highest existing tag.
-          latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          # The digit keeps a prefixed tag from an independently versioned
+          # package (`viz-v1.0.0`) out of the core stream's latest-tag check.
+          latest=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)
           if [ -n "$latest" ] && \
              [ "$(printf '%s\n%s\n' "$version" "${latest#v}" | sort -V | head -n1)" = "$version" ]; then
             echo "::error::$tag is not an increase over the latest tag $latest. If the release draft is wrong (it reads v0.0.1 until the first release is published), pass an explicit version input."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,14 @@
 name: Release
 
-# All packages version in lockstep from the `v*` tag, so one tag releases the
+# All packages version in lockstep from the core tag, so one tag releases the
 # whole set: XLibur, XLibur.Bundle, and the three font engine packages.
+#
+# The glob requires a digit after the `v` so it matches only the core version
+# stream. A bare `v*` would also match a prefixed tag from an independently
+# versioned package (`viz-v1.0.0`), firing a full core release off it.
 on:
   push:
-    tags: ['v*']
+    tags: ['v[0-9]*']
   # Called by release-publish.yml, which creates the tag and then invokes this
   # workflow directly. A tag pushed with GITHUB_TOKEN does not trigger the
   # `push: tags` trigger above, so the call has to be explicit.


### PR DESCRIPTION
## Summary

`v*` matches any tag beginning with `v`, so a prefixed tag from a package on its own version
stream — say `report-v1.0.0` written as `viz-v1.0.0` — would fire a full five-package core
release, and would then become the "latest tag" that `release-publish.yml` checks every
subsequent version against. Requiring a digit after the `v` confines both to `v0.106.0`-style
core tags.

Groundwork for versioning `XLibur.Report` independently of core (see spec 13), but it stands on
its own as a guard: nothing today creates a non-core `v`-leading tag, and this makes sure nothing
can start.

## Changes

- `release.yml` — `push: tags` trigger `v*` → `v[0-9]*`
- `release-publish.yml` — latest-tag lookup `git tag --list 'v*'` → `'v[0-9]*'`
- Comments on both recording why the glob is narrowed

## Related Issues

None.

## Testing

Existing tags are unaffected — `git tag --list 'v[0-9]*'` still returns both `v0.105.0` and
`v0.106.0`, 2 of 2, so the core stream is matched exactly as before. A prefixed tag is excluded
by construction: the pattern requires a digit in position two.

- [ ] Added or updated unit tests — n/a, workflow-only change
- [x] All existing tests pass — no code touched
- [x] Tested manually (tag glob verified against the repo's real tags)

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
