### PR TITLE
chore: remove redundant casts flagged by S1905

### DIFF
--- a/XLibur.Benchmarks/ShifterCorpusDump.cs
+++ b/XLibur.Benchmarks/ShifterCorpusDump.cs
@@ -72,7 +72,7 @@ public static class ShifterCorpusDump
     private static string Row(string formula, int first, int last, int shift, bool foreignFormula)
     {
         using var wb = NewWorkbook(out var shiftedSheet, out var otherSheet);
-        var shifted = (XLRange)shiftedSheet.Range(first, 1, last, XLHelper.MaxColumnNumber);
+        var shifted = shiftedSheet.Range(first, 1, last, XLHelper.MaxColumnNumber);
         var host = foreignFormula ? otherSheet : shiftedSheet;
         return Format(formula, first, last, shift, foreignFormula,
             Invoke(() => XLCellFormulaShifter.ShiftFormulaRows(formula, host, shifted, shift)),
@@ -82,7 +82,7 @@ public static class ShifterCorpusDump
     private static string Column(string formula, int first, int last, int shift, bool foreignFormula)
     {
         using var wb = NewWorkbook(out var shiftedSheet, out var otherSheet);
-        var shifted = (XLRange)shiftedSheet.Range(1, first, XLHelper.MaxRowNumber, last);
+        var shifted = shiftedSheet.Range(1, first, XLHelper.MaxRowNumber, last);
         var host = foreignFormula ? otherSheet : shiftedSheet;
         return Format(formula, first, last, shift, foreignFormula,
             Invoke(() => XLCellFormulaShifter.ShiftFormulaColumns(formula, host, shifted, shift)),

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -145,7 +145,7 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
     }
 
     public XLConditionalFormat(XLRange range, bool copyDefaultModify = false)
-        : this((XLWorksheet)range.Worksheet)
+        : this(range.Worksheet)
     {
         Areas = new XLAreaList(Area.FromRangeAddress(range.RangeAddress));
         CopyDefaultModify = copyDefaultModify;


### PR DESCRIPTION
## Summary

- Remove all open SonarCloud S1905 redundant casts (`XLRange` / `XLWorksheet`). The call sites already return those concrete types.

## Changes

- `XLibur.Benchmarks/ShifterCorpusDump.cs`: drop `(XLRange)` on `shiftedSheet.Range(...)` in `Row` and `Column` (`XLWorksheet.Range` already returns `XLRange`)
- `XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs`: drop `(XLWorksheet)` on `range.Worksheet` (`XLRangeBase.Worksheet` already returns `XLWorksheet`)

## Related Issues

- https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=XLibur_XLibur&open=AZ-nMD-y--pWpbX2ie1g
- https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=XLibur_XLibur&open=AZ-nMD-y--pWpbX2ie1f
- https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=XLibur_XLibur&open=AZ-Ol9SpgKjolbGS0hI-

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually (describe below if applicable)

`dotnet build` of `XLibur` and `XLibur.Benchmarks` succeeded with 0 warnings.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
