### PR TITLE
feat(pivot): round-trip the chartFormats collection

### DIFF
--- a/XLibur.Tests/Excel/PivotTables/PivotChartFormatTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotChartFormatTests.cs
@@ -1,0 +1,299 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using XLibur.Excel;
+using XLibur.Excel.IO;
+
+namespace XLibur.Tests.Excel.PivotTables;
+
+/// <summary>
+/// A PivotChart keeps its manual per-series and per-point formatting in the chart part, but the
+/// <c>chartFormats</c> collection on the pivot table is what ties each formatting record to the
+/// pivot area it applies to. Losing the collection on load leaves the chart pointing at nothing,
+/// so the formatting silently disappears on the next save.
+/// </summary>
+public class PivotChartFormatTests
+{
+    [Test]
+    public async Task ChartFormats_SurviveARoundTrip()
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithChartFormats(input);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        var written = ReadChartFormats(output);
+
+        await Assert.That(written.Count).IsEqualTo(2);
+
+        await Assert.That(written[0].Chart!.Value).IsEqualTo(0U);
+        await Assert.That(written[0].Format!.Value).IsEqualTo(3U);
+        await Assert.That(written[0].Series?.Value ?? false).IsTrue();
+        await Assert.That(written[0].PivotArea).IsNotNull();
+
+        await Assert.That(written[1].Chart!.Value).IsEqualTo(1U);
+        await Assert.That(written[1].Format!.Value).IsEqualTo(7U);
+        await Assert.That(written[1].Series?.Value ?? false).IsFalse();
+    }
+
+    /// <summary>
+    /// The pivot area is the half of the record that says what is being formatted, so a
+    /// round trip that kept only the ids would still lose the link.
+    /// </summary>
+    [Test]
+    public async Task ChartFormatPivotArea_SurvivesARoundTrip()
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithChartFormats(input);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        var pivotArea = ReadChartFormats(output)[0].PivotArea!;
+        var reference = pivotArea.PivotAreaReferences!.Elements<PivotAreaReference>().Single();
+
+        await Assert.That(reference.Field!.Value).IsEqualTo(0U);
+        await Assert.That(reference.Elements<FieldItem>().Single().Val!.Value).IsEqualTo(1U);
+    }
+
+    [Test]
+    public async Task LoadedChartFormats_AreExposedOnThePivotTable()
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithChartFormats(input);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        var pt = (XLPivotTable)wb.Worksheet("PivotSheet").PivotTables.Single();
+
+        await Assert.That(pt.ChartFormats.Count).IsEqualTo(2);
+        await Assert.That(pt.ChartFormats[0].Chart).IsEqualTo(0U);
+        await Assert.That(pt.ChartFormats[0].Format).IsEqualTo(3U);
+        await Assert.That(pt.ChartFormats[0].Series).IsTrue();
+    }
+
+    /// <summary>
+    /// The overwhelming majority of pivot tables have no chart, and an empty
+    /// <c>chartFormats</c> element is not valid, so nothing must be written for them.
+    /// </summary>
+    [Test]
+    public async Task PivotTableWithoutChartFormats_WritesNoChartFormatsElement()
+    {
+        using var wb = new XLWorkbook();
+        var data = wb.AddWorksheet("Data");
+        var range = data.FirstCell().InsertData(new object[]
+        {
+            ("Pastry", "Sold"),
+            ("Waffle", 3),
+            ("Donut", 5),
+        });
+
+        var pivots = wb.AddWorksheet("Pivots");
+        var pt = pivots.PivotTables.Add("pvt", pivots.Cell("A1"), range);
+        pt.RowLabels.Add("Pastry");
+        pt.Values.Add("Sold");
+
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var definition = doc.WorkbookPart!.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Single()
+            .PivotTableDefinition;
+
+        await Assert.That(definition.Elements<ChartFormats>().Any()).IsFalse();
+    }
+
+    private static System.Collections.Generic.List<ChartFormat> ReadChartFormats(MemoryStream saved)
+    {
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        var definition = doc.WorkbookPart!.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Single()
+            .PivotTableDefinition;
+
+        return definition.Elements<ChartFormats>()
+            .SelectMany(cf => cf.Elements<ChartFormat>())
+            .ToList();
+    }
+
+    /// <summary>
+    /// A minimal workbook whose pivot table carries a <c>chartFormats</c> collection: one record
+    /// formatting a whole series and one formatting a single point.
+    /// </summary>
+    private static void CreateWorkbookWithChartFormats(Stream stream)
+    {
+        using var doc = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+        var workbookPart = doc.AddWorkbookPart();
+        workbookPart.Workbook = new Workbook();
+        var sheets = workbookPart.Workbook.AppendChild(new Sheets());
+
+        var dataSheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(dataSheetPart), SheetId = 1, Name = "Data" });
+
+        var sheetData = new SheetData();
+        sheetData.Append(CreateRow(1, "Name", "Revenue"));
+        sheetData.Append(CreateNumericRow(2, "Cookies", 500));
+        sheetData.Append(CreateNumericRow(3, "Cake", 800));
+        dataSheetPart.Worksheet = new Worksheet(sheetData);
+
+        var pivotSheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(pivotSheetPart), SheetId = 2, Name = "PivotSheet" });
+        pivotSheetPart.Worksheet = new Worksheet(new SheetData());
+
+        var cachePart = workbookPart.AddNewPart<PivotTableCacheDefinitionPart>();
+        var cachePartId = workbookPart.GetIdOfPart(cachePart);
+
+        var cacheDefinition = new PivotCacheDefinition
+        {
+            Id = "rId1",
+            RefreshOnLoad = true,
+            CreatedVersion = 5,
+            RefreshedVersion = 5,
+        };
+        cacheDefinition.AddNamespaceDeclaration("r", OpenXmlConst.RelationshipsNs);
+
+        var cacheSource = new CacheSource { Type = SourceValues.Worksheet };
+        cacheSource.Append(new WorksheetSource { Sheet = "Data", Reference = "A1:B3" });
+        cacheDefinition.Append(cacheSource);
+
+        var cacheFields = new CacheFields();
+
+        var nameField = new CacheField { Name = "Name" };
+        var nameShared = new SharedItems { ContainsSemiMixedTypes = false, ContainsString = true, ContainsNumber = false, Count = 2 };
+        nameShared.Append(new StringItem { Val = "Cookies" });
+        nameShared.Append(new StringItem { Val = "Cake" });
+        nameField.SharedItems = nameShared;
+        cacheFields.Append(nameField);
+
+        var revenueField = new CacheField { Name = "Revenue" };
+        revenueField.SharedItems = new SharedItems
+        {
+            ContainsSemiMixedTypes = false,
+            ContainsString = false,
+            ContainsNumber = true,
+            MinValue = 500,
+            MaxValue = 800,
+        };
+        cacheFields.Append(revenueField);
+
+        cacheFields.Count = 2;
+        cacheDefinition.Append(cacheFields);
+
+        var recordsPart = cachePart.AddNewPart<PivotTableCacheRecordsPart>();
+        var records = new PivotCacheRecords { Count = 2 };
+        records.Append(new PivotCacheRecord(new FieldItem { Val = 0 }, new NumberItem { Val = 500 }));
+        records.Append(new PivotCacheRecord(new FieldItem { Val = 1 }, new NumberItem { Val = 800 }));
+        recordsPart.PivotCacheRecords = records;
+
+        cachePart.PivotCacheDefinition = cacheDefinition;
+
+        var pivotCaches = new PivotCaches();
+        pivotCaches.Append(new PivotCache { CacheId = 0, Id = cachePartId });
+        workbookPart.Workbook.Append(pivotCaches);
+
+        var pivotTablePart = pivotSheetPart.AddNewPart<PivotTablePart>();
+        pivotTablePart.CreateRelationshipToPart(cachePart);
+
+        var pivotTableDef = new PivotTableDefinition
+        {
+            Name = "PivotTable1",
+            CacheId = 0,
+            DataCaption = "Values",
+            CreatedVersion = 5,
+            UpdatedVersion = 5,
+        };
+
+        pivotTableDef.Append(new Location { Reference = "A1:B4", FirstHeaderRow = 1, FirstDataRow = 2, FirstDataColumn = 1 });
+
+        var pivotFields = new PivotFields { Count = 2 };
+        var pf0 = new PivotField { Axis = PivotTableAxisValues.AxisRow, ShowAll = false };
+        var items0 = new Items { Count = 3 };
+        items0.Append(new Item { Index = 0 });
+        items0.Append(new Item { Index = 1 });
+        items0.Append(new Item { ItemType = ItemValues.Default });
+        pf0.Append(items0);
+        pivotFields.Append(pf0);
+        pivotFields.Append(new PivotField { DataField = true, ShowAll = false });
+        pivotTableDef.Append(pivotFields);
+
+        var rowFields = new RowFields { Count = 1 };
+        rowFields.Append(new Field { Index = 0 });
+        pivotTableDef.Append(rowFields);
+
+        var rowItems = new RowItems { Count = 3 };
+        rowItems.Append(new RowItem(new MemberPropertyIndex { Val = 0 }));
+        rowItems.Append(new RowItem(new MemberPropertyIndex { Val = 1 }));
+        rowItems.Append(new RowItem(new MemberPropertyIndex()) { ItemType = ItemValues.Grand });
+        pivotTableDef.Append(rowItems);
+
+        var colItems = new ColumnItems { Count = 1 };
+        colItems.Append(new RowItem(new MemberPropertyIndex()) { ItemType = ItemValues.Grand });
+        pivotTableDef.Append(colItems);
+
+        var dataFields = new DataFields { Count = 1 };
+        dataFields.Append(new DataField { Name = "Sum of Revenue", Field = 1 });
+        pivotTableDef.Append(dataFields);
+
+        // The element under test. Schema order puts chartFormats after dataFields and before
+        // pivotTableStyleInfo.
+        var chartFormats = new ChartFormats { Count = 2 };
+        chartFormats.Append(BuildChartFormat(chart: 0, format: 3, series: true, fieldItem: 1));
+        chartFormats.Append(BuildChartFormat(chart: 1, format: 7, series: false, fieldItem: 0));
+        pivotTableDef.Append(chartFormats);
+
+        pivotTableDef.Append(new PivotTableStyle { Name = "PivotStyleLight16", ShowRowHeaders = true, ShowColumnHeaders = true });
+
+        pivotTablePart.PivotTableDefinition = pivotTableDef;
+    }
+
+    private static ChartFormat BuildChartFormat(uint chart, uint format, bool series, uint fieldItem)
+    {
+        var pivotArea = new PivotArea { DataOnly = false, Outline = false, FieldPosition = 0U };
+        var references = new PivotAreaReferences { Count = 1 };
+        var reference = new PivotAreaReference { Field = 0U, Count = 1U, Selected = false };
+        reference.Append(new FieldItem { Val = fieldItem });
+        references.Append(reference);
+        pivotArea.Append(references);
+
+        var chartFormat = new ChartFormat { Chart = chart, Format = format, Series = series };
+        chartFormat.Append(pivotArea);
+        return chartFormat;
+    }
+
+    private static Row CreateRow(uint rowIndex, params string[] values)
+    {
+        var row = new Row { RowIndex = rowIndex };
+        for (var i = 0; i < values.Length; i++)
+        {
+            row.Append(new Cell
+            {
+                CellReference = $"{(char)('A' + i)}{rowIndex}",
+                DataType = CellValues.String,
+                CellValue = new CellValue(values[i]),
+            });
+        }
+
+        return row;
+    }
+
+    private static Row CreateNumericRow(uint rowIndex, string name, double value)
+    {
+        var row = new Row { RowIndex = rowIndex };
+        row.Append(new Cell { CellReference = $"A{rowIndex}", DataType = CellValues.String, CellValue = new CellValue(name) });
+        row.Append(new Cell { CellReference = $"B{rowIndex}", DataType = CellValues.Number, CellValue = new CellValue(value) });
+        return row;
+    }
+}

