### PR TITLE
perf(calc): resolve references without re-parsing the address string

### DIFF
--- a/XLibur.Benchmarks/FormulaEvaluationBenchmarks.cs
+++ b/XLibur.Benchmarks/FormulaEvaluationBenchmarks.cs
@@ -1,0 +1,106 @@
+using BenchmarkDotNet.Attributes;
+using XLibur.Excel;
+using XLibur.Fonts.SixLabors.V1;
+
+namespace XLibur.Benchmarks;
+
+/// <summary>
+/// Isolates the cost of resolving a <c>ReferenceNode</c> to a range during formula
+/// evaluation. <c>RecalculateAllFormulas</c> marks every formula dirty and then
+/// recalculates, so each iteration re-resolves every reference and the measurement is
+/// repeatable.
+/// </summary>
+/// <remarks>
+/// The three shapes separate the two costs that <c>ReferenceNode.GetReference</c> used to
+/// pay on every evaluation — parsing the address string, and allocating a <c>Reference</c>:
+/// <list type="bullet">
+/// <item>
+/// <see cref="UniqueSameSheet"/> gives every row its own formula text, so
+/// <c>ExpressionCache</c> hands out one AST per row and each node is resolved exactly once.
+/// Nothing can be reused across evaluations, so this measures the address parsing alone.
+/// </item>
+/// <item>
+/// <see cref="SharedSameSheet"/> repeats one formula text down the column, so a single AST
+/// (and therefore a single <c>ReferenceNode</c>) is resolved once per row. This is the shape
+/// a per-node memo can serve, on the sheet-less path.
+/// </item>
+/// <item>
+/// <see cref="SharedCrossSheet"/> does the same through a sheet prefix, which has to resolve
+/// the worksheet before building the address — the path where a memo has to be keyed on the
+/// resolved sheet rather than cached outright.
+/// </item>
+/// </list>
+/// Row count is deliberately far below the 250K of <see cref="XLiburReadBenchmarks"/>: this
+/// benchmark is measuring per-reference cost, not load throughput, and a smaller sheet keeps
+/// iterations short enough for BenchmarkDotNet to take a useful number of them.
+/// </remarks>
+[MemoryDiagnoser]
+public class FormulaEvaluationBenchmarks
+{
+    private const int RowCount = 20_000;
+    private const int LookupRows = 20;
+
+    private XLWorkbook _uniqueSameSheet = null!;
+    private XLWorkbook _sharedSameSheet = null!;
+    private XLWorkbook _sharedCrossSheet = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        SixLaborsV1FontBootstrap.Register();
+
+        // Distinct formula text per row: one AST each, every reference resolved once.
+        _uniqueSameSheet = Build(out var uniqueSheet);
+        for (var row = 1; row <= RowCount; row++)
+            uniqueSheet.Cell(row, 6).FormulaA1 = $"SUM(D{row}:E{row})";
+
+        // One formula text for the whole column: one AST, resolved RowCount times.
+        _sharedSameSheet = Build(out var sharedSheet);
+        for (var row = 1; row <= RowCount; row++)
+            sharedSheet.Cell(row, 6).FormulaA1 = "SUM($D$1:$E$1)";
+
+        // As above, but through a sheet prefix, so the worksheet must be resolved first.
+        _sharedCrossSheet = Build(out var crossSheet);
+        var lookup = _sharedCrossSheet.AddWorksheet("Lookup");
+        for (var row = 1; row <= LookupRows; row++)
+            lookup.Cell(row, 1).Value = row;
+
+        for (var row = 1; row <= RowCount; row++)
+            crossSheet.Cell(row, 6).FormulaA1 = $"SUM(Lookup!$A$1:$A${LookupRows})";
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _uniqueSameSheet.Dispose();
+        _sharedSameSheet.Dispose();
+        _sharedCrossSheet.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public void UniqueSameSheet() => _uniqueSameSheet.RecalculateAllFormulas();
+
+    [Benchmark]
+    public void SharedSameSheet() => _sharedSameSheet.RecalculateAllFormulas();
+
+    [Benchmark]
+    public void SharedCrossSheet() => _sharedCrossSheet.RecalculateAllFormulas();
+
+    /// <summary>
+    /// A workbook with the two operand columns populated and no formulas yet; the caller adds
+    /// the shape it wants to measure.
+    /// </summary>
+    private static XLWorkbook Build(out IXLWorksheet sheet)
+    {
+        var workbook = new XLWorkbook();
+        sheet = workbook.AddWorksheet("Data");
+
+        for (var row = 1; row <= RowCount; row++)
+        {
+            sheet.Cell(row, 4).Value = row;
+            sheet.Cell(row, 5).Value = row * 2;
+        }
+
+        return workbook;
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/ReferenceNodeResolutionTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ReferenceNodeResolutionTests.cs
@@ -1,0 +1,191 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// Covers how a <c>ReferenceNode</c> resolves to a range during evaluation. The node builds
+/// the address from the area the parser produced and memoises the result, so these assert the
+/// shapes that construction has to get right and the cases where a memo must not be reused.
+/// </summary>
+public class ReferenceNodeResolutionTests
+{
+    [Test]
+    public async Task RelativeRange_ResolvesToAllCellsInArea()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").Value = 2;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("B2").Value = 8;
+        ws.Cell("D1").FormulaA1 = "SUM(A1:B2)";
+
+        await Assert.That(ws.Cell("D1").Value).IsEqualTo(15);
+    }
+
+    [Test]
+    public async Task AbsoluteRange_ResolvesToTheSameCellsAsTheRelativeForm()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").Value = 2;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("B2").Value = 8;
+        ws.Cell("D1").FormulaA1 = "SUM($A$1:$B$2)";
+
+        await Assert.That(ws.Cell("D1").Value).IsEqualTo(15);
+    }
+
+    [Test]
+    public async Task MixedAbsoluteAndRelativeEndpoints_ResolveToTheWholeArea()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").Value = 2;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("B2").Value = 8;
+        ws.Cell("D1").FormulaA1 = "SUM($A1:B$2)";
+
+        await Assert.That(ws.Cell("D1").Value).IsEqualTo(15);
+    }
+
+    /// <summary>
+    /// A column reference has no row axis, so the missing axis has to span the whole sheet
+    /// rather than collapse to a single row.
+    /// </summary>
+    [Test]
+    public async Task ColumnReference_SpansEveryRow()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("A500").Value = 2;
+        ws.Cell("B1").Value = 4;
+        ws.Cell("C1").FormulaA1 = "SUM(A:B)";
+
+        await Assert.That(ws.Cell("C1").Value).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task RowReference_SpansEveryColumn()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("ZZ1").Value = 2;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("A4").FormulaA1 = "SUM(1:2)";
+
+        await Assert.That(ws.Cell("A4").Value).IsEqualTo(7);
+    }
+
+    /// <summary>
+    /// The parser hands back the endpoints in the order they were written, which need not be
+    /// top-left then bottom-right. The address has to be normalized before use.
+    /// </summary>
+    [Test]
+    public async Task ReversedEndpoints_ResolveToTheSameAreaAsTheNormalizedForm()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").Value = 2;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("B2").Value = 8;
+        ws.Cell("D1").FormulaA1 = "SUM(B2:A1)";
+
+        await Assert.That(ws.Cell("D1").Value).IsEqualTo(15);
+    }
+
+    [Test]
+    public async Task CrossSheetReference_ResolvesAgainstThePrefixedSheet()
+    {
+        using var wb = new XLWorkbook();
+        var data = wb.AddWorksheet("Data");
+        var main = wb.AddWorksheet("Main");
+        data.Cell("A1").Value = 3;
+        data.Cell("A2").Value = 4;
+        main.Cell("A1").FormulaA1 = "SUM(Data!A1:A2)";
+
+        await Assert.That(main.Cell("A1").Value).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task CrossSheetReferenceToMissingSheet_IsRefError()
+    {
+        using var wb = new XLWorkbook();
+        var main = wb.AddWorksheet("Main");
+        main.Cell("A1").FormulaA1 = "SUM(Missing!A1:A2)";
+
+        await Assert.That(main.Cell("A1").Value).IsEqualTo(XLError.CellReference);
+    }
+
+    /// <summary>
+    /// The same formula text is shared by every cell that holds it, so one AST — and one
+    /// <c>ReferenceNode</c> — serves them all. Each cell must still see the value of the
+    /// range as evaluated for it.
+    /// </summary>
+    [Test]
+    public async Task SharedFormulaText_ResolvesTheSameRangeForEveryCell()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 5;
+        ws.Cell("A2").Value = 6;
+        ws.Cell("C1").FormulaA1 = "SUM($A$1:$A$2)";
+        ws.Cell("C2").FormulaA1 = "SUM($A$1:$A$2)";
+        ws.Cell("C3").FormulaA1 = "SUM($A$1:$A$2)";
+
+        await Assert.That(ws.Cell("C1").Value).IsEqualTo(11);
+        await Assert.That(ws.Cell("C2").Value).IsEqualTo(11);
+        await Assert.That(ws.Cell("C3").Value).IsEqualTo(11);
+    }
+
+    /// <summary>
+    /// A resolved reference is memoised per node. Replacing the referenced sheet with a fresh
+    /// one of the same name gives the prefix a different worksheet to resolve to, and the
+    /// memo must not answer for the old one.
+    /// </summary>
+    [Test]
+    public async Task ReplacingTheReferencedSheet_ResolvesAgainstTheNewSheet()
+    {
+        using var wb = new XLWorkbook();
+        var main = wb.AddWorksheet("Main");
+        var data = wb.AddWorksheet("Data");
+        data.Cell("A1").Value = 1;
+        main.Cell("A1").FormulaA1 = "Data!A1";
+
+        await Assert.That(main.Cell("A1").Value).IsEqualTo(1);
+
+        data.Delete();
+        var replacement = wb.AddWorksheet("Data");
+        replacement.Cell("A1").Value = 99;
+
+        wb.RecalculateAllFormulas();
+
+        await Assert.That(main.Cell("A1").Value).IsEqualTo(99);
+    }
+
+    /// <summary>
+    /// Re-evaluating the same formula has to reflect the current contents of the referenced
+    /// range, not the contents it had when the reference was first resolved.
+    /// </summary>
+    [Test]
+    public async Task ReevaluatingAfterAnEdit_SeesTheUpdatedValues()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("A2").Value = 2;
+        ws.Cell("C1").FormulaA1 = "SUM(A1:A2)";
+
+        await Assert.That(ws.Cell("C1").Value).IsEqualTo(3);
+
+        ws.Cell("A2").Value = 40;
+
+        await Assert.That(ws.Cell("C1").Value).IsEqualTo(41);
+    }
+}

