### PR TITLE
ci: exclude the docs website from SonarCloud analysis

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,6 +77,7 @@ jobs:
           /d:sonar.token="$SONAR_TOKEN"
           /d:sonar.host.url="https://sonarcloud.io"
           /d:sonar.cs.vscoveragexml.reportsPaths="**/*coverage.xml"
+          /d:sonar.exclusions="docs-website/**"
           /d:sonar.coverage.exclusions="XLibur.Examples/**,XLibur.Benchmarks/**,XLibur.Report.Examples/**,XLibur.Report.Benchmarks/**"
           /d:sonar.cpd.exclusions="XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs,XLibur/Excel/CalcEngine/Functions/Distributions.cs,XLibur/Excel/CalcEngine/Functions/Regression.cs"
           /d:sonar.issue.ignore.multicriteria=e1


### PR DESCRIPTION
Adds `sonar.exclusions="docs-website/**"` to the `dotnet sonarscanner begin` invocation in `build-and-test.yml`.

`docs-website` is the Docusaurus site — its TypeScript config, sidebars and markdown are not part of the shipped library, so analysing them only adds noise to the quality gate. This excludes the directory from analysis entirely, not just from coverage.

There is no `sonar-project.properties` in the repo; the workflow step is the only place the scanner is configured.