--- a/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -124,7 +124,8 @@ internal static class PivotTableDefinitionPartReader
 
         LoadConditionalFormats(pivotTable.ConditionalFormats, xlPivotTable, sheet, context);
 
-        // TODO: chartFormats
+        LoadChartFormats(pivotTable.ChartFormats, xlPivotTable);
+
         // pivotHierarchies is OLAP and thus for now out of scope.
         var pivotTableStyle = pivotTable.GetFirstChild<PivotTableStyle>();
         LoadPivotTableStyle(pivotTableStyle, xlPivotTable);
@@ -192,6 +193,34 @@ internal static class PivotTableDefinitionPartReader
                 DxfStyleValue = dxfStyle.Value,
             };
             xlPivotTable.AddFormat(xlFormat);
+        }
+    }
+
+    /// <summary>
+    /// Load the <c>chartFormats</c> collection — the manual formatting a PivotChart carries for
+    /// individual series and data points. The chart part holds the formatting itself; these
+    /// records tie each one to the pivot area it applies to, so dropping them leaves the chart
+    /// pointing at nothing.
+    /// </summary>
+    private static void LoadChartFormats(ChartFormats? chartFormats, XLPivotTable xlPivotTable)
+    {
+        if (chartFormats is null)
+            return;
+
+        foreach (var chartFormat in chartFormats.Cast<ChartFormat>())
+        {
+            var chart = chartFormat.Chart?.Value ?? throw PartStructureException.MissingAttribute();
+            var format = chartFormat.Format?.Value ?? throw PartStructureException.MissingAttribute();
+            var series = chartFormat.Series?.Value ?? false;
+
+            var pivotArea = chartFormat.PivotArea ?? throw PartStructureException.ExpectedElementNotFound();
+            var xlChartFormat = new XLPivotChartFormat(LoadPivotArea(pivotArea))
+            {
+                Chart = chart,
+                Format = format,
+                Series = series,
+            };
+            xlPivotTable.AddChartFormat(xlChartFormat);
         }
     }
 