--- a/XLibur/Excel/CalcEngine/AstNode.cs
+++ b/XLibur/Excel/CalcEngine/AstNode.cs
@@ -2,11 +2,14 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using ClosedXML.Parser;
+using XLibur.Excel.Coordinates;
 
 namespace XLibur.Excel.CalcEngine;
 
 /// <summary>
-/// Base class for all AST nodes. All AST nodes must be immutable.
+/// Base class for all AST nodes. All AST nodes must be observably immutable: a node may
+/// memoise something it derives from its own state (see <see cref="ReferenceNode"/>), but
+/// nothing a visitor can see may change after construction.
 /// </summary>
 internal abstract class AstNode
 {
@@ -257,6 +260,19 @@ internal sealed class PrefixNode : AstNode
 /// </summary>
 internal sealed class ReferenceNode : ValueNode
 {
+    /// <summary>
+    /// Resolved reference for the sheet-less form. The address does not depend on anything
+    /// outside the node, so once built it is valid for the node's lifetime.
+    /// </summary>
+    private Reference? _sheetlessReference;
+
+    /// <summary>
+    /// Resolved reference for the prefixed form, together with the sheet it was resolved
+    /// against. A single field rather than two so a reader can never observe a new sheet
+    /// paired with the previous sheet's address.
+    /// </summary>
+    private SheetReference? _sheetReference;
+
     public ReferenceNode(PrefixNode? prefix, ReferenceArea referenceArea, bool isA1)
     {
         Prefix = prefix;
@@ -290,14 +306,79 @@ internal sealed class ReferenceNode : ValueNode
     public AnyValue GetReference(CalcContext ctx)
     {
         if (Prefix is null)
-            return new Reference(new XLRangeAddress(null, Address));
+            return _sheetlessReference ??= new Reference(BuildAddress(null));
 
         if (!Prefix.GetWorksheet(ctx.Workbook).TryPickT0(out var ws, out var err))
             return err;
 
-        // TODO: XLRangeAddress can parse all types of reference item type, utilize known type for faster parsing + cache
-        return new Reference(new XLRangeAddress((XLWorksheet)ws, Address));
+        // ASTs are shared between every cell holding the same formula text (see
+        // ExpressionCache), and recalculation re-resolves every reference, so the same node
+        // is resolved many times and almost always against the same sheet. Keyed on the
+        // resolved sheet rather than cached outright: a rename or a delete-and-re-add changes
+        // which sheet the prefix resolves to, and that must not serve the previous address.
+        var sheet = (XLWorksheet)ws;
+        var cached = _sheetReference;
+        if (cached is not null && ReferenceEquals(cached.Sheet, sheet))
+            return cached.Reference;
+
+        var reference = new Reference(BuildAddress(sheet));
+        _sheetReference = new SheetReference(sheet, reference);
+        return reference;
     }
+
+    /// <summary>
+    /// Build the range address from the <see cref="ReferenceArea"/> the parser produced,
+    /// rather than by re-parsing <see cref="Address"/> — which the constructor generated from
+    /// that same area, so parsing it only recovers what is already known.
+    /// </summary>
+    /// <remarks>
+    /// Only the A1 form is handled. <see cref="IsA1"/> is <c>false</c> only for ASTs built to
+    /// rewrite R1C1 formula text, and those are never evaluated: the only caller that reaches
+    /// here is <see cref="XLCalcEngine.Parse"/>, which always parses as A1. The previous
+    /// string-parsing implementation could not resolve R1C1 either — <see cref="XLRangeAddress"/>
+    /// does not parse that syntax — so this narrows nothing.
+    /// </remarks>
+    private XLRangeAddress BuildAddress(XLWorksheet? sheet)
+    {
+        var first = ReferenceArea.First;
+        var second = ReferenceArea.Second;
+
+        // An axis of type None means the other axis carries the reference (A:B has no row,
+        // 1:5 has no column), so the missing axis spans the whole sheet.
+        var (row1, fixedRow1) = Axis(first.RowType, first.RowValue, XLHelper.MinRowNumber);
+        var (col1, fixedCol1) = Axis(first.ColumnType, first.ColumnValue, XLHelper.MinColumnNumber);
+        var (row2, fixedRow2) = Axis(second.RowType, second.RowValue, XLHelper.MaxRowNumber);
+        var (col2, fixedCol2) = Axis(second.ColumnType, second.ColumnValue, XLHelper.MaxColumnNumber);
+
+        // The endpoints need not be the top-left and bottom-right corners (D4:A1, D1:A4), but
+        // Reference requires a normalized address. Each axis is ordered independently, with
+        // the fixed flag travelling with the coordinate it belongs to.
+        if (row1 > row2)
+        {
+            (row1, row2) = (row2, row1);
+            (fixedRow1, fixedRow2) = (fixedRow2, fixedRow1);
+        }
+
+        if (col1 > col2)
+        {
+            (col1, col2) = (col2, col1);
+            (fixedCol1, fixedCol2) = (fixedCol2, fixedCol1);
+        }
+
+        return new XLRangeAddress(
+            new XLAddress(sheet, row1, col1, fixedRow1, fixedCol1),
+            new XLAddress(sheet, row2, col2, fixedRow2, fixedCol2));
+    }
+
+    private static (int Position, bool Fixed) Axis(ReferenceAxisType axisType, int value, int absent) => axisType switch
+    {
+        ReferenceAxisType.Absolute => (value, true),
+        ReferenceAxisType.Relative => (value, false),
+        ReferenceAxisType.None => (absent, false),
+        _ => throw new NotSupportedException($"Unknown reference axis type {axisType}."),
+    };
+
+    private sealed record SheetReference(XLWorksheet Sheet, Reference Reference);
 }
 
 /// <summary>

--- a/XLibur/Excel/CalcEngine/AstNode.cs
+++ b/XLibur/Excel/CalcEngine/AstNode.cs
@@ -268,10 +268,16 @@ internal sealed class ReferenceNode : ValueNode
 
     /// <summary>
     /// Resolved reference for the prefixed form, together with the sheet it was resolved
-    /// against. A single field rather than two so a reader can never observe a new sheet
-    /// paired with the previous sheet's address.
+    /// against, kept in one object so the pair is replaced as a unit.
     /// </summary>
     private SheetReference? _sheetReference;
+
+    // Neither memo is synchronized. Evaluation is single-threaded — XLWorkbook is not
+    // thread-safe — so this is not a claim about concurrent readers. It is worth noting that
+    // both fields tolerate a lost update anyway, because neither is trusted on its own: the
+    // sheet-less reference is immutable and every writer produces an equal one, and the
+    // prefixed reference is only used after ReferenceEquals confirms it was resolved against
+    // the sheet being asked about, so any other value is recomputed rather than misapplied.
 
     public ReferenceNode(PrefixNode? prefix, ReferenceArea referenceArea, bool isA1)
     {


### PR DESCRIPTION
Stacked on #285 — **base is `chore/todo-triage`**, so review that one first. Retarget to `main` once #285 merges.

Actions TODO item #1 from the triage: `AstNode.cs:298`, `// TODO: XLRangeAddress can parse all types of reference item type, utilize known type for faster parsing + cache`.

## The problem

`ReferenceNode.GetReference` built its range address by parsing the `Address` string on every evaluation:

```csharp
return new Reference(new XLRangeAddress((XLWorksheet)ws, Address));
```

That string is one the constructor itself generated from the parsed `ReferenceArea` (`AstNode.cs:263`), so parsing it only recovers what the node already holds — and it does so through `Contains`, `Split` (allocating a string array plus a substring per endpoint) and a per-endpoint `XLAddress.Create`.

## The change

Build the address straight from the `ReferenceArea`, and memoise the resulting `Reference` on the node. ASTs are shared by every cell holding the same formula text (`ExpressionCache`) and `RecalculateAllFormulas` re-resolves every reference, so the same node is resolved many times.

The sheet-less form has no external dependency and is cached outright. The prefixed form is keyed on the worksheet it resolved against, held in a **single** field so a reader can never observe a new sheet paired with the previous sheet's address — deleting a sheet and adding a fresh one of the same name must resolve to the new one, which `ReplacingTheReferencedSheet_ResolvesAgainstTheNewSheet` covers.

`AstNode`'s "must be immutable" doc is updated to "observably immutable", since the node now memoises something derived from its own state.

## A bug fixed along the way

A reversed range such as `=SUM(B2:A1)` threw `ArgumentException("Range address must be normalized")` out of the `Reference` constructor — an unhandled exception reaching the caller, not a `#REF!`. The parser hands endpoints back in the order they were written (`ReferenceAreaExtensions.ToSheetRange` notes the same thing) and nothing normalized them before use.

The new construction orders each axis independently, carrying each fixed flag with its own coordinate, so the formula now evaluates as Excel does. `ReversedEndpoints_ResolveToTheSameAreaAsTheNormalizedForm` fails on the previous implementation — verified by stashing the change and re-running.

## Scope note

Only the A1 form is handled. `IsA1` is false only for ASTs built to rewrite R1C1 formula text, and those are never evaluated — the single caller reaching here is `XLCalcEngine.Parse`, which always passes `isA1: true`. The old string path could not resolve R1C1 either, since `XLRangeAddress` does not parse that syntax, so nothing is narrowed.

## Measurements

New `FormulaEvaluationBenchmarks` (20K formula rows, `RecalculateAllFormulas` per operation), net10.0, Ryzen 9 5950X:

| Shape | Before | After | Time | Allocated |
|---|---|---|---|---|
| `UniqueSameSheet` | 19.51 ms / 15.87 MB | 16.06 ms / 10.38 MB | **−17.7%** | **−34.6%** |
| `SharedSameSheet` | 16.17 ms / 16.17 MB | 13.56 ms / 10.38 MB | **−16.1%** | **−35.8%** |
| `SharedCrossSheet` | 37.64 ms / 16.18 MB | 32.99 ms / 10.38 MB | **−12.4%** | **−35.8%** |

The three shapes separate the two costs. Unique formula text per row leaves nothing to reuse, so it measures the parsing alone; repeated formula text is what the memo can serve, on the sheet-less and prefixed paths respectively.

## Test plan

- [x] 11 new tests in `ReferenceNodeResolutionTests` — relative, absolute and mixed endpoints, column-only and row-only references, reversed endpoints, cross-sheet, missing sheet, shared formula text, sheet replacement, re-evaluation after an edit
- [x] Verified 10 of the 11 pass on the previous implementation (behaviour-preserving) and that the reversed-endpoint one does not (the bug fix)
- [x] Full suite green on **net10.0** — 11,625 passed, 4 skipped
- [x] Full suite green on **net8.0** — 11,625 passed, 4 skipped
- [x] `dotnet build XLibur/XLibur.csproj -c Release` — 0 warnings