### PR TITLE
feat(pivot): round-trip the chartFormats collection

### DIFF
--- a/XLibur.Benchmarks/FormulaEvaluationBenchmarks.cs
+++ b/XLibur.Benchmarks/FormulaEvaluationBenchmarks.cs
@@ -1,0 +1,106 @@
+using BenchmarkDotNet.Attributes;
+using XLibur.Excel;
+using XLibur.Fonts.SixLabors.V1;
+
+namespace XLibur.Benchmarks;
+
+/// <summary>
+/// Isolates the cost of resolving a <c>ReferenceNode</c> to a range during formula
+/// evaluation. <c>RecalculateAllFormulas</c> marks every formula dirty and then
+/// recalculates, so each iteration re-resolves every reference and the measurement is
+/// repeatable.
+/// </summary>
+/// <remarks>
+/// The three shapes separate the two costs that <c>ReferenceNode.GetReference</c> used to
+/// pay on every evaluation — parsing the address string, and allocating a <c>Reference</c>:
+/// <list type="bullet">
+/// <item>
+/// <see cref="UniqueSameSheet"/> gives every row its own formula text, so
+/// <c>ExpressionCache</c> hands out one AST per row and each node is resolved exactly once.
+/// Nothing can be reused across evaluations, so this measures the address parsing alone.
+/// </item>
+/// <item>
+/// <see cref="SharedSameSheet"/> repeats one formula text down the column, so a single AST
+/// (and therefore a single <c>ReferenceNode</c>) is resolved once per row. This is the shape
+/// a per-node memo can serve, on the sheet-less path.
+/// </item>
+/// <item>
+/// <see cref="SharedCrossSheet"/> does the same through a sheet prefix, which has to resolve
+/// the worksheet before building the address — the path where a memo has to be keyed on the
+/// resolved sheet rather than cached outright.
+/// </item>
+/// </list>
+/// Row count is deliberately far below the 250K of <see cref="XLiburReadBenchmarks"/>: this
+/// benchmark is measuring per-reference cost, not load throughput, and a smaller sheet keeps
+/// iterations short enough for BenchmarkDotNet to take a useful number of them.
+/// </remarks>
+[MemoryDiagnoser]
+public class FormulaEvaluationBenchmarks
+{
+    private const int RowCount = 20_000;
+    private const int LookupRows = 20;
+
+    private XLWorkbook _uniqueSameSheet = null!;
+    private XLWorkbook _sharedSameSheet = null!;
+    private XLWorkbook _sharedCrossSheet = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        SixLaborsV1FontBootstrap.Register();
+
+        // Distinct formula text per row: one AST each, every reference resolved once.
+        _uniqueSameSheet = Build(out var uniqueSheet);
+        for (var row = 1; row <= RowCount; row++)
+            uniqueSheet.Cell(row, 6).FormulaA1 = $"SUM(D{row}:E{row})";
+
+        // One formula text for the whole column: one AST, resolved RowCount times.
+        _sharedSameSheet = Build(out var sharedSheet);
+        for (var row = 1; row <= RowCount; row++)
+            sharedSheet.Cell(row, 6).FormulaA1 = "SUM($D$1:$E$1)";
+
+        // As above, but through a sheet prefix, so the worksheet must be resolved first.
+        _sharedCrossSheet = Build(out var crossSheet);
+        var lookup = _sharedCrossSheet.AddWorksheet("Lookup");
+        for (var row = 1; row <= LookupRows; row++)
+            lookup.Cell(row, 1).Value = row;
+
+        for (var row = 1; row <= RowCount; row++)
+            crossSheet.Cell(row, 6).FormulaA1 = $"SUM(Lookup!$A$1:$A${LookupRows})";
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _uniqueSameSheet.Dispose();
+        _sharedSameSheet.Dispose();
+        _sharedCrossSheet.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public void UniqueSameSheet() => _uniqueSameSheet.RecalculateAllFormulas();
+
+    [Benchmark]
+    public void SharedSameSheet() => _sharedSameSheet.RecalculateAllFormulas();
+
+    [Benchmark]
+    public void SharedCrossSheet() => _sharedCrossSheet.RecalculateAllFormulas();
+
+    /// <summary>
+    /// A workbook with the two operand columns populated and no formulas yet; the caller adds
+    /// the shape it wants to measure.
+    /// </summary>
+    private static XLWorkbook Build(out IXLWorksheet sheet)
+    {
+        var workbook = new XLWorkbook();
+        sheet = workbook.AddWorksheet("Data");
+
+        for (var row = 1; row <= RowCount; row++)
+        {
+            sheet.Cell(row, 4).Value = row;
+            sheet.Cell(row, 5).Value = row * 2;
+        }
+
+        return workbook;
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/ReferenceNodeResolutionTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ReferenceNodeResolutionTests.cs
@@ -1,0 +1,191 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// Covers how a <c>ReferenceNode</c> resolves to a range during evaluation. The node builds
+/// the address from the area the parser produced and memoises the result, so these assert the
+/// shapes that construction has to get right and the cases where a memo must not be reused.
+/// </summary>
+public class ReferenceNodeResolutionTests
+{
+    [Test]
+    public async Task RelativeRange_ResolvesToAllCellsInArea()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").Value = 2;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("B2").Value = 8;
+        ws.Cell("D1").FormulaA1 = "SUM(A1:B2)";
+
+        await Assert.That(ws.Cell("D1").Value).IsEqualTo(15);
+    }
+
+    [Test]
+    public async Task AbsoluteRange_ResolvesToTheSameCellsAsTheRelativeForm()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").Value = 2;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("B2").Value = 8;
+        ws.Cell("D1").FormulaA1 = "SUM($A$1:$B$2)";
+
+        await Assert.That(ws.Cell("D1").Value).IsEqualTo(15);
+    }
+
+    [Test]
+    public async Task MixedAbsoluteAndRelativeEndpoints_ResolveToTheWholeArea()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").Value = 2;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("B2").Value = 8;
+        ws.Cell("D1").FormulaA1 = "SUM($A1:B$2)";
+
+        await Assert.That(ws.Cell("D1").Value).IsEqualTo(15);
+    }
+
+    /// <summary>
+    /// A column reference has no row axis, so the missing axis has to span the whole sheet
+    /// rather than collapse to a single row.
+    /// </summary>
+    [Test]
+    public async Task ColumnReference_SpansEveryRow()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("A500").Value = 2;
+        ws.Cell("B1").Value = 4;
+        ws.Cell("C1").FormulaA1 = "SUM(A:B)";
+
+        await Assert.That(ws.Cell("C1").Value).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task RowReference_SpansEveryColumn()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("ZZ1").Value = 2;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("A4").FormulaA1 = "SUM(1:2)";
+
+        await Assert.That(ws.Cell("A4").Value).IsEqualTo(7);
+    }
+
+    /// <summary>
+    /// The parser hands back the endpoints in the order they were written, which need not be
+    /// top-left then bottom-right. The address has to be normalized before use.
+    /// </summary>
+    [Test]
+    public async Task ReversedEndpoints_ResolveToTheSameAreaAsTheNormalizedForm()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").Value = 2;
+        ws.Cell("A2").Value = 4;
+        ws.Cell("B2").Value = 8;
+        ws.Cell("D1").FormulaA1 = "SUM(B2:A1)";
+
+        await Assert.That(ws.Cell("D1").Value).IsEqualTo(15);
+    }
+
+    [Test]
+    public async Task CrossSheetReference_ResolvesAgainstThePrefixedSheet()
+    {
+        using var wb = new XLWorkbook();
+        var data = wb.AddWorksheet("Data");
+        var main = wb.AddWorksheet("Main");
+        data.Cell("A1").Value = 3;
+        data.Cell("A2").Value = 4;
+        main.Cell("A1").FormulaA1 = "SUM(Data!A1:A2)";
+
+        await Assert.That(main.Cell("A1").Value).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task CrossSheetReferenceToMissingSheet_IsRefError()
+    {
+        using var wb = new XLWorkbook();
+        var main = wb.AddWorksheet("Main");
+        main.Cell("A1").FormulaA1 = "SUM(Missing!A1:A2)";
+
+        await Assert.That(main.Cell("A1").Value).IsEqualTo(XLError.CellReference);
+    }
+
+    /// <summary>
+    /// The same formula text is shared by every cell that holds it, so one AST — and one
+    /// <c>ReferenceNode</c> — serves them all. Each cell must still see the value of the
+    /// range as evaluated for it.
+    /// </summary>
+    [Test]
+    public async Task SharedFormulaText_ResolvesTheSameRangeForEveryCell()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 5;
+        ws.Cell("A2").Value = 6;
+        ws.Cell("C1").FormulaA1 = "SUM($A$1:$A$2)";
+        ws.Cell("C2").FormulaA1 = "SUM($A$1:$A$2)";
+        ws.Cell("C3").FormulaA1 = "SUM($A$1:$A$2)";
+
+        await Assert.That(ws.Cell("C1").Value).IsEqualTo(11);
+        await Assert.That(ws.Cell("C2").Value).IsEqualTo(11);
+        await Assert.That(ws.Cell("C3").Value).IsEqualTo(11);
+    }
+
+    /// <summary>
+    /// A resolved reference is memoised per node. Replacing the referenced sheet with a fresh
+    /// one of the same name gives the prefix a different worksheet to resolve to, and the
+    /// memo must not answer for the old one.
+    /// </summary>
+    [Test]
+    public async Task ReplacingTheReferencedSheet_ResolvesAgainstTheNewSheet()
+    {
+        using var wb = new XLWorkbook();
+        var main = wb.AddWorksheet("Main");
+        var data = wb.AddWorksheet("Data");
+        data.Cell("A1").Value = 1;
+        main.Cell("A1").FormulaA1 = "Data!A1";
+
+        await Assert.That(main.Cell("A1").Value).IsEqualTo(1);
+
+        data.Delete();
+        var replacement = wb.AddWorksheet("Data");
+        replacement.Cell("A1").Value = 99;
+
+        wb.RecalculateAllFormulas();
+
+        await Assert.That(main.Cell("A1").Value).IsEqualTo(99);
+    }
+
+    /// <summary>
+    /// Re-evaluating the same formula has to reflect the current contents of the referenced
+    /// range, not the contents it had when the reference was first resolved.
+    /// </summary>
+    [Test]
+    public async Task ReevaluatingAfterAnEdit_SeesTheUpdatedValues()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("A2").Value = 2;
+        ws.Cell("C1").FormulaA1 = "SUM(A1:A2)";
+
+        await Assert.That(ws.Cell("C1").Value).IsEqualTo(3);
+
+        ws.Cell("A2").Value = 40;
+
+        await Assert.That(ws.Cell("C1").Value).IsEqualTo(41);
+    }
+}

