### PR TITLE
fix(report): repair the main build after #305 and #306 landed together

### DIFF
--- a/XLibur.Report.Tests/Functions/ExcelFunctionBridgeTests.cs
+++ b/XLibur.Report.Tests/Functions/ExcelFunctionBridgeTests.cs
@@ -271,6 +271,8 @@ public class ExcelFunctionBridgeTests
     {
         public List<string> Names { get; } = new();
 
+        public CultureInfo Culture => CultureInfo.InvariantCulture;
+
         public bool SupportsFunctions => true;
 
         public object? Evaluate(string expression, ExpressionScope scope) => null;


### PR DESCRIPTION
`main` does not build. Two lines, one of them blank.

```
XLibur.Report.Tests/Functions/ExcelFunctionBridgeTests.cs(270,44): error CS0535:
'ExcelFunctionBridgeTests.RecordingEngine' does not implement interface member
'IExpressionEngine.Culture'
```

Both target frameworks, so every job in `build-and-test` fails at the Build step and no tests run at all.

## How it got in

A semantic conflict between two PRs that were each green.

- #305 (`d983fac5`) added `CultureInfo Culture { get; }` to `IExpressionEngine` and gave the existing test double, `FunctionlessEngine`, an implementation.
- #306 (`877b2462`) added a second test double, `RecordingEngine`, to the same file. It was branched before #305 landed, so at the time it was written the interface had no `Culture`.

Neither PR touched a line the other did, so git merged both cleanly and nothing flagged it. The break exists only in the combination, which is why #306's own run passed and the run for the merge commit — the first build of the two together — failed.

## Verified

`dotnet build XLibur.slnx -c Release` succeeds with 0 warnings and 0 errors, and 466/466 report tests pass, on `upstream/main` plus this commit.

## Note

This blocks #307 too, which is otherwise unrelated — it inherits the failure through the merge with `main`. I will rebase it once this lands.
