### PR TITLE
fix(report): bind defined names by scope, the way Excel resolves them

### DIFF
--- a/XLibur.Report.Tests/Ranges/DefinedNameScopeTests.cs
+++ b/XLibur.Report.Tests/Ranges/DefinedNameScopeTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+using XLibur.Report.Ranges;
+
+namespace XLibur.Report.Tests.Ranges;
+
+/// <summary>
+/// Which defined names bind when more than one of them shares a name.
+/// </summary>
+/// <remarks>
+/// Excel scopes a defined name either to the workbook or to one sheet, and the same name may be
+/// declared once per sheet on top of a workbook-wide one. Binding follows those rules: every
+/// sheet-scoped name binds, and a workbook-scoped name binds except on a sheet that declares its
+/// own. Every range named <c>Items</c> reads the <c>Items</c> variable, which is what a template
+/// repeating one section per sheet wants.
+/// </remarks>
+public class DefinedNameScopeTests
+{
+    private static List<SaleItem> ThreeItems() =>
+        new[] { ("Widget", 2, 5m), ("Gadget", 3, 10m), ("Doohickey", 1, 7.5m) }
+            .Select(r => new SaleItem
+            {
+                Product = r.Item1,
+                Quantity = r.Item2,
+                UnitPrice = r.Item3,
+                SoldOn = new DateTime(2026, 1, 1),
+            })
+            .ToList();
+
+    /// <summary>
+    /// Adds a one-row template block at <paramref name="firstRow"/> — the row after it is the
+    /// options row — and returns the range the two occupy.
+    /// </summary>
+    private static IXLRange TemplateBlock(IXLWorksheet sheet, int firstRow)
+    {
+        sheet.Cell(firstRow, 1).Value = "{{ item.Product }}";
+        return sheet.Range(firstRow, 1, firstRow + 1, 3);
+    }
+
+    private static XLGenerateResult Generate(IXLWorkbook workbook, object? items)
+    {
+        using var template = new XLTemplate(workbook);
+        template.AddVariable("Items", items);
+        return template.Generate();
+    }
+
+    /// <summary>
+    /// The case from issue #274: one section per sheet, each marked with a sheet-scoped name of the
+    /// same name. Both used to be de-duplicated down to one, and the second sheet came out blank
+    /// with nothing in <see cref="XLGenerateResult.ParsingErrors"/> to say why.
+    /// </summary>
+    [Test]
+    public async Task TheSameSheetScopedNameOnTwoSheetsBindsOnBoth()
+    {
+        using var workbook = new XLWorkbook();
+        var first = workbook.AddWorksheet("Q1");
+        var second = workbook.AddWorksheet("Q2");
+        first.DefinedNames.Add("Items", TemplateBlock(first, 1));
+        second.DefinedNames.Add("Items", TemplateBlock(second, 1));
+
+        var result = Generate(workbook, ThreeItems());
+
+        await Assert.That(result.ParsingErrors).IsEmpty();
+        foreach (var sheet in new[] { first, second })
+        {
+            await Assert.That(sheet.Cell("A1").Value.GetText()).IsEqualTo("Widget");
+            await Assert.That(sheet.Cell("A2").Value.GetText()).IsEqualTo("Gadget");
+            await Assert.That(sheet.Cell("A3").Value.GetText()).IsEqualTo("Doohickey");
+        }
+    }
+
+    /// <summary>
+    /// Excel resolves <c>Items</c> written on <c>Q2</c> to <c>Q2</c>'s own name. A defined name here
+    /// is not read from anywhere — it is a range — so the sheet it covers stands in for the sheet a
+    /// reference would be written on, and the workbook-scoped name covering that sheet is dropped.
+    /// </summary>
+    [Test]
+    public async Task ASheetScopedNameShadowsTheWorkbookOneCoveringItsOwnSheet()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Report");
+        workbook.DefinedNames.Add("Items", TemplateBlock(sheet, 1));
+        sheet.DefinedNames.Add("Items", TemplateBlock(sheet, 5));
+
+        var result = Generate(workbook, ThreeItems());
+
+        await Assert.That(result.ParsingErrors).IsEmpty();
+
+        // The shadowed block never expanded, so nothing below it moved.
+        await Assert.That(sheet.Cell("A5").Value.GetText()).IsEqualTo("Widget");
+        await Assert.That(sheet.Cell("A6").Value.GetText()).IsEqualTo("Gadget");
+        await Assert.That(sheet.Cell("A7").Value.GetText()).IsEqualTo("Doohickey");
+        await Assert.That(sheet.Cell("A1").IsEmpty()).IsTrue();
+    }
+
+    /// <summary>
+    /// Shadowing reaches one sheet, not the workbook: a workbook-scoped name goes on binding
+    /// wherever no sheet has declared its own.
+    /// </summary>
+    [Test]
+    public async Task TheWorkbookNameStillBindsOnSheetsThatDoNotShadowIt()
+    {
+        using var workbook = new XLWorkbook();
+        var first = workbook.AddWorksheet("Q1");
+        var second = workbook.AddWorksheet("Q2");
+        workbook.DefinedNames.Add("Items", TemplateBlock(first, 1));
+        second.DefinedNames.Add("Items", TemplateBlock(second, 1));
+
+        var result = Generate(workbook, ThreeItems());
+
+        await Assert.That(result.ParsingErrors).IsEmpty();
+        foreach (var sheet in new[] { first, second })
+        {
+            await Assert.That(sheet.Cell("A1").Value.GetText()).IsEqualTo("Widget");
+            await Assert.That(sheet.Cell("A3").Value.GetText()).IsEqualTo("Doohickey");
+        }
+    }
+
+    /// <summary>
+    /// Excel holds defined names in one case-insensitive namespace, so a sheet-scoped <c>items</c>
+    /// shadows a workbook-scoped <c>ITEMS</c>.
+    /// </summary>
+    /// <remarks>
+    /// Driven through the binder rather than through a template, because a template matches its
+    /// variables case-sensitively: neither spelling would find an <c>Items</c> variable, so both
+    /// blocks would come out unbound and the two answers would be indistinguishable.
+    /// </remarks>
+    [Test]
+    public async Task ShadowingComparesNamesTheWayExcelDoes()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Report");
+        workbook.DefinedNames.Add("ITEMS", TemplateBlock(sheet, 1));
+        sheet.DefinedNames.Add("items", TemplateBlock(sheet, 5));
+
+        var variables = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Items"] = ThreeItems(),
+        };
+
+        var bound = RangeBinder.Resolve(workbook, variables, new TemplateErrors());
+
+        await Assert.That(bound.Count).IsEqualTo(1);
+        await Assert.That(bound[0].Area.FirstRow).IsEqualTo(5);
+    }
+
+    /// <summary>
+    /// A workbook-scoped name on its own is the ordinary case and is unaffected by any of this.
+    /// </summary>
+    [Test]
+    public async Task AWorkbookNameWithNothingShadowingItBindsOnce()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Report");
+        workbook.DefinedNames.Add("Items", TemplateBlock(sheet, 1));
+
+        var result = Generate(workbook, ThreeItems());
+
+        await Assert.That(result.ParsingErrors).IsEmpty();
+        await Assert.That(sheet.Cell("A1").Value.GetText()).IsEqualTo("Widget");
+        await Assert.That(sheet.Cell("A3").Value.GetText()).IsEqualTo("Doohickey");
+        await Assert.That(sheet.Cell("A4").IsEmpty()).IsTrue();
+    }
+
+    /// <summary>
+    /// A sheet-scoped name on a sheet the workbook-scoped one does not cover leaves it alone: both
+    /// bind, on their own sheets, from the same variable.
+    /// </summary>
+    [Test]
+    public async Task BothScopesBindWhenTheyCoverDifferentSheets()
+    {
+        using var workbook = new XLWorkbook();
+        var summary = workbook.AddWorksheet("Summary");
+        var detail = workbook.AddWorksheet("Detail");
+        workbook.DefinedNames.Add("Items", TemplateBlock(summary, 1));
+        detail.DefinedNames.Add("Items", TemplateBlock(detail, 1));
+
+        Generate(workbook, ThreeItems());
+
+        await Assert.That(summary.Cell("A2").Value.GetText()).IsEqualTo("Gadget");
+        await Assert.That(detail.Cell("A2").Value.GetText()).IsEqualTo("Gadget");
+    }
+}