--- a/XLibur.Tests/Excel/PivotTables/PivotChartFormatTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotChartFormatTests.cs
@@ -1,0 +1,299 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using XLibur.Excel;
+using XLibur.Excel.IO;
+
+namespace XLibur.Tests.Excel.PivotTables;
+
+/// <summary>
+/// A PivotChart keeps its manual per-series and per-point formatting in the chart part, but the
+/// <c>chartFormats</c> collection on the pivot table is what ties each formatting record to the
+/// pivot area it applies to. Losing the collection on load leaves the chart pointing at nothing,
+/// so the formatting silently disappears on the next save.
+/// </summary>
+public class PivotChartFormatTests
+{
+    [Test]
+    public async Task ChartFormats_SurviveARoundTrip()
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithChartFormats(input);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        var written = ReadChartFormats(output);
+
+        await Assert.That(written.Count).IsEqualTo(2);
+
+        await Assert.That(written[0].Chart!.Value).IsEqualTo(0U);
+        await Assert.That(written[0].Format!.Value).IsEqualTo(3U);
+        await Assert.That(written[0].Series?.Value ?? false).IsTrue();
+        await Assert.That(written[0].PivotArea).IsNotNull();
+
+        await Assert.That(written[1].Chart!.Value).IsEqualTo(1U);
+        await Assert.That(written[1].Format!.Value).IsEqualTo(7U);
+        await Assert.That(written[1].Series?.Value ?? false).IsFalse();
+    }
+
+    /// <summary>
+    /// The pivot area is the half of the record that says what is being formatted, so a
+    /// round trip that kept only the ids would still lose the link.
+    /// </summary>
+    [Test]
+    public async Task ChartFormatPivotArea_SurvivesARoundTrip()
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithChartFormats(input);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        var pivotArea = ReadChartFormats(output)[0].PivotArea!;
+        var reference = pivotArea.PivotAreaReferences!.Elements<PivotAreaReference>().Single();
+
+        await Assert.That(reference.Field!.Value).IsEqualTo(0U);
+        await Assert.That(reference.Elements<FieldItem>().Single().Val!.Value).IsEqualTo(1U);
+    }
+
+    [Test]
+    public async Task LoadedChartFormats_AreExposedOnThePivotTable()
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithChartFormats(input);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        var pt = (XLPivotTable)wb.Worksheet("PivotSheet").PivotTables.Single();
+
+        await Assert.That(pt.ChartFormats.Count).IsEqualTo(2);
+        await Assert.That(pt.ChartFormats[0].Chart).IsEqualTo(0U);
+        await Assert.That(pt.ChartFormats[0].Format).IsEqualTo(3U);
+        await Assert.That(pt.ChartFormats[0].Series).IsTrue();
+    }
+
+    /// <summary>
+    /// The overwhelming majority of pivot tables have no chart, and an empty
+    /// <c>chartFormats</c> element is not valid, so nothing must be written for them.
+    /// </summary>
+    [Test]
+    public async Task PivotTableWithoutChartFormats_WritesNoChartFormatsElement()
+    {
+        using var wb = new XLWorkbook();
+        var data = wb.AddWorksheet("Data");
+        var range = data.FirstCell().InsertData(new object[]
+        {
+            ("Pastry", "Sold"),
+            ("Waffle", 3),
+            ("Donut", 5),
+        });
+
+        var pivots = wb.AddWorksheet("Pivots");
+        var pt = pivots.PivotTables.Add("pvt", pivots.Cell("A1"), range);
+        pt.RowLabels.Add("Pastry");
+        pt.Values.Add("Sold");
+
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var definition = doc.WorkbookPart!.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Single()
+            .PivotTableDefinition;
+
+        await Assert.That(definition.Elements<ChartFormats>().Any()).IsFalse();
+    }
+
+    private static System.Collections.Generic.List<ChartFormat> ReadChartFormats(MemoryStream saved)
+    {
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        var definition = doc.WorkbookPart!.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Single()
+            .PivotTableDefinition;
+
+        return definition.Elements<ChartFormats>()
+            .SelectMany(cf => cf.Elements<ChartFormat>())
+            .ToList();
+    }
+
+    /// <summary>
+    /// A minimal workbook whose pivot table carries a <c>chartFormats</c> collection: one record
+    /// formatting a whole series and one formatting a single point.
+    /// </summary>
+    private static void CreateWorkbookWithChartFormats(Stream stream)
+    {
+        using var doc = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+        var workbookPart = doc.AddWorkbookPart();
+        workbookPart.Workbook = new Workbook();
+        var sheets = workbookPart.Workbook.AppendChild(new Sheets());
+
+        var dataSheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(dataSheetPart), SheetId = 1, Name = "Data" });
+
+        var sheetData = new SheetData();
+        sheetData.Append(CreateRow(1, "Name", "Revenue"));
+        sheetData.Append(CreateNumericRow(2, "Cookies", 500));
+        sheetData.Append(CreateNumericRow(3, "Cake", 800));
+        dataSheetPart.Worksheet = new Worksheet(sheetData);
+
+        var pivotSheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(pivotSheetPart), SheetId = 2, Name = "PivotSheet" });
+        pivotSheetPart.Worksheet = new Worksheet(new SheetData());
+
+        var cachePart = workbookPart.AddNewPart<PivotTableCacheDefinitionPart>();
+        var cachePartId = workbookPart.GetIdOfPart(cachePart);
+
+        var cacheDefinition = new PivotCacheDefinition
+        {
+            Id = "rId1",
+            RefreshOnLoad = true,
+            CreatedVersion = 5,
+            RefreshedVersion = 5,
+        };
+        cacheDefinition.AddNamespaceDeclaration("r", OpenXmlConst.RelationshipsNs);
+
+        var cacheSource = new CacheSource { Type = SourceValues.Worksheet };
+        cacheSource.Append(new WorksheetSource { Sheet = "Data", Reference = "A1:B3" });
+        cacheDefinition.Append(cacheSource);
+
+        var cacheFields = new CacheFields();
+
+        var nameField = new CacheField { Name = "Name" };
+        var nameShared = new SharedItems { ContainsSemiMixedTypes = false, ContainsString = true, ContainsNumber = false, Count = 2 };
+        nameShared.Append(new StringItem { Val = "Cookies" });
+        nameShared.Append(new StringItem { Val = "Cake" });
+        nameField.SharedItems = nameShared;
+        cacheFields.Append(nameField);
+
+        var revenueField = new CacheField { Name = "Revenue" };
+        revenueField.SharedItems = new SharedItems
+        {
+            ContainsSemiMixedTypes = false,
+            ContainsString = false,
+            ContainsNumber = true,
+            MinValue = 500,
+            MaxValue = 800,
+        };
+        cacheFields.Append(revenueField);
+
+        cacheFields.Count = 2;
+        cacheDefinition.Append(cacheFields);
+
+        var recordsPart = cachePart.AddNewPart<PivotTableCacheRecordsPart>();
+        var records = new PivotCacheRecords { Count = 2 };
+        records.Append(new PivotCacheRecord(new FieldItem { Val = 0 }, new NumberItem { Val = 500 }));
+        records.Append(new PivotCacheRecord(new FieldItem { Val = 1 }, new NumberItem { Val = 800 }));
+        recordsPart.PivotCacheRecords = records;
+
+        cachePart.PivotCacheDefinition = cacheDefinition;
+
+        var pivotCaches = new PivotCaches();
+        pivotCaches.Append(new PivotCache { CacheId = 0, Id = cachePartId });
+        workbookPart.Workbook.Append(pivotCaches);
+
+        var pivotTablePart = pivotSheetPart.AddNewPart<PivotTablePart>();
+        pivotTablePart.CreateRelationshipToPart(cachePart);
+
+        var pivotTableDef = new PivotTableDefinition
+        {
+            Name = "PivotTable1",
+            CacheId = 0,
+            DataCaption = "Values",
+            CreatedVersion = 5,
+            UpdatedVersion = 5,
+        };
+
+        pivotTableDef.Append(new Location { Reference = "A1:B4", FirstHeaderRow = 1, FirstDataRow = 2, FirstDataColumn = 1 });
+
+        var pivotFields = new PivotFields { Count = 2 };
+        var pf0 = new PivotField { Axis = PivotTableAxisValues.AxisRow, ShowAll = false };
+        var items0 = new Items { Count = 3 };
+        items0.Append(new Item { Index = 0 });
+        items0.Append(new Item { Index = 1 });
+        items0.Append(new Item { ItemType = ItemValues.Default });
+        pf0.Append(items0);
+        pivotFields.Append(pf0);
+        pivotFields.Append(new PivotField { DataField = true, ShowAll = false });
+        pivotTableDef.Append(pivotFields);
+
+        var rowFields = new RowFields { Count = 1 };
+        rowFields.Append(new Field { Index = 0 });
+        pivotTableDef.Append(rowFields);
+
+        var rowItems = new RowItems { Count = 3 };
+        rowItems.Append(new RowItem(new MemberPropertyIndex { Val = 0 }));
+        rowItems.Append(new RowItem(new MemberPropertyIndex { Val = 1 }));
+        rowItems.Append(new RowItem(new MemberPropertyIndex()) { ItemType = ItemValues.Grand });
+        pivotTableDef.Append(rowItems);
+
+        var colItems = new ColumnItems { Count = 1 };
+        colItems.Append(new RowItem(new MemberPropertyIndex()) { ItemType = ItemValues.Grand });
+        pivotTableDef.Append(colItems);
+
+        var dataFields = new DataFields { Count = 1 };
+        dataFields.Append(new DataField { Name = "Sum of Revenue", Field = 1 });
+        pivotTableDef.Append(dataFields);
+
+        // The element under test. Schema order puts chartFormats after dataFields and before
+        // pivotTableStyleInfo.
+        var chartFormats = new ChartFormats { Count = 2 };
+        chartFormats.Append(BuildChartFormat(chart: 0, format: 3, series: true, fieldItem: 1));
+        chartFormats.Append(BuildChartFormat(chart: 1, format: 7, series: false, fieldItem: 0));
+        pivotTableDef.Append(chartFormats);
+
+        pivotTableDef.Append(new PivotTableStyle { Name = "PivotStyleLight16", ShowRowHeaders = true, ShowColumnHeaders = true });
+
+        pivotTablePart.PivotTableDefinition = pivotTableDef;
+    }
+
+    private static ChartFormat BuildChartFormat(uint chart, uint format, bool series, uint fieldItem)
+    {
+        var pivotArea = new PivotArea { DataOnly = false, Outline = false, FieldPosition = 0U };
+        var references = new PivotAreaReferences { Count = 1 };
+        var reference = new PivotAreaReference { Field = 0U, Count = 1U, Selected = false };
+        reference.Append(new FieldItem { Val = fieldItem });
+        references.Append(reference);
+        pivotArea.Append(references);
+
+        var chartFormat = new ChartFormat { Chart = chart, Format = format, Series = series };
+        chartFormat.Append(pivotArea);
+        return chartFormat;
+    }
+
+    private static Row CreateRow(uint rowIndex, params string[] values)
+    {
+        var row = new Row { RowIndex = rowIndex };
+        for (var i = 0; i < values.Length; i++)
+        {
+            row.Append(new Cell
+            {
+                CellReference = $"{(char)('A' + i)}{rowIndex}",
+                DataType = CellValues.String,
+                CellValue = new CellValue(values[i]),
+            });
+        }
+
+        return row;
+    }
+
+    private static Row CreateNumericRow(uint rowIndex, string name, double value)
+    {
+        var row = new Row { RowIndex = rowIndex };
+        row.Append(new Cell { CellReference = $"A{rowIndex}", DataType = CellValues.String, CellValue = new CellValue(name) });
+        row.Append(new Cell { CellReference = $"B{rowIndex}", DataType = CellValues.Number, CellValue = new CellValue(value) });
+        return row;
+    }
+}

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
@@ -1,6 +1,11 @@
-﻿using XLibur.Excel;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using TUnit.Assertions.Enums;
+using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.PivotTables;
 
