### PR TITLE
fix(worksheet): correct Use/Used typo in the NamedRange obsolete message

### DIFF
--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -594,7 +594,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
     }
 
 
-    [Obsolete($"Used {nameof(DefinedName)} instead.")]
+    [Obsolete($"Use {nameof(DefinedName)} instead.")]
     IXLDefinedName IXLWorksheet.NamedRange(string rangeName) => DefinedName(rangeName);
 
     IXLDefinedName IXLWorksheet.DefinedName(string name) => DefinedName(name);


### PR DESCRIPTION
Actions TODO task #11 from the triage. Based on `main` — independent of everything else in flight.

`XLWorksheet.cs:597` read `"Used {nameof(DefinedName)} instead."` where its nine sibling deprecations read `"Use"`. The message surfaces in the compiler warning consumers see, so the typo is user-visible.

Message text only — not part of the API signature, so `PublicAPI.*.txt` are unaffected.

## Test plan

- [x] `dotnet build XLibur/XLibur.csproj -c Release` — 0 warnings
- No test changes: a one-word string literal in an attribute.