### PR TITLE
refactor(pivot): move the save-time pivot cache id off XLPivotCache

### DIFF
--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
@@ -1,6 +1,11 @@
-﻿using XLibur.Excel;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using TUnit.Assertions.Enums;
+using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.PivotTables;
 
@@ -55,6 +60,110 @@ public class XLPivotCacheTests
         await Assert.That(pivotCache.ItemsToRetainPerField).IsEqualTo(XLItemsToRetain.None);
         await Assert.That(pivotCache.SaveSourceData).IsFalse();
         await Assert.That(pivotCache.RefreshDataOnOpen).IsTrue();
+    }
+
+    /// <summary>
+    /// The <c>cacheId</c> a pivot table part writes is a position in the workbook's
+    /// <c>pivotCaches</c> element, not a property of the cache, so the two have to agree.
+    /// With more than one cache in play a mix-up points each pivot table at the wrong source
+    /// instead of merely writing an odd number.
+    /// </summary>
+    [Test]
+    public async Task SavedPivotTables_ReferenceTheCacheIdTheWorkbookListsForTheirOwnCache()
+    {
+        using var wb = BuildWorkbookWithTwoCaches();
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+
+        await AssertCacheIdsAgreeWithWorkbook(ms);
+    }
+
+    /// <summary>
+    /// Cache ids are assigned per save. Saving twice has to renumber from scratch rather than
+    /// continue where the previous save left off.
+    /// </summary>
+    [Test]
+    public async Task SavingTwice_AssignsTheSameCacheIdsAgain()
+    {
+        using var wb = BuildWorkbookWithTwoCaches();
+
+        using var first = new MemoryStream();
+        wb.SaveAs(first);
+
+        using var second = new MemoryStream();
+        wb.SaveAs(second);
+
+        await AssertCacheIdsAgreeWithWorkbook(first);
+        await AssertCacheIdsAgreeWithWorkbook(second);
+        await Assert.That(ReadCacheIds(second)).IsEquivalentTo(ReadCacheIds(first), CollectionOrdering.Matching);
+    }
+
+    private static XLWorkbook BuildWorkbookWithTwoCaches()
+    {
+        var wb = new XLWorkbook();
+        var data = wb.AddWorksheet("Data");
+        var pastries = data.FirstCell().InsertData(new object[]
+        {
+            ("Pastry", "Sold"),
+            ("Waffle", 3),
+            ("Donut", 5),
+        });
+        var doughs = data.Cell("D1").InsertData(new object[]
+        {
+            ("Dough", "Batches"),
+            ("Puff", 2),
+            ("Choux", 7),
+        });
+
+        var pivots = wb.AddWorksheet("Pivots");
+        var byPastry = pivots.PivotTables.Add("byPastry", pivots.Cell("A1"), pastries);
+        byPastry.RowLabels.Add("Pastry");
+        byPastry.Values.Add("Sold");
+
+        var byDough = pivots.PivotTables.Add("byDough", pivots.Cell("F1"), doughs);
+        byDough.RowLabels.Add("Dough");
+        byDough.Values.Add("Batches");
+
+        return wb;
+    }
+
+    /// <summary>
+    /// Every <c>cacheId</c> written by a pivot table part, in part order.
+    /// </summary>
+    private static List<uint> ReadCacheIds(MemoryStream saved)
+    {
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        return doc.WorkbookPart!.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Select(part => part.PivotTableDefinition!.CacheId!.Value)
+            .OrderBy(id => id)
+            .ToList();
+    }
+
+    private static async Task AssertCacheIdsAgreeWithWorkbook(MemoryStream saved)
+    {
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+
+        var declared = doc.WorkbookPart!.Workbook.PivotCaches!
+            .Elements<PivotCache>()
+            .Select(cache => cache.CacheId!.Value)
+            .ToList();
+
+        var referenced = doc.WorkbookPart.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Select(part => part.PivotTableDefinition!.CacheId!.Value)
+            .ToList();
+
+        await Assert.That(declared).IsEquivalentTo(new uint[] { 0, 1 }, CollectionOrdering.Matching);
+        await Assert.That(referenced.Count).IsEqualTo(2);
+
+        // Each pivot table must point at a declared cache, and at a different one from the
+        // other: the two were built from separate source ranges.
+        await Assert.That(referenced.Distinct().Count()).IsEqualTo(2);
+        foreach (var cacheId in referenced)
+            await Assert.That(declared).Contains(cacheId);
     }
 
     [Test]