@@ -55,6 +60,110 @@ public class XLPivotCacheTests
         await Assert.That(pivotCache.ItemsToRetainPerField).IsEqualTo(XLItemsToRetain.None);
         await Assert.That(pivotCache.SaveSourceData).IsFalse();
         await Assert.That(pivotCache.RefreshDataOnOpen).IsTrue();
+    }
+
+    /// <summary>
+    /// The <c>cacheId</c> a pivot table part writes is a position in the workbook's
+    /// <c>pivotCaches</c> element, not a property of the cache, so the two have to agree.
+    /// With more than one cache in play a mix-up points each pivot table at the wrong source
+    /// instead of merely writing an odd number.
+    /// </summary>
+    [Test]
+    public async Task SavedPivotTables_ReferenceTheCacheIdTheWorkbookListsForTheirOwnCache()
+    {
+        using var wb = BuildWorkbookWithTwoCaches();
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+
+        await AssertCacheIdsAgreeWithWorkbook(ms);
+    }
+
+    /// <summary>
+    /// Cache ids are assigned per save. Saving twice has to renumber from scratch rather than
+    /// continue where the previous save left off.
+    /// </summary>
+    [Test]
+    public async Task SavingTwice_AssignsTheSameCacheIdsAgain()
+    {
+        using var wb = BuildWorkbookWithTwoCaches();
+
+        using var first = new MemoryStream();
+        wb.SaveAs(first);
+
+        using var second = new MemoryStream();
+        wb.SaveAs(second);
+
+        await AssertCacheIdsAgreeWithWorkbook(first);
+        await AssertCacheIdsAgreeWithWorkbook(second);
+        await Assert.That(ReadCacheIds(second)).IsEquivalentTo(ReadCacheIds(first), CollectionOrdering.Matching);
+    }
+
+    private static XLWorkbook BuildWorkbookWithTwoCaches()
+    {
+        var wb = new XLWorkbook();
+        var data = wb.AddWorksheet("Data");
+        var pastries = data.FirstCell().InsertData(new object[]
+        {
+            ("Pastry", "Sold"),
+            ("Waffle", 3),
+            ("Donut", 5),
+        });
+        var doughs = data.Cell("D1").InsertData(new object[]
+        {
+            ("Dough", "Batches"),
+            ("Puff", 2),
+            ("Choux", 7),
+        });
+
+        var pivots = wb.AddWorksheet("Pivots");
+        var byPastry = pivots.PivotTables.Add("byPastry", pivots.Cell("A1"), pastries);
+        byPastry.RowLabels.Add("Pastry");
+        byPastry.Values.Add("Sold");
+
+        var byDough = pivots.PivotTables.Add("byDough", pivots.Cell("F1"), doughs);
+        byDough.RowLabels.Add("Dough");
+        byDough.Values.Add("Batches");
+
+        return wb;
+    }
+
+    /// <summary>
+    /// Every <c>cacheId</c> written by a pivot table part, in part order.
+    /// </summary>
+    private static List<uint> ReadCacheIds(MemoryStream saved)
+    {
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        return doc.WorkbookPart!.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Select(part => part.PivotTableDefinition!.CacheId!.Value)
+            .OrderBy(id => id)
+            .ToList();
+    }
+
+    private static async Task AssertCacheIdsAgreeWithWorkbook(MemoryStream saved)
+    {
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+
+        var declared = doc.WorkbookPart!.Workbook.PivotCaches!
+            .Elements<PivotCache>()
+            .Select(cache => cache.CacheId!.Value)
+            .ToList();
+
+        var referenced = doc.WorkbookPart.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Select(part => part.PivotTableDefinition!.CacheId!.Value)
+            .ToList();
+
+        await Assert.That(declared).IsEquivalentTo(new uint[] { 0, 1 }, CollectionOrdering.Matching);
+        await Assert.That(referenced.Count).IsEqualTo(2);
+
+        // Each pivot table must point at a declared cache, and at a different one from the
+        // other: the two were built from separate source ranges.
+        await Assert.That(referenced.Distinct().Count()).IsEqualTo(2);
+        foreach (var cacheId in referenced)
+            await Assert.That(declared).Contains(cacheId);
     }
 
     [Test]

