### PR TITLE
fix(validation): never write a data validation with an empty sqref

### DIFF
--- a/XLibur.Tests/Excel/DataValidations/EmptyDataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/EmptyDataValidationTests.cs
@@ -1,0 +1,155 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.DataValidations;
+
+/// <summary>
+/// A data validation rule applies to a set of ranges, written as the <c>sqref</c> attribute.
+/// The schema requires that attribute to be non-empty, so a rule that has ended up covering
+/// nothing must never reach the file: Excel treats <c>sqref=""</c> as corruption and repairs
+/// the workbook, dropping every validation on the sheet.
+/// </summary>
+public class EmptyDataValidationTests
+{
+    [Test]
+    public async Task AddingValidationOverAnExistingOne_DropsTheRuleItFullyCovers()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+
+        ws.Range("A1:A3").CreateDataValidation().WholeNumber.EqualOrGreaterThan(1);
+        await Assert.That(ws.DataValidations.Count()).IsEqualTo(1);
+
+        // Covers every cell the first rule applied to, so that rule now applies to nothing.
+        ws.Range("A1:A5").CreateDataValidation().WholeNumber.EqualOrGreaterThan(2);
+
+        await Assert.That(ws.DataValidations.Count()).IsEqualTo(1);
+        await Assert.That(ws.DataValidations.Single().Ranges.Single().RangeAddress.ToString())
+            .IsEqualTo("A1:A5");
+    }
+
+    /// <summary>
+    /// The counterpart: a rule only partly covered keeps the remainder and must survive.
+    /// </summary>
+    [Test]
+    public async Task AddingValidationOverPartOfAnExistingOne_KeepsTheUncoveredRemainder()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+
+        ws.Range("A1:A5").CreateDataValidation().WholeNumber.EqualOrGreaterThan(1);
+        ws.Range("A2:A3").CreateDataValidation().WholeNumber.EqualOrGreaterThan(2);
+
+        await Assert.That(ws.DataValidations.Count()).IsEqualTo(2);
+
+        var remainder = ws.DataValidations
+            .Single(dv => dv.Ranges.Count() > 1)
+            .Ranges.Select(r => r.RangeAddress.ToString())
+            .ToList();
+
+        await Assert.That(remainder).IsEquivalentTo(new[] { "A1:A1", "A4:A5" });
+    }
+
+    [Test]
+    public async Task ValidationCoveredByAnother_IsAbsentFromTheSavedFile()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Range("A1:A3").CreateDataValidation().WholeNumber.EqualOrGreaterThan(1);
+        ws.Range("A1:A5").CreateDataValidation().WholeNumber.EqualOrGreaterThan(2);
+
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+
+        var written = ReadSqrefs(ms);
+        await Assert.That(written).IsEquivalentTo(new[] { "A1:A5" });
+    }
+
+    /// <summary>
+    /// <c>ClearRanges</c> is public and leaves the rule in the collection with no coverage, so
+    /// it reaches the writer independently of any range splitting.
+    /// </summary>
+    [Test]
+    public async Task ValidationWithClearedRanges_IsAbsentFromTheSavedFile()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        var cleared = ws.Range("A1:A3").CreateDataValidation();
+        cleared.WholeNumber.EqualOrGreaterThan(1);
+        ws.Range("C1:C3").CreateDataValidation().WholeNumber.EqualOrGreaterThan(2);
+
+        cleared.ClearRanges();
+
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+
+        var written = ReadSqrefs(ms);
+        await Assert.That(written).IsEquivalentTo(new[] { "C1:C3" });
+    }
+
+    /// <summary>
+    /// When the only rule on the sheet is emptied there is nothing left to write, and the
+    /// <c>dataValidations</c> element must not be emitted holding a single broken child.
+    /// </summary>
+    [Test]
+    public async Task SheetWhoseOnlyValidationWasCleared_WritesNoDataValidationsElement()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        var only = ws.Range("A1:A3").CreateDataValidation();
+        only.WholeNumber.EqualOrGreaterThan(1);
+        only.ClearRanges();
+
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var worksheet = doc.WorkbookPart!.WorksheetParts.Single().Worksheet;
+
+        await Assert.That(worksheet.Elements<DocumentFormat.OpenXml.Spreadsheet.DataValidations>().Any())
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task SavedValidations_RoundTripWithoutLosingCoverage()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Data");
+            ws.Range("A1:A3").CreateDataValidation().WholeNumber.EqualOrGreaterThan(1);
+            ws.Range("A1:A5").CreateDataValidation().WholeNumber.EqualOrGreaterThan(2);
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        using var reloaded = new XLWorkbook(ms);
+        var sheet = reloaded.Worksheet("Data");
+
+        await Assert.That(sheet.DataValidations.Count()).IsEqualTo(1);
+        await Assert.That(sheet.DataValidations.Single().Ranges.Single().RangeAddress.ToString())
+            .IsEqualTo("A1:A5");
+    }
+
+    /// <summary>
+    /// Every <c>sqref</c> written to the sheet. Any empty entry here is the corruption this
+    /// class exists to prevent.
+    /// </summary>
+    private static string[] ReadSqrefs(MemoryStream saved)
+    {
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        var worksheet = doc.WorkbookPart!.WorksheetParts.Single().Worksheet;
+
+        return worksheet
+            .Elements<DocumentFormat.OpenXml.Spreadsheet.DataValidations>()
+            .SelectMany(dvs => dvs.Elements<DataValidation>())
+            .Select(dv => dv.SequenceOfReferences!.InnerText)
+            .ToArray();
+    }
+}

