### PR TITLE
fix(report): order and label under the engine's culture, not the machine's

### DIFF
--- a/XLibur.Report.DynamicLinq/DynamicLinqExpressionEngine.cs
+++ b/XLibur.Report.DynamicLinq/DynamicLinqExpressionEngine.cs
@@ -91,6 +91,9 @@ public sealed class DynamicLinqExpressionEngine : IExpressionEngine
     }
 
     /// <inheritdoc />
+    public CultureInfo Culture => _culture;
+
+    /// <inheritdoc />
     /// <remarks>
     /// Always <c>false</c>. See the remarks on <see cref="DynamicLinqExpressionEngine"/>: the
     /// Excel-function bridge belongs to the default engine, and <c>XLTemplate</c> skips registering it

--- a/XLibur.Report.Tests/Expressions/DynamicLinqEngineTests.cs
+++ b/XLibur.Report.Tests/Expressions/DynamicLinqEngineTests.cs
@@ -226,6 +226,19 @@ public class DynamicLinqEngineTests
     }
 
     /// <summary>
+    /// The culture is readable, which is what lets sorting and group labels follow the report's culture
+    /// rather than the machine's.
+    /// </summary>
+    [Test]
+    public async Task CultureIsExposed()
+    {
+        var czech = CultureInfo.GetCultureInfo("cs-CZ");
+
+        await Assert.That(Engine.Culture).IsEqualTo(CultureInfo.InvariantCulture);
+        await Assert.That(new DynamicLinqExpressionEngine(czech).Culture).IsEqualTo(czech);
+    }
+
+    /// <summary>
     /// The engine declines to host functions, and says so rather than accepting them and ignoring them.
     /// </summary>
     [Test]

--- a/XLibur.Report.Tests/Expressions/ScribanExpressionEngineTests.cs
+++ b/XLibur.Report.Tests/Expressions/ScribanExpressionEngineTests.cs
@@ -163,6 +163,19 @@ public class ScribanExpressionEngineTests
         await Assert.That(result).IsEqualTo("1234,5");
     }
 
