### PR TITLE
fix(report): generate hidden sheets, rather than half of one

### DIFF
--- a/XLibur.Report.Tests/XLTemplateTests.cs
+++ b/XLibur.Report.Tests/XLTemplateTests.cs
@@ -148,8 +148,12 @@ public class XLTemplateTests
         await Assert.That(workbook.Worksheet("Report").Cell("A1").Value.GetText()).IsEqualTo("Perth");
     }
 
+    /// <summary>
+    /// A hidden sheet is where a report keeps its lookup tables and working data, so it is generated
+    /// like any other. Generation follows the data, not what the reader can see.
+    /// </summary>
     [Test]
-    public async Task HiddenSheetsAreNotGenerated()
+    public async Task HiddenSheetsAreGenerated()
     {
         using var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Hidden");
@@ -160,7 +164,53 @@ public class XLTemplateTests
 
         template.Generate();
 
-        await Assert.That(sheet.Cell("A1").Value.GetText()).IsEqualTo("{{ value }}");
+        await Assert.That(sheet.Cell("A1").Value.GetText()).IsEqualTo("generated");
+    }
+
+    [Test]
+    public async Task VeryHiddenSheetsAreGenerated()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("VeryHidden");
+        sheet.Cell("A1").Value = "{{ value }}";
+        sheet.Visibility = XLWorksheetVisibility.VeryHidden;
+        using var template = new XLTemplate(workbook);
+        template.AddVariable("value", "generated");
+
+        template.Generate();
+
+        await Assert.That(sheet.Cell("A1").Value.GetText()).IsEqualTo("generated");
+    }
+
+    /// <summary>
+    /// Both halves of the generation path have to agree about a hidden sheet. Issue #278 is the
+    /// counter-example: the cell pass skipped hidden sheets while the bound ranges on them expanded
+    /// anyway, so the same template block behaved differently depending on whether a defined name
+    /// happened to cover it.
+    /// </summary>
+    [Test]
+    public async Task HiddenSheetHasBothItsCellsAndItsBoundRangesGenerated()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Lookup");
+        sheet.Cell("A1").Value = "{{ Company }}";
+        sheet.Cell("A4").Value = "{{ item.Product }}";
+        workbook.DefinedNames.Add("Items", sheet.Range(4, 1, 5, 3));
+        sheet.Visibility = XLWorksheetVisibility.Hidden;
+
+        using var template = new XLTemplate(workbook);
+        template.AddVariable("Company", "Contoso");
+        template.AddVariable("Items", new List<SaleItem>
+        {
+            new() { Product = "Widget" },
+            new() { Product = "Gadget" },
+        });
+
+        template.Generate();
+
+        await Assert.That(sheet.Cell("A1").Value.GetText()).IsEqualTo("Contoso");
+        await Assert.That(sheet.Cell("A4").Value.GetText()).IsEqualTo("Widget");
+        await Assert.That(sheet.Cell("A5").Value.GetText()).IsEqualTo("Gadget");
     }
 
     /// <summary>
@@ -282,7 +332,7 @@ public class XLTemplateTests
     }
 
     [Test]
-    public async Task EveryVisibleSheetIsGenerated()
+    public async Task EverySheetIsGenerated()
     {
         using var workbook = new XLWorkbook();
         workbook.AddWorksheet("First").Cell("A1").Value = "{{ value }}";

--- a/XLibur.Report/Ranges/RangeInterpreter.cs
+++ b/XLibur.Report/Ranges/RangeInterpreter.cs
@@ -16,6 +16,11 @@ namespace XLibur.Report.Ranges;
 /// which is harmless because their values are already resolved. Cells <em>inside</em> a bound
 /// range are skipped by that first pass — they refer to <c>item</c>, which only exists once
 /// expansion puts a row's data in scope.
+/// <para>
+/// Visibility plays no part in either step. A hidden sheet is a normal place to keep the lookup
+/// tables and working data a report is built from, so generation follows the data rather than what
+/// the reader can see, and every sheet is treated alike.
+/// </para>
 /// </remarks>
 internal sealed class RangeInterpreter
 {
@@ -67,7 +72,7 @@ internal sealed class RangeInterpreter
 
     private void EvaluateOutsideBoundRanges(IXLWorkbook workbook, List<BoundRange> bound, ExpressionScope globalScope)
     {
-        foreach (var worksheet in workbook.Worksheets.Where(IsGenerated).ToList())
+        foreach (var worksheet in workbook.Worksheets.ToList())
         {
             var areas = bound
                 .Where(b => ReferenceEquals(b.Worksheet, worksheet))
@@ -86,6 +91,4 @@ internal sealed class RangeInterpreter
             }
         }
     }
-
-    internal static bool IsGenerated(IXLWorksheet worksheet) => worksheet.Visibility == XLWorksheetVisibility.Visible;
 }

