### PR TITLE
docs: spec 13, a public core surface for XLibur.Report

### DIFF
--- a/docs/specs/13-report-core-public-api.md
+++ b/docs/specs/13-report-core-public-api.md
@@ -1,0 +1,250 @@
+# Spec 13 — A Public Core Surface for `XLibur.Report`
+
+**Area:** Arch · API · Packaging  **Effort:** M  **Status:** Proposed
+**Parallelizable?** Tasks 1 and 2 are fully independent; task 3 needs both.
+
+## Summary
+
+`XLibur.Report` reads core internals through an `InternalsVisibleTo` grant. That is fine while
+the two ship as one version off one tag, and it is what spec 12 assumed. It stops being fine
+the moment Report versions independently, which is now the intent: Report moves on its own
+cadence, is pre-1.0, and should neither inherit core's version nor drag core along when it
+breaks.
+
+This spec replaces the friend grant with a small, supported public surface — **two additions,
+expressed in types that are already public** — so Report can depend on a published core
+package with an honest version floor.
+
+It is a core-only change. Report's own refactor onto the new surface (task 3) is a separate
+piece of work on the Report branch and is described here only so the surface can be judged
+against its consumer.
+
+## Current state
+
+`XLibur/Properties/AssemblyInfo.cs` grants:
+
+```csharp
+[assembly: InternalsVisibleTo("XLibur.Report")]
+[assembly: InternalsVisibleTo("XLibur.Report.Tests")]
+```
+
+Building Report against the released `XLibur 0.106.0` package instead of the project fails with
+**9 errors** (`CS0122` inaccessible, `CS0246` not found) across exactly two files:
+
+| File | Internals used |
+|---|---|
+| `XLibur.Report/Functions/ExcelFunctionBridge.cs` | `XLCalcEngine`, `FunctionDefinition`, `AnyValue`, `ScalarValue`, `CalcContext`, `MissingContextException` |
+| `XLibur.Report/Rewriting/PivotRewriter.cs` | `XLPivotCache`, `XLPivotSourceReference`, `SheetArea`, `Area` |
+
+The Report branch also *added* two core members to serve the bridge, which this spec supersedes:
+
+- `FunctionRegistry.Names` (new `public` member on an `internal` class)
+- `XLCalcEngine.Functions` (new `internal` property)
+
+Reproduce the failure from the Report branch:
+
+```
+dotnet build XLibur.Report/XLibur.Report.csproj -c Release -p:XLiburPackAgainstReleasedCore=true
+```
+
+## Why an open version floor over internals is unsafe
+
+Internals carry no compatibility contract, so `XLibur >= 0.107.0` would be a promise core never
+made. The failure is not hypothetical, because Report is an addon *to* core and consumers will
+routinely reference both:
+
+```xml
+<PackageReference Include="XLibur" Version="0.120.0" />
+<PackageReference Include="XLibur.Report" Version="0.1.0" />  <!-- built against 0.107.0 internals -->
+```
+
+NuGet unifies core upward to 0.120.0. Report was compiled against internals that may since have
+been renamed, resharpened or deleted, and fails at runtime with `MissingMethodException` or
+`TypeLoadException`. Restore is silent; the break surfaces in production.
+
+The alternative — pinning Report to one exact core version — is lockstep wearing a different
+number, and makes every core release a Report release. Hence a real public surface.
+
+## Design
+
+Guiding principle: **expose a purpose-built API in terms of types that are already public**
+(`XLCellValue`, `XLError`, `IXLRange`, `IXLWorksheet`), rather than publishing the internals as
+they stand. `AnyValue`, `ScalarValue`, `CalcContext`, `FunctionDefinition`, `SheetArea` and
+`Area` are deep calc-engine and coordinate representations; publishing them freezes
+implementation detail permanently for the sake of two call sites.
+
+### A. Invoking a workbook function without a grid
+
+New file `XLibur/Excel/CalcEngine/XLFunctionLibrary.cs`.
+
+```csharp
+namespace XLibur.Excel.CalcEngine;
+
+/// <summary>
+/// The workbook function library, callable outside a worksheet — the same functions a cell
+/// formula can call, evaluated without a grid to be relative to.
+/// </summary>
+public sealed class XLFunctionLibrary
+{
+    /// <param name="culture">Culture for parsing and formatting. Defaults to invariant.</param>
+    public XLFunctionLibrary(CultureInfo? culture = null);
+
+    /// <summary>Names of every available function, in Excel's own casing.</summary>
+    public IReadOnlyCollection<string> Names { get; }
+
+    /// <summary>
+    /// Calls <paramref name="name"/> with <paramref name="arguments"/>.
+    /// </summary>
+    /// <returns>
+    /// <c>false</c> if no function has that name, leaving <paramref name="result"/> default.
+    /// Otherwise <c>true</c>; a call that was made but could not succeed — wrong arity, wrong
+    /// argument type, a division by zero — returns <c>true</c> with an <see cref="XLError"/>
+    /// result, which is how Excel itself reports these.
+    /// </returns>
+    /// <exception cref="XLNoWorksheetContextException">
+    /// The function needs a worksheet to be relative to (<c>ROW</c>, <c>OFFSET</c>,
+    /// <c>INDIRECT</c> and the like). Those belong in a real cell formula.
+    /// </exception>
+    public bool TryInvoke(string name, ReadOnlySpan<XLCellValue> arguments, out XLCellValue result);
+}
+```
+
+Also new: `XLNoWorksheetContextException` in `XLibur.Excel.CalcEngine.Exceptions`, a public
+wrapper over the internal `MissingContextException`.
+
+Why `XLCellValue` is the right currency:
+
+- It already models every scalar the bridge converts to and from — blank, logical, number, text,
+  error — so `AnyValue` and `ScalarValue` stay internal.
+- Array and reference results have no `XLCellValue` representation, so the case Report already
+  rejects becomes unrepresentable rather than needing a public `AnyValue`. `TryInvoke` returns
+  `XLError.IncompatibleValue` for them, matching Report's current behaviour.
+- Callers keep their own domain conversions. Report's `DateTime` → OA-date mapping is Report's
+  concern and stays in Report.
+
+Implementation is a thin adapter over what already exists: construct an `XLCalcEngine`, look the
+name up in its `FunctionRegistry`, arity-check against `MinParams`/`MaxParams`, build the
+no-grid `CalcContext`, convert in and out, and translate `MissingContextException`. The
+`FunctionRegistry.Names` and `XLCalcEngine.Functions` members the Report branch added stay
+`internal` and serve this class instead of serving Report directly.
+
+### B. Re-pointing a pivot cache's source
+
+`IXLPivotCache` is **already public** and already exposes `Refresh()` and
+`SetRefreshDataOnOpen()`. The only gap is the source reference, currently
+`internal IXLPivotSource XLPivotCache.Source { get; set; }`. Add three members:
+
+```csharp
+public interface IXLPivotCache            // additions only, no changes to existing members
+{
+    /// <summary>
+    /// The range this cache reads from, when the source is a direct range on a sheet.
+    /// Null when the source is a named range or a table — use <see cref="SourceWorksheet"/>.
+    /// </summary>
+    IXLRange? SourceRange { get; }
+
+    /// <summary>
+    /// The worksheet this cache reads from, resolved through the named range or table when the
+    /// source is one. Null if the source cannot be resolved, e.g. a deleted name.
+    /// </summary>
+    IXLWorksheet? SourceWorksheet { get; }
+
+    /// <summary>Re-points the cache at <paramref name="range"/>. Does not refresh.</summary>
+    IXLPivotCache SetSourceRange(IXLRange range);
+}
+```
+
+These map one-to-one onto what `PivotRewriter` does today: `SourceWorksheet` replaces its
+`SourceSheetName` helper (which calls the internal `TryGetSource`), and
+`SourceRange`/`SetSourceRange` replace reading and assigning `XLPivotSourceReference` over
+`SheetArea`. Report's expansion arithmetic then works in `IXLRange` and never needs `Area`.
+
+Adding members to a public interface is a source-breaking change for external implementers.
+`IXLPivotCache` is not designed to be implemented outside the library — `XLPivotCache` is its
+only implementation and the constructor is internal — so this is acceptable pre-1.0. Note it in
+the changelog under Breaking Changes.
+
+### What stays internal (non-goals)
+
+`XLCalcEngine`, `FunctionRegistry`, `FunctionDefinition`, `CalcContext`, `AnyValue`,
+`ScalarValue`, `MissingContextException`, `XLPivotCache`, `XLPivotSourceReference`,
+`IXLPivotSource`, `SheetArea`, `Area`. If a task finds itself widening any of these, the design
+above is being bypassed — stop and revise the spec instead.
+
+Out of scope: registering *custom* functions with the calc engine, evaluating whole formula
+strings outside a workbook, and any other pivot-source kind (consolidation ranges, external
+sources). None are needed by Report and each is a larger design in its own right.
+
+### The test-assembly grant stays
+
+Drop `InternalsVisibleTo("XLibur.Report")`. **Keep `InternalsVisibleTo("XLibur.Report.Tests")`**,
+with a comment recording that the asymmetry is deliberate.
+
+The compatibility contract that matters is the *shipped package's*. `XLibur.Report.Tests` is
+`IsPackable=false`, lives in this repo, and always builds against the core in this tree, so its
+use of internals — asserting on a pivot cache's `RecordCount`, which is not on the public
+surface and should not be — costs nothing and constrains nothing. Publishing a record count
+merely to avoid an asymmetry would be the tail wagging the dog.
+
+## Work plan
+
+| # | Task | Files | Depends on |
+|---|---|---|---|
+| 1 | `XLFunctionLibrary` + `XLNoWorksheetContextException`, with tests | `XLibur/Excel/CalcEngine/XLFunctionLibrary.cs`, `.../Exceptions/`, `XLibur.Tests/Excel/CalcEngine/` | — |
+| 2 | `IXLPivotCache.SourceRange` / `SourceWorksheet` / `SetSourceRange`, with tests | `XLibur/Excel/PivotTables/IXLPivotCache.cs`, `XLPivotCache.cs`, `XLibur.Tests/Excel/PivotTables/` | — |
+| 3 | Drop the `XLibur.Report` friend grant; keep the `.Tests` one | `XLibur/Properties/AssemblyInfo.cs` | 1, 2 |
+| 4 | Release core **0.107.0** carrying all of the above | — | 1, 2, 3 |
+| 5 | *(Report branch, separate PR)* refactor `ExcelFunctionBridge` and `PivotRewriter` onto the new surface; revert the `FunctionRegistry.Names` / `XLCalcEngine.Functions` additions to plain internals | `XLibur.Report/**` | 4 |
+
+Tasks 1 and 2 are disjoint and can run in parallel. Task 3 is a two-line deletion that will not
+compile until 1 and 2 are complete *and* task 5 has landed on the Report branch — so on core's
+own branch, task 3 lands together with a temporary `ProjectReference` build check, or simply
+after Report is refactored. Sequence 1‖2 → 5 → 3 → 4 if the Report branch can absorb the
+refactor before core releases.
+
+## Acceptance criteria
+
+1. `dotnet build XLibur.Report/XLibur.Report.csproj -c Release -p:XLiburPackAgainstReleasedCore=true`
+   against core ≥ 0.107.0 succeeds with **0 errors**. It currently produces 9.
+2. `XLibur/Properties/AssemblyInfo.cs` contains no `InternalsVisibleTo("XLibur.Report")`.
+   The `XLibur.Report.Tests` grant is still present and commented.
+3. Every type named under *What stays internal* is still `internal`. Assert this in a test that
+   reflects over the public surface, so a later change cannot widen one by accident.
+4. The `XLibur.Report` test suite passes unchanged — the refactor is behaviour-preserving.
+   No Report test may be edited to accommodate the new API except where it named an internal type
+   directly.
+5. `XLFunctionLibrary` covers what the bridge needs: `Names` is non-empty and includes `SUM`;
+   `TryInvoke("SUM", [1, 2, 3])` yields `6`; an unknown name returns `false`; wrong arity returns
+   `true` with `XLError.IncompatibleValue`; `ROW` throws `XLNoWorksheetContextException`.
+6. A pivot cache loaded from a file reports a non-null `SourceRange` for a range source and a
+   non-null `SourceWorksheet` for a named-range source; `SetSourceRange` followed by `Refresh()`
+   re-reads from the new range. Verify against a real workbook, per the repo's file-format rule.
+7. The packed `XLibur.Report.nuspec` declares `<dependency id="XLibur" version="0.107.0" />` —
+   the floor, not a MinVer-computed pin. This is the check that proves the lockstep is gone.
+
+## Risks
+
+- **The public surface is permanent.** `TryInvoke`'s signature in particular is hard to widen
+  later. Review the shape before implementing; a wrong shape here is worse than the friend grant.
+- **`ReadOnlySpan<XLCellValue>` cannot be used in an `async` method or captured.** Report's bridge
+  is synchronous, so this is free today; if a future caller needs otherwise, add an
+  `IReadOnlyList<XLCellValue>` overload rather than changing this one.
+- **`XLCellValue` round-tripping may lose fidelity** for values the calc engine represents more
+  precisely than a cell can. Task 1 must include a test per scalar kind. If a genuine loss is
+  found, record it here rather than reaching for `AnyValue`.
+- **Interface additions break external implementers** of `IXLPivotCache` (see §B). Judged
+  acceptable pre-1.0; changelog it.
+- **Report cannot release until core 0.107.0 is out.** This spec is a hard prerequisite for
+  Report's independent version stream, not a parallel workstream.
+
+## References
+
+- Spec 12 — [Report templating](12-report-templating.md), *Core APIs this depends on*, which
+  documents the internal call patterns being replaced. Its Summary states Report's only touch on
+  core is an `InternalsVisibleTo` grant; this spec is what makes that no longer true.
+  *(That file is on the `feat/spec-12-report-templating` branch — the link resolves once it
+  merges.)*
+- `XLibur.Report/XLibur.Report.csproj` — `XLiburCoreFloor` (0.107.0) and the
+  `XLiburPackAgainstReleasedCore` switch that flips the core reference from project to package.
+- NuGet [dependency resolution](https://learn.microsoft.com/nuget/concepts/dependency-resolution)
+  — lowest-applicable wins, and why a floor is a floor and not a pin.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,6 +1,6 @@
 # XLibur Improvement Roadmap
 
-Eleven prioritized, self-contained specs covering features, compatibility, architecture, and performance (memory + read/write times). Each spec is written to be handed to an independent agent/model: it states the problem with measured numbers, points at the exact files, prescribes a design, breaks the work into PR-sized tasks, and defines measurable acceptance criteria.
+Twelve prioritized, self-contained specs covering features, compatibility, architecture, and performance (memory + read/write times). Each spec is written to be handed to an independent agent/model: it states the problem with measured numbers, points at the exact files, prescribes a design, breaks the work into PR-sized tasks, and defines measurable acceptance criteria.
 
 Specs 01–10 are the original top-ten set; spec 11 is a follow-on that came out of implementing spec 03 (see below).
 
@@ -21,6 +21,20 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 09 | [Threaded comments + round-trip fidelity](09-threaded-comments-roundtrip.md) | Feature · Compat | M | ✅ **Done** (#258) | Comments vs fidelity-audit split |
 | 10 | [Chart formatting depth](10-chart-formatting-depth.md) | Feature | L | ✅ **Done** (PRs 1–4) | 4 PRs, 2–3 independent |
 | 11 | [Create-path allocation reduction](11-create-path-allocations.md) | Perf (write) | M | ✅ **Tasks 1–4 done** | Task 4 lands in 11; 05 rebases |
+| 13 | [Public core surface for `XLibur.Report`](13-report-core-public-api.md) | Arch · API · Packaging | M | Proposed | Tasks 1 and 2 independent |
+
+Spec 12 (report templating) is on the `feat/spec-12-report-templating` branch and joins this
+table when that branch merges. Spec 13 is numbered around it.
+
+Spec 13 came out of preparing `XLibur.Report` to version independently of core. Report reads core
+internals through an `InternalsVisibleTo` grant, which is safe only while the two ship as one
+version off one tag. Building it against the released core package fails with 9 errors across two
+files. Internals carry no compatibility contract, so a version floor over them would be a promise
+core never made — a consumer referencing both packages gets core unified upward by NuGet and
+Report breaks at runtime. 13 replaces the grant with two narrow public additions, a function
+library callable without a grid and a pivot cache source that can be re-pointed, both expressed in
+already-public types. **It is a hard prerequisite for Report's own version stream**, and ships in
+core 0.107.0.
 
 Spec 11 was added after spec 03 landed: 03 halved the *save* phase and showed the rest of it is
 `System.IO.Packaging`, leaving the *create* phase as 72% of the write benchmark. It is a follow-on,


### PR DESCRIPTION
## Summary

`XLibur.Report` reads core internals through an `InternalsVisibleTo` grant. That is safe while
the two ship as one version off one tag — what spec 12 assumed — and it stops being safe the
moment Report versions independently, which is now the intent.

Internals carry no compatibility contract, so an `XLibur >= 0.107.0` floor over them would be a
promise core never made. Report is an addon *to* core, so consumers routinely reference both
packages; NuGet unifies core upward and Report breaks at runtime on internals that moved, with
restore staying silent about it.

This PR is the **spec only** — no code. It is core-only and independent of the Report branch.

## Changes

- `docs/specs/13-report-core-public-api.md` — new spec
- `docs/specs/README.md` — roadmap row and rationale

Measured starting point: building Report against the released `XLibur 0.106.0` package fails with
**9 errors** across exactly two files — `ExcelFunctionBridge` reaching for `XLCalcEngine`,
`FunctionDefinition`, `AnyValue`, `ScalarValue` and `CalcContext`, and `PivotRewriter` reaching
for `XLPivotCache`, `XLPivotSourceReference`, `SheetArea` and `Area`.

The spec replaces the grant with two narrow additions expressed in types that are **already
public**, rather than publishing those internals as they stand and freezing deep calc-engine and
coordinate detail forever:

- `XLFunctionLibrary` — the workbook function library callable without a grid. Trading in
  `XLCellValue` keeps `AnyValue`, `ScalarValue`, `CalcContext` and `FunctionDefinition` internal,
  and makes array results *unrepresentable* rather than needing a public type for a case Report
  already rejects.
- `SourceRange` / `SourceWorksheet` / `SetSourceRange` on `IXLPivotCache`, which is already public
  and already has `Refresh()` and `SetRefreshDataOnOpen()`.

Three judgement calls worth a reviewer's eye:

1. **The `XLibur.Report.Tests` friend grant stays**; only `XLibur.Report`'s is dropped. The
   contract that matters is the shipped package's, and a non-packable test project in this repo
   constrains nothing — its assertion on the internal `RecordCount` is not a reason to publish a
   record count.
2. **Adding members to `IXLPivotCache` is source-breaking** for external implementers. Judged
   acceptable pre-1.0 since `XLPivotCache` is the only implementation and its constructor is
   internal, but it wants a Breaking Changes changelog entry when implemented.
3. **Numbering.** Spec 12 lives only on `feat/spec-12-report-templating`, so 13 is numbered
   around it and 12 joins the roadmap table when that branch merges. The `12-report-templating.md`
   link is marked as resolving on merge rather than left looking broken.

One thing the spec supersedes: the Report branch added `FunctionRegistry.Names` and
`XLCalcEngine.Functions` to core to serve the bridge directly. Under spec 13 those stay internal
and serve `XLFunctionLibrary` instead.

Ships in core **0.107.0**, which is the floor Report then declares. Hard prerequisite for
Report's independent version stream.

## Related Issues

Follows #269 (tag globs scoped so a `report-v*` tag cannot fire a core release).

## Testing

Documentation only — no code, no build impact.

- [ ] Added or updated unit tests — n/a, spec only
- [x] All existing tests pass — no code touched
- [x] Tested manually — the 9-error baseline in the spec was reproduced with
      `dotnet build XLibur.Report/XLibur.Report.csproj -c Release -p:XLiburPackAgainstReleasedCore=true`

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