--- a/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -51,6 +51,7 @@ internal static class PivotTableDefinitionPartWriter2
         WriteDataFields(xml, pt, context);
         WriteFormats(xml, pt, context);
         WriteConditionalFormats(xml, pt);
+        WriteChartFormats(xml, pt);
         WritePivotTableStyleInfo(xml, pt);
 
         // Because extensions are pretty large, always write them.
@@ -410,6 +411,33 @@ internal static class PivotTableDefinitionPartWriter2
             }
             xml.WriteEndElement(); // formats
         }
+    }
+
+    /// <summary>
+    /// Write the <c>chartFormats</c> collection. Sits between <c>conditionalFormats</c> and
+    /// <c>pivotTableStyleInfo</c>, which is where the schema sequence puts it.
+    /// </summary>
+    private static void WriteChartFormats(XmlWriter xml, XLPivotTable pt)
+    {
+        if (pt.ChartFormats.Count == 0)
+            return;
+
+        xml.WriteStartElement("chartFormats", Main2006SsNs);
+        xml.WriteAttribute("count", pt.ChartFormats.Count);
+        foreach (var chartFormat in pt.ChartFormats)
+        {
+            xml.WriteStartElement("chartFormat", Main2006SsNs);
+
+            // chart and format are required, so they are written even at their default value.
+            xml.WriteAttribute("chart", chartFormat.Chart);
+            xml.WriteAttribute("format", chartFormat.Format);
+            xml.WriteAttributeDefault("series", chartFormat.Series, false);
+
+            WritePivotArea(xml, chartFormat.PivotArea);
+            xml.WriteEndElement(); // chartFormat
+        }
+
+        xml.WriteEndElement(); // chartFormats
     }
 
     private static void WriteConditionalFormats(XmlWriter xml, XLPivotTable pt)