--- a/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -28,7 +28,7 @@ internal static class PivotTableDefinitionPartWriter2
         xml.WriteStartElement("pivotTableDefinition", Main2006SsNs);
         xml.WriteAttributeString("xmlns", Main2006SsNs);
 
-        WritePivotTableAttributes(xml, pt);
+        WritePivotTableAttributes(xml, pt, context);
 
         // Location
         xml.WriteStartElement("location", Main2006SsNs);
@@ -73,10 +73,10 @@ internal static class PivotTableDefinitionPartWriter2
         xml.Close();
     }
 
-    private static void WritePivotTableAttributes(XmlWriter xml, XLPivotTable pt)
+    private static void WritePivotTableAttributes(XmlWriter xml, XLPivotTable pt, SaveContext context)
     {
         xml.WriteAttribute("name", pt.Name);
-        xml.WriteAttribute("cacheId", pt.PivotCache.CacheId!.Value); // TODO: Maybe not nullable?
+        xml.WriteAttribute("cacheId", context.GetPivotCacheId(pt.PivotCache));
         xml.WriteAttributeDefault("dataOnRows", pt.DataOnRows, false);
         xml.WriteAttributeOptional("dataPosition", pt.DataPosition);
         xml.WriteAttributeOptional("autoFormatId", pt.AutoFormatId);

--- a/XLibur/Excel/PivotTables/XLPivotCache.cs
+++ b/XLibur/Excel/PivotTables/XLPivotCache.cs
@@ -105,11 +105,6 @@ internal sealed class XLPivotCache : IXLPivotCache
 
     #endregion
 
-    /// <summary>
-    /// Pivot cache definition id from the file.
-    /// </summary>
-    internal uint? CacheId { get; set; }
-
     internal Guid Guid { get; }
 
     /// <summary>

--- a/XLibur/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/XLibur/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -23,7 +23,7 @@ public partial class XLWorkbook
             SharedStyles = new Dictionary<XLStyleValue, StyleInfo>();
             TableId = 0;
             TableNames = [];
-            PivotSourceCacheId = 0;
+            PivotCacheIds = new Dictionary<XLPivotCache, uint>();
         }
 
         public Dictionary<XLStyleValue, int> DifferentialFormats { get; private set; }
@@ -41,11 +41,12 @@ public partial class XLWorkbook
         public HashSet<string> TableNames { get; private set; }
 
         /// <summary>
-        /// A free id that can be used by the workbook to reference to a pivot cache.
-        /// The <c>PivotCaches</c> element in a workbook connects the parts with pivot
-        /// cache parts.
+        /// The id each pivot cache is written under, assigned while the <c>pivotCaches</c>
+        /// element of workbook.xml is rebuilt and read back when each pivot table part writes
+        /// its <c>cacheId</c> attribute. The id is a position in that rebuilt element, so it
+        /// belongs to the save rather than to the cache, and is only meaningful within one.
         /// </summary>
-        public uint PivotSourceCacheId { get; set; }
+        public Dictionary<XLPivotCache, uint> PivotCacheIds { get; private set; }
 
         /// <summary>
         /// A map of shared string ids. The index is the actual index from sharedStringId, and
@@ -76,6 +77,24 @@ public partial class XLWorkbook
             }
 
             return sharedStringId;
