### PR TITLE
feat(pivot): round-trip the filters collection

### DIFF
--- a/XLibur.Tests/Excel/PivotTables/PivotFilterTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotFilterTests.cs
@@ -1,0 +1,366 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using XLibur.Excel;
+using XLibur.Excel.IO;
+
+namespace XLibur.Tests.Excel.PivotTables;
+
+/// <summary>
+/// The <c>filters</c> collection holds the label, value, date and top-N filters applied to pivot
+/// fields — what Excel offers from a field's dropdown. Dropping it on load silently un-filters
+/// the pivot table on the next save, which changes what the workbook shows.
+/// </summary>
+/// <remarks>
+/// Not the report-filter axis: that is <c>pageFields</c>, modelled by
+/// <c>XLPivotTable.Filters</c>, and was already supported.
+/// </remarks>
+public class PivotFilterTests
+{
+    [Test]
+    public async Task PivotFilters_SurviveARoundTrip()
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithPivotFilters(input);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        var written = ReadPivotFilters(output);
+
+        await Assert.That(written.Count).IsEqualTo(2);
+
+        var caption = written[0];
+        await Assert.That(caption.Field!.Value).IsEqualTo(0U);
+        await Assert.That(caption.Id!.Value).IsEqualTo(1U);
+        await Assert.That(caption.Type!.InnerText).IsEqualTo("captionEqual");
+        await Assert.That(caption.StringValue1!.Value).IsEqualTo("Cookies");
+        await Assert.That(caption.Name!.Value).IsEqualTo("Only cookies");
+
+        var value = written[1];
+        await Assert.That(value.Field!.Value).IsEqualTo(1U);
+        await Assert.That(value.Id!.Value).IsEqualTo(2U);
+        await Assert.That(value.Type!.InnerText).IsEqualTo("valueGreaterThan");
+        await Assert.That(value.EvaluationOrder!.Value).IsEqualTo(-1);
+    }
+
+    /// <summary>
+    /// <c>autoFilter</c> is required by the schema and carries the actual criteria, so a round
+    /// trip that kept only the attributes would still lose what the filter does.
+    /// </summary>
+    [Test]
+    public async Task PivotFilterAutoFilter_SurvivesARoundTrip()
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithPivotFilters(input);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        var autoFilter = ReadPivotFilters(output)[0].AutoFilter;
+        await Assert.That(autoFilter).IsNotNull();
+
+        var filterColumn = autoFilter!.Elements<FilterColumn>().Single();
+        await Assert.That(filterColumn.ColumnId!.Value).IsEqualTo(0U);
+
+        var filterValue = filterColumn.Elements<Filters>().Single().Elements<Filter>().Single();
+        await Assert.That(filterValue.Val!.Value).IsEqualTo("Cookies");
+    }
+
+    /// <summary>
+    /// The top-N filter carries a <c>top10</c> child rather than a value list, so it exercises a
+    /// different branch of the preserved sub-tree.
+    /// </summary>
+    [Test]
+    public async Task PivotFilterTop10AutoFilter_SurvivesARoundTrip()
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithPivotFilters(input);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        var autoFilter = ReadPivotFilters(output)[1].AutoFilter!;
+        var top10 = autoFilter.Elements<FilterColumn>().Single().Elements<Top10>().Single();
+
+        await Assert.That(top10.Top!.Value).IsTrue();
+        await Assert.That(top10.Val!.Value).IsEqualTo(3D);
+    }
+
+    [Test]
+    public async Task LoadedPivotFilters_AreExposedOnThePivotTable()
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithPivotFilters(input);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        var pt = (XLPivotTable)wb.Worksheet("PivotSheet").PivotTables.Single();
+
+        await Assert.That(pt.PivotFilters.Count).IsEqualTo(2);
+        await Assert.That(pt.PivotFilters[0].Type).IsEqualTo("captionEqual");
+        await Assert.That(pt.PivotFilters[0].StringValue1).IsEqualTo("Cookies");
+        await Assert.That(pt.PivotFilters[1].EvaluationOrder).IsEqualTo(-1);
+        await Assert.That(pt.PivotFilters[1].AutoFilterXml).Contains("top10");
+    }
+
+    /// <summary>
+    /// Most pivot tables have no filters, and an empty <c>filters</c> element is not valid, so
+    /// nothing must be written for them.
+    /// </summary>
+    [Test]
+    public async Task PivotTableWithoutFilters_WritesNoFiltersElement()
+    {
+        using var wb = new XLWorkbook();
+        var data = wb.AddWorksheet("Data");
+        var range = data.FirstCell().InsertData(new object[]
+        {
+            ("Pastry", "Sold"),
+            ("Waffle", 3),
+            ("Donut", 5),
+        });
+
+        var pivots = wb.AddWorksheet("Pivots");
+        var pt = pivots.PivotTables.Add("pvt", pivots.Cell("A1"), range);
+        pt.RowLabels.Add("Pastry");
+        pt.Values.Add("Sold");
+
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var definition = doc.WorkbookPart!.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Single()
+            .PivotTableDefinition;
+
+        await Assert.That(definition.Elements<PivotFilters>().Any()).IsFalse();
+    }
+
+    private static List<PivotFilter> ReadPivotFilters(MemoryStream saved)
+    {
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        var definition = doc.WorkbookPart!.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Single()
+            .PivotTableDefinition;
+
+        return definition.Elements<PivotFilters>()
+            .SelectMany(f => f.Elements<PivotFilter>())
+            .ToList();
+    }
+
+    /// <summary>
+    /// A minimal workbook whose pivot table carries two filters: a caption filter holding a value
+    /// list, and a value filter holding a top-N.
+    /// </summary>
+    private static void CreateWorkbookWithPivotFilters(Stream stream)
+    {
+        using var doc = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+        var workbookPart = doc.AddWorkbookPart();
+        workbookPart.Workbook = new Workbook();
+        var sheets = workbookPart.Workbook.AppendChild(new Sheets());
+
+        var dataSheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(dataSheetPart), SheetId = 1, Name = "Data" });
+
+        var sheetData = new SheetData();
+        sheetData.Append(CreateRow(1, "Name", "Revenue"));
+        sheetData.Append(CreateNumericRow(2, "Cookies", 500));
+        sheetData.Append(CreateNumericRow(3, "Cake", 800));
+        dataSheetPart.Worksheet = new Worksheet(sheetData);
+
+        var pivotSheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(pivotSheetPart), SheetId = 2, Name = "PivotSheet" });
+        pivotSheetPart.Worksheet = new Worksheet(new SheetData());
+
+        var cachePart = workbookPart.AddNewPart<PivotTableCacheDefinitionPart>();
+        var cachePartId = workbookPart.GetIdOfPart(cachePart);
+
+        var cacheDefinition = new PivotCacheDefinition
+        {
+            Id = "rId1",
+            RefreshOnLoad = true,
+            CreatedVersion = 5,
+            RefreshedVersion = 5,
+        };
+        cacheDefinition.AddNamespaceDeclaration("r", OpenXmlConst.RelationshipsNs);
+
+        var cacheSource = new CacheSource { Type = SourceValues.Worksheet };
+        cacheSource.Append(new WorksheetSource { Sheet = "Data", Reference = "A1:B3" });
+        cacheDefinition.Append(cacheSource);
+
+        var cacheFields = new CacheFields();
+
+        var nameField = new CacheField { Name = "Name" };
+        var nameShared = new SharedItems { ContainsSemiMixedTypes = false, ContainsString = true, ContainsNumber = false, Count = 2 };
+        nameShared.Append(new StringItem { Val = "Cookies" });
+        nameShared.Append(new StringItem { Val = "Cake" });
+        nameField.SharedItems = nameShared;
+        cacheFields.Append(nameField);
+
+        var revenueField = new CacheField { Name = "Revenue" };
+        revenueField.SharedItems = new SharedItems
+        {
+            ContainsSemiMixedTypes = false,
+            ContainsString = false,
+            ContainsNumber = true,
+            MinValue = 500,
+            MaxValue = 800,
+        };
+        cacheFields.Append(revenueField);
+
+        cacheFields.Count = 2;
+        cacheDefinition.Append(cacheFields);
+
+        var recordsPart = cachePart.AddNewPart<PivotTableCacheRecordsPart>();
+        var records = new PivotCacheRecords { Count = 2 };
+        records.Append(new PivotCacheRecord(new FieldItem { Val = 0 }, new NumberItem { Val = 500 }));
+        records.Append(new PivotCacheRecord(new FieldItem { Val = 1 }, new NumberItem { Val = 800 }));
+        recordsPart.PivotCacheRecords = records;
+
+        cachePart.PivotCacheDefinition = cacheDefinition;
+
+        var pivotCaches = new PivotCaches();
+        pivotCaches.Append(new PivotCache { CacheId = 0, Id = cachePartId });
+        workbookPart.Workbook.Append(pivotCaches);
+
+        var pivotTablePart = pivotSheetPart.AddNewPart<PivotTablePart>();
+        pivotTablePart.CreateRelationshipToPart(cachePart);
+
+        var pivotTableDef = new PivotTableDefinition
+        {
+            Name = "PivotTable1",
+            CacheId = 0,
+            DataCaption = "Values",
+            CreatedVersion = 5,
+            UpdatedVersion = 5,
+        };
+
+        pivotTableDef.Append(new Location { Reference = "A1:B4", FirstHeaderRow = 1, FirstDataRow = 2, FirstDataColumn = 1 });
+
+        var pivotFields = new PivotFields { Count = 2 };
+        var pf0 = new PivotField { Axis = PivotTableAxisValues.AxisRow, ShowAll = false };
+        var items0 = new Items { Count = 3 };
+        items0.Append(new Item { Index = 0 });
+        items0.Append(new Item { Index = 1 });
+        items0.Append(new Item { ItemType = ItemValues.Default });
+        pf0.Append(items0);
+        pivotFields.Append(pf0);
+        pivotFields.Append(new PivotField { DataField = true, ShowAll = false });
+        pivotTableDef.Append(pivotFields);
+
+        var rowFields = new RowFields { Count = 1 };
+        rowFields.Append(new Field { Index = 0 });
+        pivotTableDef.Append(rowFields);
+
+        var rowItems = new RowItems { Count = 3 };
+        rowItems.Append(new RowItem(new MemberPropertyIndex { Val = 0 }));
+        rowItems.Append(new RowItem(new MemberPropertyIndex { Val = 1 }));
+        rowItems.Append(new RowItem(new MemberPropertyIndex()) { ItemType = ItemValues.Grand });
+        pivotTableDef.Append(rowItems);
+
+        var colItems = new ColumnItems { Count = 1 };
+        colItems.Append(new RowItem(new MemberPropertyIndex()) { ItemType = ItemValues.Grand });
+        pivotTableDef.Append(colItems);
+
+        var dataFields = new DataFields { Count = 1 };
+        dataFields.Append(new DataField { Name = "Sum of Revenue", Field = 1 });
+        pivotTableDef.Append(dataFields);
+
+        pivotTableDef.Append(new PivotTableStyle { Name = "PivotStyleLight16", ShowRowHeaders = true, ShowColumnHeaders = true });
+
+        // The element under test. Schema order puts filters after pivotTableStyleInfo.
+        var filters = new PivotFilters { Count = 2 };
+        filters.Append(BuildCaptionFilter());
+        filters.Append(BuildValueFilter());
+        pivotTableDef.Append(filters);
+
+        pivotTablePart.PivotTableDefinition = pivotTableDef;
+    }
+
+    /// <summary>
+    /// A caption filter whose <c>autoFilter</c> holds an explicit value list.
+    /// </summary>
+    private static PivotFilter BuildCaptionFilter()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        var filterValues = new Filters();
+        filterValues.Append(new Filter { Val = "Cookies" });
+        filterColumn.Append(filterValues);
+
+        var autoFilter = new AutoFilter { Reference = "A1:A3" };
+        autoFilter.Append(filterColumn);
+
+        var pivotFilter = new PivotFilter
+        {
+            Field = 0U,
+            Id = 1U,
+            Type = PivotFilterValues.CaptionEqual,
+            StringValue1 = "Cookies",
+            Name = "Only cookies",
+        };
+        pivotFilter.Append(autoFilter);
+        return pivotFilter;
+    }
+
+    /// <summary>
+    /// A value filter whose <c>autoFilter</c> holds a top-N instead, and a non-default
+    /// <c>evalOrder</c>.
+    /// </summary>
+    private static PivotFilter BuildValueFilter()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(new Top10 { Top = true, Val = 3D });
+
+        var autoFilter = new AutoFilter { Reference = "B1:B3" };
+        autoFilter.Append(filterColumn);
+
+        var pivotFilter = new PivotFilter
+        {
+            Field = 1U,
+            Id = 2U,
+            Type = PivotFilterValues.ValueGreaterThan,
+            EvaluationOrder = -1,
+        };
+        pivotFilter.Append(autoFilter);
+        return pivotFilter;
+    }
+
+    private static Row CreateRow(uint rowIndex, params string[] values)
+    {
+        var row = new Row { RowIndex = rowIndex };
+        for (var i = 0; i < values.Length; i++)
+        {
+            row.Append(new Cell
+            {
+                CellReference = $"{(char)('A' + i)}{rowIndex}",
+                DataType = CellValues.String,
+                CellValue = new CellValue(values[i]),
+            });
+        }
+
+        return row;
+    }
+
+    private static Row CreateNumericRow(uint rowIndex, string name, double value)
+    {
+        var row = new Row { RowIndex = rowIndex };
+        row.Append(new Cell { CellReference = $"A{rowIndex}", DataType = CellValues.String, CellValue = new CellValue(name) });
+        row.Append(new Cell { CellReference = $"B{rowIndex}", DataType = CellValues.Number, CellValue = new CellValue(value) });
+        return row;
+    }
+}

