### PR TITLE
perf(ranges): stop CopyTo degrading as the sheet fills up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,14 @@
 
 - **86% fewer allocations styling a range, row or column in bulk** (~234 → ~33 bytes per cell): setting a style on a container collected every child cell into a `HashSet` of wrappers before writing anything. Containers that can enumerate exactly those cells now walk the addresses and write the style slice directly. ([#185](https://github.com/XLibur/XLibur/pull/185) by [@jafin](https://github.com/jafin))
 
+#### Copying and clearing ranges
+
+- **`IXLRange.CopyTo` no longer gets slower as the sheet fills up** ([#271](https://github.com/XLibur/XLibur/issues/271)): copying a range in a loop was quadratic in the number of copies, so the natural way to expand a template — one `CopyTo` per generated row — degraded badly. On a 30,000-row sheet with no data validations at all, a 1×10 `CopyTo` cost ~420 µs against ~160 µs on the same sheet when nearly empty; it is now ~13 µs and flat. Three things were at fault, all fixed:
+
+  - `Clear(XLClearOptions.All)`, which `CopyTo` runs over its target first, created a data validation covering the target and immediately deleted it *on every call*, even with no validations on the sheet. Going through `Add`/`Delete` is what splits an overlapping rule so only the cleared cells lose their validation, so it is still done when a rule actually overlaps — and skipped when none does. `XLCell.Clear` already guarded this way.
+  - A range index promoted itself from a flat list to a QuadTree after 20 `Add` calls rather than 20 live entries, so a collection that only ever held one range at a time still built a tree.
+  - QuadTree quadrants are created on demand and never torn down, so an index that had seen many add/remove cycles kept a skeleton of empty quadrants that every subsequent removal walked. Each quadrant now tracks how many ranges its subtree holds, and traversals skip subtrees holding none.
+
 #### Saving
 
 - **50% fewer allocations on save** (237.1 → 117.9 MB for the same benchmark), with wall time improving from 1187–1290 ms to 1051–1167 ms. Four save helpers materialised a cell wrapper for every used cell just to read one property and now read the underlying storage directly; `int`/`uint` cell values are formatted into a span instead of allocating a string each; style-key hashes are memoised, cutting `StyleKey.GetHashCode` by 95% over 100K styles. Saved output is byte-identical to before. ([#179](https://github.com/XLibur/XLibur/pull/179) by [@jafin](https://github.com/jafin))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@
 
 #### Copying and clearing ranges
 
-- **`IXLRange.CopyTo` no longer gets slower as the sheet fills up** ([#271](https://github.com/XLibur/XLibur/issues/271)): copying a range in a loop was quadratic in the number of copies, so the natural way to expand a template — one `CopyTo` per generated row — degraded badly. On a 30,000-row sheet with no data validations at all, a 1×10 `CopyTo` cost ~420 µs against ~160 µs on the same sheet when nearly empty; it is now ~13 µs and flat. Three things were at fault, all fixed:
+- **`IXLRange.CopyTo` no longer gets slower as the sheet fills up** ([#271](https://github.com/XLibur/XLibur/issues/271), [#303](https://github.com/XLibur/XLibur/pull/303) by [@jafin](https://github.com/jafin)): copying a range in a loop was quadratic in the number of copies, so the natural way to expand a template — one `CopyTo` per generated row — degraded badly. On a 30,000-row sheet with no data validations at all, a 1×10 `CopyTo` cost ~420 µs against ~160 µs on the same sheet when nearly empty; it is now ~13 µs and flat. Three things were at fault, all fixed:
 
   - `Clear(XLClearOptions.All)`, which `CopyTo` runs over its target first, created a data validation covering the target and immediately deleted it *on every call*, even with no validations on the sheet. Going through `Add`/`Delete` is what splits an overlapping rule so only the cleared cells lose their validation, so it is still done when a rule actually overlaps — and skipped when none does. `XLCell.Clear` already guarded this way.
   - A range index promoted itself from a flat list to a QuadTree after 20 `Add` calls rather than 20 live entries, so a collection that only ever held one range at a time still built a tree.

--- a/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -249,6 +249,50 @@ public class DataValidationTests
     }
 
     [Test]
+    public async Task ClearingDataValidationOnASheetWithoutAnyIsANoOp()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("DataValidation");
+
+        // Clear used to add a rule covering the range and delete it again regardless, which left the
+        // collection empty but cost more the bigger the sheet's validation index had grown (#271).
+        ws.Range("A1:C3").Clear(XLClearOptions.DataValidation);
+        ws.Range("A1:C3").Clear(XLClearOptions.All);
+
+        await Assert.That(ws.DataValidations.Count()).IsEqualTo(0);
+        await Assert.That(ws.Cell("B2").HasDataValidation).IsFalse();
+    }
+
+    [Test]
+    public async Task ClearingDataValidationLeavesRulesOutsideTheRangeAlone()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("DataValidation");
+        ws.Range("E1:E3").CreateDataValidation().WholeNumber.Between(0, 100);
+
+        ws.Range("A1:C3").Clear(XLClearOptions.All);
+
+        await Assert.That(ws.DataValidations.Count()).IsEqualTo(1);
+        await Assert.That(ws.Range("E1:E3").Cells().All(c => c.HasDataValidation)).IsTrue();
+    }
+
+    [Test]
+    public async Task CopyToClearsOnlyTheValidationItOverwrites()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("DataValidation");
+        ws.Range("A1:C1").Value = "template";
+        ws.Range("A5:C5").CreateDataValidation().WholeNumber.Between(0, 100);
+        ws.Range("A6:C6").CreateDataValidation().WholeNumber.Between(0, 100);
+
+        ws.Range("A1:C1").CopyTo(ws.Cell("A5"));
+
+        await Assert.That(ws.Range("A5:C5").Cells().Any(c => c.HasDataValidation)).IsFalse();
+        await Assert.That(ws.Range("A6:C6").Cells().All(c => c.HasDataValidation)).IsTrue();
+        await Assert.That(ws.Cell("A5").GetString()).IsEqualTo("template");
+    }
+
+    [Test]
     public async Task NewDataValidationSplitsRange()
     {
         using var wb = new XLWorkbook();

--- a/XLibur.Tests/Excel/Encryption/WorkbookEncryptionTests.cs
+++ b/XLibur.Tests/Excel/Encryption/WorkbookEncryptionTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using OpenMcdf;
 using XLibur.Excel;
 using XLibur.Excel.Exceptions;
+using XLibur.Excel.IO.Encryption;
 using XLibur.Tests.Utils;
 
 namespace XLibur.Tests.Excel.Encryption;
@@ -476,6 +478,133 @@ public class WorkbookEncryptionTests
         // And the file it came from is untouched by any of that.
         using var original = new XLWorkbook(encryptedFile.Path, new LoadOptions { Password = Password });
         await Assert.That(original.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("before");
+    }
+
+    /// <summary>
+    /// Thrown by <see cref="FailingEncryptor"/>, so that a test asserting a save failed cannot be
+    /// satisfied by some other failure that happens to carry a common exception type.
+    /// </summary>
+    private sealed class EncryptionFailure : Exception
+    {
+        public EncryptionFailure()
+            : base("Simulated encryption failure.")
+        {
+        }
+    }
+
+    /// <summary>
+    /// An encryption that fails before it produces anything, standing in for the failures the real
+    /// one can suffer and a test cannot provoke: an out-of-memory on the two full-size allocations,
+    /// or a cryptographic fault.
+    /// </summary>
+    private sealed class FailingEncryptor : IWorkbookEncryptor
+    {
+        public void Encrypt(Stream destination, byte[] package, string password) =>
+            throw new EncryptionFailure();
+    }
+
+    /// <summary>
+    /// Whether two sets of bytes are identical, as a single assertion rather than a diff of two
+    /// buffers that run to kilobytes.
+    /// </summary>
+    private static async Task AssertBytesAreUnchanged(byte[] before, byte[] after)
+    {
+        await Assert.That(after.Length).IsEqualTo(before.Length);
+        await Assert.That(after.SequenceEqual(before)).IsTrue();
+    }
+
+    [Test]
+    public async Task Save_leaves_the_file_it_would_overwrite_untouched_when_the_encryption_fails()
+    {
+        using var file = new TemporaryFile();
+        WriteEncryptedFile(file.Path, Password);
+        var before = File.ReadAllBytes(file.Path);
+
+        using var wb = new XLWorkbook(file.Path, new LoadOptions { Password = Password });
+        wb.Worksheet("Data").Cell("A1").Value = "after";
+        wb.Encryptor = new FailingEncryptor();
+
+        // The whole point of encrypting into a buffer: the destination is opened for writing only
+        // once the bytes that replace it exist, so a failure before that leaves the file alone.
+        await Assert.That(() => wb.Save()).Throws<EncryptionFailure>();
+        await AssertBytesAreUnchanged(before, File.ReadAllBytes(file.Path));
+    }
+
+    [Test]
+    public async Task Save_leaves_the_stream_it_would_overwrite_untouched_when_the_encryption_fails()
+    {
+        using var origin = new MemoryStream();
+        var encrypted = CreateEncryptedWorkbook(Password);
+        origin.Write(encrypted, 0, encrypted.Length);
+        origin.Position = 0;
+
+        using var wb = new XLWorkbook(origin, new LoadOptions { Password = Password });
+        wb.Worksheet("Data").Cell("A4").Value = "never written";
+        wb.Encryptor = new FailingEncryptor();
+
+        await Assert.That(() => wb.Save()).Throws<EncryptionFailure>();
+
+        // Truncating first would have emptied this stream and then spent the encryption with
+        // nothing in it, which is what the ordering in SaveEncrypted exists to avoid.
+        await AssertBytesAreUnchanged(encrypted, origin.ToArray());
+
+        // And what is still there is still a workbook, not merely the right number of bytes.
+        using var reopened = new XLWorkbook(new MemoryStream(origin.ToArray()), new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("Hello encrypted world");
+    }
+
+    [Test]
+    public async Task SaveAs_leaves_the_file_it_would_overwrite_untouched_when_the_encryption_fails()
+    {
+        using var file = new TemporaryFile();
+        WriteEncryptedFile(file.Path, Password, "the file that was already there");
+        var before = File.ReadAllBytes(file.Path);
+
+        using var wb = new XLWorkbook();
+        wb.AddWorksheet("Data").Cell("A1").Value = "the workbook that failed to encrypt";
+        wb.Encryptor = new FailingEncryptor();
+
+        await Assert.That(() => wb.SaveAs(file.Path, new SaveOptions { Password = Password }))
+            .Throws<EncryptionFailure>();
+        await AssertBytesAreUnchanged(before, File.ReadAllBytes(file.Path));
+    }
+
+    [Test]
+    public async Task SaveAs_to_a_stream_reports_a_failed_encryption()
+    {
+        using var destination = new MemoryStream();
+        using var wb = new XLWorkbook();
+        wb.AddWorksheet("Data").Cell("A1").Value = "the workbook that failed to encrypt";
+        wb.Encryptor = new FailingEncryptor();
+
+        // This path encrypts straight into the caller's stream rather than into a buffer, because
+        // there is nothing to lose: SaveAs to a stream writes from wherever the stream is and never
+        // truncates, so it has no prior content of its own to protect. What it owes the caller is
+        // the failure itself.
+        await Assert.That(() => wb.SaveAs(destination, new SaveOptions { Password = Password }))
+            .Throws<EncryptionFailure>();
+    }
+
+    [Test]
+    public async Task Save_replaces_the_file_when_the_encryption_succeeds()
+    {
+        // The control for the three tests above: the destination is left alone because the
+        // encryption failed, not because a save with this shape never writes anything.
+        using var file = new TemporaryFile();
+        WriteEncryptedFile(file.Path, Password);
+        var before = File.ReadAllBytes(file.Path);
+
+        using (var wb = new XLWorkbook(file.Path, new LoadOptions { Password = Password }))
+        {
+            wb.Worksheet("Data").Cell("A1").Value = "after";
+            wb.Save();
+        }
+
+        var after = File.ReadAllBytes(file.Path);
+        await Assert.That(after.SequenceEqual(before)).IsFalse();
+
+        using var reopened = new XLWorkbook(file.Path, new LoadOptions { Password = Password });
+        await Assert.That(reopened.Worksheet("Data").Cell("A1").GetString()).IsEqualTo("after");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeIndexTest.cs
@@ -241,6 +241,94 @@ public class RangeIndexTest
         await Assert.That(ranges.Count).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task AddingAndRemovingOneRangeAtATimeNeverBuildsQuadTree()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var index = CreateRangeIndex(ws);
+
+        // A collection that never holds more than one range has nothing to gain from a QuadTree.
+        // Promotion used to be driven by the number of Add calls, so this loop built one — and then
+        // every RemoveAll walked the quadrants it had accumulated, which is what made XLRangeBase.Clear
+        // (and therefore CopyTo) quadratic on a large sheet.
+        for (var i = 1; i <= 500; i++)
+        {
+            var range = ws.Range(i, 1, i, 10);
+            index.Add(range);
+            index.RemoveAll(r => true);
+        }
+
+        await Assert.That(index.IsIndexed).IsFalse();
+        await Assert.That(index.GetAll().Any()).IsFalse();
+    }
+
+    [Test]
+    public async Task QuadTreeRemainsConsistentAcrossRemoveAndReAdd()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var index = FillIndexWithTestData(ws);
+
+        await Assert.That(index.IsIndexed).IsTrue();
+
+        // Empty the tree, then refill it: entries added after a subtree has been emptied must still be
+        // found, i.e. the per-quadrant occupancy count that lets traversals skip empty subtrees has to
+        // come back up as well as down.
+        var removed = index.RemoveAll(_ => true);
+        await Assert.That(removed).IsEqualTo(TestCount);
+        await Assert.That(index.GetAll().Any()).IsFalse();
+
+        for (var i = 1; i <= TestCount; i++)
+        {
+            index.Add(ws.Range(i * 2, 2, i * 2, 4));
+        }
+
+        await Assert.That(index.GetAll().Count()).IsEqualTo(TestCount);
+
+        for (var i = 1; i <= TestCount; i++)
+        {
+            var address = new XLAddress(ws, i * 2, 3, false, false);
+            await Assert.That(index.Contains(in address)).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task QuadTreeRemoveAllKeepsNonMatchingRangesFindable()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var index = FillIndexWithTestData(ws);
+
+        var removed = index.RemoveAll(r => r.RangeAddress.FirstAddress.RowNumber % 4 == 0);
+
+        await Assert.That(removed).IsEqualTo(TestCount / 2);
+        await Assert.That(index.GetAll().Count()).IsEqualTo(TestCount - TestCount / 2);
+
+        for (var i = 1; i <= TestCount; i++)
+        {
+            var address = new XLAddress(ws, i * 2, 3, false, false);
+            await Assert.That(index.Contains(in address)).IsEqualTo(i % 2 == 1);
+        }
+    }
+
+    [Test]
+    public async Task QuadTreeRemoveByAddressAllowsReAddingSameAddress()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var index = FillIndexWithTestData(ws);
+        var address = new XLAddress(ws, 200, 3, false, false);
+
+        await Assert.That(index.Remove(ws.Range(200, 2, 200, 4).RangeAddress)).IsTrue();
+        await Assert.That(index.Contains(in address)).IsFalse();
+        await Assert.That(index.Remove(ws.Range(200, 2, 200, 4).RangeAddress)).IsFalse();
+
+        await Assert.That(index.Add(ws.Range(200, 2, 200, 4))).IsTrue();
+        await Assert.That(index.Contains(in address)).IsTrue();
+        await Assert.That(index.GetAll().Count()).IsEqualTo(TestCount);
+    }
+
     private static XLRangeIndex<IXLRangeBase> CreateRangeIndex(IXLWorksheet worksheet)
     {
         return new XLRangeIndex<IXLRangeBase>((XLWorksheet)worksheet);

--- a/XLibur/Excel/DataValidation/XLDataValidations.cs
+++ b/XLibur/Excel/DataValidation/XLDataValidations.cs
@@ -95,6 +95,16 @@ internal sealed class XLDataValidations : IXLDataValidations
             .Distinct();
     }
 
+    /// <summary>
+    /// Whether any data validation rule covers a cell of <paramref name="rangeAddress"/>. Cheaper than
+    /// <see cref="GetAllInRange"/> when only the yes/no answer is wanted: it stops at the first hit and
+    /// skips the de-duplication.
+    /// </summary>
+    internal bool AnyInRange(in XLRangeAddress rangeAddress)
+    {
+        return rangeAddress.IsValid && _dataValidationIndex.Intersects(in rangeAddress);
+    }
+
     public IEnumerator<IXLDataValidation> GetEnumerator()
     {
         return _dataValidations.GetEnumerator();

--- a/XLibur/Excel/IO/Encryption/IWorkbookEncryptor.cs
+++ b/XLibur/Excel/IO/Encryption/IWorkbookEncryptor.cs
@@ -1,0 +1,40 @@
+using System.IO;
+
+namespace XLibur.Excel.IO.Encryption;
+
+/// <summary>
+/// Turns the .xlsx bytes of a built package into the encrypted compound file that carries them.
+/// </summary>
+/// <remarks>
+/// A named boundary around the one step of a save that can fail after the package exists but before
+/// the destination has been touched. <see cref="XLWorkbook"/> holds one of these rather than calling
+/// <see cref="WorkbookEncryption"/> directly, so that a test can substitute an encryption that fails
+/// and observe what the destination looks like afterwards.
+/// </remarks>
+internal interface IWorkbookEncryptor
+{
+    /// <summary>
+    /// Encrypts <paramref name="package"/> into a compound file written to
+    /// <paramref name="destination"/>.
+    /// </summary>
+    void Encrypt(Stream destination, byte[] package, string password);
+}
+
+/// <summary>
+/// The encryption every workbook uses unless something has substituted another: agile encryption
+/// with the parameters Excel writes.
+/// </summary>
+internal sealed class WorkbookEncryptor : IWorkbookEncryptor
+{
+    /// <summary>
+    /// The instance <see cref="XLWorkbook"/> starts with. Stateless, so one is enough.
+    /// </summary>
+    public static readonly WorkbookEncryptor Default = new();
+
+    private WorkbookEncryptor()
+    {
+    }
+
+    public void Encrypt(Stream destination, byte[] package, string password) =>
+        WorkbookEncryption.Encrypt(destination, package, password);
+}

--- a/XLibur/Excel/Patterns/Quadrant.cs
+++ b/XLibur/Excel/Patterns/Quadrant.cs
@@ -119,6 +119,9 @@ internal class Quadrant
         if (Children == null && addToChild)
             Children = children;
 
+        if (res)
+            _subtreeCount++;
+
         return res;
     }
 
@@ -127,6 +130,9 @@ internal class Quadrant
     /// </summary>
     public IEnumerable<IXLAddressable> GetAll()
     {
+        if (_subtreeCount == 0)
+            yield break;
+
         if (Ranges != null)
         {
             foreach (var range in Ranges)
@@ -137,6 +143,9 @@ internal class Quadrant
         {
             foreach (var childQuadrant in Children)
             {
+                if (childQuadrant._subtreeCount == 0)
+                    continue;
+
                 var childRanges = childQuadrant.GetAll();
                 foreach (var range in childRanges)
                     yield return range;
@@ -149,6 +158,9 @@ internal class Quadrant
     /// </summary>
     public IEnumerable<IXLAddressable> GetIntersectedRanges(IXLRangeAddress rangeAddress)
     {
+        if (_subtreeCount == 0)
+            yield break;
+
         if (Ranges != null)
         {
             foreach (var range in Ranges)
@@ -167,6 +179,9 @@ internal class Quadrant
     /// </summary>
     public IEnumerable<IXLAddressable> GetIntersectedRanges(IXLAddress address)
     {
+        if (_subtreeCount == 0)
+            yield break;
+
         if (Ranges != null)
         {
             foreach (var range in Ranges)
@@ -188,6 +203,9 @@ internal class Quadrant
     /// </summary>
     public bool CoversAnyRange(in XLAddress address)
     {
+        if (_subtreeCount == 0)
+            return false;
+
         if (_ranges is not null)
         {
             foreach (var range in _ranges.Values)
@@ -221,7 +239,7 @@ internal class Quadrant
 
         foreach (var childQuadrant in Children)
         {
-            if (childQuadrant.Intersects(in rangeAddress))
+            if (childQuadrant._subtreeCount > 0 && childQuadrant.Intersects(in rangeAddress))
             {
                 foreach (var range in childQuadrant.GetIntersectedRanges(rangeAddress))
                     yield return range;
@@ -236,7 +254,7 @@ internal class Quadrant
 
         foreach (var childQuadrant in Children)
         {
-            if (childQuadrant.Covers(in address))
+            if (childQuadrant._subtreeCount > 0 && childQuadrant.Covers(in address))
             {
                 foreach (var range in childQuadrant.GetIntersectedRanges(address))
                     yield return range;
@@ -250,6 +268,9 @@ internal class Quadrant
     /// <returns>True if the range was removed, false if it does not exist in the QuadTree.</returns>
     public bool Remove(IXLRangeAddress rangeAddress)
     {
+        if (_subtreeCount == 0)
+            return false;
+
         var res = false;
 
         var coveredByChild = false;
@@ -268,6 +289,9 @@ internal class Quadrant
         if (!coveredByChild && _ranges?.Remove(rangeAddress) == true)
             res = true;
 
+        if (res)
+            _subtreeCount--;
+
         return res;
     }
 
@@ -275,32 +299,63 @@ internal class Quadrant
     /// Remove all the ranges matching specified criteria from the quadrant and its child quadrants (recursively).
     /// Don't use it for searching intersections as it would be much less efficient than <see cref="GetIntersectedRanges(IXLRangeAddress)"/>.
     /// </summary>
-    public IEnumerable<IXLAddressable> RemoveAll(Predicate<IXLAddressable> predicate)
+    /// <remarks>
+    /// Eager rather than lazy: every caller wants the whole set (or just its size), and removal has to
+    /// stay all-or-nothing for <see cref="_subtreeCount"/> to keep matching the contents — a half-consumed
+    /// lazy walk used to yield ranges it had not removed yet.
+    /// </remarks>
+    public IReadOnlyList<IXLAddressable> RemoveAll(Predicate<IXLAddressable> predicate)
     {
+        var removed = new List<IXLAddressable>();
+        RemoveAllInto(predicate, removed);
+        return removed;
+    }
+
+    /// <summary>
+    /// Recursive worker for <see cref="RemoveAll"/>. Returns the number of ranges removed from this
+    /// quadrant and its descendants, so each level can adjust its own <see cref="_subtreeCount"/>.
+    /// </summary>
+    private int RemoveAllInto(Predicate<IXLAddressable> predicate, List<IXLAddressable> removed)
+    {
+        // Child quadrants are created on demand but never destroyed, so a long-lived index that has
+        // seen many add/remove cycles keeps a skeleton of empty quadrants. Without this test every
+        // removal would walk that skeleton, which is what made a Clear/CopyTo loop quadratic (#271).
+        if (_subtreeCount == 0)
+            return 0;
+
+        var count = 0;
+
         if (_ranges != null)
         {
-            var ranges = _ranges.Values.Where(r => predicate(r));
-            var keysToRemove = new List<IXLRangeAddress>();
-            foreach (var range in ranges)
+            List<IXLRangeAddress>? keysToRemove = null;
+            foreach (var range in _ranges.Values)
             {
-                keysToRemove.Add(range.RangeAddress);
-                yield return range;
+                if (!predicate(range))
+                    continue;
+
+                (keysToRemove ??= new List<IXLRangeAddress>()).Add(range.RangeAddress);
+                removed.Add(range);
             }
 
-            foreach (var keyToRemove in keysToRemove)
+            if (keysToRemove != null)
             {
-                _ranges.Remove(keyToRemove);
-            }
-        }
-
-        if (Children != null)
-        {
-            foreach (var childQuadrant in Children)
-                foreach (var childRange in childQuadrant.RemoveAll(predicate))
+                foreach (var keyToRemove in keysToRemove)
                 {
-                    yield return childRange;
+                    if (_ranges.Remove(keyToRemove))
+                        count++;
                 }
+            }
         }
+
+        var children = Children;
+        if (children != null)
+        {
+            for (var i = 0; i < children.Count; i++)
+                count += children[i].RemoveAllInto(predicate, removed);
+        }
+
+        _subtreeCount -= count;
+        return count;
     }
 
     #endregion Public Methods
@@ -316,6 +371,14 @@ internal class Quadrant
     /// Collection of ranges belonging to the current quadrant (that cannot fit into child quadrants).
     /// </summary>
     private Dictionary<IXLRangeAddress, IXLAddressable>? _ranges;
+
+    /// <summary>
+    /// Number of ranges held by this quadrant and every descendant. <see cref="Children"/> is created
+    /// lazily but never torn down, so an index that has seen many add/remove cycles accumulates empty
+    /// quadrants; this count lets every traversal skip a subtree that has nothing in it instead of
+    /// walking that skeleton.
+    /// </summary>
+    private int _subtreeCount;
 
     #endregion Private Fields
 

--- a/XLibur/Excel/Ranges/Index/XLRangeIndex.cs
+++ b/XLibur/Excel/Ranges/Index/XLRangeIndex.cs
@@ -26,6 +26,12 @@ internal abstract class XLRangeIndex : IXLRangeIndex
 
     #region Public Methods
 
+    /// <summary>
+    /// Whether the index has switched from the flat list to the QuadTree. Promotion happens once the
+    /// index holds <see cref="MinimumCountForIndexing"/> ranges at the same time, and is one-way.
+    /// </summary>
+    internal bool IsIndexed => _quadTree is not null;
+
     public abstract bool MatchesType(XLRangeType rangeType);
 
     public bool Add(IXLAddressable range)
@@ -37,18 +43,23 @@ internal abstract class XLRangeIndex : IXLRangeIndex
 
         CheckWorksheet(range.RangeAddress.Worksheet);
 
-        _count++;
-        if (_count < MinimumCountForIndexing)
-        {
-            if (_rangeList.Any(r => r == range))
-                return false;
-
-            _rangeList.Add(range);
-            return true;
-        }
-
+        // Promotion is driven by how many ranges the index actually holds, not by how many have ever
+        // been added: a collection that never holds more than a handful at a time — a Clear() that
+        // adds a data validation and immediately deletes it, say — has nothing to gain from a
+        // QuadTree, and paid for one after 20 such round trips (#271).
         if (_quadTree == null)
+        {
+            if (_rangeList.Count < MinimumCountForIndexing)
+            {
+                if (_rangeList.Any(r => r == range))
+                    return false;
+
+                _rangeList.Add(range);
+                return true;
+            }
+
             InitializeTree();
+        }
 
         return _quadTree!.Add(range);
     }
@@ -158,7 +169,6 @@ internal abstract class XLRangeIndex : IXLRangeIndex
     protected readonly List<IXLAddressable> _rangeList;
 
     private readonly IXLWorksheet _worksheet;
-    private int _count;
     protected Quadrant? _quadTree;
 
     #endregion Private Fields

--- a/XLibur/Excel/Ranges/XLRangeBase.cs
+++ b/XLibur/Excel/Ranges/XLRangeBase.cs
@@ -376,7 +376,12 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
         if (clearOptions.HasFlag(XLClearOptions.ConditionalFormats))
             RemoveConditionalFormatting();
 
-        if (clearOptions.HasFlag(XLClearOptions.DataValidation))
+        // Adding a rule over the range and deleting it again is not the same as Delete(range): going
+        // through Add is what splits an overlapping rule so that only the cleared cells lose their
+        // validation. With nothing overlapping it is a pure round trip, so skip it — that round trip
+        // was the whole cost of CopyTo on a large sheet (#271).
+        if (clearOptions.HasFlag(XLClearOptions.DataValidation) &&
+            Worksheet.DataValidations.AnyInRange(RangeAddress))
         {
             var validation = CreateDataValidation();
             Worksheet.DataValidations.Delete(validation);

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -458,10 +458,10 @@ public partial class XLWorkbook : IXLWorkbook
     /// steps that allocate the workbook twice over — would leave an empty file where the workbook
     /// was. This trades one more copy of the encrypted container for that not happening.
     /// </remarks>
-    private static MemoryStream EncryptToBuffer(MemoryStream package, string password)
+    private MemoryStream EncryptToBuffer(MemoryStream package, string password)
     {
         var container = new MemoryStream();
-        IO.Encryption.WorkbookEncryption.Encrypt(container, package.ToArray(), password);
+        Encryptor.Encrypt(container, package.ToArray(), password);
 
         // No rewind: WriteTo copies the whole buffer regardless of position.
         return container;
@@ -602,7 +602,7 @@ public partial class XLWorkbook : IXLWorkbook
         if (!string.IsNullOrEmpty(options.Password))
         {
             var package = BuildPackageInMemory(options);
-            IO.Encryption.WorkbookEncryption.Encrypt(stream, package.ToArray(), options.Password);
+            Encryptor.Encrypt(stream, package.ToArray(), options.Password);
 
             AdoptEncryptedOrigin(package, options.Password, file: null, stream);
             return;
@@ -858,6 +858,18 @@ public partial class XLWorkbook : IXLWorkbook
     private string? _encryptedFile;
 
     private Stream? _encryptedStream;
+
+    /// <summary>
+    /// The encryption a save runs the built package through before it touches the destination.
+    /// </summary>
+    /// <remarks>
+    /// Settable so that a test can substitute an encryption that fails, which is the only way to
+    /// exercise what a save leaves behind when the encryption does. Per workbook rather than static,
+    /// so a substitution cannot outlive the workbook it was made for. Production code never assigns
+    /// it.
+    /// </remarks>
+    internal IO.Encryption.IWorkbookEncryptor Encryptor { get; set; } =
+        IO.Encryption.WorkbookEncryptor.Default;
 
     #endregion Fields
 


### PR DESCRIPTION
Fixes #271.

`IXLRange.CopyTo` got steadily slower as the target sheet grew, so copying a range in a loop was quadratic in the number of copies. The issue proposed guarding the create-and-delete in `XLRangeBase.Clear`, and flagged that something inside `DataValidations.Add`/`Delete` looked O(used rows) even with an empty collection — "the guard hides it rather than fixing it". That second read was right. This PR does both.

## Causes

**1. `Clear` created and deleted a data validation unconditionally.** `CopyTo` runs `Clear(XLClearOptions.All)` over its target first, and that always added a rule covering the range and immediately deleted it — even on a sheet with no data validations at all.

The pair is not pointless in general: going through `DataValidations.Add` is what makes `SplitExistingRanges` carve the cleared area out of any rule that overlaps it, which a plain `Delete(range)` would not do. So it is now guarded rather than replaced — identical behaviour whenever a rule actually intersects, and an index lookup that finds nothing otherwise. `XLCell.Clear` already guarded exactly this way (`&& HasDataValidation`); the range version never got it.

**2. The range index promoted itself on adds ever made, not entries held.** `XLRangeIndex` counted `Add` calls and switched from a flat list to a QuadTree at 20. A collection that never held more than one range at a time — a `Clear` that adds a validation and deletes it again, say — still built a tree after 20 round trips. Promotion is now driven by live entry count.

**3. Quadrants are created on demand and never torn down, and `RemoveAll` walked the whole tree.** After thousands of add/remove cycles at distinct addresses, that skeleton of empty quadrants *is* the cost, and it grows with the number of rows touched. This is the O(used rows) term the issue asked about. Each quadrant now tracks how many ranges its subtree holds, and every traversal (`GetAll`, `GetIntersectedRanges`, `CoversAnyRange`, `Remove`, `RemoveAll`) skips a subtree holding none.

`Quadrant.RemoveAll` also becomes eager. Every caller wants the whole set or just its size, occupancy bookkeeping needs removal to be all-or-nothing, and it retires a pre-existing hazard: the lazy version yielded a level's ranges *before* removing them, so an abandoned enumeration left ranges reported as removed but still in the tree.

## Measurements

Ten buckets of 3,000 operations over a 30,000-row x 10-column sheet, .NET 10, Release, no data validations / conditional formats / merged ranges / sparklines on the sheet. Mean µs per operation within the bucket, so a rising row is the quadratic term. First and last bucket shown.

| | before (1st → 10th) | after (1st → 10th) |
|---|---|---|
| `CopyTo` (1×10) | 168 → **399** | 32 → **8** |
| `Clear(All)` | 52 → **366** | 14 → **3.6** |
| `Clear(DataValidation)` | 48 → **363** | 4.4 → **1.9** |
| `Clear(Contents)` | 4.8 → 1.7 (flat) | 1.3 → 1.1 (flat) |
| create + delete a validation directly | 40 → **375** | 9.3 → **6.5** |
| `GetAllInRange(...).Any()` | 0.6 → 0.4 (flat) | 0.8 → 0.4 (flat) |

The last two rows separate the two fixes. The create-and-delete row does not go through the new guard at all, so its 375 → 6.5 µs is the index fixes on their own: neither fix depends on the other, and the underlying bug is gone rather than hidden.

## Tests

Seven new tests; the whole suite passes unchanged on net8.0 and net10.0 (11,677 passed, 0 failed, 4 skipped).

`RangeIndexTest`:
- `AddingAndRemovingOneRangeAtATimeNeverBuildsQuadTree` — the regression guard for cause 2; fails on the old code, which promotes at the 20th add.
- `QuadTreeRemainsConsistentAcrossRemoveAndReAdd` — occupancy has to come back up as well as down, or entries added after a subtree was emptied become invisible.
- `QuadTreeRemoveAllKeepsNonMatchingRangesFindable` — partial `RemoveAll` leaves survivors findable.
- `QuadTreeRemoveByAddressAllowsReAddingSameAddress`.

`DataValidationTests`:
- `ClearingDataValidationOnASheetWithoutAnyIsANoOp`
- `ClearingDataValidationLeavesRulesOutsideTheRangeAlone`
- `CopyToClearsOnlyTheValidationItOverwrites`

The existing `DataValidationClearSplitsRange` covers the case the guard must not change — clearing a cell inside a larger rule still splits it — and passes unchanged.

## Notes

- `XLRangeIndex.IsIndexed` is a new `internal` property exposing whether the index has promoted to a QuadTree. It is what makes cause 2 assertable.
- `XLDataValidations.AnyInRange` is a new `internal` helper: `GetAllInRange(...).Any()` would work but builds a `Distinct` over the hits, and `Clear` only needs the yes/no answer.
- No public API change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved range and data-validation processing for faster workbook operations, especially when copying or clearing ranges.
  * Reduced unnecessary indexing work and improved handling of large or frequently modified ranges.

* **Bug Fixes**
  * Clearing ranges now preserves validations outside the selected area and removes only affected rules.
  * Failed encrypted saves no longer overwrite existing files or streams.
  * Successful encrypted saves continue to replace the target as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->