--- a/docs-website/docs/report-templating.md
+++ b/docs-website/docs/report-templating.md
@@ -204,6 +204,20 @@ template.Workbook.Worksheet("Sales").SheetView.FreezeRows(3);
 template.SaveAs("SalesReport.xlsx");
 ```
 
+### Every sheet is generated
+
+Generation covers **every** worksheet in the workbook, including hidden and very hidden ones. A
+hidden sheet is a normal place to keep the lookup tables and working data a report is built from,
+so expressions in its cells are evaluated and its bound ranges expand exactly as they would on a
+visible sheet — hiding a sheet controls what the reader sees, not what gets generated.
+
+To leave a sheet out of the report, delete it after generating rather than hiding it:
+
+```csharp
+template.Generate();
+template.Workbook.Worksheet("Working").Delete();
+```
+
 ### Saving to a stream
 
 ```csharp


### PR DESCRIPTION
Resolves #278 with **Option B**: hidden sheets are generated, fully.

## The split

`RangeInterpreter` filtered the pre-expansion cell pass to visible sheets, and that was the only visibility check in the package. `RangeBinder.Resolve` walks every sheet's defined names without one, and `ReferenceRewriter` / `PivotRewriter` iterate `workbook.Worksheets` unfiltered. So on a hidden sheet a free `{{ Company }}` cell kept its literal text while a bound range on the same sheet expanded, ran its tags, wrote its totals, and had its charts and pivot caches re-pointed at the result.

The observable consequence was that the same template block behaved differently depending on whether a defined name happened to cover it — not something a template author can predict from the outside.

## Why B rather than A

A hidden sheet is a normal place to keep a report's lookup tables and working data — the thing `<<Hidden>>` and `<<Delete>>` exist to support at the column level. Generation should follow the data rather than what the reader can see. Hiding a sheet controls what the reader sees; deleting it after `Generate()` is what keeps it out of the report, and the docs now say so.

This inverts `HiddenSheetsAreNotGenerated`, so that test is rewritten rather than extended.

## Changes

- **`RangeInterpreter`** — drop the `Where(IsGenerated)` filter, and the `IsGenerated` predicate with it. That also retires its confusing name-clash with `IXLTemplate.IsGenerated`, which means whether `Generate()` has run (issue note 2). The class remarks now state that visibility plays no part, so the filter does not come back.
- **Tests** — `HiddenSheetsAreNotGenerated` → `HiddenSheetsAreGenerated`, plus the two cases that had no test at all: a bound range on a hidden sheet alongside a free cell (the issue's repro, pinning that both halves of the path now agree), and a `VeryHidden` sheet. `EveryVisibleSheetIsGenerated` → `EverySheetIsGenerated`, since the distinction it named is gone.
- **Docs** — a "Every sheet is generated" section under *Generating* in `report-templating.md` (issue note 3), including how to leave a sheet out of the report.

## Verification

- `XLibur.Report.Tests` on net10.0: 450 passed, 0 failed.
- Full solution builds Release with 0 warnings (`TreatWarningsAsErrors=true`).

## Notes

- Nothing internal creates sheets during generation, so removing the filter cannot catch a temp sheet of the package's own — the upstream `TempSheetBuffer` / `VeryHidden` buffer design was rejected in spec 12 and never implemented here.
- No CHANGELOG entry: `XLibur.Report` has never shipped and has no CHANGELOG presence at all, not even the #273 feature entry. Worth a separate pass before the package's first release.
