### PR TITLE
perf(report): share the Excel function library between templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@
 
 #### Formula engine
 
-- **The Excel function table is built once per process instead of once per calc engine** — about 70 KB and 0.12 ms back on every engine constructed, which is one per workbook that touches a formula plus a fresh one on some internal evaluation paths. Opening a workbook allocates 644 → 574 KB. The ~400-entry table is the same whatever the culture (a function takes its culture from the calculation context, not from the engine holding it) and nothing mutates it after it is built, so the per-engine copy only ever bought a private duplicate of a constant. ([#276](https://github.com/XLibur/XLibur/issues/276) by [@jafin](https://github.com/jafin))
+- **The Excel function table is built once per process instead of once per calc engine** — about 70 KB and 0.12 ms back on every engine constructed, which is one per workbook that touches a formula plus a fresh one on some internal evaluation paths. Opening a workbook allocates 644 → 574 KB. The ~400-entry table is the same whatever the culture (a function takes its culture from the calculation context, not from the engine holding it) and nothing mutates it after it is built, so the per-engine copy only ever bought a private duplicate of a constant. ([#276](https://github.com/XLibur/XLibur/issues/276), [#306](https://github.com/XLibur/XLibur/pull/306) by [@jafin](https://github.com/jafin))
 
 #### Styling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,10 @@
 
 - **Repeated access to the same cell is cheaper**: `ws.Cell(r, c)` minted a fresh `XLCell` every call, so the per-object style cache never hit and a `.Style` access threw away an 80-byte `XLStyle` one statement later. A small direct-mapped cache now hands back the same wrapper for the same address. ([#185](https://github.com/XLibur/XLibur/pull/185) by [@jafin](https://github.com/jafin))
 
+#### Formula engine
+
+- **The Excel function table is built once per process instead of once per calc engine** — about 70 KB and 0.12 ms back on every engine constructed, which is one per workbook that touches a formula plus a fresh one on some internal evaluation paths. Opening a workbook allocates 644 → 574 KB. The ~400-entry table is the same whatever the culture (a function takes its culture from the calculation context, not from the engine holding it) and nothing mutates it after it is built, so the per-engine copy only ever bought a private duplicate of a constant. ([#276](https://github.com/XLibur/XLibur/issues/276) by [@jafin](https://github.com/jafin))
+
 #### Styling
 
 - **86% fewer allocations styling a range, row or column in bulk** (~234 → ~33 bytes per cell): setting a style on a container collected every child cell into a `HashSet` of wrappers before writing anything. Containers that can enumerate exactly those cells now walk the addresses and write the style slice directly. ([#185](https://github.com/XLibur/XLibur/pull/185) by [@jafin](https://github.com/jafin))

--- a/XLibur.Report.Benchmarks/TemplateConstructionBenchmarks.cs
+++ b/XLibur.Report.Benchmarks/TemplateConstructionBenchmarks.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using XLibur.Excel;
+using XLibur.Report;
+
+namespace XLibur.Report.Benchmarks;
+
+/// <summary>
+/// What it costs to <em>start</em> a report, as opposed to generate one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ReportGenerateBenchmarks"/> measures a report big enough that its setup disappears
+/// into the noise. This one measures the setup, because the service generating a hundred small
+/// reports an hour pays it a hundred times and the row work barely at all.
+/// </para>
+/// <para>
+/// Issue #276 is why it exists. Constructing an <see cref="XLTemplate"/> used to import the whole
+/// ~400-function Excel library into the expression engine one function at a time — about 30 KB
+/// apiece inside Scriban, so some 12 MB per template, discarded when the template was disposed.
+/// That was more than nine tenths of everything a small report allocated, and twenty times the cost
+/// of opening the template workbook it accompanied. The library is now imported once per culture
+/// and shared, which is what <see cref="ConstructTemplate"/> should show against
+/// <see cref="OpenWorkbook"/>: the template constructor ought to be a rounding error next to
+/// opening the file, and it was not.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class TemplateConstructionBenchmarks
+{
+    private const string SheetName = "Report";
+
+    private string _path = string.Empty;
+    private XLWorkbook? _workbook;
+    private List<ReportRow> _rows = new();
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _rows = ReportData.Rows(25);
+
+        _path = Path.Combine(Path.GetTempPath(), "XLibur.Report.Benchmarks.Construction.xlsx");
+        using (var template = Template())
+        {
+            template.SaveAs(_path);
+        }
+
+        // Kept open, so ConstructTemplate measures the constructor and nothing else.
+        _workbook = new XLWorkbook(_path);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _workbook?.Dispose();
+        _workbook = null;
+
+        if (File.Exists(_path))
+        {
+            File.Delete(_path);
+        }
+    }
+
+    /// <summary>The baseline the constructor should be measured against: reading the .xlsx.</summary>
+    [Benchmark(Baseline = true)]
+    public int OpenWorkbook()
+    {
+        using var workbook = new XLWorkbook(_path);
+
+        return workbook.Worksheets.Count;
+    }
+
+    /// <summary>The constructor alone, over a workbook that is already open.</summary>
+    [Benchmark]
+    public bool ConstructTemplate()
+    {
+        using var template = new XLTemplate(_workbook!);
+
+        return template.IsGenerated;
+    }
+
+    /// <summary>
+    /// The whole shape of a request that returns one small report: open, bind, generate, save.
+    /// </summary>
+    [Benchmark]
+    public long SmallReport()
+    {
+        using var workbook = new XLWorkbook(_path);
+        using var template = new XLTemplate(workbook);
+        template.AddVariable("Rows", _rows);
+        template.Generate();
+
+        using var stream = new MemoryStream();
+        template.SaveAs(stream);
+
+        return stream.Length;
+    }
+
+    private static XLWorkbook Template()
+    {
+        var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet(SheetName);
+
+        sheet.Cell("A1").Value = "Region";
+        sheet.Cell("B1").Value = "Product";
+        sheet.Cell("C1").Value = "Total";
+
+        sheet.Cell("A2").Value = "{{ item.Region }}";
+        sheet.Cell("B2").Value = "{{ item.Product }}";
+        sheet.Cell("C2").Value = "{{ item.Total }}";
+        sheet.Cell("C3").Value = "<<Sum>>";
+
+        workbook.DefinedNames.Add("Rows", sheet.Range("A2:C3"));
+
+        return workbook;
+    }
+}

--- a/XLibur.Report.Tests/Functions/ExcelFunctionBridgeTests.cs
+++ b/XLibur.Report.Tests/Functions/ExcelFunctionBridgeTests.cs
@@ -187,6 +187,71 @@ public class ExcelFunctionBridgeTests
         await Assert.That(engine.AddFunctionCalls).IsEqualTo(0);
     }
 
+    /// <summary>
+    /// The default engine is handed the library as one shared object, but any other engine — the
+    /// DynamicLinq one, or a caller's own — still receives it a function at a time through
+    /// <see cref="IExpressionEngine.AddFunction"/>.
+    /// </summary>
+    [Test]
+    public async Task OtherEnginesAreStillGivenEachFunction()
+    {
+        var engine = new RecordingEngine();
+
+        ExcelFunctionBridge.Register(engine);
+
+        await Assert.That(engine.Names).Contains("SUM");
+        await Assert.That(engine.Names).Contains("UPPER");
+        await Assert.That(engine.Names.Count).IsGreaterThan(100);
+    }
+
+    [Test]
+    public async Task AFunctionAddedToTheEngineShadowsTheExcelOne()
+    {
+        var engine = BridgedEngine();
+        engine.AddFunction("UPPER", new Func<string, string>(_ => "shadowed"));
+
+        var result = engine.Evaluate("UPPER(\"contoso\")", ExpressionScope.Empty);
+
+        await Assert.That(result).IsEqualTo("shadowed");
+    }
+
+    /// <summary>
+    /// The Excel library is one object shared by every engine, so an engine that shadows a function
+    /// must not be writing into it. This is the test that would catch that: a second engine has to
+    /// still see the real UPPER.
+    /// </summary>
+    [Test]
+    public async Task ShadowingAFunctionDoesNotAffectAnotherEngine()
+    {
+        var shadowed = BridgedEngine();
+        shadowed.AddFunction("UPPER", new Func<string, string>(_ => "shadowed"));
+
+        var untouched = BridgedEngine();
+        var result = untouched.Evaluate("UPPER(\"contoso\")", ExpressionScope.Empty);
+
+        await Assert.That(result).IsEqualTo("CONTOSO");
+    }
+
+    [Test]
+    public async Task ABoundVariableShadowsAFunctionOfTheSameName()
+    {
+        var result = BridgedEngine().Evaluate("SUM", Scope(("SUM", "a variable")));
+
+        await Assert.That(result).IsEqualTo("a variable");
+    }
+
+    /// <summary>Every engine gets the library, not just the first one to ask for it.</summary>
+    [Test]
+    public async Task EachEngineGetsTheLibrary()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            var result = BridgedEngine().Evaluate("SUM(1, 2, 3)", ExpressionScope.Empty);
+
+            await Assert.That(Number(result)).IsEqualTo(6d);
+        }
+    }
+
     private sealed class FunctionlessEngine : IExpressionEngine
     {
         public int AddFunctionCalls { get; private set; }
@@ -198,5 +263,18 @@ public class ExcelFunctionBridgeTests
         public string Interpolate(string text, ExpressionScope scope) => text;
 
         public void AddFunction(string name, Delegate function) => AddFunctionCalls++;
+    }
+
+    private sealed class RecordingEngine : IExpressionEngine
+    {
+        public List<string> Names { get; } = new();
+
+        public bool SupportsFunctions => true;
+
+        public object? Evaluate(string expression, ExpressionScope scope) => null;
+
+        public string Interpolate(string text, ExpressionScope scope) => text;
+
+        public void AddFunction(string name, Delegate function) => Names.Add(name);
     }
 }

--- a/XLibur.Report/Expressions/ScribanExpressionEngine.cs
+++ b/XLibur.Report/Expressions/ScribanExpressionEngine.cs
@@ -42,6 +42,7 @@ public sealed class ScribanExpressionEngine : IExpressionEngine
     private readonly ConditionalWeakTable<ExpressionScope, ScriptObject> _scopeObjects = new();
     private readonly ScriptObject _functions = new();
     private readonly CultureInfo _culture;
+    private ScriptObject? _excelFunctions;
     private TemplateContext? _context;
 
     /// <summary>Creates an engine evaluating under <paramref name="culture"/>, invariant by default.</summary>
@@ -64,6 +65,25 @@ public sealed class ScribanExpressionEngine : IExpressionEngine
         }
 
         _functions.Import(name, function);
+    }
+
+    /// <summary>
+    /// Adopts a prepared set of Excel functions, shared with every other engine registered for the
+    /// same culture rather than imported one at a time into this one.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="functions"/> is read-only and shared, so it goes on the stack *below*
+    /// <see cref="_functions"/>: anything <see cref="AddFunction"/> adds shadows an Excel function
+    /// of the same name, and this engine never writes to the shared object. Bound variables are
+    /// pushed later still, so a variable named <c>SUM</c> shadows both — the order a template author
+    /// would expect.
+    /// </remarks>
+    internal void UseExcelFunctions(ScriptObject functions)
+    {
+        _excelFunctions = functions;
+
+        // Dropped rather than amended: the stack is ordered, and this belongs at the bottom of it.
+        _context = null;
     }
 
     /// <inheritdoc />
@@ -130,6 +150,12 @@ public sealed class ScribanExpressionEngine : IExpressionEngine
         };
 
         context.PushCulture(_culture);
+
+        // The shared Excel library first, so this engine's own functions shadow it.
+        if (_excelFunctions is not null)
+        {
+            context.PushGlobal(_excelFunctions);
+        }
 
         // Pushed once and never popped, so functions registered later through AddFunction are
         // still visible: the same ScriptObject instance stays on the stack.

--- a/XLibur.Report/Functions/ExcelFunctionBridge.cs
+++ b/XLibur.Report/Functions/ExcelFunctionBridge.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Scriban.Runtime;
 using XLibur.Excel;
 using XLibur.Excel.CalcEngine;
 using XLibur.Excel.CalcEngine.Exceptions;
@@ -29,6 +31,13 @@ namespace XLibur.Report.Functions;
 /// report that they were called outside a worksheet rather than returning something misleading.
 /// Cell references belong in real Excel formulas, which generation expands and Excel evaluates.
 /// </para>
+/// <para>
+/// Registration is built once per culture and shared by every template. It has to be: importing
+/// the ~400 functions into a Scriban <see cref="ScriptObject"/> costs about 30 KB each, which made
+/// constructing an <see cref="XLTemplate"/> allocate some 12 MB — more than nine tenths of what
+/// generating a small report allocated in total, and twenty times the cost of opening the template
+/// workbook. Sharing the imported object turns that into one <c>PushGlobal</c>.
+/// </para>
 /// </remarks>
 internal static class ExcelFunctionBridge
 {
@@ -36,7 +45,20 @@ internal static class ExcelFunctionBridge
     internal delegate object? ExcelFunction(params object?[] arguments);
 
     /// <summary>
-    /// Registers every function the calc engine knows about with <paramref name="engine"/>.
+    /// The adapters for one culture, and — for the default engine — those same adapters already
+    /// imported into a Scriban globals object.
+    /// </summary>
+    /// <remarks>
+    /// Keyed by culture because the adapters close over the one they convert arguments with.
+    /// In practice this holds a single entry: <see cref="XLTemplate"/> registers under the
+    /// invariant culture, matching <see cref="ScribanExpressionEngine"/>'s own default.
+    /// </remarks>
+    private static readonly ConcurrentDictionary<CultureInfo, IReadOnlyList<(string Name, Delegate Function)>> Adapters = new();
+
+    private static readonly ConcurrentDictionary<CultureInfo, ScriptObject> ScribanGlobals = new();
+
+    /// <summary>
+    /// Makes every function the calc engine knows about callable from <paramref name="engine"/>.
     /// Engines that cannot host functions are left alone.
     /// </summary>
     public static void Register(IExpressionEngine engine, CultureInfo? culture = null)
@@ -47,7 +69,52 @@ internal static class ExcelFunctionBridge
         }
 
         culture ??= CultureInfo.InvariantCulture;
+
+        // The default engine takes the whole library as one shared globals object rather than
+        // ~400 separate imports, which is the entire cost of this bridge.
+        if (engine is ScribanExpressionEngine scriban)
+        {
+            scriban.UseExcelFunctions(ScribanGlobals.GetOrAdd(culture, BuildScribanGlobals));
+            return;
+        }
+
+        // Any other engine — XLibur.Report.DynamicLinq, or a caller's own — is fed one at a time
+        // through the interface. The adapters themselves are still shared.
+        foreach (var (name, function) in AdaptersFor(culture))
+        {
+            engine.AddFunction(name, function);
+        }
+    }
+
+    private static ScriptObject BuildScribanGlobals(CultureInfo culture)
+    {
+        var globals = new ScriptObject();
+
+        foreach (var (name, function) in AdaptersFor(culture))
+        {
+            globals.Import(name, function);
+        }
+
+        return globals;
+    }
+
+    private static IReadOnlyList<(string Name, Delegate Function)> AdaptersFor(CultureInfo culture) =>
+        Adapters.GetOrAdd(culture, BuildAdapters);
+
+    /// <summary>
+    /// One adapter per registered function, closing over a single calc engine.
+    /// </summary>
+    /// <remarks>
+    /// Sharing that engine across templates — and so across threads — is safe because these calls
+    /// have no grid: <see cref="CalcContext.CalcEngine"/> is reached only when reading a cell, which
+    /// needs a worksheet, and without one the call has already failed with the
+    /// <see cref="MissingContextException"/> translated below. The engine is here to be handed to a
+    /// <see cref="CalcContext"/>, not to hold state for the call.
+    /// </remarks>
+    private static IReadOnlyList<(string Name, Delegate Function)> BuildAdapters(CultureInfo culture)
+    {
         var calcEngine = new XLCalcEngine(culture);
+        var adapters = new List<(string Name, Delegate Function)>();
 
         foreach (var name in calcEngine.Functions.Names)
         {
@@ -57,10 +124,12 @@ internal static class ExcelFunctionBridge
             }
 
             var function = definition;
-            engine.AddFunction(
+            adapters.Add((
                 name.ToUpperInvariant(),
-                new ExcelFunction(arguments => Invoke(calcEngine, function, culture, arguments)));
+                new ExcelFunction(arguments => Invoke(calcEngine, function, culture, arguments))));
         }
+
+        return adapters;
     }
 
     private static object? Invoke(

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -62,7 +62,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
     {
         _culture = culture;
         _cache = new ExpressionCache(this);
-        var funcRegistry = GetFunctionTable();
+        var funcRegistry = FunctionTable;
         Functions = funcRegistry;
         _parser = new FormulaParser(funcRegistry);
         _visitor = new CalculationVisitor(funcRegistry);
@@ -616,7 +616,19 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
         return result;
     }
 
-    // build/get static keyword table
+    /// <summary>
+    /// The function table, built once for the process and shared by every engine.
+    /// </summary>
+    /// <remarks>
+    /// The table is the same ~400 entries whatever the culture — a <see cref="FunctionDefinition"/>
+    /// takes its culture from the <see cref="CalcContext"/> it is called with, not from the engine
+    /// that holds it — so building one per engine only bought a private copy of a constant. Sharing
+    /// it is safe for exactly as long as it stays read-only after this returns: nothing calls
+    /// <see cref="FunctionRegistry.RegisterFunction"/> outside the registrations below, and a
+    /// per-engine function would have to go somewhere other than here.
+    /// </remarks>
+    private static readonly FunctionRegistry FunctionTable = GetFunctionTable();
+
     private static FunctionRegistry GetFunctionTable()
     {
         var fr = new FunctionRegistry();


### PR DESCRIPTION
Closes #276.

The issue asks for a number first, and the number moves the answer: it is neither A nor B, and it turns out not to need C's opt-in either.

## Where the cost actually is

Measured per template, 411 functions:

| | time | alloc |
|---|---|---|
| `new XLCalcEngine` — the function table (**Option A**) | 0.12 ms | 75 KB |
| Building the 411 adapter delegates (**Option B**) | 0.10 ms | 39 KB |
| **`ScriptObject.Import` × 411 into Scriban** | **7.9 ms** | **12,481 KB** |
| *for scale:* opening the template .xlsx | 4.3 ms | 645 KB |

So **D is out** — a small report allocated 16.4 MB, of which 12.6 MB was this, more than nine tenths of the run and nineteen times the cost of opening the workbook it accompanied.

But **A saves 0.6% of it and B saves 0.3%**. The issue's own caveat about B — "still re-imports into each engine" — is the entire bill. Neither fixes #276.

## Why not C

C's instinct is right: the cost should be skippable. The flag form isn't, though, because no default is correct. Off, and a template author who writes `{{ SUM(items.Total) }}` gets an error pointing at a setting that lives in someone else's code. On, and nobody gets the saving.

The measurement that settles it: **reusing an already-imported `ScriptObject` costs 0.010 ms and 30 KB** — three orders of magnitude below rebuilding it. Import once, share the result, and there is nothing left to opt out of.

## What this does

Two commits:

1. **`perf(calc)`** — `XLCalcEngine`'s function table becomes a static built once for the process. Small (~70 KB per engine) but it applies to every workbook that touches a formula, not just to reports, and the existing "build/get static keyword table" comment says it was the intent. Safe because the table is culture-independent (a `FunctionDefinition` takes its culture from the `CalcContext`, not the engine) and nothing calls `RegisterFunction` outside `GetFunctionTable`. Opening a workbook: 644 → 574 KB.

2. **`perf(report)`** — the bridge builds one adapter set and one Scriban globals object per culture and hands the same instances to every engine.

Ordering is the part worth reviewing: the shared object is pushed *below* the engine's own function object, so `AddFunction` still shadows an Excel function of the same name and never writes into the shared one. Bound variables are pushed later still and shadow both — a variable named `SUM` wins, as a template author would expect. Non-Scriban engines (`XLibur.Report.DynamicLinq`, or a caller's own) still receive functions one at a time through `IExpressionEngine.AddFunction`, now from the shared adapters.

Sharing one `XLCalcEngine` across the adapters — and so across threads — is safe because these calls have no grid: `CalcContext.CalcEngine` is reached only from `GetCellValue`, which needs a worksheet, and without one the call has already failed with the `MissingContextException` the bridge translates.

## Results

`TemplateConstructionBenchmarks`, new in this PR — `OpenWorkbook` is the baseline the constructor should be measured against:

| | before | after |
|---|--:|--:|
| `ConstructTemplate` | 3.245 ms / 12,636 KB | **0.0013 ms / 3.74 KB** |
| `SmallReport` (open, bind, generate, save) | 8.081 ms / 16,383 KB | **4.084 ms / 3,671 KB** |
| `OpenWorkbook` (baseline) | 2.121 ms / 644 KB | 2.099 ms / 574 KB |

Constructing a template was 19.6× the allocation of opening the workbook; it is now 0.007×. A small report halves in time and drops 78% of its allocation.

The report test suite is the same result from a different angle: 8.7s → 4.4s over 450 tests, most of which build a template.

## Verification

- `XLibur.Tests`: 11,677 passed, 0 failed, 4 pre-existing skips.
- `XLibur.Report.Tests`: 455 passed, 0 failed (5 new).
- Full solution builds Release with 0 warnings (`TreatWarningsAsErrors=true`).

New tests pin the sharing semantics rather than the speed: that an `AddFunction` shadows an Excel function, that **shadowing in one engine leaves another engine's `UPPER` intact** (the test that fails if anyone "optimises" by writing into the shared object), that a bound variable shadows a function name, that each engine gets the library, and that a non-Scriban engine still receives every function through the interface.

## Note

The 12.5 MB is now retained for process life instead of being transient garbage — one copy, on first use, strictly better than today for anyone generating more than a single report. If that retained figure ever matters, C's lazy-resolution variant composes on top: a `ScriptObject` resolving names on demand would retain 30 KB per function actually used. Not worth the machinery until it shows up somewhere real.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved formula processing efficiency by reusing Excel function definitions across calculations.
  - Reduced initialization time and memory usage when creating multiple calculation engines.
  - Improved report template construction and small-report generation performance.

- **Reliability**
  - Enhanced support for custom functions, including predictable overriding and isolation between calculation contexts.
  - Ensured bound values take precedence over functions with the same name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->