--- a/XLibur/Excel/CalcEngine/AstNode.cs
+++ b/XLibur/Excel/CalcEngine/AstNode.cs
@@ -2,11 +2,14 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using ClosedXML.Parser;
+using XLibur.Excel.Coordinates;
 
 namespace XLibur.Excel.CalcEngine;
 
 /// <summary>
-/// Base class for all AST nodes. All AST nodes must be immutable.
+/// Base class for all AST nodes. All AST nodes must be observably immutable: a node may
+/// memoise something it derives from its own state (see <see cref="ReferenceNode"/>), but
+/// nothing a visitor can see may change after construction.
 /// </summary>
 internal abstract class AstNode
 {
@@ -257,6 +260,19 @@ internal sealed class PrefixNode : AstNode
 /// </summary>
 internal sealed class ReferenceNode : ValueNode
 {
+    /// <summary>
+    /// Resolved reference for the sheet-less form. The address does not depend on anything
+    /// outside the node, so once built it is valid for the node's lifetime.
+    /// </summary>
+    private Reference? _sheetlessReference;
+
+    /// <summary>
+    /// Resolved reference for the prefixed form, together with the sheet it was resolved
+    /// against. A single field rather than two so a reader can never observe a new sheet
+    /// paired with the previous sheet's address.
+    /// </summary>
+    private SheetReference? _sheetReference;
+
     public ReferenceNode(PrefixNode? prefix, ReferenceArea referenceArea, bool isA1)
     {
         Prefix = prefix;
@@ -290,14 +306,79 @@ internal sealed class ReferenceNode : ValueNode
     public AnyValue GetReference(CalcContext ctx)
     {
         if (Prefix is null)
-            return new Reference(new XLRangeAddress(null, Address));
+            return _sheetlessReference ??= new Reference(BuildAddress(null));
 
         if (!Prefix.GetWorksheet(ctx.Workbook).TryPickT0(out var ws, out var err))
             return err;
 
-        // TODO: XLRangeAddress can parse all types of reference item type, utilize known type for faster parsing + cache
-        return new Reference(new XLRangeAddress((XLWorksheet)ws, Address));
+        // ASTs are shared between every cell holding the same formula text (see
+        // ExpressionCache), and recalculation re-resolves every reference, so the same node
+        // is resolved many times and almost always against the same sheet. Keyed on the
+        // resolved sheet rather than cached outright: a rename or a delete-and-re-add changes
+        // which sheet the prefix resolves to, and that must not serve the previous address.
+        var sheet = (XLWorksheet)ws;
+        var cached = _sheetReference;
+        if (cached is not null && ReferenceEquals(cached.Sheet, sheet))
+            return cached.Reference;
+
+        var reference = new Reference(BuildAddress(sheet));
+        _sheetReference = new SheetReference(sheet, reference);
+        return reference;
     }
+
+    /// <summary>
+    /// Build the range address from the <see cref="ReferenceArea"/> the parser produced,
+    /// rather than by re-parsing <see cref="Address"/> — which the constructor generated from
+    /// that same area, so parsing it only recovers what is already known.
+    /// </summary>
+    /// <remarks>
+    /// Only the A1 form is handled. <see cref="IsA1"/> is <c>false</c> only for ASTs built to
+    /// rewrite R1C1 formula text, and those are never evaluated: the only caller that reaches
+    /// here is <see cref="XLCalcEngine.Parse"/>, which always parses as A1. The previous
+    /// string-parsing implementation could not resolve R1C1 either — <see cref="XLRangeAddress"/>
+    /// does not parse that syntax — so this narrows nothing.
+    /// </remarks>
+    private XLRangeAddress BuildAddress(XLWorksheet? sheet)
+    {
+        var first = ReferenceArea.First;
+        var second = ReferenceArea.Second;
+
+        // An axis of type None means the other axis carries the reference (A:B has no row,
+        // 1:5 has no column), so the missing axis spans the whole sheet.
+        var (row1, fixedRow1) = Axis(first.RowType, first.RowValue, XLHelper.MinRowNumber);
+        var (col1, fixedCol1) = Axis(first.ColumnType, first.ColumnValue, XLHelper.MinColumnNumber);
+        var (row2, fixedRow2) = Axis(second.RowType, second.RowValue, XLHelper.MaxRowNumber);
+        var (col2, fixedCol2) = Axis(second.ColumnType, second.ColumnValue, XLHelper.MaxColumnNumber);
+
+        // The endpoints need not be the top-left and bottom-right corners (D4:A1, D1:A4), but
+        // Reference requires a normalized address. Each axis is ordered independently, with
+        // the fixed flag travelling with the coordinate it belongs to.
+        if (row1 > row2)
+        {
+            (row1, row2) = (row2, row1);
+            (fixedRow1, fixedRow2) = (fixedRow2, fixedRow1);
+        }
+
+        if (col1 > col2)
+        {
+            (col1, col2) = (col2, col1);
+            (fixedCol1, fixedCol2) = (fixedCol2, fixedCol1);
+        }
+
+        return new XLRangeAddress(
+            new XLAddress(sheet, row1, col1, fixedRow1, fixedCol1),
+            new XLAddress(sheet, row2, col2, fixedRow2, fixedCol2));
+    }
+
+    private static (int Position, bool Fixed) Axis(ReferenceAxisType axisType, int value, int absent) => axisType switch
+    {
+        ReferenceAxisType.Absolute => (value, true),
+        ReferenceAxisType.Relative => (value, false),
+        ReferenceAxisType.None => (absent, false),
+        _ => throw new NotSupportedException($"Unknown reference axis type {axisType}."),
+    };
+
+    private sealed record SheetReference(XLWorksheet Sheet, Reference Reference);
 }
 
 /// <summary>

--- a/XLibur/Excel/CalcEngine/AstNode.cs
+++ b/XLibur/Excel/CalcEngine/AstNode.cs
@@ -268,10 +268,16 @@ internal sealed class ReferenceNode : ValueNode
 
     /// <summary>
     /// Resolved reference for the prefixed form, together with the sheet it was resolved
-    /// against. A single field rather than two so a reader can never observe a new sheet
-    /// paired with the previous sheet's address.
+    /// against, kept in one object so the pair is replaced as a unit.
     /// </summary>
     private SheetReference? _sheetReference;
+
+    // Neither memo is synchronized. Evaluation is single-threaded — XLWorkbook is not
+    // thread-safe — so this is not a claim about concurrent readers. It is worth noting that
+    // both fields tolerate a lost update anyway, because neither is trusted on its own: the
+    // sheet-less reference is immutable and every writer produces an equal one, and the
+    // prefixed reference is only used after ReferenceEquals confirms it was resolved against
+    // the sheet being asked about, so any other value is recomputed rather than misapplied.
 
     public ReferenceNode(PrefixNode? prefix, ReferenceArea referenceArea, bool isA1)
     {

--- a/XLibur/Excel/CalcEngine/DependencyTree.cs
+++ b/XLibur/Excel/CalcEngine/DependencyTree.cs
@@ -95,7 +95,9 @@ internal sealed class DependencyTree
                         tree.AddFormula(bookArea, formula, workbook);
                     }
                 }
-                // TODO: Implement other formulas. Don't throw on data table or shared formulas.
+                // TODO: Register data-table formulas too. They are skipped, so their dependents
+                // fall back to a full recalculation (see XLCalcEngine.TryEvaluateSingleCell).
+                // FormulaType.Shared is never produced, so it needs no handling here.
             }
         }
 