--- a/XLibur/Excel/PivotTables/XLPivotChartFormat.cs
+++ b/XLibur/Excel/PivotTables/XLPivotChartFormat.cs
@@ -1,0 +1,40 @@
+namespace XLibur.Excel;
+
+/// <summary>
+/// A link between a pivot area and a formatting record of a pivot chart. Excel writes one per
+/// chart element it has formatted by hand, so dropping them loses the manual formatting of a
+/// PivotChart even though the chart part itself survives.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="XLPivotTable.ChartFormat"/>, which is the pivot table's own
+/// <c>chartFormat</c> attribute — an id used by <c>/chartSpace/pivotSource/fmtId/@val</c> to tie
+/// a chart to this table. This type is an entry of the <c>chartFormats</c> collection.
+/// </remarks>
+internal sealed class XLPivotChartFormat
+{
+    internal XLPivotChartFormat(XLPivotArea pivotArea)
+    {
+        PivotArea = pivotArea;
+    }
+
+    /// <summary>
+    /// Pivot area the chart formatting applies to.
+    /// </summary>
+    internal XLPivotArea PivotArea { get; }
+
+    /// <summary>
+    /// Zero-based index of the chart element this record formats.
+    /// </summary>
+    internal uint Chart { get; init; }
+
+    /// <summary>
+    /// Index of the formatting record held by the chart part itself. XLibur does not interpret
+    /// it — the value is round-tripped so the chart keeps pointing at the right record.
+    /// </summary>
+    internal uint Format { get; init; }
+
+    /// <summary>
+    /// Whether the record formats a whole data series rather than a single data point.
+    /// </summary>
+    internal bool Series { get; init; }
+}