--- a/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -130,7 +130,8 @@ internal static class PivotTableDefinitionPartReader
         var pivotTableStyle = pivotTable.GetFirstChild<PivotTableStyle>();
         LoadPivotTableStyle(pivotTableStyle, xlPivotTable);
 
-        // TODO: filters
+        LoadPivotFilters(pivotTable.PivotFilters, xlPivotTable);
+
         // rowHierarchiesUsage is OLAP and thus for now out of scope.
         // colHierarchiesUsage is OLAP and thus for now out of scope.
         LoadExtensionList(pivotTable, xlPivotTable);
@@ -221,6 +222,43 @@ internal static class PivotTableDefinitionPartReader
                 Series = series,
             };
             xlPivotTable.AddChartFormat(xlChartFormat);
+        }
+    }
+
+    /// <summary>
+    /// Load the <c>filters</c> collection — the label, value, date and top-N filters applied to
+    /// pivot fields. Not the report-filter axis, which is <c>pageFields</c> and is loaded above.
+    /// </summary>
+    private static void LoadPivotFilters(PivotFilters? pivotFilters, XLPivotTable xlPivotTable)
+    {
+        if (pivotFilters is null)
+            return;
+
+        foreach (var pivotFilter in pivotFilters.Cast<PivotFilter>())
+        {
+            var field = pivotFilter.Field?.Value ?? throw PartStructureException.MissingAttribute();
+            var id = pivotFilter.Id?.Value ?? throw PartStructureException.MissingAttribute();
+
+            // The type token is kept as written rather than mapped to an enum: XLibur does not
+            // act on it, and a token survives a value a newer Excel introduced.
+            var type = pivotFilter.Type?.InnerText ?? throw PartStructureException.MissingAttribute();
+
+            // autoFilter is required by the schema and is a sub-tree in its own right, so it is
+            // carried through verbatim instead of being modelled.
+            var autoFilter = pivotFilter.AutoFilter ?? throw PartStructureException.ExpectedElementNotFound();
+
+            var xlPivotFilter = new XLPivotFilter(field, id, type, autoFilter.OuterXml)
+            {
+                EvaluationOrder = pivotFilter.EvaluationOrder?.Value ?? 0,
+                MemberPropertyField = pivotFilter.MemberPropertyFieldId?.Value,
+                MeasureHierarchy = pivotFilter.MeasureHierarchy?.Value,
+                MeasureField = pivotFilter.MeasureField?.Value,
+                Name = pivotFilter.Name?.Value,
+                Description = pivotFilter.Description?.Value,
+                StringValue1 = pivotFilter.StringValue1?.Value,
+                StringValue2 = pivotFilter.StringValue2?.Value,
+            };
+            xlPivotTable.AddPivotFilter(xlPivotFilter);
         }
     }
 

