### PR TITLE
chore: use XLPicture return type in XLPictureGroupView.AddCore (CA1859)

### DIFF
--- a/XLibur/Excel/Drawings/XLPictureGroupView.cs
+++ b/XLibur/Excel/Drawings/XLPictureGroupView.cs
@@ -48,7 +48,7 @@ internal sealed class XLPictureGroupView : IXLPictureGroup, IEquatable<XLPicture
 
     public override int GetHashCode() => HashCode.Combine(_worksheet, _groupKey);
 
-    private IXLPicture AddCore(Stream stream, string? name)
+    private XLPicture AddCore(Stream stream, string? name)
     {
         var pictures = (XLPictures)_worksheet.Pictures;
         var member = ((IEnumerable<XLPicture>)pictures).FirstOrDefault(p => p.GroupInfo?.GroupKey == _groupKey)


### PR DESCRIPTION
## Summary

- Change private `XLPictureGroupView.AddCore` return type from `IXLPicture` to `XLPicture` to clear SonarCloud/Roslyn CA1859. Callers already wrap it as `IXLPicture` on the public `Add` overloads; `AddToGroup` already returns `XLPicture`.

## Changes

- `XLibur/Excel/Drawings/XLPictureGroupView.cs`: `AddCore` → `XLPicture`

## Related Issues

- SonarCloud CA1859: https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=XLibur_XLibur&open=AZ7aPVqQ5NXmL4P0hn95

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually (describe below if applicable)

`dotnet build` of `XLibur` succeeded with 0 warnings. Signature-only change on a private helper; no behavior change.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