--- a/XLibur/Excel/Coordinates/SheetPoint.cs
+++ b/XLibur/Excel/Coordinates/SheetPoint.cs
@@ -44,7 +44,6 @@ internal readonly struct SheetPoint : IEquatable<SheetPoint>
     {
     }
 
-    /// TODO: SheetId doesn't work nicely with renames, but will in the future.
     /// <summary>
     /// A sheet id of a point. Id of a sheet never changes during workbook
     /// lifecycle (<see cref="XLWorksheet.SheetId"/>), but the sheet may be

--- a/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -124,7 +124,8 @@ internal static class PivotTableDefinitionPartReader
 
         LoadConditionalFormats(pivotTable.ConditionalFormats, xlPivotTable, sheet, context);
 
-        // TODO: chartFormats
+        LoadChartFormats(pivotTable.ChartFormats, xlPivotTable);
+
         // pivotHierarchies is OLAP and thus for now out of scope.
         var pivotTableStyle = pivotTable.GetFirstChild<PivotTableStyle>();
         LoadPivotTableStyle(pivotTableStyle, xlPivotTable);
@@ -192,6 +193,34 @@ internal static class PivotTableDefinitionPartReader
                 DxfStyleValue = dxfStyle.Value,
             };
             xlPivotTable.AddFormat(xlFormat);
