### PR TITLE
fix: Save() preserves the encryption a workbook was loaded with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,20 @@
 
 - **Password-protected workbooks (ECMA-376 encryption)**: `LoadOptions.Password` opens an encrypted workbook and `SaveOptions.Password` writes one. Reading covers both schemes in the wild — agile encryption (Office 2010 and later) and standard encryption (Office 2007); writing uses agile encryption with the parameters Excel itself writes (AES-256-CBC, SHA-512, 100,000 spins and a fresh random key per save). Previously an encrypted file could not be opened at all and failed opaquely.
 
-  A wrong or missing password throws `XLInvalidPasswordException`, which is what a caller re-prompts on; an altered package whose HMAC fails throws `XLEncryptionException`, because there the password was right. A legacy `.xls` is detected and named rather than mistaken for an encrypted workbook. The password is never carried from load to save — a plain `SaveAs` cannot silently produce a file the caller can no longer open. ([#245](https://github.com/XLibur/XLibur/pull/245) by [@jafin](https://github.com/jafin))
+  A wrong or missing password throws `XLInvalidPasswordException`, which is what a caller re-prompts on; an altered package whose HMAC fails throws `XLEncryptionException`, because there the password was right. A legacy `.xls` is detected and named rather than mistaken for an encrypted workbook. ([#245](https://github.com/XLibur/XLibur/pull/245) by [@jafin](https://github.com/jafin))
+
+  `Save` and `SaveAs` read a missing `SaveOptions.Password` differently, because they are asking for different things. **`Save` preserves the encryption of the file it came from** — a workbook opened with a password is written back to that file encrypted under the same password, so a load/edit/save round trip works in one call. Giving `Save` a password rotates it in place, or encrypts an origin that was plain; `Save` cannot remove encryption at all. **`SaveAs` states the encryption of the file it writes** — a password means encrypt with it, no password means plaintext, whatever the workbook was loaded as, so a plain `SaveAs` can never silently produce a file the caller cannot open, and is how encryption is removed.
+
+  ```csharp
+  using var workbook = new XLWorkbook("Confidential.xlsx", new LoadOptions { Password = "s3cret" });
+  workbook.Worksheet("Data").Cell("A1").Value = "Updated";
+
+  workbook.Save();                                          // still encrypted, same password
+  workbook.Save(new SaveOptions { Password = "n3w" });      // rotated in place
+  workbook.SaveAs("Public.xlsx");                           // plain — explicitly asked for
+  ```
+
+  The load password is therefore retained for the lifetime of the workbook, which is what lets `Save` re-encrypt; derived keys are still zeroed after use. ([#251](https://github.com/XLibur/XLibur/issues/251) by [@jafin](https://github.com/jafin))
 
 #### Charts
 

--- a/XLibur.Tests/Excel/Encryption/WorkbookEncryptionTests.cs
+++ b/XLibur.Tests/Excel/Encryption/WorkbookEncryptionTests.cs
@@ -355,6 +355,40 @@ public class WorkbookEncryptionTests
     }
 
     [Test]
+    public async Task Save_back_to_a_stream_leaves_no_tail_of_the_larger_workbook_it_replaced()
+    {
+        const string RowText = "row text long enough to make the package worth measuring";
+
+        using var origin = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Data");
+            for (var row = 1; row <= 2000; row++)
+                ws.Cell(row, 1).Value = RowText;
+
+            wb.SaveAs(origin, new SaveOptions { Password = Password });
+        }
+
+        var lengthBefore = origin.Length;
+        origin.Position = 0;
+
+        using (var wb = new XLWorkbook(origin, new LoadOptions { Password = Password }))
+        {
+            wb.Worksheet("Data").Rows(2, 2000).Delete();
+            wb.Save();
+        }
+
+        // The stream has to end where the new container ends. Whatever the larger one left beyond
+        // that is trailing rubbish on the file, which is why the truncation happens after the
+        // write rather than before the encryption.
+        await Assert.That(origin.Length).IsLessThan(lengthBefore);
+
+        using var reopened = new XLWorkbook(new MemoryStream(origin.ToArray()), new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell(1, 1).GetString()).IsEqualTo(RowText);
+        await Assert.That(reopened.Worksheet("Data").Cell(2, 1).GetString()).IsEqualTo(string.Empty);
+    }
+
+    [Test]
     public async Task Save_says_so_when_the_stream_it_was_loaded_from_cannot_be_written_back_to()
     {
         // A read-only stream can still be decrypted and read; it is only the write back that is

--- a/XLibur.Tests/Excel/Encryption/WorkbookEncryptionTests.cs
+++ b/XLibur.Tests/Excel/Encryption/WorkbookEncryptionTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using OpenMcdf;
 using XLibur.Excel;
 using XLibur.Excel.Exceptions;
+using XLibur.Tests.Utils;
 
 namespace XLibur.Tests.Excel.Encryption;
 
@@ -211,6 +213,235 @@ public class WorkbookEncryptionTests
             if (File.Exists(path))
                 File.Delete(path);
         }
+    }
+
+    /// <summary>
+    /// Writes a small encrypted workbook to <paramref name="path"/>, as the file the round-trip
+    /// tests below open and save back.
+    /// </summary>
+    private static void WriteEncryptedFile(string path, string password, string cellValue = "before")
+    {
+        using var wb = new XLWorkbook();
+        wb.AddWorksheet("Data").Cell("A1").Value = cellValue;
+        wb.SaveAs(path, new SaveOptions { Password = password });
+    }
+
+    /// <summary>
+    /// Whether the bytes are an encrypted container rather than an ordinary package. The two are
+    /// told apart by their first byte: a compound file starts 0xD0, a zip starts 'P'.
+    /// </summary>
+    private static bool IsEncryptedContainer(byte[] bytes) => bytes.Length > 0 && bytes[0] == 0xD0;
+
+    [Test]
+    public async Task Save_writes_an_encrypted_file_back_encrypted_with_the_password_it_was_opened_with()
+    {
+        using var file = new TemporaryFile();
+        WriteEncryptedFile(file.Path, Password);
+
+        using (var wb = new XLWorkbook(file.Path, new LoadOptions { Password = Password }))
+        {
+            wb.Worksheet("Data").Cell("A1").Value = "after";
+            wb.Save();
+        }
+
+        // The edit reached the file, and the file is still encrypted under the same password.
+        await Assert.That(IsEncryptedContainer(File.ReadAllBytes(file.Path))).IsTrue();
+
+        using var reopened = new XLWorkbook(file.Path, new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("after");
+    }
+
+    [Test]
+    public async Task Save_repeated_on_an_encrypted_file_keeps_working()
+    {
+        using var file = new TemporaryFile();
+        WriteEncryptedFile(file.Path, Password);
+
+        using (var wb = new XLWorkbook(file.Path, new LoadOptions { Password = Password }))
+        {
+            wb.Worksheet("Data").Cell("A1").Value = "first";
+            wb.Save();
+
+            wb.Worksheet("Data").Cell("A1").Value = "second";
+            wb.Save();
+        }
+
+        using var reopened = new XLWorkbook(file.Path, new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("second");
+    }
+
+    [Test]
+    public async Task Save_with_a_password_rotates_the_password_in_place()
+    {
+        using var file = new TemporaryFile();
+        WriteEncryptedFile(file.Path, Password);
+
+        using (var wb = new XLWorkbook(file.Path, new LoadOptions { Password = Password }))
+            wb.Save(new SaveOptions { Password = "n3wsecret" });
+
+        using var reopened = new XLWorkbook(file.Path, new LoadOptions { Password = "n3wsecret" });
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("before");
+
+        // The password it was opened with no longer opens it.
+        await Assert.That(() => new XLWorkbook(file.Path, new LoadOptions { Password = Password }))
+            .Throws<XLInvalidPasswordException>();
+    }
+
+    [Test]
+    public async Task Save_with_a_password_encrypts_a_workbook_that_was_loaded_from_a_plain_file()
+    {
+        using var file = new TemporaryFile();
+        using (var wb = new XLWorkbook())
+        {
+            wb.AddWorksheet("Data").Cell("A1").Value = "was plain";
+            wb.SaveAs(file.Path);
+        }
+
+        using (var wb = new XLWorkbook(file.Path))
+        {
+            wb.Worksheet("Data").Cell("A2").Value = "now secret";
+            wb.Save(new SaveOptions { Password = Password });
+        }
+
+        await Assert.That(IsEncryptedContainer(File.ReadAllBytes(file.Path))).IsTrue();
+
+        using var reopened = new XLWorkbook(file.Path, new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("was plain");
+        await Assert.That(reopened.Worksheet("Data").Cell("A2").GetString()).IsEqualTo("now secret");
+    }
+
+    [Test]
+    public async Task Save_on_a_workbook_loaded_from_a_plain_file_leaves_it_plain()
+    {
+        using var file = new TemporaryFile();
+        using (var wb = new XLWorkbook())
+        {
+            wb.AddWorksheet("Data").Cell("A1").Value = "before";
+            wb.SaveAs(file.Path);
+        }
+
+        using (var wb = new XLWorkbook(file.Path))
+        {
+            wb.Worksheet("Data").Cell("A1").Value = "after";
+            wb.Save();
+        }
+
+        await Assert.That(IsEncryptedContainer(File.ReadAllBytes(file.Path))).IsFalse();
+
+        using var reopened = new XLWorkbook(file.Path);
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("after");
+    }
+
+    [Test]
+    public async Task Save_writes_the_encrypted_container_back_to_the_stream_it_was_loaded_from()
+    {
+        using var origin = new MemoryStream();
+        var encrypted = CreateEncryptedWorkbook(Password);
+        origin.Write(encrypted, 0, encrypted.Length);
+        origin.Position = 0;
+
+        using (var wb = new XLWorkbook(origin, new LoadOptions { Password = Password }))
+        {
+            wb.Worksheet("Data").Cell("A4").Value = "written back";
+            wb.Save();
+        }
+
+        var saved = origin.ToArray();
+        await Assert.That(IsEncryptedContainer(saved)).IsTrue();
+
+        using var reopened = new XLWorkbook(new MemoryStream(saved), new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell("A4").GetString()).IsEqualTo("written back");
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("Hello encrypted world");
+    }
+
+    [Test]
+    public async Task Save_says_so_when_the_stream_it_was_loaded_from_cannot_be_written_back_to()
+    {
+        // A read-only stream can still be decrypted and read; it is only the write back that is
+        // impossible, and that has to be said rather than skipped.
+        using var origin = new MemoryStream(CreateEncryptedWorkbook(Password), writable: false);
+        using var wb = new XLWorkbook(origin, new LoadOptions { Password = Password });
+
+        await Assert.That(() => wb.Save()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Save_after_an_encrypted_SaveAs_updates_the_file_that_SaveAs_wrote()
+    {
+        using var file = new TemporaryFile();
+        using var wb = new XLWorkbook();
+        wb.AddWorksheet("Data").Cell("A1").Value = "first";
+        wb.SaveAs(file.Path, new SaveOptions { Password = Password });
+
+        // SaveAs used to leave the load source pointing at whatever the workbook was built from,
+        // which made this Save a no-op.
+        wb.Worksheet("Data").Cell("A1").Value = "second";
+        wb.Save();
+
+        using var reopened = new XLWorkbook(file.Path, new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("second");
+    }
+
+    [Test]
+    public async Task Save_after_an_encrypted_SaveAs_to_a_stream_updates_that_stream()
+    {
+        using var destination = new MemoryStream();
+        using var wb = new XLWorkbook();
+        wb.AddWorksheet("Data").Cell("A1").Value = "first";
+        wb.SaveAs(destination, new SaveOptions { Password = Password });
+
+        wb.Worksheet("Data").Cell("A1").Value = "second";
+        wb.Save();
+
+        using var reopened = new XLWorkbook(
+            new MemoryStream(destination.ToArray()), new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("second");
+    }
+
+    [Test]
+    public async Task SaveAs_without_a_password_over_the_same_path_removes_the_encryption()
+    {
+        using var file = new TemporaryFile();
+        WriteEncryptedFile(file.Path, Password);
+
+        using (var wb = new XLWorkbook(file.Path, new LoadOptions { Password = Password }))
+        {
+            wb.Worksheet("Data").Cell("A1").Value = "no longer secret";
+
+            // The documented way to decrypt in place: SaveAs states the encryption of the file it
+            // writes, and no password means none.
+            wb.SaveAs(file.Path);
+        }
+
+        await Assert.That(IsEncryptedContainer(File.ReadAllBytes(file.Path))).IsFalse();
+
+        using var reopened = new XLWorkbook(file.Path);
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("no longer secret");
+    }
+
+    [Test]
+    public async Task Save_after_a_plain_SaveAs_does_not_bring_the_encryption_back()
+    {
+        using var encryptedFile = new TemporaryFile();
+        using var plainFile = new TemporaryFile();
+        WriteEncryptedFile(encryptedFile.Path, Password);
+
+        using (var wb = new XLWorkbook(encryptedFile.Path, new LoadOptions { Password = Password }))
+        {
+            wb.SaveAs(plainFile.Path);
+
+            wb.Worksheet("Data").Cell("A1").Value = "still plain";
+            wb.Save();
+        }
+
+        await Assert.That(IsEncryptedContainer(File.ReadAllBytes(plainFile.Path))).IsFalse();
+
+        using var reopened = new XLWorkbook(plainFile.Path);
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("still plain");
+
+        // And the file it came from is untouched by any of that.
+        using var original = new XLWorkbook(encryptedFile.Path, new LoadOptions { Password = Password });
+        await Assert.That(original.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("before");
     }
 
     [Test]

--- a/XLibur/Excel/IO/Encryption/WorkbookEncryption.cs
+++ b/XLibur/Excel/IO/Encryption/WorkbookEncryption.cs
@@ -47,8 +47,10 @@ internal static class WorkbookEncryption
         var (encryptionInfo, encryptedPackage) = EncryptedPackageContainer.ReadStreams(source);
         var package = DecryptPackage(encryptionInfo, encryptedPackage, password);
 
-        // Writable, because the workbook keeps this as its backing package and the save path copies
-        // from and patches a package rather than only reading it.
+        // Over the decrypted bytes rather than a copy of them: the workbook keeps this as the base
+        // package a save copies out of, and only ever reads it. A save of an encrypted workbook
+        // builds a fresh package to patch, because the compound file it produces has to be written
+        // whole rather than patched in place.
         return new MemoryStream(package);
     }
 

--- a/XLibur/Excel/LoadOptions.cs
+++ b/XLibur/Excel/LoadOptions.cs
@@ -34,6 +34,12 @@ public class LoadOptions
     /// <see cref="Exceptions.XLInvalidPasswordException"/>. This is the password that encrypts the
     /// whole file, unrelated to workbook and sheet protection, which control edit permissions
     /// inside a file that anyone can open.
+    /// <para>
+    /// When the file was encrypted, the password is retained for the lifetime of the workbook so
+    /// that <c>Save</c> can write it back encrypted. It is an ordinary string, as passwords are
+    /// throughout this API, so it lives until the GC reclaims it; keep the workbook short-lived if
+    /// that matters to your threat model.
+    /// </para>
     /// </remarks>
     public string? Password { get; set; }
 

--- a/XLibur/Excel/SaveOptions.cs
+++ b/XLibur/Excel/SaveOptions.cs
@@ -46,15 +46,26 @@ public class SaveOptions
     public bool GenerateCalculationChain { get; set; } = true;
 
     /// <summary>
-    /// Password used to encrypt the saved workbook. Default value is <c>null</c>, which saves an
-    /// ordinary unencrypted file. When set, the file is written with agile encryption
-    /// (AES-256-CBC, SHA-512), the profile Excel itself writes.
+    /// Password used to encrypt the saved workbook. When set, the file is written with agile
+    /// encryption (AES-256-CBC, SHA-512), the profile Excel itself writes.
     /// </summary>
     /// <remarks>
-    /// A workbook opened with <see cref="LoadOptions.Password"/> is <em>not</em> re-encrypted
-    /// automatically on save; the password has to be given here again. Carrying it over implicitly
-    /// would mean a plain <c>SaveAs</c> silently produced a file the caller could not open without
-    /// a password they never mentioned.
+    /// The default of <c>null</c> means different things to the two save methods, because they
+    /// mean different things themselves:
+    /// <list type="bullet">
+    /// <item>
+    ///   <c>SaveAs</c> states the encryption of the file it writes, so <c>null</c> is <em>no
+    ///   encryption</em>. A plain <c>SaveAs</c> therefore cannot silently produce a file the caller
+    ///   could not open without a password they never mentioned, and is how encryption is removed
+    ///   from a workbook that was loaded with it.
+    /// </item>
+    /// <item>
+    ///   <c>Save</c> puts a workbook back where it came from as it was, so <c>null</c> is
+    ///   <em>unchanged</em>: one opened with <see cref="LoadOptions.Password"/> is written back
+    ///   encrypted under that password. Setting a password rotates it, or encrypts an origin that
+    ///   was not encrypted before. <c>Save</c> cannot remove encryption.
+    /// </item>
+    /// </list>
     /// </remarks>
     public string? Password { get; set; }
 

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -354,8 +354,13 @@ public partial class XLWorkbook : IXLWorkbook
     }
 
     /// <summary>
-    ///   Saves the current workbook.
+    ///   Saves the current workbook back to the file or stream it was loaded from.
     /// </summary>
+    /// <remarks>
+    /// Preserves the encryption of the origin: a workbook opened with
+    /// <see cref="LoadOptions.Password"/> is written back encrypted with that same password. Use
+    /// <see cref="SaveAs(string)"/> to write a workbook without the encryption it was loaded with.
+    /// </remarks>
     public void Save()
     {
         Save(false);
@@ -380,12 +385,90 @@ public partial class XLWorkbook : IXLWorkbook
         if (_loadSource == XLLoadSource.New)
             throw new InvalidOperationException("This is a new file. Please use one of the 'SaveAs' methods.");
 
+        // A null password here means "leave the encryption as it was", not "write plaintext": Save
+        // puts a workbook back the way it came, so one opened with a password goes back encrypted
+        // under that password. Naming a password rotates it, or encrypts an origin that was plain.
+        // Dropping encryption is deliberately not expressible here — that is what SaveAs is for.
+        var password = string.IsNullOrEmpty(options.Password) ? _encryptionPassword : options.Password;
+        if (!string.IsNullOrEmpty(password))
+        {
+            SaveEncrypted(password, options);
+            return;
+        }
+
         if (_loadSource == XLLoadSource.Stream)
         {
             CreatePackage(_originalStream!, false, _spreadsheetDocumentType, options);
         }
         else
             CreatePackage(_originalFile!, _spreadsheetDocumentType, options);
+    }
+
+    /// <summary>
+    /// Writes the workbook back to its origin as an encrypted compound file.
+    /// </summary>
+    private void SaveEncrypted(string password, SaveOptions options)
+    {
+        // Build the whole package before touching the destination. When the origin is not yet
+        // encrypted the destination is also the file or stream this package is being copied from,
+        // so writing to it first would pull the ground out from under the copy.
+        var package = BuildPackageInMemory(options);
+        var packageBytes = package.ToArray();
+
+        var file = _encryptedFile ?? (_loadSource == XLLoadSource.File ? _originalFile : null);
+        if (file is not null)
+        {
+            using (var destination = File.Create(file))
+                IO.Encryption.WorkbookEncryption.Encrypt(destination, packageBytes, password);
+
+            AdoptEncryptedOrigin(package, password, file, stream: null);
+            return;
+        }
+
+        var originStream = _encryptedStream ?? _originalStream!;
+        if (!originStream.CanWrite || !originStream.CanSeek)
+        {
+            throw new InvalidOperationException(
+                "The stream this workbook was loaded from is not writable and seekable, so Save cannot write the encrypted workbook back to it. Use one of the 'SaveAs' methods.");
+        }
+
+        originStream.Position = 0;
+        originStream.SetLength(0);
+        IO.Encryption.WorkbookEncryption.Encrypt(originStream, packageBytes, password);
+
+        AdoptEncryptedOrigin(package, password, file: null, originStream);
+    }
+
+    /// <summary>
+    /// Records the encrypted compound file just written as the workbook's origin, and keeps the
+    /// plaintext package that produced it as the base the next save copies and patches.
+    /// </summary>
+    /// <remarks>
+    /// The container that was written is a compound file rather than a package, so it cannot serve
+    /// as that base itself. Neither can whatever the base was a moment ago, because this save may
+    /// have written over it. The package built here is the one copy of the plaintext that is
+    /// certainly still good.
+    /// </remarks>
+    private void AdoptEncryptedOrigin(MemoryStream package, string password, string? file, Stream? stream)
+    {
+        _loadSource = XLLoadSource.Stream;
+        _originalStream = package;
+        _originalFile = null;
+
+        _encryptionPassword = password;
+        _encryptedFile = file;
+        _encryptedStream = stream;
+    }
+
+    /// <summary>
+    /// Forgets that the workbook came from an encrypted container, after a save that wrote it out
+    /// as an ordinary package.
+    /// </summary>
+    private void ClearEncryptedOrigin()
+    {
+        _encryptionPassword = null;
+        _encryptedFile = null;
+        _encryptedStream = null;
     }
 
     /// <summary>
@@ -417,15 +500,16 @@ public partial class XLWorkbook : IXLWorkbook
         var directoryName = Path.GetDirectoryName(file);
         if (!string.IsNullOrWhiteSpace(directoryName)) Directory.CreateDirectory(directoryName);
 
+        // SaveAs states the encryption of the file it writes: a password means encrypt with it,
+        // no password means write plaintext, whichever the workbook was loaded as. That asymmetry
+        // with Save is the point — Save puts a file back as it was, SaveAs describes a new one.
         if (!string.IsNullOrEmpty(options.Password))
         {
-            using var package = BuildPackageInMemory(options);
-            using var destination = File.Create(file);
-            IO.Encryption.WorkbookEncryption.Encrypt(destination, package.ToArray(), options.Password);
+            var package = BuildPackageInMemory(options);
+            using (var destination = File.Create(file))
+                IO.Encryption.WorkbookEncryption.Encrypt(destination, package.ToArray(), options.Password);
 
-            // The load source is deliberately left alone. What is on disk now is a compound file,
-            // so pointing the workbook at it would break the next save, which expects to reopen and
-            // patch a package.
+            AdoptEncryptedOrigin(package, options.Password, file, stream: null);
             return;
         }
 
@@ -458,6 +542,7 @@ public partial class XLWorkbook : IXLWorkbook
         _loadSource = XLLoadSource.File;
         _originalFile = file;
         _originalStream = null;
+        ClearEncryptedOrigin();
     }
 
     /// <summary>
@@ -487,11 +572,10 @@ public partial class XLWorkbook : IXLWorkbook
 
         if (!string.IsNullOrEmpty(options.Password))
         {
-            using var package = BuildPackageInMemory(options);
+            var package = BuildPackageInMemory(options);
             IO.Encryption.WorkbookEncryption.Encrypt(stream, package.ToArray(), options.Password);
 
-            // As with the file overload, the load source keeps pointing at the unencrypted package
-            // this workbook was built from rather than at the compound file just written.
+            AdoptEncryptedOrigin(package, options.Password, file: null, stream);
             return;
         }
 
@@ -538,13 +622,15 @@ public partial class XLWorkbook : IXLWorkbook
         _loadSource = XLLoadSource.Stream;
         _originalStream = stream;
         _originalFile = null;
+        ClearEncryptedOrigin();
     }
 
     /// <summary>
     /// Builds the complete unencrypted package in memory so it can be encrypted as a whole. Mirrors
     /// what the stream overload of <see cref="SaveAs(Stream, SaveOptions)"/> does per load source,
-    /// but leaves the workbook's own load source untouched, because the caller is writing a
-    /// compound file that this workbook could not later reopen as a package.
+    /// but into a buffer, because a compound file has to be written in one go rather than patched
+    /// in place. The returned stream is positioned at the start and owned by the caller, which
+    /// keeps it as the workbook's new package base — see <see cref="AdoptEncryptedOrigin"/>.
     /// </summary>
     private MemoryStream BuildPackageInMemory(SaveOptions options)
     {
@@ -718,9 +804,31 @@ public partial class XLWorkbook : IXLWorkbook
 
     #region Fields
 
+    /// <summary>
+    /// Where the plaintext package a save copies and patches comes from. For an encrypted workbook
+    /// this is always <see cref="XLLoadSource.Stream"/> over a package held in memory, because the
+    /// container the workbook actually came from is a compound file rather than a package.
+    /// </summary>
     private XLLoadSource _loadSource = XLLoadSource.New;
+
     private string? _originalFile;
     private Stream? _originalStream;
+
+    /// <summary>
+    /// The password this workbook was opened with, or last saved under. Non-null exactly when the
+    /// workbook's origin is an encrypted container, which is what lets <see cref="Save()"/> put it
+    /// back the way it came. Held for the lifetime of the workbook rather than for the load, so a
+    /// caller who wants the password out of memory sooner should keep the workbook short-lived.
+    /// </summary>
+    private string? _encryptionPassword;
+
+    /// <summary>
+    /// The encrypted container <see cref="Save()"/> writes back to. Exactly one of these is set
+    /// while <see cref="_encryptionPassword"/> is non-null, and neither is otherwise.
+    /// </summary>
+    private string? _encryptedFile;
+
+    private Stream? _encryptedStream;
 
     #endregion Fields
 
@@ -762,8 +870,12 @@ public partial class XLWorkbook : IXLWorkbook
         {
             // The workbook is backed by the decrypted package rather than by the file on disk. The
             // file is a compound file, not a package, so the save path could not copy and patch it.
+            // It stays the origin all the same, so Save writes it back re-encrypted rather than
+            // patching the copy in memory that nothing would ever read again.
             _loadSource = XLLoadSource.Stream;
             _originalStream = decrypted;
+            _encryptionPassword = loadOptions.Password;
+            _encryptedFile = file;
             Load(decrypted);
         }
         else
@@ -810,9 +922,16 @@ public partial class XLWorkbook : IXLWorkbook
         // workbook. One that isn't can only be an ordinary package, and is passed straight through
         // so that callers streaming a plain .xlsx keep working exactly as before.
         var isEncrypted = stream.CanSeek && IO.Encryption.EncryptedPackageContainer.IsCompoundFile(stream);
-        _originalStream = isEncrypted
-            ? IO.Encryption.WorkbookEncryption.Decrypt(stream, loadOptions.Password)
-            : stream;
+        if (isEncrypted)
+        {
+            // As with the file constructor: the decrypted package backs the workbook, while the
+            // caller's stream stays the origin Save writes the re-encrypted container back to.
+            _originalStream = IO.Encryption.WorkbookEncryption.Decrypt(stream, loadOptions.Password);
+            _encryptionPassword = loadOptions.Password;
+            _encryptedStream = stream;
+        }
+        else
+            _originalStream = stream;
 
         Load(_originalStream);
         SharedStringTable.TrimExcess();
@@ -1197,6 +1316,14 @@ public partial class XLWorkbook : IXLWorkbook
 
     public override string ToString()
     {
+        // An encrypted workbook is backed by a package in memory, which says nothing useful about
+        // where it came from. Name the container instead.
+        if (_encryptedFile is not null)
+            return $"XLWorkbook({_encryptedFile}, encrypted)";
+
+        if (_encryptedStream is not null)
+            return $"XLWorkbook({_encryptedStream}, encrypted)";
+
         return _loadSource switch
         {
             XLLoadSource.New => "XLWorkbook(new)",

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -413,18 +413,20 @@ public partial class XLWorkbook : IXLWorkbook
         // encrypted the destination is also the file or stream this package is being copied from,
         // so writing to it first would pull the ground out from under the copy.
         var package = BuildPackageInMemory(options);
-        var packageBytes = package.ToArray();
 
         var file = _encryptedFile ?? (_loadSource == XLLoadSource.File ? _originalFile : null);
         if (file is not null)
         {
+            using (var container = EncryptToBuffer(package, password))
             using (var destination = File.Create(file))
-                IO.Encryption.WorkbookEncryption.Encrypt(destination, packageBytes, password);
+                container.WriteTo(destination);
 
             AdoptEncryptedOrigin(package, password, file, stream: null);
             return;
         }
 
+        // Checked before the encryption rather than after it, so an unusable stream costs the
+        // caller an exception rather than a key derivation first.
         var originStream = _encryptedStream ?? _originalStream!;
         if (!originStream.CanWrite || !originStream.CanSeek)
         {
@@ -432,11 +434,37 @@ public partial class XLWorkbook : IXLWorkbook
                 "The stream this workbook was loaded from is not writable and seekable, so Save cannot write the encrypted workbook back to it. Use one of the 'SaveAs' methods.");
         }
 
-        originStream.Position = 0;
-        originStream.SetLength(0);
-        IO.Encryption.WorkbookEncryption.Encrypt(originStream, packageBytes, password);
+        using (var container = EncryptToBuffer(package, password))
+        {
+            originStream.Position = 0;
+            container.WriteTo(originStream);
+        }
+
+        // Only now, once the new content is in: anything the old container had beyond the end of
+        // the new one is what is left to drop.
+        originStream.SetLength(originStream.Position);
 
         AdoptEncryptedOrigin(package, password, file: null, originStream);
+    }
+
+    /// <summary>
+    /// Encrypts a package into a buffer, so that a destination is overwritten only once the bytes
+    /// that replace it exist.
+    /// </summary>
+    /// <remarks>
+    /// Encrypting straight into the destination would empty it first and then spend the key
+    /// derivation, the encryption and the integrity hash with nothing in it, because the container
+    /// is only written once all of that is done. A failure anywhere in there — and these are the
+    /// steps that allocate the workbook twice over — would leave an empty file where the workbook
+    /// was. This trades one more copy of the encrypted container for that not happening.
+    /// </remarks>
+    private static MemoryStream EncryptToBuffer(MemoryStream package, string password)
+    {
+        var container = new MemoryStream();
+        IO.Encryption.WorkbookEncryption.Encrypt(container, package.ToArray(), password);
+
+        // No rewind: WriteTo copies the whole buffer regardless of position.
+        return container;
     }
 
     /// <summary>
@@ -506,8 +534,9 @@ public partial class XLWorkbook : IXLWorkbook
         if (!string.IsNullOrEmpty(options.Password))
         {
             var package = BuildPackageInMemory(options);
+            using (var container = EncryptToBuffer(package, options.Password))
             using (var destination = File.Create(file))
-                IO.Encryption.WorkbookEncryption.Encrypt(destination, package.ToArray(), options.Password);
+                container.WriteTo(destination);
 
             AdoptEncryptedOrigin(package, options.Password, file, stream: null);
             return;

--- a/docs-website/docs/encryption.md
+++ b/docs-website/docs/encryption.md
@@ -81,53 +81,79 @@ using var ms = new MemoryStream();
 workbook.SaveAs(ms, new SaveOptions { Password = "s3cret" });
 ```
 
-## The password is never carried from load to save
+## `Save` keeps the encryption, `SaveAs` states it
 
-Opening a workbook with a password does **not** cause it to be re-encrypted when you save it. To
-keep a file encrypted, supply the password again:
+The two save methods treat a missing password differently, because they are asking for different
+things.
+
+**`Save()` puts a workbook back where it came from, as it came.** A file opened with a password is
+written back to that file encrypted, under the same password:
 
 ```csharp
 using var workbook = new XLWorkbook("Confidential.xlsx", new LoadOptions { Password = "s3cret" });
 
 workbook.Worksheet("Data").Cell("A1").Value = "Updated";
 
-// Still encrypted — the password has to be given again
-workbook.SaveAs("Confidential.xlsx", new SaveOptions { Password = "s3cret" });
+workbook.Save();          // Confidential.xlsx — still encrypted, still "s3cret"
 ```
 
-This is deliberate. If the password carried over implicitly, a plain `SaveAs` would silently
-produce a file the caller could not open without a password they never mentioned. The flip side
-is that forgetting it decrypts the file, so make the save password explicit wherever a file is
-meant to stay protected.
+**`SaveAs` describes the file it is about to write.** A password means encrypt with it, no password
+means plain, whatever the workbook was loaded as:
 
-Removing the protection is therefore just a save without a password:
+```csharp
+workbook.SaveAs("Public.xlsx");                                              // plain
+workbook.SaveAs("Copy.xlsx", new SaveOptions { Password = "s3cret" });       // encrypted
+```
+
+So a null `Password` means *unchanged* to `Save` and *none* to `SaveAs`. The asymmetry is the
+point: a plain `SaveAs` can never silently produce a file you cannot open, and a plain `Save` can
+never silently drop the protection off a file that had it.
+
+### Changing the password
+
+Give `Save` a password and it replaces the one the file already had, in place:
 
 ```csharp
 using var workbook = new XLWorkbook("Confidential.xlsx", new LoadOptions { Password = "s3cret" });
-workbook.SaveAs("Public.xlsx");                    // plain, unencrypted
+workbook.Save(new SaveOptions { Password = "n3wsecret" });
 ```
 
-And changing it is a save with a different one:
+The same call on a workbook that was *not* loaded encrypted encrypts it for the first time:
 
 ```csharp
-workbook.SaveAs("Confidential.xlsx", new SaveOptions { Password = "n3wsecret" });
+using var workbook = new XLWorkbook("Public.xlsx");
+workbook.Save(new SaveOptions { Password = "s3cret" });   // Public.xlsx is now encrypted
 ```
 
-:::warning `Save()` does not update an encrypted file in place
-A workbook opened from an encrypted file is backed by the decrypted copy held in memory, because
-the file on disk is a compound file rather than a package the save path can patch. `Save()` writes
-to that in-memory copy and leaves the file on disk untouched — your changes go nowhere.
+### Removing the password
 
-Always use `SaveAs` for a workbook that was loaded encrypted:
+`Save` cannot remove encryption — there is no way to express it, which is what stops it happening
+by accident. Decrypting is a `SaveAs` without a password, and the path can be the one you are
+already at:
 
 ```csharp
-// Wrong — the file on disk is not updated
-workbook.Save();
+using var workbook = new XLWorkbook("Confidential.xlsx", new LoadOptions { Password = "s3cret" });
 
-// Right
-workbook.SaveAs("Confidential.xlsx", new SaveOptions { Password = "s3cret" });
+workbook.SaveAs("Confidential.xlsx");   // decrypted in place
+workbook.SaveAs("Public.xlsx");         // or written out plain somewhere else
 ```
-:::
+
+After that the workbook is no longer an encrypted one, so a later `Save()` keeps writing plain
+files. `SaveAs` sets the encryption state as well as using it.
+
+### Streams behave the same way
+
+`Save()` on a workbook loaded from a stream writes the re-encrypted container back to that same
+stream, so the stream has to be writable and seekable — `Save` says so with an
+`InvalidOperationException` if it is not, rather than dropping the changes:
+
+```csharp
+using var file = File.Open("Confidential.xlsx", FileMode.Open, FileAccess.ReadWrite);
+using var workbook = new XLWorkbook(file, new LoadOptions { Password = "s3cret" });
+
+workbook.Worksheet("Data").Cell("A1").Value = "Updated";
+workbook.Save();          // the stream now holds the re-encrypted workbook
+```
 
 ## Handling a wrong password
 
@@ -225,7 +251,9 @@ using var workbook = new XLWorkbook(buffer, new LoadOptions { Password = "s3cret
   encrypting files in bulk, and do not put an encrypted save inside a tight loop.
 - **Derived keys are zeroed** after use with `CryptographicOperations.ZeroMemory`. Passwords are
   ordinary strings, matching the rest of the API, so they live in memory until the GC reclaims
-  them — if that matters in your threat model, keep their lifetime short.
+  them. A workbook opened from an encrypted file holds its load password for as long as the
+  workbook lives, because that is what lets `Save()` put the file back encrypted — if that matters
+  in your threat model, keep the workbook short-lived.
 - **The whole file is encrypted**, not individual sheets. Excel offers no way to encrypt part of a
   workbook, so neither does XLibur. Split the data across files if different audiences need
   different access.

--- a/docs/specs/06-workbook-encryption.md
+++ b/docs/specs/06-workbook-encryption.md
@@ -111,8 +111,30 @@ What shipped, against the scope table:
 | Write Standard | ❌ excluded by design |
 | XOR / RC4 legacy | ❌ excluded by design |
 
-Public surface is `LoadOptions.Password` and `SaveOptions.Password`; a workbook opened with a
-password is deliberately *not* re-encrypted on save unless one is supplied.
+Public surface is `LoadOptions.Password` and `SaveOptions.Password`.
+
+### Save-time encryption state, revised by #251
+
+As shipped in #245, a workbook opened with a password was *not* re-encrypted on save unless one
+was supplied — and `Save()` on such a workbook wrote to the decrypted copy in memory and left the
+file on disk untouched, discarding the edits without a word. Issue #251 replaced that with a rule
+per method rather than one for both:
+
+- **`Save` preserves the encryption state it loaded with.** A workbook opened with a password is
+  written back to its origin encrypted under that password. A password on `SaveOptions` rotates it,
+  or encrypts an origin that was plain. `Save` cannot remove encryption.
+- **`SaveAs` states the encryption state.** A password means encrypt with it, no password means
+  write plaintext — unchanged from #245, and the only way to decrypt a file.
+
+So a null `SaveOptions.Password` means *unchanged* to `Save` and *none* to `SaveAs`. This requires
+the load password to be retained for the lifetime of the workbook, which is a deliberate widening
+of what #245 held; derived keys are still zeroed as before.
+
+Mechanically, an encrypted workbook keeps its load provenance (`_encryptedFile`/`_encryptedStream`
+plus `_encryptionPassword`) separately from the decrypted package that backs it, rather than
+overloading `_loadSource = Stream` to mean "backed by memory, origin forgotten". `SaveAs` no longer
+leaves the load source stale either: after an encrypted `SaveAs` the workbook's origin is the
+container it just wrote.
 
 ### CFB layer: OpenMcdf, approved
 


### PR DESCRIPTION
## Summary

A workbook loaded from a password-protected file could not be saved back to it. `Save()` returned normally and wrote nothing — the edits were lost, silently.

`Save(SaveOptions)` dispatched on a load source that the encrypted branch of the constructor had set to `Stream` to mean "backed by the decrypted copy in memory". So it wrote the package into that `MemoryStream` and never opened the file on disk.

`Save` and `SaveAs` now read a missing `SaveOptions.Password` differently, which is what their names already suggest:

- **`Save` preserves the encryption state of its origin.** A workbook opened with a password is written back to that file or stream encrypted under the same password. A password on `SaveOptions` rotates it, or encrypts an origin that was plain. `Save` cannot remove encryption.
- **`SaveAs` states the encryption state of the file it writes.** A password means encrypt with it, no password means plaintext — unchanged, and the only way to decrypt a file.

So a null password means *unchanged* to one and *none* to the other. The asymmetry is the point: a plain `SaveAs` can never silently produce a file the caller cannot open, and a plain `Save` can never silently drop the protection off a file that had it.

```csharp
using var workbook = new XLWorkbook("Confidential.xlsx", new LoadOptions { Password = "s3cret" });
workbook.Worksheet("Data").Cell("A1").Value = "Updated";

workbook.Save();                                      // still encrypted, same password
workbook.Save(new SaveOptions { Password = "n3w" });  // rotated in place
workbook.SaveAs("Public.xlsx");                       // plain — explicitly asked for
```

## Changes

- **`Save()` re-encrypts to the origin.** An encrypted workbook keeps its origin — `_encryptedFile`/`_encryptedStream` plus the load password — separately from the decrypted package that backs it, rather than overloading `_loadSource = Stream` to mean "backed by memory, origin forgotten".

- **The load password is retained for the lifetime of the workbook.** A deliberate widening of what #245 held, and what lets `Save` re-encrypt. Derived keys are still zeroed after use; `LoadOptions.Password` and the user guide both say so.

- **`SaveAs` no longer leaves the load source stale.** After an encrypted `SaveAs` the container it wrote becomes the workbook's origin, so a following `Save()` updates that file instead of throwing "this is a new file". Plaintext `SaveAs` clears the encrypted origin, so a following `Save()` keeps writing plain files.

- **After an encrypted write, the package just built is retained as the base the next save patches.** The container on disk is a compound file and cannot serve as that base, and the file or stream it replaced may have been the base a moment earlier. Costs one package-sized `MemoryStream` for the workbook's life — less than the transient peak an encrypted save already needs.

- **`Save` to a stream that is not writable and seekable throws `InvalidOperationException` naming `SaveAs`.** Without it the failure surfaces as `NotSupportedException: Memory stream is not expandable` from inside the zip writer.

- **`ToString()` names the encrypted container** rather than the in-memory package, which says nothing about where the workbook came from.

- Corrected a comment in `WorkbookEncryption.Decrypt` claiming the returned stream gets patched in place — `new MemoryStream(byte[])` is writable but not expandable, and nothing patches it.

- Docs: rewrote the two `encryption.md` sections documenting the old contract, including removing the `Save()` limitation warning admonition; updated the `LoadOptions.Password` and `SaveOptions.Password` XML docs; added a revision note to `docs/specs/06-workbook-encryption.md`; amended the still-unreleased #245 CHANGELOG entry so the release notes describe what actually ships.

### Decisions taken on the issue's open questions

The issue left three points open. Resolved as:

| Question | Resolution |
|---|---|
| Full fix, or the smaller "throw from `Save()`" alternative? | Full fix — a load/edit/save round trip is a reasonable thing to want |
| `Save(new SaveOptions { Password })` on a workbook **not** loaded encrypted | Honoured — encrypts in place, rather than throwing or being ignored |
| Decrypting in place | `SaveAs` only, per the issue's stated preference. No `RemoveEncryption` flag; `Save` cannot change encryption state in that direction at all |

## Related Issues

Fixes #251

## Testing

- [x] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually (described below)

11 new tests in `XLibur.Tests/Excel/Encryption/WorkbookEncryptionTests.cs`, covering: re-encrypting to a file and to a stream, repeated `Save`, password rotation, encrypting a plain origin, `Save` after an encrypted `SaveAs` to both a file and a stream, decrypting in place, the non-writable stream error, and two regression guards that a plain workbook stays plain.

Reverting `XLWorkbook.cs` and re-running confirms **8 of the 11 fail on the previous behaviour** — the other 3 are the regression guards, which should pass either way.

Full suite: **11,618 tests, 0 failures**, 4 pre-existing skips. Clean build across net8.0/net9.0/net10.0 with `TreatWarningsAsErrors`.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Encrypted workbooks now preserve encryption when using **Save**.
  * Passwords can be changed during an in-place save.
  * **SaveAs** explicitly controls encryption, including plaintext export.
  * Encrypted workbooks can be saved back to supported files and streams.

* **Bug Fixes**
  * Improved handling of repeated saves, encryption transitions, and source-file preservation.

* **Documentation**
  * Clarified password retention, Save versus SaveAs behavior, stream requirements, and related error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->