--- a/XLibur/Excel/DataValidation/XLDataValidations.cs
+++ b/XLibur/Excel/DataValidation/XLDataValidations.cs
@@ -259,15 +259,22 @@ internal sealed class XLDataValidations : IXLDataValidations
     {
         if (_skipSplittingExistingRanges) return;
 
+        // Distinct because the index holds one entry per area, so a rule covering several
+        // intersecting areas would otherwise be split once per area. SplitBy is idempotent —
+        // later calls find nothing left intersecting — but there is no reason to repeat it,
+        // and the emptied-rule sweep below needs each rule considered once.
+        var split = _dataValidationIndex.GetIntersectedRanges((XLRangeAddress)rangeAddress)
+            .Select(entry => entry.DataValidation)
+            .Distinct()
+            .ToList();
+
         try
         {
             _skipSplittingExistingRanges = true;
-            var entries = _dataValidationIndex.GetIntersectedRanges((XLRangeAddress)rangeAddress)
-                .ToList();
 
-            foreach (var entry in entries)
+            foreach (var dataValidation in split)
             {
-                entry.DataValidation.SplitBy(rangeAddress);
+                dataValidation.SplitBy(rangeAddress);
             }
         }
         finally
@@ -275,7 +282,15 @@ internal sealed class XLDataValidations : IXLDataValidations
             _skipSplittingExistingRanges = false;
         }
 
-        //TODO Remove empty data validations
+        // A rule whose coverage lay entirely inside rangeAddress has no areas left: the new
+        // rule took every cell it applied to. Excel cannot express a rule that applies to
+        // nothing — sqref must be non-empty — and the rule is now unreachable, so drop it
+        // rather than leave it in the collection to be written as sqref="".
+        foreach (var dataValidation in split)
+        {
+            if (dataValidation.Areas.Count == 0)
+                Delete(dataValidation);
+        }
     }
 
     /// <summary>