+        }
+    }
+
+    /// <summary>
+    /// Load the <c>chartFormats</c> collection — the manual formatting a PivotChart carries for
+    /// individual series and data points. The chart part holds the formatting itself; these
+    /// records tie each one to the pivot area it applies to, so dropping them leaves the chart
+    /// pointing at nothing.
+    /// </summary>
+    private static void LoadChartFormats(ChartFormats? chartFormats, XLPivotTable xlPivotTable)
+    {
+        if (chartFormats is null)
+            return;
+
+        foreach (var chartFormat in chartFormats.Cast<ChartFormat>())
+        {
+            var chart = chartFormat.Chart?.Value ?? throw PartStructureException.MissingAttribute();
+            var format = chartFormat.Format?.Value ?? throw PartStructureException.MissingAttribute();
+            var series = chartFormat.Series?.Value ?? false;
+
+            var pivotArea = chartFormat.PivotArea ?? throw PartStructureException.ExpectedElementNotFound();
+            var xlChartFormat = new XLPivotChartFormat(LoadPivotArea(pivotArea))
+            {
+                Chart = chart,
+                Format = format,
+                Series = series,
+            };
+            xlPivotTable.AddChartFormat(xlChartFormat);
         }
     }
 

--- a/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -51,6 +51,7 @@ internal static class PivotTableDefinitionPartWriter2
         WriteDataFields(xml, pt, context);
         WriteFormats(xml, pt, context);
         WriteConditionalFormats(xml, pt);
+        WriteChartFormats(xml, pt);
         WritePivotTableStyleInfo(xml, pt);
 
         // Because extensions are pretty large, always write them.
@@ -410,6 +411,33 @@ internal static class PivotTableDefinitionPartWriter2
             }
             xml.WriteEndElement(); // formats
         }
+    }
+
+    /// <summary>
+    /// Write the <c>chartFormats</c> collection. Sits between <c>conditionalFormats</c> and
+    /// <c>pivotTableStyleInfo</c>, which is where the schema sequence puts it.
+    /// </summary>
+    private static void WriteChartFormats(XmlWriter xml, XLPivotTable pt)
+    {
+        if (pt.ChartFormats.Count == 0)
+            return;
+
+        xml.WriteStartElement("chartFormats", Main2006SsNs);
+        xml.WriteAttribute("count", pt.ChartFormats.Count);
+        foreach (var chartFormat in pt.ChartFormats)
+        {
+            xml.WriteStartElement("chartFormat", Main2006SsNs);
+
+            // chart and format are required, so they are written even at their default value.
+            xml.WriteAttribute("chart", chartFormat.Chart);
+            xml.WriteAttribute("format", chartFormat.Format);
+            xml.WriteAttributeDefault("series", chartFormat.Series, false);
+
+            WritePivotArea(xml, chartFormat.PivotArea);
+            xml.WriteEndElement(); // chartFormat
+        }
+
+        xml.WriteEndElement(); // chartFormats
     }
 
     private static void WriteConditionalFormats(XmlWriter xml, XLPivotTable pt)

--- a/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -28,7 +28,7 @@ internal static class PivotTableDefinitionPartWriter2
         xml.WriteStartElement("pivotTableDefinition", Main2006SsNs);
         xml.WriteAttributeString("xmlns", Main2006SsNs);
 
-        WritePivotTableAttributes(xml, pt);
+        WritePivotTableAttributes(xml, pt, context);
 
         // Location
         xml.WriteStartElement("location", Main2006SsNs);
@@ -73,10 +73,10 @@ internal static class PivotTableDefinitionPartWriter2
         xml.Close();
     }
 