--- a/XLibur.Report/Ranges/RangeBinder.cs
+++ b/XLibur.Report/Ranges/RangeBinder.cs
@@ -11,10 +11,17 @@ namespace XLibur.Report.Ranges;
 /// Works out which of a workbook's defined names mark repeating template rows.
 /// </summary>
 /// <remarks>
+/// <para>
 /// A name marks a repeating range when it resolves to a collection: either a variable of the same
 /// name, or — for a name like <c>Customer_Orders</c> — a property path walked from one. Names that
 /// resolve to nothing, or to a single value, are left alone; a template is free to use defined
 /// names for their ordinary purpose.
+/// </para>
+/// <para>
+/// Names are gathered under Excel's scoping rules rather than de-duplicated workbook-wide, so a
+/// template may declare the same name once per sheet — <c>Q1!Items</c> and <c>Q2!Items</c> — and
+/// have every one of them bind. See <see cref="EnumerateNames"/>.
+/// </para>
 /// </remarks>
 internal static class RangeBinder
 {
@@ -28,15 +35,9 @@ internal static class RangeBinder
         TemplateErrors errors)
     {
         var bound = new List<BoundRange>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var definedName in EnumerateNames(workbook))
         {
-            if (!seen.Add(definedName.Name))
-            {
-                continue;
-            }
-
             if (!TryResolveItems(definedName.Name, variables, out var items))
             {
                 continue;
@@ -67,20 +68,67 @@ internal static class RangeBinder
             .ToList();
     }
 
+    /// <summary>
+    /// The names a template can bind, with Excel's scoping applied.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every sheet-scoped name is yielded — the same name on two sheets is two names in Excel, and a
+    /// template with one section per sheet is the obvious way to write it — followed by each
+    /// workbook-scoped name that no sheet has shadowed.
+    /// </para>
+    /// <para>
+    /// Excel decides shadowing by where a reference is written: a sheet-scoped name hides the
+    /// workbook-scoped one of that name on its own sheet, and nowhere else. A defined name here is
+    /// not read from anywhere, it <em>is</em> a range, so the sheet it sits on stands in for the
+    /// sheet a reference would be written on. A workbook-scoped <c>Items</c> covering <c>Q1!A5:C5</c>
+    /// therefore keeps binding when <c>Q2</c> declares its own <c>Items</c>, and is dropped when
+    /// <c>Q1</c> does.
+    /// </para>
+    /// </remarks>
     private static IEnumerable<IXLDefinedName> EnumerateNames(IXLWorkbook workbook)
     {
-        foreach (var name in workbook.DefinedNames.ValidNamedRanges())
-        {
-            yield return name;
-        }
+        var declaringSheets = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var worksheet in workbook.Worksheets)
         {
             foreach (var name in worksheet.DefinedNames.ValidNamedRanges())
             {
+                if (!declaringSheets.TryGetValue(name.Name, out var sheets))
+                {
+                    sheets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    declaringSheets[name.Name] = sheets;
+                }
+
+                sheets.Add(worksheet.Name);
                 yield return name;
             }
         }
+
+        foreach (var name in workbook.DefinedNames.ValidNamedRanges())
+        {
+            if (!IsShadowed(name, declaringSheets))
+            {
+                yield return name;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether the sheet a workbook-scoped name covers declares a name of its own by that name.
+    /// </summary>
+    /// <remarks>
+    /// The name's ranges are only read when some sheet declares the name at all, which is almost
+    /// never; a lookup that misses costs a dictionary probe and no parsing of <c>RefersTo</c>.
+    /// </remarks>
+    private static bool IsShadowed(IXLDefinedName name, Dictionary<string, HashSet<string>> declaringSheets)
+    {
+        if (!declaringSheets.TryGetValue(name.Name, out var sheets))
+        {
+            return false;
+        }
+
+        return name.Ranges.Any(range => sheets.Contains(range.Worksheet.Name));
     }
 
     /// <summary>

--- a/docs/report-templating.md
+++ b/docs/report-templating.md
@@ -97,6 +97,23 @@ entirely.
 Defined names may address a property path with an underscore: a name `Order_Lines` binds
 `order.Lines` where `Order` is the bound variable.
 
+### Name scope
+
+Names bind under Excel's own scoping. A name scoped to a **sheet** may be declared once per sheet, and
+every one of them binds — the natural way to write a template with a section per sheet:
+
+```
+Q1!Items → Q1!A2:C3     both bind, both read the Items variable
+Q2!Items → Q2!A2:C3
+```
+
+A name scoped to the **workbook** binds everywhere except on a sheet that declares its own name of that
+name, which shadows it there and nowhere else. Shadowing is silent: it is what Excel does, so it is not
+reported as a template error.
+
+The name is what selects the variable, so all the ranges above read `Items`. To bind two sheets to
+different data, give the ranges different names.
+
 ## Tags
 
 `<<Tag param=value>>` in a range's options row. Parameters may be bare flags (`desc`), assigned


### PR DESCRIPTION
Fixes #274. Option A, as agreed on the issue.

## What was wrong

`RangeBinder.Resolve` de-duplicated defined names with a single workbook-wide, case-insensitive `HashSet<string>`, so of two names sharing a name only the first ever bound. Two consequences, both silent:

1. **Two sheets each declaring a sheet-scoped name of the same name** — legal in Excel, and the natural way to write a template with one section per sheet. Only the first bound. The second sheet's placeholders fell through to the pre-expansion pass, where `item` is not in scope, and rendered blank. Nothing reached `ParsingErrors`, so the report looked like it had worked.
2. **A workbook-scoped name and a sheet-scoped name sharing a name** — the workbook-scoped one won everywhere, where Excel has the sheet-scoped one shadow it on its own sheet.

## What it does now

Names are gathered under Excel's scoping rather than de-duplicated. Every sheet-scoped name binds. A workbook-scoped name binds except where a sheet declares its own name of that name.

Excel decides shadowing by where a reference is *written*, and a defined name here is not read from anywhere — it **is** a range. So the sheet it covers stands in for the sheet a reference would be written on, and shadowing reaches that sheet alone:

```
Workbook  Items -> Q1!A5:C5        binds: Q1!A5:C5   (Q1 declares no Items)
Sheet Q2  Items -> Q2!A5:C5        binds: Q2!A5:C5

Workbook  Items -> Q2!A5:C5        drops: Q2!A5:C5   (shadowed on its own sheet)
Sheet Q2  Items -> Q2!A10:C10      binds: Q2!A10:C10
```

Legitimate shadowing is **silent**. It is what Excel does, not a template mistake, and `TemplateErrors` has no warning severity — anything recorded there reads as an error and would show up on every well-formed template using the pattern.

The name still selects the variable, so every range named `Items` binds the `Items` collection. For case (1) that is exactly what a per-sheet template wants; a template that needs two sheets bound to different data gives the ranges different names. Documented in `docs/report-templating.md`.

## Cost

`IsShadowed` is one dictionary probe per workbook-scoped name. `RefersTo` is only parsed for a name that some sheet actually declares, which is almost never — so the common path does no more work than before, and one `HashSet` allocation less.

## Tests

`XLibur.Report.Tests/Ranges/DefinedNameScopeTests.cs`, six tests: the issue's two cases, the workbook name still binding on sheets that do not shadow it, both scopes binding when they cover different sheets, the plain single-name case unaffected, and name comparison.

`ShadowingComparesNamesTheWayExcelDoes` drives `RangeBinder.Resolve` directly rather than a template, and the test says why: XLibur holds defined names case-insensitively, but `XLTemplate._variables` is `StringComparer.Ordinal`, so neither `ITEMS` nor `items` would find an `Items` variable and both blocks would come out unbound — the two answers would be indistinguishable through a template. That mismatch is its own problem and has been raised separately.

467/467 report tests pass; solution builds clean with `TreatWarningsAsErrors`.
