### PR TITLE
test(io): pin the crash-atomicity of encrypted saves

### DIFF
--- a/XLibur.Tests/Excel/Encryption/WorkbookEncryptionTests.cs
+++ b/XLibur.Tests/Excel/Encryption/WorkbookEncryptionTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using OpenMcdf;
 using XLibur.Excel;
 using XLibur.Excel.Exceptions;
+using XLibur.Excel.IO.Encryption;
 using XLibur.Tests.Utils;
 
 namespace XLibur.Tests.Excel.Encryption;
@@ -476,6 +478,133 @@ public class WorkbookEncryptionTests
         // And the file it came from is untouched by any of that.
         using var original = new XLWorkbook(encryptedFile.Path, new LoadOptions { Password = Password });
         await Assert.That(original.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("before");
+    }
+
+    /// <summary>
+    /// Thrown by <see cref="FailingEncryptor"/>, so that a test asserting a save failed cannot be
+    /// satisfied by some other failure that happens to carry a common exception type.
+    /// </summary>
+    private sealed class EncryptionFailure : Exception
+    {
+        public EncryptionFailure()
+            : base("Simulated encryption failure.")
+        {
+        }
+    }
+
+    /// <summary>
+    /// An encryption that fails before it produces anything, standing in for the failures the real
+    /// one can suffer and a test cannot provoke: an out-of-memory on the two full-size allocations,
+    /// or a cryptographic fault.
+    /// </summary>
+    private sealed class FailingEncryptor : IWorkbookEncryptor
+    {
+        public void Encrypt(Stream destination, byte[] package, string password) =>
+            throw new EncryptionFailure();
+    }
+
+    /// <summary>
+    /// Whether two sets of bytes are identical, as a single assertion rather than a diff of two
+    /// buffers that run to kilobytes.
+    /// </summary>
+    private static async Task AssertBytesAreUnchanged(byte[] before, byte[] after)
+    {
+        await Assert.That(after.Length).IsEqualTo(before.Length);
+        await Assert.That(after.SequenceEqual(before)).IsTrue();
+    }
+
+    [Test]
+    public async Task Save_leaves_the_file_it_would_overwrite_untouched_when_the_encryption_fails()
+    {
+        using var file = new TemporaryFile();
+        WriteEncryptedFile(file.Path, Password);
+        var before = File.ReadAllBytes(file.Path);
+
+        using var wb = new XLWorkbook(file.Path, new LoadOptions { Password = Password });
+        wb.Worksheet("Data").Cell("A1").Value = "after";
+        wb.Encryptor = new FailingEncryptor();
+
+        // The whole point of encrypting into a buffer: the destination is opened for writing only
+        // once the bytes that replace it exist, so a failure before that leaves the file alone.
+        await Assert.That(() => wb.Save()).Throws<EncryptionFailure>();
+        await AssertBytesAreUnchanged(before, File.ReadAllBytes(file.Path));
+    }
+
+    [Test]
+    public async Task Save_leaves_the_stream_it_would_overwrite_untouched_when_the_encryption_fails()
+    {
+        using var origin = new MemoryStream();
+        var encrypted = CreateEncryptedWorkbook(Password);
+        origin.Write(encrypted, 0, encrypted.Length);
+        origin.Position = 0;
+
+        using var wb = new XLWorkbook(origin, new LoadOptions { Password = Password });
+        wb.Worksheet("Data").Cell("A4").Value = "never written";
+        wb.Encryptor = new FailingEncryptor();
+
+        await Assert.That(() => wb.Save()).Throws<EncryptionFailure>();
+
+        // Truncating first would have emptied this stream and then spent the encryption with
+        // nothing in it, which is what the ordering in SaveEncrypted exists to avoid.
+        await AssertBytesAreUnchanged(encrypted, origin.ToArray());
+
+        // And what is still there is still a workbook, not merely the right number of bytes.
+        using var reopened = new XLWorkbook(new MemoryStream(origin.ToArray()), new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("Hello encrypted world");
+    }
+
+    [Test]
+    public async Task SaveAs_leaves_the_file_it_would_overwrite_untouched_when_the_encryption_fails()
+    {
+        using var file = new TemporaryFile();
+        WriteEncryptedFile(file.Path, Password, "the file that was already there");
+        var before = File.ReadAllBytes(file.Path);
+
+        using var wb = new XLWorkbook();
+        wb.AddWorksheet("Data").Cell("A1").Value = "the workbook that failed to encrypt";
+        wb.Encryptor = new FailingEncryptor();
+
+        await Assert.That(() => wb.SaveAs(file.Path, new SaveOptions { Password = Password }))
+            .Throws<EncryptionFailure>();
+        await AssertBytesAreUnchanged(before, File.ReadAllBytes(file.Path));
+    }
+
+    [Test]
+    public async Task SaveAs_to_a_stream_reports_a_failed_encryption()
+    {
+        using var destination = new MemoryStream();
+        using var wb = new XLWorkbook();
+        wb.AddWorksheet("Data").Cell("A1").Value = "the workbook that failed to encrypt";
+        wb.Encryptor = new FailingEncryptor();
+
+        // This path encrypts straight into the caller's stream rather than into a buffer, because
+        // there is nothing to lose: SaveAs to a stream writes from wherever the stream is and never
+        // truncates, so it has no prior content of its own to protect. What it owes the caller is
+        // the failure itself.
+        await Assert.That(() => wb.SaveAs(destination, new SaveOptions { Password = Password }))
+            .Throws<EncryptionFailure>();
+    }
+
+    [Test]
+    public async Task Save_replaces_the_file_when_the_encryption_succeeds()
+    {
+        // The control for the three tests above: the destination is left alone because the
+        // encryption failed, not because a save with this shape never writes anything.
+        using var file = new TemporaryFile();
+        WriteEncryptedFile(file.Path, Password);
+        var before = File.ReadAllBytes(file.Path);
+
+        using (var wb = new XLWorkbook(file.Path, new LoadOptions { Password = Password }))
+        {
+            wb.Worksheet("Data").Cell("A1").Value = "after";
+            wb.Save();
+        }
+
+        var after = File.ReadAllBytes(file.Path);
+        await Assert.That(after.SequenceEqual(before)).IsFalse();
+
+        using var reopened = new XLWorkbook(file.Path, new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("after");
     }
 
     [Test]

--- a/XLibur/Excel/IO/Encryption/IWorkbookEncryptor.cs
+++ b/XLibur/Excel/IO/Encryption/IWorkbookEncryptor.cs
@@ -1,0 +1,40 @@
+using System.IO;
+
+namespace XLibur.Excel.IO.Encryption;
+
+/// <summary>
+/// Turns the .xlsx bytes of a built package into the encrypted compound file that carries them.
+/// </summary>
+/// <remarks>
+/// A named boundary around the one step of a save that can fail after the package exists but before
+/// the destination has been touched. <see cref="XLWorkbook"/> holds one of these rather than calling
+/// <see cref="WorkbookEncryption"/> directly, so that a test can substitute an encryption that fails
+/// and observe what the destination looks like afterwards.
+/// </remarks>
+internal interface IWorkbookEncryptor
+{
+    /// <summary>
+    /// Encrypts <paramref name="package"/> into a compound file written to
+    /// <paramref name="destination"/>.
+    /// </summary>
+    void Encrypt(Stream destination, byte[] package, string password);
+}
+
+/// <summary>
+/// The encryption every workbook uses unless something has substituted another: agile encryption
+/// with the parameters Excel writes.
+/// </summary>
+internal sealed class WorkbookEncryptor : IWorkbookEncryptor
+{
+    /// <summary>
+    /// The instance <see cref="XLWorkbook"/> starts with. Stateless, so one is enough.
+    /// </summary>
+    public static readonly WorkbookEncryptor Default = new();
+
+    private WorkbookEncryptor()
+    {
+    }
+
+    public void Encrypt(Stream destination, byte[] package, string password) =>
+        WorkbookEncryption.Encrypt(destination, package, password);
+}

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -458,10 +458,10 @@ public partial class XLWorkbook : IXLWorkbook
     /// steps that allocate the workbook twice over — would leave an empty file where the workbook
     /// was. This trades one more copy of the encrypted container for that not happening.
     /// </remarks>
-    private static MemoryStream EncryptToBuffer(MemoryStream package, string password)
+    private MemoryStream EncryptToBuffer(MemoryStream package, string password)
     {
         var container = new MemoryStream();
-        IO.Encryption.WorkbookEncryption.Encrypt(container, package.ToArray(), password);
+        Encryptor.Encrypt(container, package.ToArray(), password);
 
         // No rewind: WriteTo copies the whole buffer regardless of position.
         return container;
@@ -602,7 +602,7 @@ public partial class XLWorkbook : IXLWorkbook
         if (!string.IsNullOrEmpty(options.Password))
         {
             var package = BuildPackageInMemory(options);
-            IO.Encryption.WorkbookEncryption.Encrypt(stream, package.ToArray(), options.Password);
+            Encryptor.Encrypt(stream, package.ToArray(), options.Password);
 
             AdoptEncryptedOrigin(package, options.Password, file: null, stream);
             return;
@@ -858,6 +858,18 @@ public partial class XLWorkbook : IXLWorkbook
     private string? _encryptedFile;
 
     private Stream? _encryptedStream;
+
+    /// <summary>
+    /// The encryption a save runs the built package through before it touches the destination.
+    /// </summary>
+    /// <remarks>
+    /// Settable so that a test can substitute an encryption that fails, which is the only way to
+    /// exercise what a save leaves behind when the encryption does. Per workbook rather than static,
+    /// so a substitution cannot outlive the workbook it was made for. Production code never assigns
+    /// it.
+    /// </remarks>
+    internal IO.Encryption.IWorkbookEncryptor Encryptor { get; set; } =
+        IO.Encryption.WorkbookEncryptor.Default;
 
     #endregion Fields
 


### PR DESCRIPTION
## Summary

#284 changed the encrypted save paths to encrypt into a buffer and copy the finished container over the destination, rather than emptying the destination first and leaving it empty across the encryption. What that buys is a failure guarantee: if the encryption fails, the destination is still whatever it was.

Nothing verified it. `WorkbookEncryption` is an `internal static` class called directly, so there was no way to make the encryption fail on demand and then look at what had been left behind — the guarantee held only as long as nobody reordered it back.

This adds the seam (option 2 from the issue) and the tests that pin the guarantee.

## Changes

- **`XLibur/Excel/IO/Encryption/IWorkbookEncryptor.cs`** (new) — the interface, plus a sealed `WorkbookEncryptor.Default` that delegates to the existing `WorkbookEncryption.Encrypt`. No encryption code moved or changed.
- **`XLibur/Excel/XLWorkbook.cs`** — an `internal IWorkbookEncryptor Encryptor { get; set; }` initialised to the default. `EncryptToBuffer` becomes an instance method, and both call sites go through the property: `EncryptToBuffer` (used by `Save` and by `SaveAs(string, SaveOptions)`) and the password branch of `SaveAs(Stream, SaveOptions)`.
- **`XLibur.Tests/Excel/Encryption/WorkbookEncryptionTests.cs`** — a failing encryptor and five tests.

**On the shape of the seam.** It is a per-workbook property rather than the static property or the constructor parameter the issue sketched. It gets what those were after — no mutable global to restore, no dependence on `[assembly: NotInParallel]` — and it needs no new constructor overloads, because loading only ever calls `Decrypt`: a test can set the encryptor on an already-loaded workbook and then save it. Production code never assigns it.

No public API change; `Encryptor` is internal and reaches the tests through the existing `InternalsVisibleTo`.

## Related Issues

Closes #293. Follows #284, which introduced the buffering being tested here.

## Testing

- [x] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually

Five tests added:

| Destination | Asserts |
|---|---|
| `Save()` to a file | throws, and the file is byte-for-byte unchanged |
| `Save()` to a stream | throws, the stream is byte-for-byte unchanged, and what is still there reopens as a workbook |
| `SaveAs(string, SaveOptions)` | throws, and the file it would have overwritten is byte-for-byte unchanged |
| `SaveAs(Stream, SaveOptions)` | throws |
| `Save()` — negative control | the file *is* replaced when the encryption succeeds |

`SaveAs(Stream, SaveOptions)` asserts only the propagation, deliberately. That path encrypts straight into the caller's stream and never truncates, so it has no prior content of its own to protect; asserting an empty stream there would be pinning when the fake happens to throw rather than anything about the save. The test says so.

**The three atomicity tests were checked against the ordering they exist to prevent.** With all three destinations temporarily reverted to the pre-#284 shape — truncate, then encrypt into the destination — they fail with 0 bytes where 28,672 were expected, and the control still passes.

Full suite green on net10.0: 11,677 passed, 4 skipped (pre-existing), 0 failed.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