--- a/XLibur/Excel/PivotTables/XLPivotTable.cs
+++ b/XLibur/Excel/PivotTables/XLPivotTable.cs
@@ -23,6 +23,7 @@ internal sealed class XLPivotTable : IXLPivotTable
 
     private readonly List<XLPivotFormat> _formats = new();
     private readonly List<XLPivotConditionalFormat> _conditionalFormats = new();
+    private readonly List<XLPivotChartFormat> _chartFormats = new();
     private XLPivotCache _cache;
     private int _filterFieldsPageWrap;
     private bool _outline = true;
@@ -124,6 +125,8 @@ internal sealed class XLPivotTable : IXLPivotTable
     internal IReadOnlyList<XLPivotFormat> Formats => _formats;
 
     internal IReadOnlyList<XLPivotConditionalFormat> ConditionalFormats => _conditionalFormats;
+
+    internal IReadOnlyList<XLPivotChartFormat> ChartFormats => _chartFormats;
 
     public IXLPivotTable CopyTo(IXLCell targetCell)
     {
@@ -810,6 +813,11 @@ internal sealed class XLPivotTable : IXLPivotTable
     internal void AddConditionalFormat(XLPivotConditionalFormat conditionalFormat)
     {
         _conditionalFormats.Add(conditionalFormat);
+    }
+
+    internal void AddChartFormat(XLPivotChartFormat chartFormat)
+    {
+        _chartFormats.Add(chartFormat);
     }
 
     #region location


### PR DESCRIPTION
Actions TODO item #10 from the triage (`PivotTableDefinitionPartReader.cs:127`, `// TODO: chartFormats`).

Replaces #291, which was based on `fix/pivot-cache-id-nullability` (#287). That branch has since merged, so this is the same change rebased onto `main` — no content differences.

## The data loss

A PivotChart keeps its manual per-series and per-point formatting in the chart part, but the `chartFormats` collection on the pivot table is what ties each formatting record to the pivot area it applies to. The reader skipped the element entirely, so loading and saving a workbook with a formatted PivotChart dropped every link and the formatting silently disappeared.

Worth separating from something that already worked: the `chartFormat` **attribute** was handled (`XLPivotTable.ChartFormat`) — that is the pivot table id `/chartSpace/pivotSource/fmtId/@val` points at. This PR is about the `chartFormats` **element**.

## The change

Follows the existing `formats`/`conditionalFormats` pattern exactly:

- `XLPivotChartFormat`, mirroring `XLPivotFormat`
- `LoadChartFormats` in the reader, `WriteChartFormats` in the writer
- both reuse `LoadPivotArea`/`WritePivotArea`, so the pivot area travels with the ids

The write sits between `conditionalFormats` and `pivotTableStyleInfo`, where the schema sequence puts it, and emits nothing when the collection is empty — an empty `chartFormats` element is not valid, and almost no pivot table has a chart. `chart` and `format` are required attributes so they are always written; `series` only when true.

## Tests

4 added in `PivotChartFormatTests`, on a minimal workbook whose pivot table carries two records — one formatting a whole series, one a single point:

- the ids survive
- **the pivot area inside the record survives** — a round trip that kept only the ids would still lose the link, so this is asserted separately
- the loaded model exposes them
- nothing is written for a pivot table without a chart

**3 of the 4 fail against the unfixed reader/writer** — verified by stashing the change. The fourth is the no-chart case, which passed before and must keep passing.

## Test plan

- [x] Full suite green on **net10.0** against current `main` — 11,643 passed, 4 skipped
- [x] `dotnet build XLibur/XLibur.csproj -c Release` — 0 warnings
- [x] New tests verified to fail without the reader/writer changes