-    private static void WritePivotTableAttributes(XmlWriter xml, XLPivotTable pt)
+    private static void WritePivotTableAttributes(XmlWriter xml, XLPivotTable pt, SaveContext context)
     {
         xml.WriteAttribute("name", pt.Name);
-        xml.WriteAttribute("cacheId", pt.PivotCache.CacheId!.Value); // TODO: Maybe not nullable?
+        xml.WriteAttribute("cacheId", context.GetPivotCacheId(pt.PivotCache));
         xml.WriteAttributeDefault("dataOnRows", pt.DataOnRows, false);
         xml.WriteAttributeOptional("dataPosition", pt.DataPosition);
         xml.WriteAttributeOptional("autoFormatId", pt.AutoFormatId);

--- a/XLibur/Excel/PivotTables/XLPivotCache.cs
+++ b/XLibur/Excel/PivotTables/XLPivotCache.cs
@@ -105,11 +105,6 @@ internal sealed class XLPivotCache : IXLPivotCache
 
     #endregion
 
-    /// <summary>
-    /// Pivot cache definition id from the file.
-    /// </summary>
-    internal uint? CacheId { get; set; }
-
     internal Guid Guid { get; }
 
     /// <summary>

--- a/XLibur/Excel/PivotTables/XLPivotChartFormat.cs
+++ b/XLibur/Excel/PivotTables/XLPivotChartFormat.cs
@@ -1,0 +1,40 @@
+namespace XLibur.Excel;
+
+/// <summary>
+/// A link between a pivot area and a formatting record of a pivot chart. Excel writes one per
+/// chart element it has formatted by hand, so dropping them loses the manual formatting of a
+/// PivotChart even though the chart part itself survives.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="XLPivotTable.ChartFormat"/>, which is the pivot table's own
+/// <c>chartFormat</c> attribute — an id used by <c>/chartSpace/pivotSource/fmtId/@val</c> to tie
+/// a chart to this table. This type is an entry of the <c>chartFormats</c> collection.
+/// </remarks>
+internal sealed class XLPivotChartFormat
+{
+    internal XLPivotChartFormat(XLPivotArea pivotArea)
+    {
+        PivotArea = pivotArea;
+    }
+
+    /// <summary>
+    /// Pivot area the chart formatting applies to.
+    /// </summary>
+    internal XLPivotArea PivotArea { get; }
+
+    /// <summary>
+    /// Zero-based index of the chart element this record formats.
+    /// </summary>
+    internal uint Chart { get; init; }
+
+    /// <summary>
+    /// Index of the formatting record held by the chart part itself. XLibur does not interpret
+    /// it — the value is round-tripped so the chart keeps pointing at the right record.
+    /// </summary>
+    internal uint Format { get; init; }
+
+    /// <summary>
+    /// Whether the record formats a whole data series rather than a single data point.
+    /// </summary>
+    internal bool Series { get; init; }
+}

--- a/XLibur/Excel/PivotTables/XLPivotTable.cs
+++ b/XLibur/Excel/PivotTables/XLPivotTable.cs
@@ -23,6 +23,7 @@ internal sealed class XLPivotTable : IXLPivotTable
 
     private readonly List<XLPivotFormat> _formats = new();
     private readonly List<XLPivotConditionalFormat> _conditionalFormats = new();
+    private readonly List<XLPivotChartFormat> _chartFormats = new();
     private XLPivotCache _cache;
     private int _filterFieldsPageWrap;
     private bool _outline = true;
@@ -124,6 +125,8 @@ internal sealed class XLPivotTable : IXLPivotTable
     internal IReadOnlyList<XLPivotFormat> Formats => _formats;
 
     internal IReadOnlyList<XLPivotConditionalFormat> ConditionalFormats => _conditionalFormats;
+
+    internal IReadOnlyList<XLPivotChartFormat> ChartFormats => _chartFormats;
 
     public IXLPivotTable CopyTo(IXLCell targetCell)
     {
@@ -810,6 +813,11 @@ internal sealed class XLPivotTable : IXLPivotTable
     internal void AddConditionalFormat(XLPivotConditionalFormat conditionalFormat)
     {
         _conditionalFormats.Add(conditionalFormat);
+    }
+
+    internal void AddChartFormat(XLPivotChartFormat chartFormat)
+    {
+        _chartFormats.Add(chartFormat);
     }
 
     #region location

--- a/XLibur/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/XLibur/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -23,7 +23,7 @@ public partial class XLWorkbook
             SharedStyles = new Dictionary<XLStyleValue, StyleInfo>();
             TableId = 0;
             TableNames = [];
-            PivotSourceCacheId = 0;
+            PivotCacheIds = new Dictionary<XLPivotCache, uint>();
         }
 
         public Dictionary<XLStyleValue, int> DifferentialFormats { get; private set; }
@@ -41,11 +41,12 @@ public partial class XLWorkbook
         public HashSet<string> TableNames { get; private set; }
 
         /// <summary>
-        /// A free id that can be used by the workbook to reference to a pivot cache.
-        /// The <c>PivotCaches</c> element in a workbook connects the parts with pivot
-        /// cache parts.
+        /// The id each pivot cache is written under, assigned while the <c>pivotCaches</c>
+        /// element of workbook.xml is rebuilt and read back when each pivot table part writes
+        /// its <c>cacheId</c> attribute. The id is a position in that rebuilt element, so it
+        /// belongs to the save rather than to the cache, and is only meaningful within one.
         /// </summary>
-        public uint PivotSourceCacheId { get; set; }
+        public Dictionary<XLPivotCache, uint> PivotCacheIds { get; private set; }
 
         /// <summary>
         /// A map of shared string ids. The index is the actual index from sharedStringId, and
@@ -76,6 +77,24 @@ public partial class XLWorkbook
             }
 
             return sharedStringId;