+        }
+
+        /// <summary>
+        /// The id <paramref name="pivotCache"/> is written under. Every cache reachable from a
+        /// pivot table is registered while <c>pivotCaches</c> is rebuilt, which happens before
+        /// any pivot table part is written, so a miss means the two have gone out of step.
+        /// </summary>
+        internal uint GetPivotCacheId(XLPivotCache pivotCache)
+        {
+            if (!PivotCacheIds.TryGetValue(pivotCache, out var cacheId))
+            {
+                throw new UnreachableException(
+                    "Pivot cache was not assigned an id while the workbook pivotCaches element was rebuilt. " +
+                    "Every cache used by a pivot table is registered there before any pivot table part is " +
+                    "written, so the pivot table being written references a cache the workbook does not list.");
+            }
+
+            return cacheId;
         }
 
         internal int? GetNumberFormat(XLNumberFormatValue? numberFormat)

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -1019,7 +1019,7 @@ public partial class XLWorkbook
     private static void SynchronizeWorkbookPivotCacheReferences(WorkbookPart workbookPart,
         IReadOnlyList<IXLPivotTable> allPivotTables, SaveContext context)
     {
-        context.PivotSourceCacheId = 0;
+        context.PivotCacheIds.Clear();
         var xlUsedCaches = new List<XLPivotCache>();
         var seenUsedCaches = new HashSet<IXLPivotCache>();
         foreach (var pt in allPivotTables)
@@ -1033,10 +1033,11 @@ public partial class XLWorkbook
             var pivotCaches = new PivotCaches();
             workbookPart.Workbook!.PivotCaches = pivotCaches;
 
-            foreach (var source in xlUsedCaches)
+            for (var i = 0; i < xlUsedCaches.Count; i++)
             {
-                var cacheId = context.PivotSourceCacheId++;
-                source.CacheId = cacheId;
+                var source = xlUsedCaches[i];
+                var cacheId = (uint)i;
+                context.PivotCacheIds[source] = cacheId;
                 pivotCaches.AppendChild(new PivotCache { CacheId = cacheId, Id = source.WorkbookCacheRelId });
             }
         }


### PR DESCRIPTION
Third in the stack — **base is `fix/astnode-reference-cache`** (#286), which sits on `chore/todo-triage` (#285). Review #285 → #286 → this. Retarget as each merges.

Actions TODO item #12 from the triage: `PivotTableDefinitionPartWriter2.cs:79`, `xml.WriteAttribute("cacheId", pt.PivotCache.CacheId!.Value); // TODO: Maybe not nullable?`

## The answer to the TODO

It did not need to be nullable — but the reason is that it did not belong on the cache at all.

`XLPivotCache.CacheId` was documented as *"Pivot cache definition id from the file"*, which was never true. `PivotTableDefinitionPartReader.cs:233` **discards** the `cacheId` it reads:

```csharp
_ = pivotTable.CacheId?.Value ?? throw PartStructureException.MissingAttribute();
```

so nothing ever set the property on load. Its only writer is `SynchronizeWorkbookPivotCacheReferences`, which assigns each cache a position while rebuilding the workbook `pivotCaches` element, and its only reader is `PivotTableDefinitionPartWriter2`. The value is a property of *one save*, not of the cache — which is precisely why it had to be nullable, since a cache that has not been saved has no id.

## The change

Move it to `SaveContext` as a cache→id map behind a `GetPivotCacheId` accessor, and delete the property. The writer now reads a plain `uint`, and a lookup miss throws `UnreachableException` naming the invariant — the same shape as the existing `GetSharedStringId` — rather than the `NullReferenceException` you would get from dropping the `!`.

The ordering that makes this safe is unchanged, and is now stated where it matters: `CreateParts` runs `PreparePivotCaches` (registering every cache reachable from any pivot table on any sheet) before the per-sheet loop writes any pivot table part.

`PivotSourceCacheId` is gone from `SaveContext`. It was reset to `0` at the top of the only method that used it and read nowhere else — a loop counter with workbook-level scope. The loop now indexes directly.

**No behaviour change.** Ids are still positions in the rebuilt `pivotCaches` element, assigned in the same order.

## Tests

Two added to `XLPivotCacheTests`, both built on a workbook with **two distinct caches** — with only one cache a mix-up is invisible, whereas with two it points a pivot table at the wrong source rather than merely writing an odd number.

- `SavedPivotTables_ReferenceTheCacheIdTheWorkbookListsForTheirOwnCache` — every written `cacheId` matches a cache the workbook declares, and the two tables resolve to different ones.
- `SavingTwice_AssignsTheSameCacheIdsAgain` — ids are per-save, so a second save renumbers from scratch instead of continuing from the first.

Both were confirmed to have teeth: against a writer emitting a constant `cacheId` they fail with `Expected to be 2, but found 1`.

## Test plan

- [x] Full suite green on **net10.0** — 11,627 passed, 4 skipped
- [x] Full suite green on **net8.0** — 11,627 passed, 4 skipped
- [x] `dotnet build XLibur/XLibur.csproj -c Release` — 0 warnings
- [x] New tests verified to fail against a deliberately broken writer