### PR TITLE
docs: close task #5 and record why

### DIFF
--- a/docs/todos.md
+++ b/docs/todos.md
@@ -107,17 +107,17 @@ its own period runs from this release.
 
 | Task | Item(s) | Kind | Status |
 |------|---------|------|--------|
-| #1 | 7 | Bug — empty data validations written with empty `sqref` | In review — [#290](https://github.com/XLibur/XLibur/pull/290) |
-| #2 | 10 | Feature — pivot `chartFormats` round trip | In review — [#294](https://github.com/XLibur/XLibur/pull/294) |
+| #1 | 7 | Bug — empty data validations written with empty `sqref` | **Merged** — [#290](https://github.com/XLibur/XLibur/pull/290) |
+| #2 | 10 | Feature — pivot `chartFormats` round trip | **Merged** — [#294](https://github.com/XLibur/XLibur/pull/294) |
 | #3 | 11 | Feature — pivot `filters` round trip | Not started |
-| #4 | 2, 4 | Correctness — structured references in the dependency tree | Not started |
-| #5 | 3 | Perf — register data-table formulas in the dependency tree | Not started |
+| #4 | 2, 4 | Correctness — structured references in the dependency tree | In review — [#297](https://github.com/XLibur/XLibur/pull/297) |
+| #5 | 3 | Perf — register data-table formulas in the dependency tree | **Closed, will not do** — see below |
 | #6 | 1 | Perf — cache parsed reference addresses | **Merged** — [#286](https://github.com/XLibur/XLibur/pull/286) |
 | #7 | 12 | Cleanup — `CacheId` nullability | **Merged** — [#287](https://github.com/XLibur/XLibur/pull/287) |
 | #8 | 17 | Hardening — validate pivot field item values | Not started |
-| #9 | — | Decision — dispose of the orphan `IXLBaseCollection` interface | Decided — deprecated now, removed after a deprecation period |
+| #9 | — | Decision — dispose of the orphan `IXLBaseCollection` interface | **Merged** — [#296](https://github.com/XLibur/XLibur/pull/296) |
 | #10 | 5, 8, 9, 13–16, 18–27 | Decision — removal release for 17 obsolete members | Decided — groups 1–3 removed in the next minor `v0.x`; removal not yet done |
-| #11 | — | Typo — `"Used"` → `"Use"` | In review — [#292](https://github.com/XLibur/XLibur/pull/292) |
+| #11 | — | Typo — `"Used"` → `"Use"` | **Merged** — [#292](https://github.com/XLibur/XLibur/pull/292) |
 
 ---
 