--- a/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -53,6 +53,7 @@ internal static class PivotTableDefinitionPartWriter2
         WriteConditionalFormats(xml, pt);
         WriteChartFormats(xml, pt);
         WritePivotTableStyleInfo(xml, pt);
+        WritePivotFilters(xml, pt);
 
         // Because extensions are pretty large, always write them.
         xml.WriteStartElement("extLst");
@@ -438,6 +439,43 @@ internal static class PivotTableDefinitionPartWriter2
         }
 
         xml.WriteEndElement(); // chartFormats
+    }
+
+    /// <summary>
+    /// Write the <c>filters</c> collection. Sits after <c>pivotTableStyleInfo</c>, which is
+    /// where the schema sequence puts it — not next to <c>formats</c>, despite the name.
+    /// </summary>
+    private static void WritePivotFilters(XmlWriter xml, XLPivotTable pt)
+    {
+        if (pt.PivotFilters.Count == 0)
+            return;
+
+        xml.WriteStartElement("filters", Main2006SsNs);
+        xml.WriteAttribute("count", pt.PivotFilters.Count);
+        foreach (var pivotFilter in pt.PivotFilters)
+        {
+            xml.WriteStartElement("filter", Main2006SsNs);
+
+            // fld, id and type are required, so they are written even at their default value.
+            xml.WriteAttribute("fld", pivotFilter.Field);
+            xml.WriteAttributeOptional("mpFld", pivotFilter.MemberPropertyField);
+            xml.WriteAttribute("type", pivotFilter.Type);
+            xml.WriteAttributeDefault("evalOrder", pivotFilter.EvaluationOrder, 0);
+            xml.WriteAttribute("id", pivotFilter.Id);
+            xml.WriteAttributeOptional("iMeasureHier", pivotFilter.MeasureHierarchy);
+            xml.WriteAttributeOptional("iMeasureFld", pivotFilter.MeasureField);
+            xml.WriteAttributeOptional("name", pivotFilter.Name);
+            xml.WriteAttributeOptional("description", pivotFilter.Description);
+            xml.WriteAttributeOptional("stringValue1", pivotFilter.StringValue1);
+            xml.WriteAttributeOptional("stringValue2", pivotFilter.StringValue2);
+
+            // Written back exactly as it was read. See XLPivotFilter.AutoFilterXml.
+            xml.WriteRaw(pivotFilter.AutoFilterXml);
+
+            xml.WriteEndElement(); // filter
+        }
+
+        xml.WriteEndElement(); // filters
     }
 
     private static void WriteConditionalFormats(XmlWriter xml, XLPivotTable pt)