+    /// <summary>
+    /// The culture is readable, which is what lets sorting and group labels follow the report's
+    /// culture rather than the machine's.
+    /// </summary>
+    [Test]
+    public async Task CultureIsExposed()
+    {
+        var german = CultureInfo.GetCultureInfo("de-DE");
+
+        await Assert.That(new ScribanExpressionEngine().Culture).IsEqualTo(CultureInfo.InvariantCulture);
+        await Assert.That(new ScribanExpressionEngine(german).Culture).IsEqualTo(german);
+    }
+
     [Test]
     public async Task InnerScopeShadowsOuterScope()
     {

--- a/XLibur.Report.Tests/Functions/ExcelFunctionBridgeTests.cs
+++ b/XLibur.Report.Tests/Functions/ExcelFunctionBridgeTests.cs
@@ -191,6 +191,8 @@ public class ExcelFunctionBridgeTests
     {
         public int AddFunctionCalls { get; private set; }
 
+        public CultureInfo Culture => CultureInfo.InvariantCulture;
+
         public bool SupportsFunctions => false;
 
         public object? Evaluate(string expression, ExpressionScope scope) => null;

--- a/XLibur.Report.Tests/Tags/CultureBoundOrderingTests.cs
+++ b/XLibur.Report.Tests/Tags/CultureBoundOrderingTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using TUnit.Assertions.Enums;
+using XLibur.Excel;
+using XLibur.Report.Expressions;
+
+namespace XLibur.Report.Tests.Tags;
+
+/// <summary>
+/// Row order and group labels follow the culture the <em>engine</em> was given, never the machine's.
+/// </summary>
+/// <remarks>
+/// The engines default to invariant so that a report does not change shape with the locale it happens
+/// to be generated on, and take a culture so that a localised report can be ordered and formatted the
+/// way its readers expect. Both promises are broken if the comparer or the label reaches for
+/// <see cref="CultureInfo.CurrentCulture"/> instead, which is
+/// <see href="https://github.com/XLibur/XLibur/issues/275">#275</see>. These tests move the machine's
+/// culture and the engine's independently, so a regression to either one shows up as a different
+/// answer rather than as nothing at all.
+/// <para>
+/// The machine culture is set inside the test rather than by attribute because the suite resets it
+/// before every test, so nothing after is affected. Collection assertions pass
+/// <see cref="CollectionOrdering.Matching"/> because the order <em>is</em> the assertion — two
+/// collations of the same three products differ in nothing else.
+/// </para>
+/// </remarks>
+public class CultureBoundOrderingTests
+{
+    /// <summary>Sorts <c>Ä</c> after <c>Z</c>, where the invariant culture sorts it as an <c>A</c>.</summary>
+    private static readonly CultureInfo Swedish = CultureInfo.GetCultureInfo("sv-SE");
+
+    /// <summary>Writes a date as <c>30.07.2026</c> and a decimal with a comma.</summary>
+    private static readonly CultureInfo Czech = CultureInfo.GetCultureInfo("cs-CZ");
+
+    /// <summary>
+    /// Three products the two collations disagree about: invariant gives Äpple, Banan, Zebra;
+    /// Swedish gives Banan, Zebra, Äpple.
+    /// </summary>
+    private static List<SaleItem> Accented() => new()
+    {
+        new() { Product = "Zebra", Quantity = 1 },
+        new() { Product = "Äpple", Quantity = 2 },
+        new() { Product = "Banan", Quantity = 3 },
+    };
+
+    private static List<SaleItem> Dated() => new()
+    {
+        new() { Product = "Widget", Quantity = 2, SoldOn = new DateTime(2026, 7, 30) },
+        new() { Product = "Gadget", Quantity = 5, SoldOn = new DateTime(2026, 12, 3) },
+    };
+
+    /// <summary>
+    /// A two-column range over A3:B4 — the first column holding <paramref name="expression"/>, the
+    /// second a quantity — with row 4 the options row.
+    /// </summary>
+    private static IXLWorkbook Template(string expression, string optionsA, string optionsB = "")
+    {
+        var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Report");
+
+        sheet.Cell("A2").Value = "Key";
+        sheet.Cell("B2").Value = "Quantity";
+        sheet.Cell("A3").Value = expression;
+        sheet.Cell("B3").Value = "{{ item.Quantity }}";
+        sheet.Cell("A4").Value = optionsA;
+
+        if (optionsB.Length > 0)
+        {
+            sheet.Cell("B4").Value = optionsB;
+        }
+
+        workbook.DefinedNames.Add("Items", sheet.Range("A3:B4"));
+        return workbook;
+    }
+
+    private static void Generate(IXLWorkbook workbook, object items, IExpressionEngine? engine = null)
+    {
+        using var template = new XLTemplate(workbook, engine);
+        template.AddVariable("Items", items);
+        template.Generate();
+    }
+
+    private static List<string> ColumnText(IXLWorksheet sheet, string column, int firstRow, int count) =>
+        Enumerable.Range(firstRow, count).Select(r => sheet.Cell(column + r).Value.ToString() ?? string.Empty).ToList();
+
+    /// <summary>The subtotal rows, which with one item per group land on 4, 6 and 8.</summary>
+    private static List<string> GroupLabels(IXLWorksheet sheet, params int[] rows) =>
+        rows.Select(row => sheet.Cell("A" + row).Value.GetText()).ToList();
+
+    [Test]
+    public async Task SortIgnoresTheMachineCulture()
+    {
+        using var workbook = Template("{{ item.Product }}", optionsA: "<<Sort>>");
+        TestDefaults.SetCulture(Swedish);
+
+        // No engine given, so the default engine's invariant culture decides and the machine's
+        // Swedish collation gets no say.
+        Generate(workbook, Accented());
+
+        await Assert.That(ColumnText(workbook.Worksheet("Report"), "A", 3, 3))
+            .IsEquivalentTo(new[] { "Äpple", "Banan", "Zebra" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task SortFollowsTheEngineCulture()
+    {
+        using var workbook = Template("{{ item.Product }}", optionsA: "<<Sort>>");
+
+        Generate(workbook, Accented(), new ScribanExpressionEngine(Swedish));
+
+        await Assert.That(ColumnText(workbook.Worksheet("Report"), "A", 3, 3))
+            .IsEquivalentTo(new[] { "Banan", "Zebra", "Äpple" }, CollectionOrdering.Matching);
+    }
+
+    /// <summary>
+    /// Two keys of different types are compared as text, which is the comparer's other arm and was
+    /// the other half of the same bug. A string against a bool reaches it; invariant collation puts
+    /// <c>Äpple</c> before <c>True</c>, Swedish does not.
+    /// </summary>
+    [Test]
+    public async Task SortOfMixedTypesIgnoresTheMachineCulture()
+    {
+        using var workbook = Template("{{ item }}", optionsA: "<<Sort>>");
+        TestDefaults.SetCulture(Swedish);
+
+        Generate(workbook, new List<object?> { true, "Äpple" });
+
+        await Assert.That(workbook.Worksheet("Report").Cell("A3").Value.IsText).IsTrue();
+    }
+
+    [Test]
+    public async Task SortOfMixedTypesFollowsTheEngineCulture()
+    {
+        using var workbook = Template("{{ item }}", optionsA: "<<Sort>>");
+
+        Generate(workbook, new List<object?> { true, "Äpple" }, new ScribanExpressionEngine(Swedish));
+
+        await Assert.That(workbook.Worksheet("Report").Cell("A3").Value.IsBoolean).IsTrue();
+    }
+
+    [Test]
+    public async Task GroupOrderIgnoresTheMachineCulture()
+    {
+        using var workbook = Template("{{ item.Product }}", optionsA: "<<Group>>", optionsB: "<<Sum>>");
+        TestDefaults.SetCulture(Swedish);
+
+        Generate(workbook, Accented());
+
+        await Assert.That(GroupLabels(workbook.Worksheet("Report"), 4, 6, 8))
+            .IsEquivalentTo(new[] { "Äpple Total", "Banan Total", "Zebra Total" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task GroupOrderFollowsTheEngineCulture()
+    {
+        using var workbook = Template("{{ item.Product }}", optionsA: "<<Group>>", optionsB: "<<Sum>>");
+
+        Generate(workbook, Accented(), new ScribanExpressionEngine(Swedish));
+
+        await Assert.That(GroupLabels(workbook.Worksheet("Report"), 4, 6, 8))
+            .IsEquivalentTo(new[] { "Banan Total", "Zebra Total", "Äpple Total" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task AGroupLabelOverADateIgnoresTheMachineCulture()
+    {
+        using var workbook = Template("{{ item.SoldOn }}", optionsA: "<<Group>>", optionsB: "<<Sum>>");
+        TestDefaults.SetCulture(Czech);
+
+        Generate(workbook, Dated());
+
+        var expected = new DateTime(2026, 7, 30).ToString(null, CultureInfo.InvariantCulture);
+        await Assert.That(workbook.Worksheet("Report").Cell("A4").Value.GetText()).IsEqualTo(expected + " Total");
+    }
+
+    [Test]
+    public async Task AGroupLabelOverADateFollowsTheEngineCulture()
+    {
+        using var workbook = Template("{{ item.SoldOn }}", optionsA: "<<Group>>", optionsB: "<<Sum>>");
+
+        Generate(workbook, Dated(), new ScribanExpressionEngine(Czech));
+
+        var expected = new DateTime(2026, 7, 30).ToString(null, Czech);
+        await Assert.That(workbook.Worksheet("Report").Cell("A4").Value.GetText()).IsEqualTo(expected + " Total");
+    }
+
+    [Test]
+    public async Task AGroupLabelOverADecimalFollowsTheEngineCulture()
+    {
+        using var workbook = Template("{{ item.UnitPrice }}", optionsA: "<<Group>>", optionsB: "<<Sum>>");
+
+        Generate(
+            workbook,
+            new List<SaleItem> { new() { Product = "Widget", Quantity = 2, UnitPrice = 1.5m } },
+            new ScribanExpressionEngine(Czech));
+
+        // A decimal comma, because that is how the report this engine was given a culture for reads.
+        await Assert.That(workbook.Worksheet("Report").Cell("A4").Value.GetText()).IsEqualTo("1,5 Total");
+    }
+}

--- a/XLibur.Report/Expressions/IExpressionEngine.cs
+++ b/XLibur.Report/Expressions/IExpressionEngine.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace XLibur.Report.Expressions;
 
@@ -17,6 +18,20 @@ namespace XLibur.Report.Expressions;
 /// </remarks>
 public interface IExpressionEngine
 {
+    /// <summary>
+    /// The culture the report is generated under — how a value formats, and how two text keys
+    /// collate.
+    /// </summary>
+    /// <remarks>
+    /// The engine owns the answer because it is the thing that already had to be told: both shipped
+    /// engines take a culture and default to <see cref="CultureInfo.InvariantCulture"/>. Exposing it
+    /// is what lets the rest of the pipeline — sort order, group order, a group's <c>{0} Total</c>
+    /// label — follow the culture the <em>template</em> was given rather than the one the machine
+    /// happens to be running under, so the same template and the same data produce the same workbook
+    /// wherever it is generated.
+    /// </remarks>
+    CultureInfo Culture { get; }
+
     /// <summary>
     /// Whether this engine can expose .NET functions to templates through
     /// <see cref="AddFunction"/>. Engines that return <c>false</c> are skipped when the Excel

--- a/XLibur.Report/Expressions/ScribanExpressionEngine.cs
+++ b/XLibur.Report/Expressions/ScribanExpressionEngine.cs
@@ -48,6 +48,9 @@ public sealed class ScribanExpressionEngine : IExpressionEngine
     public ScribanExpressionEngine(CultureInfo? culture = null) => _culture = culture ?? CultureInfo.InvariantCulture;
 
     /// <inheritdoc />
+    public CultureInfo Culture => _culture;
+
+    /// <inheritdoc />
     public bool SupportsFunctions => true;
 
     /// <inheritdoc />

--- a/XLibur.Report/Ranges/GroupRenderer.cs
+++ b/XLibur.Report/Ranges/GroupRenderer.cs
@@ -90,7 +90,7 @@ internal sealed class GroupRenderer
             return null;
         }
 
-        var (ordered, orderedKeys) = Order(levels, items, keys);
+        var (ordered, orderedKeys) = Order(levels, items, keys, context.Engine.Culture);
         return new GroupRenderer(levels, ordered, orderedKeys);
     }
 
@@ -206,8 +206,10 @@ internal sealed class GroupRenderer
     private static (IReadOnlyList<object?> Items, object?[][] Keys) Order(
         List<GroupLevel> levels,
         IReadOnlyList<object?> items,
-        object?[][] keys)
+        object?[][] keys,
+        CultureInfo culture)
     {
+        var comparer = new SortKeyComparer(culture);
         IOrderedEnumerable<int>? ordered = null;
 
         for (var level = 0; level < levels.Count; level++)
@@ -224,14 +226,14 @@ internal sealed class GroupRenderer
             if (ordered is null)
             {
                 ordered = descending
-                    ? Enumerable.Range(0, items.Count).OrderByDescending(key, SortKeyComparer.Instance)
-                    : Enumerable.Range(0, items.Count).OrderBy(key, SortKeyComparer.Instance);
+                    ? Enumerable.Range(0, items.Count).OrderByDescending(key, comparer)
+                    : Enumerable.Range(0, items.Count).OrderBy(key, comparer);
             }
             else
             {
                 ordered = descending
-                    ? ordered.ThenByDescending(key, SortKeyComparer.Instance)
-                    : ordered.ThenBy(key, SortKeyComparer.Instance);
+                    ? ordered.ThenByDescending(key, comparer)
+                    : ordered.ThenBy(key, comparer);
             }
         }
 
@@ -529,7 +531,8 @@ internal sealed class GroupRenderer
             var level = _levels[run.Level];
             if (!summaryColumns.Contains(level.Column))
             {
-                sheet.Cell(run.SubtotalRow, level.Column).Value = level.TotalLabel.Replace("{0}", KeyText(run.Key));
+                sheet.Cell(run.SubtotalRow, level.Column).Value =
+                    level.TotalLabel.Replace("{0}", KeyText.For(run.Key, context.Engine.Culture));
             }
         }
     }
@@ -628,14 +631,6 @@ internal sealed class GroupRenderer
             }
         }
     }
-
-    private static string KeyText(object? key) => key switch
-    {
-        null => string.Empty,
-        string text => text,
-        IFormattable formattable => formattable.ToString(null, CultureInfo.CurrentCulture),
-        _ => key.ToString() ?? string.Empty,
-    };
 
     /// <summary>One <c>&lt;&lt;Group&gt;&gt;</c> tag, resolved against the range-wide options.</summary>
     private sealed record GroupLevel(

--- a/XLibur.Report/Tags/KeyText.cs
+++ b/XLibur.Report/Tags/KeyText.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+
+namespace XLibur.Report.Tags;
+
+/// <summary>
+/// Renders the value an expression produced as the text a report reads it as.
+/// </summary>
+/// <remarks>
+/// Under the report's culture — the one the engine was constructed with — rather than the machine's.
+/// A group label is text a human reads, so a date or a decimal in one should format the way the rest
+/// of the report does, and a default-constructed template stays invariant end to end. The comparer
+/// renders the same way for keys it can only order as text, so a label and the position it appears
+/// in agree about what the key says.
+/// </remarks>
+internal static class KeyText
+{
+    public static string For(object? key, CultureInfo culture) => key switch
+    {
+        null => string.Empty,
+        string text => text,
+        IFormattable formattable => formattable.ToString(null, culture),
+        _ => key.ToString() ?? string.Empty,
+    };
+}

--- a/XLibur.Report/Tags/SortKeyComparer.cs
+++ b/XLibur.Report/Tags/SortKeyComparer.cs
@@ -5,17 +5,35 @@ using System.Globalization;
 namespace XLibur.Report.Tags;
 
 /// <summary>
-/// Orders the values an expression produced, keeping blanks together at the end.
+/// Orders the values an expression produced under the report's culture, keeping blanks together at
+/// the end.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Sorting and grouping both order rows by an evaluated expression, and neither knows the type in
 /// advance — the same key is a decimal in one template and a string in the next. Values of the same
 /// comparable type compare directly; numbers of different types compare numerically rather than
 /// textually, so <c>9</c> does not sort after <c>10</c>; anything else falls back to its text form.
+/// </para>
+/// <para>
+/// Text collates under the culture the engine was given, never under the machine's. Collation is the
+/// one part of ordering a locale genuinely changes — Swedish sorts <c>å</c> after <c>z</c>, Czech
+/// treats <c>ch</c> as a letter of its own — so a report meant for those readers should honour it,
+/// and every other report should get the same row order wherever it was generated. That is only true
+/// if the answer comes from the template rather than from the current thread, which is why this
+/// takes a culture instead of reading <see cref="CultureInfo.CurrentCulture"/>.
+/// </para>
 /// </remarks>
 internal sealed class SortKeyComparer : IComparer<object?>
 {
-    public static readonly SortKeyComparer Instance = new();
+    private readonly CultureInfo _culture;
+    private readonly CompareInfo _collation;
+
+    public SortKeyComparer(CultureInfo culture)
+    {
+        _culture = culture ?? throw new ArgumentNullException(nameof(culture));
+        _collation = _culture.CompareInfo;
+    }
 
     public int Compare(object? x, object? y)
     {
@@ -27,6 +45,13 @@ internal sealed class SortKeyComparer : IComparer<object?>
         if (y is null)
         {
             return -1;
+        }
+
+        // Strings are taken before the general comparable case, because string.CompareTo collates
+        // under CultureInfo.CurrentCulture — the one culture this comparer must not consult.
+        if (x is string left && y is string right)
+        {
+            return _collation.Compare(left, right);
         }
 
         if (x is IComparable comparable && x.GetType() == y.GetType())
@@ -41,7 +66,7 @@ internal sealed class SortKeyComparer : IComparer<object?>
                 .CompareTo(Convert.ToDouble(y, CultureInfo.InvariantCulture));
         }
 
-        return string.Compare(x.ToString(), y.ToString(), StringComparison.CurrentCulture);
+        return _collation.Compare(KeyText.For(x, _culture), KeyText.For(y, _culture));
     }
 
     private static bool IsNumeric(object value) =>

--- a/XLibur.Report/Tags/SortTag.cs
+++ b/XLibur.Report/Tags/SortTag.cs
@@ -46,7 +46,7 @@ public class SortTag : OptionTag
             }
         }
 
-        var comparer = SortKeyComparer.Instance;
+        var comparer = new SortKeyComparer(context.Engine.Culture);
         var sorted = Descending
             ? keyed.OrderByDescending(pair => pair.Key, comparer)
             : keyed.OrderBy(pair => pair.Key, comparer);

--- a/docs/report-templating.md
+++ b/docs/report-templating.md
@@ -61,6 +61,22 @@ lets one template survive an optional field — a middle name, a discount that i
 without testing for each. The price is that a **typo in a name is silent**, so a column that comes out
 empty is the first place to look for one.
 
+### Culture
+
+Everything the report formats or orders follows **one** culture, and it is the template's rather than
+the machine's. A default `XLTemplate` is invariant end to end, so the same template over the same data
+produces the same workbook wherever it is generated — the same row order, the same group labels, the
+same decimal point. Pass a culture to the engine to say otherwise:
+
+```csharp
+using var template = new XLTemplate("Rapport.xlsx", new ScribanExpressionEngine(new CultureInfo("sv-SE")));
+```
+
+That one argument decides how an interpolated number or date reads, how `<<Sort>>` and `<<Group>>`
+collate text — Swedish sorting `å` after `z`, Czech treating `ch` as a single letter — and how a
+group's `{0} Total` label formats a date or a decimal key. A custom tag that needs the same answer
+reads `context.Engine.Culture`.
+
 ## Bound ranges
 
 A **defined name** matching the name of a variable that holds a collection makes the rows it covers

--- a/docs/specs/12-report-templating.md
+++ b/docs/specs/12-report-templating.md
@@ -138,6 +138,7 @@ public interface IExpressionEngine                    // the pluggable seam
 {
     object? Evaluate(string expression, ExpressionScope scope);   // typed result
     string  Interpolate(string text, ExpressionScope scope);      // mixed text + {{ }}
+    CultureInfo Culture { get; }                                  // the report's culture (#275)
     bool    SupportsFunctions { get; }                            // optional capability
     void    AddFunction(string name, Delegate function);          // throws if unsupported
 }
@@ -344,6 +345,13 @@ implemented:
 - **The engine orders the rows.** All the levels are ordered in one `OrderBy`/`ThenBy` chain, so
   the leftmost is the primary key; the ordering is stable, so a `<<Sort>>` (which runs first, at
   priority 10) still decides the order within a group. `nosort` opts out per level.
+- **Ordering and labelling follow `IExpressionEngine.Culture`**, not `CultureInfo.CurrentCulture`
+  ([#275](https://github.com/XLibur/XLibur/issues/275)). `SortKeyComparer` collates text through that
+  culture's `CompareInfo` and `KeyText` formats a key through it, so a default template is invariant
+  end to end and a template handed `new ScribanExpressionEngine(new CultureInfo("sv-SE"))` sorts and
+  labels the way its readers read. Both the comparer's string arm and its mixed-type text fallback
+  were affected; `string.CompareTo` collates under the current culture, so strings are taken before
+  the general `IComparable` case.
 - **Each group gets a subtotal row** carrying whatever summary tags the options row declares, over
   that group's rows alone, plus a `{0} Total` label in the grouped column. Below the group by
   default, `summaryAbove` above it. Where several stack at one boundary they read outwards from the


### PR DESCRIPTION
## Summary

Both expression engines take a `CultureInfo` and default to invariant, precisely so that a generated report does not change shape with the machine's locale. Sorting and group labels never asked the engine: `SortKeyComparer` collated through `string.CompareTo` and a `StringComparison.CurrentCulture` fallback, and `GroupRenderer` formatted its `{0} Total` key with `CultureInfo.CurrentCulture`. The same template over the same data produced a different row order and a differently formatted label depending on where it ran.

This is **Option 1.B** from #275: thread the engine's culture down to the comparer and the label, exposing it on `IExpressionEngine` rather than carrying a second culture on `XLTemplate` that could disagree with the engine's. The engine already owns the answer, and `XLibur.Report` is unreleased (added after `v0.106.0`), so adding an interface member breaks no shipped implementer.

## Changes

- **`IExpressionEngine.Culture`** — new `CultureInfo Culture { get; }` on the seam. `ScribanExpressionEngine` and `DynamicLinqExpressionEngine` expose the culture they were constructed with; both still default to invariant.
- **`SortKeyComparer`** takes a culture and collates through its `CompareInfo`. Strings are matched **before** the general `IComparable` case, because `string.CompareTo` is itself current-culture — as #275 notes, this is not a one-line change to the fallback arm. The mixed-type fallback collates *and* renders through the same culture.
- **`GroupRenderer`** builds the comparer from `context.Engine.Culture`, and its key rendering moves out to a shared internal `KeyText` so the group label and the comparer's text fallback agree on what a key says.
- **`SortTag`** builds its comparer from `context.Engine.Culture`.
- **Docs** — a "Culture" section in `docs/report-templating.md`, plus the interface sketch and a grouping note in `docs/specs/12-report-templating.md`.

Net effect: a default-constructed `XLTemplate` is invariant end to end, and `new XLTemplate(path, new ScribanExpressionEngine(new CultureInfo("sv-SE")))` sorts, groups and labels the way its readers read.

## Related Issues

Fixes #275

## Testing

- [x] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually

New `XLibur.Report.Tests/Tags/CultureBoundOrderingTests.cs` (9 tests) moves the machine culture and the engine culture **independently**, so a regression to either shows up as a different answer rather than as nothing:

- Swedish `Ä`-after-`Z` collation over `<<Sort>>` and `<<Group>>`, in both directions (invariant engine on a Swedish machine; Swedish engine on an en-US machine).
- The comparer's mixed-type arm (a string against a bool), same two directions.
- A group label over a `DateTime` and over a `decimal` under cs-CZ.

Plus `CultureIsExposed` on each engine.

The tests were verified to bite by temporarily reintroducing each half of the bug: current-culture collation fails 6 of them, current-culture label formatting fails 3.

`XLibur.Report.Tests` on net10.0: **459 passed, 0 failed, 0 skipped.**

One note for reviewers: the new collection assertions pass `CollectionOrdering.Matching`, because TUnit's `IsEquivalentTo` is order-*insensitive* by default and the order is the whole assertion here. The pre-existing ordering tests in `TagBehaviourTests` (`SortOrdersByTheColumnItSitsUnder` and friends) do not pass it, so they would currently pass even if sorting did nothing. Left alone here to keep this PR to one subject — happy to sweep them separately.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