+        }
+
+        /// <summary>
+        /// The id <paramref name="pivotCache"/> is written under. Every cache reachable from a
+        /// pivot table is registered while <c>pivotCaches</c> is rebuilt, which happens before
+        /// any pivot table part is written, so a miss means the two have gone out of step.
+        /// </summary>
+        internal uint GetPivotCacheId(XLPivotCache pivotCache)
+        {
+            if (!PivotCacheIds.TryGetValue(pivotCache, out var cacheId))
+            {
+                throw new UnreachableException(
+                    "Pivot cache was not assigned an id while the workbook pivotCaches element was rebuilt. " +
+                    "Every cache used by a pivot table is registered there before any pivot table part is " +
+                    "written, so the pivot table being written references a cache the workbook does not list.");
+            }
+
+            return cacheId;
         }
 
         internal int? GetNumberFormat(XLNumberFormatValue? numberFormat)

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -1019,7 +1019,7 @@ public partial class XLWorkbook
     private static void SynchronizeWorkbookPivotCacheReferences(WorkbookPart workbookPart,
         IReadOnlyList<IXLPivotTable> allPivotTables, SaveContext context)
     {
-        context.PivotSourceCacheId = 0;
+        context.PivotCacheIds.Clear();
         var xlUsedCaches = new List<XLPivotCache>();
         var seenUsedCaches = new HashSet<IXLPivotCache>();
         foreach (var pt in allPivotTables)
@@ -1033,10 +1033,11 @@ public partial class XLWorkbook
             var pivotCaches = new PivotCaches();
             workbookPart.Workbook!.PivotCaches = pivotCaches;
 
-            foreach (var source in xlUsedCaches)
+            for (var i = 0; i < xlUsedCaches.Count; i++)
             {
-                var cacheId = context.PivotSourceCacheId++;
-                source.CacheId = cacheId;
+                var source = xlUsedCaches[i];
+                var cacheId = (uint)i;
+                context.PivotCacheIds[source] = cacheId;
                 pivotCaches.AppendChild(new PivotCache { CacheId = cacheId, Id = source.WorkbookCacheRelId });
             }
         }

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -1,0 +1,103 @@
+# TODO triage — SonarQube INFO issues (XLibur_XLibur)
+
+Source: SonarQube, `impactSeverities=INFO`, `issueStatuses=OPEN,CONFIRMED`, 27 issues
+(10 × `csharpsquid:S1135` TODO tags, 17 × `csharpsquid:S1133` deprecated code).
+
+Each item below was read in context and checked against the surrounding code. Verdicts:
+
+- **Stale** — removed from the code, no follow-up.
+- **Partly stale** — comment corrected, remaining work tracked.
+- **Genuine** — tracked as a task.
+
+---
+
+## Part 1 — TODO comments (S1135)
+
+| # | Location | Verdict | Task |
+|---|----------|---------|------|
+| 6 | `Coordinates/SheetPoint.cs:47` | **Stale — removed** | — |
+| 3 | `CalcEngine/DependencyTree.cs:98` | **Partly stale — reworded** | #5 |
+| 1 | `CalcEngine/AstNode.cs:298` | Genuine (perf) | #6 |
+| 2 | `CalcEngine/DependenciesVisitor.cs:194` | Genuine (correctness) | #4 |
+| 4 | `CalcEngine/Visitors/FormulaReferences.cs:103` | Genuine (correctness) | #4 |
+| 7 | `DataValidation/XLDataValidations.cs:278` | Genuine (**bug**) | #1 |
+| 10 | `IO/PivotTableDefinitionPartReader.cs:127` | Genuine (data loss) | #2 |
+| 11 | `IO/PivotTableDefinitionPartReader.cs:132` | Genuine (data loss) | #3 |
+| 12 | `IO/PivotTableDefinitionPartWriter2.cs:79` | Genuine (trivial) | #7 |
+| 17 | `PivotTables/XLPivotReference.cs:56` | Genuine (hardening) | #8 |
+
+### Removed as stale
+
+**#6 `SheetPoint.cs:47`** — `/// TODO: SheetId doesn't work nicely with renames, but will in
+the future.` Aspirational, no actionable content, and contradicted by the `<summary>` directly
+below it, which already documents the real semantics (a sheet id never changes during the
+workbook lifecycle; it is *deletion*, not renaming, that invalidates a point). It was also
+malformed — a bare `///` line sitting above the `<summary>` tag rather than inside it.
+
+### Corrected
+
+**#3 `DependencyTree.cs:98`** — was `// TODO: Implement other formulas. Don't throw on data
+table or shared formulas.` The "don't throw" half is stale: `CreateFrom` skips unhandled
+formula types silently, nothing throws, and `FormulaType.Shared` is marked `// Not used` in
+`XLCellFormula.cs:15`. The genuine remainder is that data-table formulas are never registered.
+Comment rewritten to say only that; work tracked as task #5.
+
+### Verification notes for the genuine ones
+
+- **#7 (data validations)** is a real defect, not a nicety. `SplitBy` can leave a rule with
+  zero areas, `Consolidate` preserves it, and `DataValidationWriter` then emits
+  `sqref=""` — invalid per the schema.
+- **#10 / #11 (pivot)** are both round-trip data loss. The `chartFormat` *attribute* is
+  handled; the `<chartFormats>` and `<filters>` *elements* are not read or written at all.
+  Note #11 is not the report/page filters — those are supported via `XLPivotTable.Filters`.
+- **#2 and #4** are the same underlying gap (structured references) seen from two sides, so
+  they share one task.
+
+---
+
+## Part 2 — Deprecated code (S1133) — items 5, 8, 9, 13–16, 18–27
+
+**None of these are stale.** All 17 are deliberate, correctly-written `[Obsolete]` shims doing
+their job. S1133 flags them by design and will keep flagging them until they are deleted.
+
+They are shipped public API (tracked in `PublicAPI.Shipped.txt`), so removal is a breaking
+change and a release-planning decision — not something to action item by item. Tracked as a
+single decision, **task #10**, covering three groups:
+
+| Group | Members | Locations |
+|-------|---------|-----------|
+| `NamedRange`/`NamedRanges` → `DefinedName`/`DefinedNames` | 10 | `IXLDefinedNames.cs:10`, `XLDefinedNames.cs:38`, `IXLWorkbook.cs:64,199`, `IXLWorksheet.cs:306,314`, `XLWorkbook.cs:145,275`, `XLWorksheet.cs:120,597` |
+| `SetDataValidation` → `GetDataValidation`/`CreateDataValidation` | 5 | `XLCell.cs:973`, `IXLRangeBase.cs:306`, `IXLRanges.cs:60`, `XLRangeBase.cs:1289`, `XLRanges.cs:319` |
+| `XLFontCharSet.Hangeul` → `Hangul` | 1 | `IXLFont.cs:66` |
+
+**Explicitly excluded from removal:** `XLColor.NoColor` (`XLColor_Static.cs:284`, item 22) was
+deprecated deliberately and recently in PR #232 — see `CHANGELOG.md:182`. It needs a normal
+deprecation period before it can be considered.
+
+### Two findings surfaced while triaging this part
+
+- **Task #9** — the `SetDataValidation` deprecation is only half-applied.
+  `IXLBaseCollection<TSingle, TMultiple>.SetDataValidation()` (`IXLBaseCollection.cs:11`, the
+  interface behind `IXLColumns`/`IXLRows`/`IXLCells`) is shipped public API
+  (`PublicAPI.Shipped.txt:176`) but carries no `[Obsolete]` and has no `CreateDataValidation()`
+  counterpart. Sonar missed it precisely because the attribute is absent.
+- **Task #11** — `XLWorksheet.cs:597` reads `"Used {nameof(DefinedName)} instead."`; should be
+  "Use", matching its nine siblings.
+
+---
+
+## Task summary
+
+| Task | Item(s) | Kind |
+|------|---------|------|
+| #1 | 7 | Bug — empty data validations written with empty `sqref` |
+| #2 | 10 | Feature — pivot `chartFormats` round trip |
+| #3 | 11 | Feature — pivot `filters` round trip |
+| #4 | 2, 4 | Correctness — structured references in the dependency tree |
+| #5 | 3 | Perf — register data-table formulas in the dependency tree |
+| #6 | 1 | Perf — cache parsed reference addresses |
+| #7 | 12 | Cleanup — `CacheId` nullability |
+| #8 | 17 | Hardening — validate pivot field item values |
+| #9 | — | Gap — complete the `SetDataValidation` deprecation |
+| #10 | 5, 8, 9, 13–16, 18–27 | Decision — removal release for 17 obsolete members |
+| #11 | — | Typo — `"Used"` → `"Use"` |


### PR DESCRIPTION
Actions TODO item #10 from the triage (`PivotTableDefinitionPartReader.cs:127`, `// TODO: chartFormats`).

**Base is `fix/pivot-cache-id-nullability`** (#287), because it touches the same writer. It is a *sibling* of #288, not stacked under it — both branch from #287 and are independent of each other.

## The data loss

A PivotChart keeps its manual per-series and per-point formatting in the chart part, but the `chartFormats` collection on the pivot table is what ties each formatting record to the pivot area it applies to. The reader skipped the element entirely, so loading and saving a workbook with a formatted PivotChart dropped every link and the formatting silently disappeared.

Worth separating from something that already worked: the `chartFormat` **attribute** was handled (`XLPivotTable.ChartFormat`, written at `PivotTableDefinitionPartWriter2.cs:143`) — that is the pivot table id `/chartSpace/pivotSource/fmtId/@val` points at. This PR is about the `chartFormats` **element**.

## The change

Follows the existing `formats`/`conditionalFormats` pattern exactly:

- `XLPivotChartFormat`, mirroring `XLPivotFormat`
- `LoadChartFormats` in the reader, `WriteChartFormats` in the writer
- both reuse `LoadPivotArea`/`WritePivotArea`, so the pivot area travels with the ids

The write sits between `conditionalFormats` and `pivotTableStyleInfo`, where the schema sequence puts it, and emits nothing when the collection is empty — an empty `chartFormats` element is not valid, and almost no pivot table has a chart. `chart` and `format` are required attributes so they are always written; `series` only when true.

## Tests

4 added in `PivotChartFormatTests`, on a minimal workbook whose pivot table carries two records — one formatting a whole series, one a single point:

- the ids survive
- **the pivot area inside the record survives** — a round trip that kept only the ids would still lose the link, so this is asserted separately
- the loaded model exposes them
- nothing is written for a pivot table without a chart

**3 of the 4 fail against the unfixed reader/writer** — verified by stashing the change. The fourth is the no-chart case, which passed before and must keep passing.

## Test plan

- [x] Full suite green on **net10.0** — 11,631 passed, 4 skipped
- [x] Full suite green on **net8.0** — 11,631 passed, 4 skipped
- [x] `dotnet build XLibur/XLibur.csproj -c Release` — 0 warnings
- [x] New tests verified to fail without the reader/writer changes