--- a/XLibur/Excel/PivotTables/XLPivotFilter.cs
+++ b/XLibur/Excel/PivotTables/XLPivotFilter.cs
@@ -1,0 +1,95 @@
+namespace XLibur.Excel;
+
+/// <summary>
+/// A filter applied to a pivot table field — the label, value, date and top-N filters Excel
+/// offers from a field's dropdown. One entry of the <c>filters</c> collection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distinct from <see cref="XLPivotTable.Filters"/>, which models the report-filter axis (the
+/// <c>pageFields</c> element, shown above the table). These are the filters that narrow which
+/// items of a field appear at all.
+/// </para>
+/// <para>
+/// XLibur has no API for creating or interpreting these yet, so the type exists to carry them
+/// through a load/save unchanged. The attributes are modelled because they are the part anyone
+/// exposing an API would need; <see cref="AutoFilterXml"/> is kept verbatim because
+/// <c>CT_AutoFilter</c> is a whole sub-tree of its own (<c>filterColumn</c> with any of
+/// <c>filters</c>, <c>top10</c>, <c>customFilters</c>, <c>dynamicFilter</c>, <c>colorFilter</c>
+/// or <c>iconFilter</c>) and modelling it would be a large surface with nothing reading it.
+/// </para>
+/// </remarks>
+internal sealed class XLPivotFilter
+{
+    internal XLPivotFilter(uint field, uint id, string type, string autoFilterXml)
+    {
+        Field = field;
+        Id = id;
+        Type = type;
+        AutoFilterXml = autoFilterXml;
+    }
+
+    /// <summary>
+    /// Index of the pivot field the filter applies to.
+    /// </summary>
+    internal uint Field { get; }
+
+    /// <summary>
+    /// Identifier of the filter, unique within the pivot table.
+    /// </summary>
+    internal uint Id { get; }
+
+    /// <summary>
+    /// The <c>ST_PivotFilterType</c> token, e.g. <c>captionEqual</c> or <c>dateNewerThan</c>.
+    /// Held as the raw token rather than an enum: there are around forty values, XLibur does not
+    /// act on any of them, and a token round-trips a file written by a newer Excel that uses a
+    /// value this build has never heard of.
+    /// </summary>
+    internal string Type { get; }
+
+    /// <summary>
+    /// The <c>autoFilter</c> child, verbatim, including its element tags. Required by the
+    /// schema, so every filter has one.
+    /// </summary>
+    internal string AutoFilterXml { get; }
+
+    /// <summary>
+    /// Order the filter is evaluated in relative to the other filters. Default <c>0</c>.
+    /// </summary>
+    internal int EvaluationOrder { get; init; }
+
+    /// <summary>
+    /// Index of the OLAP member property field the filter is based on (<c>mpFld</c>).
+    /// </summary>
+    internal uint? MemberPropertyField { get; init; }
+
+    /// <summary>
+    /// OLAP measure hierarchy the filter is based on (<c>iMeasureHier</c>).
+    /// </summary>
+    internal uint? MeasureHierarchy { get; init; }
+
+    /// <summary>
+    /// OLAP measure field the filter is based on (<c>iMeasureFld</c>).
+    /// </summary>
+    internal uint? MeasureField { get; init; }
+
+    /// <summary>
+    /// Name shown for the filter.
+    /// </summary>
+    internal string? Name { get; init; }
+
+    /// <summary>
+    /// Description shown for the filter.
+    /// </summary>
+    internal string? Description { get; init; }
+
+    /// <summary>
+    /// First string operand of the filter, for the types that take one.
+    /// </summary>
+    internal string? StringValue1 { get; init; }
+
+    /// <summary>
+    /// Second string operand, for the types that take a range (e.g. <c>captionBetween</c>).
+    /// </summary>
+    internal string? StringValue2 { get; init; }
+}