--- a/XLibur/Excel/IO/DataValidationWriter.cs
+++ b/XLibur/Excel/IO/DataValidationWriter.cs
@@ -32,6 +32,13 @@ internal static class DataValidationWriter
 
         foreach (var dv in xlWorksheet.DataValidations)
         {
+            // A rule can be left covering nothing — ClearRanges and RemoveRange are public and
+            // neither drops the rule. sqref is built by joining its ranges, so writing one
+            // would emit sqref="", which the schema forbids and Excel repairs the file over.
+            // A rule that applies to no cell has nothing to say, so skipping it loses nothing.
+            if (((XLDataValidation)dv).Areas.Count == 0)
+                continue;
+
             var (minReferencesAnotherSheet, minValue) = UsesExternalSheet(xlWorksheet, dv.MinValue);
             var (maxReferencesAnotherSheet, maxValue) = UsesExternalSheet(xlWorksheet, dv.MaxValue);
 


### PR DESCRIPTION
Actions TODO item #7 from the triage (`XLDataValidations.cs:278`, `//TODO Remove empty data validations`).

## The bug

A data validation rule applies to a set of ranges, written as the `sqref` attribute. The schema requires it to be non-empty, and Excel treats `sqref=""` as corruption — it repairs the workbook and drops **every** validation on the sheet, not just the broken one.

Two ways a rule ended up covering nothing, both of which reached the file:

**1. Adding a validation over a range that wholly contains an existing rule.** `SplitExistingRanges` carves the new range out of every overlapping rule via `SplitBy`, which removes each intersecting area and adds back only the remainder pieces (`XLDataValidation.cs:119-133`). When an area is fully covered, `Exclude` yields no pieces — so a rule whose entire coverage was inside the new range loses all of it. The rule stayed in the collection, `Consolidate` preserved it (it has no zero-area filter), and `DataValidationWriter.cs:102` joined its zero ranges into `""`.

```csharp
ws.Range("A1:A3").CreateDataValidation().WholeNumber.EqualOrGreaterThan(1);
ws.Range("A1:A5").CreateDataValidation().WholeNumber.EqualOrGreaterThan(2);
// before: two rules, saved as sqref="" and sqref="A1:A5"
```

**2. `ClearRanges` and `RemoveRange` are public** and neither drops the rule, so a caller can empty one directly with no splitting involved.

## The fix

Both ends:

- `SplitExistingRanges` deletes any rule left with no areas once the split completes. The new rule took every cell it applied to, so the old one is unreachable.
- `DataValidationWriter` skips any rule with no coverage, which closes (2) as well. Skipping loses nothing — a rule applying to no cell has nothing to say. When the emptied rule was the sheet's only one, the `dataValidations` element is now omitted entirely rather than written holding a single broken child.

**Why the sweep runs after the loop rather than off the coverage-changed event:** `SplitBy` drops a rule to zero areas *transiently*, between removing an area and adding back its remainder pieces. A rule with one area being split in two passes through zero on the way. Reacting to the event would delete a rule that is about to be repopulated.

Also deduped the split loop — the index holds one entry per area, so a rule covering several intersecting areas was split once per area. `SplitBy` is idempotent so this was harmless, but the emptied-rule sweep needs each rule considered once.

## Tests

6 added in `EmptyDataValidationTests`: the covered-rule case, the partial-overlap case that must still keep its remainder (`A1:A5` minus `A2:A3` → `A1`, `A4:A5`), both save paths, the only-rule-on-the-sheet case, and a round trip.

**4 of the 6 fail against the unfixed code** — verified by stashing the fix:

```
failed AddingValidationOverAnExistingOne_DropsTheRuleItFullyCovers   Expected to be 1, but found 2
failed ValidationCoveredByAnother_IsAbsentFromTheSavedFile           Expected to be equivalent to [A1:A5]
failed ValidationWithClearedRanges_IsAbsentFromTheSavedFile          Expected to be equivalent to [C1:C3]
failed SheetWhoseOnlyValidationWasCleared_WritesNoDataValidations    Expected to be false, but found True
```

The other two are behaviour-preserving regression guards.

## Test plan

- [x] Full suite green on **net10.0** — 11,620 passed, 4 skipped
- [x] Full suite green on **net8.0** — 11,620 passed, 4 skipped
- [x] `dotnet build XLibur/XLibur.csproj -c Release` — 0 warnings
- [x] New tests verified to fail on the unfixed code