@@ -133,9 +133,12 @@ changes that mostly touch different files.
 | [#286](https://github.com/XLibur/XLibur/pull/286) | Task #6 | Merged |
 | [#287](https://github.com/XLibur/XLibur/pull/287) | Task #7 | Merged |
 | [#288](https://github.com/XLibur/XLibur/pull/288) | This section | Merged |
-| [#290](https://github.com/XLibur/XLibur/pull/290) | Task #1 | Open |
-| [#292](https://github.com/XLibur/XLibur/pull/292) | Task #11 | Open |
-| [#294](https://github.com/XLibur/XLibur/pull/294) | Task #2 (replaces #291, which was stacked on #287) | Open |
+| [#290](https://github.com/XLibur/XLibur/pull/290) | Task #1 | Merged |
+| [#292](https://github.com/XLibur/XLibur/pull/292) | Task #11 | Merged |
+| [#294](https://github.com/XLibur/XLibur/pull/294) | Task #2 (replaces #291, which was stacked on #287) | Merged |
+| [#295](https://github.com/XLibur/XLibur/pull/295) | Correction to the task #9 finding | Merged |
+| [#296](https://github.com/XLibur/XLibur/pull/296) | Task #9, plus the #9 and #10 decisions | Merged |
+| [#297](https://github.com/XLibur/XLibur/pull/297) | Task #4, plus the task #5 correction | Open |
 
 ### Task #6 — reference resolution (#286)
 
@@ -187,6 +190,19 @@ applies to — was never read or written, so manual chart formatting vanished on
 `XLPivotChartFormat` plus a reader and writer following the existing `formats`/`conditionalFormats`
 pattern. Not to be confused with the `chartFormat` *attribute*, which already worked.
 
+### Task #4 — structured references in the dependency tree (#297)
+
+`DependenciesVisitor` returned nothing for every structured reference, so `=SUM(Table1[Amount])`
+registered no precedents at all and kept serving a stale value when the table changed. The
+resolution `CalculationVisitor` already performed is now shared by both visitors through
+`StructuredReferenceResolver`, which also closed the `FormulaReferences` placeholder — the same
+gap from the other side.
+
+The resolver goes through an interface rather than taking workbook/worksheet/point directly, and
+that is load-bearing: `CalcContext.Worksheet` and `FormulaAddress` throw when an expression has
+no anchoring cell, and the original code only touched them on the paths that need a formula
+location. Passing them eagerly broke 33 tests.
+
 ### Task #9 — correction
 
 The entry above in Part 2 has been rewritten. The original claim — that this was a half-applied
@@ -194,12 +210,52 @@ deprecation on the interface behind `IXLColumns`/`IXLRows`/`IXLCells` — was wr
 extends `IXLBaseCollection` and nothing implements it. There is no deprecation to complete, only
 a disposal decision, which belongs with #10.
 
+### Task #5 — closed, will not do
+
+The triage entry said data-table formulas were "skipped, so their dependents fall back to a full
+recalculation", and treated the original TODO's *"don't throw on data table or shared formulas"*
+warning as stale. **That was wrong**, and the reasoning matters more than the outcome:
+
+- `DependencyTree.AddFormula` derives precedents by **parsing the formula text**
+  (`GetFormulaPrecedents` → `formula.GetAst(engine)` → `engine.Parse(formula.A1)`).
+- A data-table formula's text is the placeholder `{TABLE(A1,}`, which is not valid formula
+  syntax.
+- Parsing it throws `ExpressionParseException: Error at char 1 of '{TABLE(A1,}': Unexpected
+  token`. Verified directly rather than reasoned about.
+
+So adding `FormulaType.DataTable` to that chain would throw — exactly what the original TODO
+warned about. Registering them properly would need precedents built from `Input1`/`Input2` and
+the table's header formulas instead of from an AST.
+
+And the payoff would be small: XLibur does not evaluate data tables at all — there is no `TABLE`
+function registered — so a data-table cell's value never changes and its dependents never need
+invalidating. The only gain is dropping the full-workbook `Recalculate` that
+`XLCalcEngine.TryEvaluateSingleCell` triggers whenever a data-table cell is read.
+
+**Decision (owner): closed, will not do.** Revisit only if that recalculation shows up as a real
+performance problem. The comment in `DependencyTree` now records why data tables are skipped.
+
+### Open bug found while investigating #5
+
+`DataTableFormulaFormat` (`XLCellFormula.cs:34`) is `"{{TABLE({0},{1}}}"`, which produces
+`{TABLE(A1,}` — the closing parenthesis is missing. This is **user-visible**: `XLCell.FormulaA1`
+returns `Formula?.A1`, so anyone reading the formula of a data-table cell gets the malformed
+text. It does not affect files, because `SheetDataWriter` writes the `dataTable` element from the
+formula's attributes rather than from this string, and nothing parses it.
+
+Not fixed, because the correct target text is a judgement call — Excel displays
+`{=TABLE(row_input,col_input)}`, so this needs more than adding the missing bracket. No test
+depends on the current value.
+
 ### Still to do
 
-- **#4 + #5** — calc-engine dependency-tree work, taken next as a pair.
 - **#10 removal** — the decision is made but the code change is not: 16 members across three
-  groups, plus the `PublicAPI.*.txt` and `CHANGELOG.md` updates a breaking change needs.
+  groups, plus the `PublicAPI.*.txt` and `CHANGELOG.md` updates a breaking change needs, and
+  the test files that still call `NamedRange`/`NamedRanges`.
 - **#3** — the largest job left. `CT_PivotFilter` carries a required full `autoFilter` subtree,
   so it needs real OpenXML modelling rather than another pass of the `formats` pattern.
 - **#8** — smallest, but needs pivot-table/cache context threaded into a static loader to
   validate input, and risks rejecting files Excel accepts. Worth weighing before doing.
+- **The `DataTableFormulaFormat` bug** above, if the intended display text can be settled.
+
+Tasks #1, #2, #4, #6, #7, #9 and #11 are done; #5 is closed as will-not-do.


### PR DESCRIPTION
Docs only. Records the owner decision to close task #5 (register data-table formulas in the dependency tree) as **will-not-do**.

## Why it is closed

The reasoning matters more than the outcome, because the triage got this one wrong.

The triage entry treated the original TODO's *"don't throw on data table or shared formulas"* warning as **stale**. It was not:

- `DependencyTree.AddFormula` derives precedents by **parsing the formula text** (`GetFormulaPrecedents` → `formula.GetAst(engine)` → `engine.Parse(formula.A1)`).
- A data-table formula's text is the placeholder `{TABLE(A1,}` — not valid formula syntax.
- Parsing it throws `ExpressionParseException: Error at char 1 of '{TABLE(A1,}': Unexpected token`. **Verified directly** rather than reasoned about.

So adding `FormulaType.DataTable` to that chain would throw — exactly what the original TODO warned about. Registering them properly needs precedents built from `Input1`/`Input2` and the table's header formulas instead of from an AST.

And the payoff would have been small regardless: XLibur does not evaluate data tables at all (no `TABLE` function is registered), so a data-table cell's value never changes and its dependents never need invalidating. The only gain is dropping the full-workbook `Recalculate` that `XLCalcEngine.TryEvaluateSingleCell` triggers whenever a data-table cell is read.

The in-code comment explaining this is in #297.

## An open bug this surfaced

`DataTableFormulaFormat` (`XLCellFormula.cs:34`) is `"{{TABLE({0},{1}}}"`, producing `{TABLE(A1,}` — the closing parenthesis is missing.

This is **user-visible**: `XLCell.FormulaA1` returns `Formula?.A1`, so reading the formula of a data-table cell gives back the malformed text. Files are unaffected — `SheetDataWriter` writes the `dataTable` element from the formula's attributes, not from this string — and nothing parses it.

Left unfixed deliberately: Excel displays `{=TABLE(row_input,col_input)}`, so getting this right is more than adding the missing bracket, and the target text is a judgement call. No test depends on the current value. Recorded in the doc so it is not lost.

## Also

Refreshes task and PR status now that #290, #292, #294, #295 and #296 have merged, and updates the "still to do" list.

## Test plan

Not applicable — Markdown only.