--- a/XLibur/Excel/PivotTables/XLPivotTable.cs
+++ b/XLibur/Excel/PivotTables/XLPivotTable.cs
@@ -24,6 +24,7 @@ internal sealed class XLPivotTable : IXLPivotTable
     private readonly List<XLPivotFormat> _formats = new();
     private readonly List<XLPivotConditionalFormat> _conditionalFormats = new();
     private readonly List<XLPivotChartFormat> _chartFormats = new();
+    private readonly List<XLPivotFilter> _pivotFilters = new();
     private XLPivotCache _cache;
     private int _filterFieldsPageWrap;
     private bool _outline = true;
@@ -127,6 +128,12 @@ internal sealed class XLPivotTable : IXLPivotTable
     internal IReadOnlyList<XLPivotConditionalFormat> ConditionalFormats => _conditionalFormats;
 
     internal IReadOnlyList<XLPivotChartFormat> ChartFormats => _chartFormats;
+
+    /// <summary>
+    /// Label, value, date and top-N filters on the pivot fields. Not the report-filter axis,
+    /// which is <see cref="Filters"/>.
+    /// </summary>
+    internal IReadOnlyList<XLPivotFilter> PivotFilters => _pivotFilters;
 
     public IXLPivotTable CopyTo(IXLCell targetCell)
     {
@@ -818,6 +825,11 @@ internal sealed class XLPivotTable : IXLPivotTable
     internal void AddChartFormat(XLPivotChartFormat chartFormat)
     {
         _chartFormats.Add(chartFormat);
+    }
+
+    internal void AddPivotFilter(XLPivotFilter pivotFilter)
+    {
+        _pivotFilters.Add(pivotFilter);
     }
 
     #region location


### PR DESCRIPTION
Actions TODO item #11 from the triage — the last data-loss item (`PivotTableDefinitionPartReader.cs`, `// TODO: filters`). Based on `main`.

## The data loss

The `filters` element holds the label, value, date and top-N filters applied to pivot fields — what Excel offers from a field's dropdown. The reader skipped it entirely, so loading and saving a workbook **silently un-filtered every pivot table in it**. That changes what the workbook *shows*, not just what metadata it carries.

Not to be confused with the report-filter axis: that is `pageFields`, modelled by `XLPivotTable.Filters`, and was already supported. The new collection is `XLPivotTable.PivotFilters`, and both summaries say which is which because the names are easy to mix up.

## Two deliberate modelling choices

**`type` is kept as its raw `ST_PivotFilterType` token, not an enum.** There are ~40 values, XLibur acts on none of them, and a token round-trips a file written by a newer Excel using a value this build has never heard of. An enum would silently drop those.

**`autoFilter` is preserved verbatim rather than modelled.** It is required by the schema and is a sub-tree in its own right — `filterColumn` with any of `filters`, `top10`, `customFilters`, `dynamicFilter`, `colorFilter`, `iconFilter`. Modelling all of that would be a large new surface with nothing reading it.

XLibur has no API for creating or interpreting pivot filters, so the goal here is **fidelity**, and the attributes that *are* modelled (`fld`, `id`, `type`, `name`, `description`, `stringValue1/2`, `evalOrder`, `mpFld`, `iMeasureHier`, `iMeasureFld`) are the ones an API would need first. Preserving a sub-tree as raw XML follows the existing precedent in `SharedStringReader` and `ThreadedCommentPartWriter`.

If you would rather see `CT_AutoFilter` fully modelled, say so and I will do it as a follow-up — but it is a lot of type surface to add speculatively.

## Placement

The write sits **after `pivotTableStyleInfo`**, which is where the schema sequence puts `filters` — not next to `formats`, despite the name. It emits nothing when the collection is empty, since an empty `filters` element is invalid and most pivot tables have none.

## Tests

5 added in `PivotFilterTests`, on a workbook whose pivot table carries a caption filter holding a value list and a value filter holding a top-N:

- the attributes survive
- **the preserved `autoFilter` survives, for both shapes** — asserted separately, because a round trip keeping only the attributes would still lose what the filter actually does
- the loaded model exposes them
- nothing is written for a pivot table without filters

**4 of the 5 fail against the unfixed reader/writer** — verified by stashing the change.

## Test plan

- [x] Full suite green on **net10.0** — 11,654 passed, 4 skipped
- [x] Full suite green on **net8.0** — 11,654 passed, 4 skipped
- [x] `dotnet build XLibur/XLibur.csproj -c Release` — 0 warnings
- [x] New tests verified to fail without the reader/writer changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading and saving pivot-table filters, including label, value, date, and top-N criteria.
  * Preserved filter settings and AutoFilter criteria when pivot-table files are reopened and saved.
  * Exposed loaded pivot filters through the pivot-table object model.
  * Prevented empty filter elements from being written when no filters are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->