### PR TITLE
feat(pivot): model a pivot filter's criteria instead of preserving the XML

### DIFF
--- a/XLibur.Tests/Excel/AutoFilters/AutoFilterRoundTripTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/AutoFilterRoundTripTests.cs
@@ -1,0 +1,242 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.AutoFilters;
+
+/// <summary>
+/// A worksheet autofilter is modelled as something that hides rows, which is narrower than the
+/// <c>filterColumn</c> element it is written to: there is no room in it for an <c>iconFilter</c>,
+/// for the button attributes, for <c>extLst</c>, or for the three dozen <c>dynamicFilter</c>
+/// types beyond the two averages. A column that has not been changed is written back from the
+/// criteria it was loaded with, so none of those are dropped by a load and save.
+/// </summary>
+public class AutoFilterRoundTripTests
+{
+    /// <summary>
+    /// <c>iconFilter</c> has no equivalent in the row-hiding model at all — there is no cell
+    /// predicate for "shows a red light" without resolving the conditional format first.
+    /// </summary>
+    [Test]
+    public async Task IconFilter_SurvivesARoundTrip()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(new IconFilter { IconSet = IconSetValues.ThreeSymbols, IconId = 1U });
+
+        var written = RoundTripFilterColumn(filterColumn).Elements<IconFilter>().Single();
+
+        await Assert.That(written.IconSet!.InnerText).IsEqualTo("3Symbols");
+        await Assert.That(written.IconId!.Value).IsEqualTo(1U);
+    }
+
+    [Test]
+    public async Task ButtonAttributes_SurviveARoundTrip()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 0U, HiddenButton = true, ShowButton = false };
+        filterColumn.Append(new Top10 { Val = 3D });
+
+        var written = RoundTripFilterColumn(filterColumn);
+
+        await Assert.That(written.HiddenButton!.Value).IsTrue();
+        await Assert.That(written.ShowButton!.Value).IsFalse();
+    }
+
+    [Test]
+    public async Task FilterColumnExtensionList_SurvivesARoundTrip()
+    {
+        var extension = new Extension { Uri = "{89765432-10FE-DCBA-9876-543210FEDCBA}" };
+        extension.AppendChild(new OpenXmlUnknownElement("x14", "filter",
+            "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"));
+
+        var extensionList = new ExtensionList();
+        extensionList.Append(extension);
+
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(new Top10 { Val = 3D });
+        filterColumn.Append(extensionList);
+
+        var written = RoundTripFilterColumn(filterColumn);
+        var writtenExtension = written.GetFirstChild<ExtensionList>()!.Elements<Extension>().Single();
+
+        await Assert.That(writtenExtension.Uri!.Value).IsEqualTo("{89765432-10FE-DCBA-9876-543210FEDCBA}");
+    }
+
+    /// <summary>
+    /// <c>ST_DynamicFilterType</c> has around forty values, of which the model covers the two
+    /// averages. Loading one of the others used to throw, because the token was looked up in a
+    /// two-entry map; now it is carried through untouched.
+    /// </summary>
+    [Test]
+    public async Task DynamicFilterTypeXLiburCannotEvaluate_LoadsAndSurvivesARoundTrip()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(new DynamicFilter { Type = DynamicFilterValues.ThisMonth, Val = 45000D });
+
+        var written = RoundTripFilterColumn(filterColumn).Elements<DynamicFilter>().Single();
+
+        await Assert.That(written.Type!.InnerText).IsEqualTo("thisMonth");
+        await Assert.That(written.Val!.Value).IsEqualTo(45000D);
+    }
+
+    /// <summary>
+    /// The two dynamic types the model does cover still drive row hiding, so they are not simply
+    /// being passed through as text.
+    /// </summary>
+    [Test]
+    public async Task AboveAverageDynamicFilter_IsStillEvaluated()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 1U };
+        filterColumn.Append(new DynamicFilter { Type = DynamicFilterValues.AboveAverage, Val = 650D });
+
+        using var input = new MemoryStream();
+        CreateWorkbookWithAutoFilter(input, filterColumn);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        var autoFilter = wb.Worksheet("Data").AutoFilter;
+
+        await Assert.That(autoFilter.Column(2).DynamicType).IsEqualTo(XLFilterDynamicType.AboveAverage);
+
+        // Only Cake, at 800, is above the 650 average of the two rows.
+        autoFilter.Reapply();
+        await Assert.That(autoFilter.VisibleRows.Select(r => r.Cell(1).GetText()).ToList())
+            .IsEquivalentTo(new[] { "Name", "Cake" });
+    }
+
+    /// <summary>
+    /// Writing an untouched column back from its loaded criteria must not outlive the caller
+    /// changing it, or an edit would be silently discarded on save.
+    /// </summary>
+    [Test]
+    public async Task ChangingAColumn_WritesTheChangeRatherThanTheLoadedCriteria()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 0U, HiddenButton = true };
+        filterColumn.Append(new IconFilter { IconSet = IconSetValues.ThreeSymbols, IconId = 1U });
+
+        using var input = new MemoryStream();
+        CreateWorkbookWithAutoFilter(input, filterColumn);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        wb.Worksheet("Data").AutoFilter.Column(1).AddFilter("Cake");
+
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        var written = ReadFilterColumns(output).Single();
+
+        await Assert.That(written.Elements<IconFilter>().Any()).IsFalse();
+        await Assert.That(written.HiddenButton?.Value ?? false).IsFalse();
+        await Assert.That(written.Elements<Filters>().Single().Elements<Filter>().Single().Val!.Value)
+            .IsEqualTo("Cake");
+    }
+
+    /// <summary>
+    /// A filter built through the API, rather than loaded, still writes what it always did.
+    /// </summary>
+    [Test]
+    public async Task FilterBuiltThroughTheApi_IsWrittenFromItsOwnState()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").SetValue("Name");
+        ws.Cell("A2").SetValue("Cookies");
+        ws.Cell("A3").SetValue("Cake");
+
+        ws.RangeUsed()!.SetAutoFilter().Column(1).AddFilter("Cake");
+
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        var written = ReadFilterColumns(output).Single();
+
+        await Assert.That(written.ColumnId!.Value).IsEqualTo(0U);
+        await Assert.That(written.Elements<Filters>().Single().Elements<Filter>().Single().Val!.Value)
+            .IsEqualTo("Cake");
+    }
+
+    private static FilterColumn RoundTripFilterColumn(FilterColumn filterColumn)
+    {
+        using var input = new MemoryStream();
+        CreateWorkbookWithAutoFilter(input, filterColumn);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        return ReadFilterColumns(output).Single();
+    }
+
+    private static List<FilterColumn> ReadFilterColumns(MemoryStream saved)
+    {
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        var worksheet = doc.WorkbookPart!.WorksheetParts.Single().Worksheet;
+
+        return worksheet.Elements<AutoFilter>().Single().Elements<FilterColumn>().ToList();
+    }
+
+    /// <summary>
+    /// A one-sheet workbook whose autofilter carries the given column.
+    /// </summary>
+    private static void CreateWorkbookWithAutoFilter(Stream stream, FilterColumn filterColumn)
+    {
+        using var doc = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+        var workbookPart = doc.AddWorkbookPart();
+        workbookPart.Workbook = new Workbook();
+        var sheets = workbookPart.Workbook.AppendChild(new Sheets());
+
+        var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(worksheetPart), SheetId = 1, Name = "Data" });
+
+        var sheetData = new SheetData();
+        sheetData.Append(CreateHeaderRow());
+        sheetData.Append(CreateDataRow(2, "Cookies", 500));
+        sheetData.Append(CreateDataRow(3, "Cake", 800));
+
+        var autoFilter = new AutoFilter { Reference = "A1:B3" };
+        autoFilter.Append(filterColumn);
+
+        // Schema order puts autoFilter after sheetData.
+        worksheetPart.Worksheet = new Worksheet(sheetData, autoFilter);
+    }
+
+    private static Row CreateHeaderRow()
+    {
+        var row = new Row { RowIndex = 1 };
+        row.Append(CreateTextCell("A1", "Name"));
+        row.Append(CreateTextCell("B1", "Revenue"));
+        return row;
+    }
+
+    private static Row CreateDataRow(uint rowIndex, string name, double revenue)
+    {
+        var row = new Row { RowIndex = rowIndex };
+        row.Append(CreateTextCell($"A{rowIndex}", name));
+        row.Append(new Cell
+        {
+            CellReference = $"B{rowIndex}",
+            DataType = CellValues.Number,
+            CellValue = new CellValue(revenue),
+        });
+
+        return row;
+    }
+
+    private static Cell CreateTextCell(string reference, string value)
+    {
+        return new Cell
+        {
+            CellReference = reference,
+            DataType = CellValues.String,
+            CellValue = new CellValue(value),
+        };
+    }
+}

--- a/XLibur.Tests/Excel/PivotTables/PivotFilterCriteriaTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotFilterCriteriaTests.cs
@@ -1,0 +1,380 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Validation;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.PivotTables;
+
+/// <summary>
+/// A pivot filter's <c>autoFilter</c> says what the filter actually keeps. It is modelled rather
+/// than preserved as a string, so every one of the six <c>filterColumn</c> children — and the
+/// parts of the element XLibur cannot act on at all — needs pinning against a round trip.
+/// </summary>
+/// <remarks>
+/// Attributes sitting at their schema default are written as absent, so the assertions here read
+/// the effective value rather than requiring the attribute to be present.
+/// </remarks>
+public class PivotFilterCriteriaTests
+{
+    /// <summary>
+    /// <c>filters</c> — the tick-box list, plus the <c>blank</c> attribute the worksheet model
+    /// has no room for.
+    /// </summary>
+    [Test]
+    public async Task ValuesFilter_SurvivesARoundTrip()
+    {
+        var filters = new Filters { Blank = true };
+        filters.Append(new Filter { Val = "Cookies" });
+        filters.Append(new Filter { Val = "Cake" });
+
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(filters);
+
+        var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn).Elements<Filters>().Single();
+
+        await Assert.That(written.Blank!.Value).IsTrue();
+        await Assert.That(written.Elements<Filter>().Select(f => f.Val!.Value).ToList())
+            .IsEquivalentTo(new[] { "Cookies", "Cake" });
+    }
+
+    /// <summary>
+    /// The other form of <c>filters</c>: date groups rather than values. The schema makes the two
+    /// a choice, so a column uses one or the other.
+    /// </summary>
+    [Test]
+    public async Task DateGroupFilter_SurvivesARoundTrip()
+    {
+        var filters = new Filters { CalendarType = CalendarValues.Hijri };
+        filters.Append(new DateGroupItem
+        {
+            DateTimeGrouping = DateTimeGroupingValues.Day,
+            Year = 2024,
+            Month = 3,
+            Day = 17,
+        });
+
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(filters);
+
+        var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn).Elements<Filters>().Single();
+
+        await Assert.That(written.CalendarType!.InnerText).IsEqualTo("hijri");
+
+        var dateGroup = written.Elements<DateGroupItem>().Single();
+        await Assert.That(dateGroup.DateTimeGrouping!.InnerText).IsEqualTo("day");
+        await Assert.That(dateGroup.Year!.Value).IsEqualTo((ushort)2024);
+        await Assert.That(dateGroup.Month!.Value).IsEqualTo((ushort)3);
+        await Assert.That(dateGroup.Day!.Value).IsEqualTo((ushort)17);
+
+        // The parts finer than the grouping stay absent: Excel reads a present part as one the
+        // filter matches on, so writing hour="0" would narrow the filter.
+        await Assert.That(dateGroup.Hour).IsNull();
+    }
+
+    /// <summary>
+    /// <c>top10</c> taking the bottom by percent, so none of the three booleans sit at their
+    /// default and all have to be written.
+    /// </summary>
+    [Test]
+    public async Task Top10Filter_SurvivesARoundTrip()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 1U };
+        filterColumn.Append(new Top10 { Top = false, Percent = true, Val = 25D, FilterValue = 640D });
+
+        var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn).Elements<Top10>().Single();
+
+        await Assert.That(written.Top!.Value).IsFalse();
+        await Assert.That(written.Percent!.Value).IsTrue();
+        await Assert.That(written.Val!.Value).IsEqualTo(25D);
+        await Assert.That(written.FilterValue!.Value).IsEqualTo(640D);
+    }
+
+    /// <summary>
+    /// <c>customFilters</c> — two comparisons joined by AND, which is the only shape that uses
+    /// both the connector and the operator attributes.
+    /// </summary>
+    [Test]
+    public async Task CustomFilters_SurviveARoundTrip()
+    {
+        var customFilters = new CustomFilters { And = true };
+        customFilters.Append(new CustomFilter { Operator = FilterOperatorValues.GreaterThanOrEqual, Val = "100" });
+        customFilters.Append(new CustomFilter { Operator = FilterOperatorValues.LessThan, Val = "900" });
+
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(customFilters);
+
+        var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn).Elements<CustomFilters>().Single();
+
+        await Assert.That(written.And!.Value).IsTrue();
+
+        var criteria = written.Elements<CustomFilter>().ToList();
+        await Assert.That(criteria.Count).IsEqualTo(2);
+        await Assert.That(criteria[0].Operator!.InnerText).IsEqualTo("greaterThanOrEqual");
+        await Assert.That(criteria[0].Val!.Value).IsEqualTo("100");
+        await Assert.That(criteria[1].Operator!.InnerText).IsEqualTo("lessThan");
+        await Assert.That(criteria[1].Val!.Value).IsEqualTo("900");
+    }
+
+    /// <summary>
+    /// <c>dynamicFilter</c> with a type outside the two averages XLibur can evaluate. Forcing
+    /// those onto <c>XLFilterDynamicType</c> would rewrite "last quarter" as "above average", so
+    /// the token is carried rather than mapped.
+    /// </summary>
+    [Test]
+    public async Task DynamicFilter_KeepsATypeXLiburCannotEvaluate()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(new DynamicFilter
+        {
+            Type = DynamicFilterValues.LastQuarter,
+            Val = 45000D,
+            MaxVal = 45090D,
+        });
+
+        var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn).Elements<DynamicFilter>().Single();
+
+        await Assert.That(written.Type!.InnerText).IsEqualTo("lastQuarter");
+        await Assert.That(written.Val!.Value).IsEqualTo(45000D);
+        await Assert.That(written.MaxVal!.Value).IsEqualTo(45090D);
+    }
+
+    /// <summary>
+    /// <c>colorFilter</c> matching a font colour rather than a fill, so <c>cellColor</c> is off
+    /// its default.
+    /// </summary>
+    [Test]
+    public async Task ColorFilter_SurvivesARoundTrip()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(new ColorFilter { FormatId = 3U, CellColor = false });
+
+        var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn).Elements<ColorFilter>().Single();
+
+        await Assert.That(written.FormatId!.Value).IsEqualTo(3U);
+        await Assert.That(written.CellColor!.Value).IsFalse();
+    }
+
+    /// <summary>
+    /// <c>iconFilter</c> — the child no part of XLibur can evaluate, and the one that survived
+    /// before only because the whole sub-tree was opaque.
+    /// </summary>
+    [Test]
+    public async Task IconFilter_SurvivesARoundTrip()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(new IconFilter { IconSet = IconSetValues.ThreeTrafficLights1, IconId = 2U });
+
+        var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn).Elements<IconFilter>().Single();
+
+        await Assert.That(written.IconSet!.InnerText).IsEqualTo("3TrafficLights1");
+        await Assert.That(written.IconId!.Value).IsEqualTo(2U);
+    }
+
+    /// <summary>
+    /// The button attributes are not modelled anywhere else in XLibur, so a model that only
+    /// covered the criteria would drop them.
+    /// </summary>
+    [Test]
+    public async Task FilterColumnButtonAttributes_SurviveARoundTrip()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 4U, HiddenButton = true, ShowButton = false };
+        filterColumn.Append(new Top10 { Val = 5D });
+
+        var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn);
+
+        await Assert.That(written.ColumnId!.Value).IsEqualTo(4U);
+        await Assert.That(written.HiddenButton!.Value).IsTrue();
+        await Assert.That(written.ShowButton!.Value).IsFalse();
+    }
+
+    /// <summary>
+    /// Nothing reads <c>extLst</c>, which is exactly why it has to be carried: it is where a
+    /// newer Excel puts whatever this build has never heard of.
+    /// </summary>
+    [Test]
+    public async Task FilterColumnExtensionList_SurvivesARoundTrip()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(new Top10 { Val = 5D });
+        filterColumn.Append(BuildExtensionList("{FEDCBA98-7654-3210-FEDC-BA9876543210}"));
+
+        var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn);
+        var extension = written.GetFirstChild<ExtensionList>()!.Elements<Extension>().Single();
+
+        await Assert.That(extension.Uri!.Value).IsEqualTo("{FEDCBA98-7654-3210-FEDC-BA9876543210}");
+    }
+
+    /// <summary>
+    /// <c>autoFilter</c> carries <c>ref</c>, <c>sortState</c> and its own <c>extLst</c> alongside
+    /// the columns. Sorting is modelled far more narrowly elsewhere in XLibur than
+    /// <c>CT_SortState</c> allows, so it is preserved rather than modelled — but preserved means
+    /// it still has to come back.
+    /// </summary>
+    [Test]
+    public async Task AutoFilterReferenceSortStateAndExtensions_SurviveARoundTrip()
+    {
+        var sortState = new SortState { Reference = "A2:A3", CaseSensitive = true };
+        sortState.Append(new SortCondition { Reference = "A2:A3", Descending = true });
+
+        var filterColumn = new FilterColumn { ColumnId = 0U };
+        filterColumn.Append(new Top10 { Val = 5D });
+
+        var autoFilter = new AutoFilter { Reference = "A1:A3" };
+        autoFilter.Append(filterColumn);
+        autoFilter.Append(sortState);
+        autoFilter.Append(BuildExtensionList("{01234567-89AB-CDEF-0123-456789ABCDEF}"));
+
+        var written = PivotFilterWorkbook.RoundTripAutoFilter(autoFilter);
+
+        await Assert.That(written.Reference!.Value).IsEqualTo("A1:A3");
+
+        var writtenSort = written.GetFirstChild<SortState>()!;
+        await Assert.That(writtenSort.Reference!.Value).IsEqualTo("A2:A3");
+        await Assert.That(writtenSort.CaseSensitive!.Value).IsTrue();
+        await Assert.That(writtenSort.Elements<SortCondition>().Single().Descending!.Value).IsTrue();
+
+        var extension = written.GetFirstChild<ExtensionList>()!.Elements<Extension>().Single();
+        await Assert.That(extension.Uri!.Value).IsEqualTo("{01234567-89AB-CDEF-0123-456789ABCDEF}");
+    }
+
+    /// <summary>
+    /// A column with no criteria at all is odd but legal, and dropping it would lose the button
+    /// attributes it exists to carry.
+    /// </summary>
+    [Test]
+    public async Task FilterColumnWithoutCriteria_SurvivesARoundTrip()
+    {
+        var filterColumn = new FilterColumn { ColumnId = 2U, ShowButton = false };
+
+        var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn);
+
+        await Assert.That(written.ColumnId!.Value).IsEqualTo(2U);
+        await Assert.That(written.ShowButton!.Value).IsFalse();
+        await Assert.That(written.ChildElements.Count).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// Several columns, so the collection is not assumed to hold one.
+    /// </summary>
+    [Test]
+    public async Task SeveralFilterColumns_SurviveARoundTripInOrder()
+    {
+        var first = new FilterColumn { ColumnId = 0U };
+        first.Append(new Top10 { Val = 5D });
+
+        var second = new FilterColumn { ColumnId = 2U };
+        second.Append(new IconFilter { IconSet = IconSetValues.FiveArrows, IconId = 4U });
+
+        var autoFilter = new AutoFilter();
+        autoFilter.Append(first);
+        autoFilter.Append(second);
+
+        var written = PivotFilterWorkbook.RoundTripAutoFilter(autoFilter).Elements<FilterColumn>().ToList();
+
+        await Assert.That(written.Count).IsEqualTo(2);
+        await Assert.That(written[0].ColumnId!.Value).IsEqualTo(0U);
+        await Assert.That(written[0].Elements<Top10>().Single().Val!.Value).IsEqualTo(5D);
+        await Assert.That(written[1].ColumnId!.Value).IsEqualTo(2U);
+        await Assert.That(written[1].Elements<IconFilter>().Single().IconSet!.InnerText).IsEqualTo("5Arrows");
+    }
+
+    /// <summary>
+    /// A workbook carrying one filter of every kind validates against the schema after a round
+    /// trip. Excel repairs a file it cannot parse rather than reporting where it broke, so this
+    /// is the check that catches a criteria writer emitting the right values in the wrong shape.
+    /// </summary>
+    [Test]
+    public async Task EveryFilterKindTogether_ProducesASchemaValidPackage()
+    {
+        var kinds = new OpenXmlElement[]
+        {
+            BuildValuesFilter(),
+            BuildDateGroupFilter(),
+            new Top10 { Top = false, Percent = true, Val = 25D, FilterValue = 640D },
+            BuildCustomFilters(),
+            new DynamicFilter { Type = DynamicFilterValues.LastQuarter, Val = 45000D },
+            new ColorFilter { FormatId = 0U, CellColor = false },
+            new IconFilter { IconSet = IconSetValues.ThreeTrafficLights1, IconId = 2U },
+        };
+
+        var filters = kinds.Select((kind, index) =>
+        {
+            var filterColumn = new FilterColumn { ColumnId = 0U };
+            filterColumn.Append(kind);
+
+            var autoFilter = new AutoFilter { Reference = "A1:A3" };
+            autoFilter.Append(filterColumn);
+
+            var pivotFilter = new PivotFilter
+            {
+                Field = 0U,
+                Id = (uint)index + 1,
+                Type = PivotFilterValues.CaptionEqual,
+            };
+            pivotFilter.Append(autoFilter);
+            return pivotFilter;
+        }).ToArray();
+
+        using var input = new MemoryStream();
+        PivotFilterWorkbook.Create(input, filters);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        // All of them came back, and the package the SDK validator sees is well-formed.
+        await Assert.That(PivotFilterWorkbook.ReadFilters(output).Count).IsEqualTo(kinds.Length);
+
+        output.Position = 0;
+        using var doc = SpreadsheetDocument.Open(output, false);
+        var errors = new OpenXmlValidator(FileFormatVersions.Office2010)
+            .Validate(doc)
+            .Select(error => $"{error.Path?.XPath}: {error.Description}")
+            .ToList();
+
+        await Assert.That(errors).IsEmpty();
+    }
+
+    private static Filters BuildValuesFilter()
+    {
+        var filters = new Filters { Blank = true };
+        filters.Append(new Filter { Val = "Cookies" });
+        return filters;
+    }
+
+    private static Filters BuildDateGroupFilter()
+    {
+        var filters = new Filters();
+        filters.Append(new DateGroupItem
+        {
+            DateTimeGrouping = DateTimeGroupingValues.Month,
+            Year = 2024,
+            Month = 3,
+        });
+
+        return filters;
+    }
+
+    private static CustomFilters BuildCustomFilters()
+    {
+        var customFilters = new CustomFilters { And = true };
+        customFilters.Append(new CustomFilter { Operator = FilterOperatorValues.GreaterThanOrEqual, Val = "100" });
+        customFilters.Append(new CustomFilter { Operator = FilterOperatorValues.LessThan, Val = "900" });
+        return customFilters;
+    }
+
+    private static ExtensionList BuildExtensionList(string uri)
+    {
+        var extension = new Extension { Uri = uri };
+        extension.AppendChild(new OpenXmlUnknownElement("x14", "filter", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"));
+
+        var extensionList = new ExtensionList();
+        extensionList.Append(extension);
+        return extensionList;
+    }
+}

--- a/XLibur.Tests/Excel/PivotTables/PivotFilterTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotFilterTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,6 +6,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel;
+using XLibur.Excel.AutoFilters;
 using XLibur.Excel.IO;
 
 namespace XLibur.Tests.Excel.PivotTables;
@@ -93,7 +94,9 @@ public class PivotFilterTests
         var autoFilter = ReadPivotFilters(output)[1].AutoFilter!;
         var top10 = autoFilter.Elements<FilterColumn>().Single().Elements<Top10>().Single();
 
-        await Assert.That(top10.Top!.Value).IsTrue();
+        // top defaults to true, so it is written only when the filter takes the bottom instead.
+        // The input spelled it out; omitting it says the same thing.
+        await Assert.That(top10.Top?.Value ?? true).IsTrue();
         await Assert.That(top10.Val!.Value).IsEqualTo(3D);
     }
 
@@ -111,7 +114,10 @@ public class PivotFilterTests
         await Assert.That(pt.PivotFilters[0].Type).IsEqualTo("captionEqual");
         await Assert.That(pt.PivotFilters[0].StringValue1).IsEqualTo("Cookies");
         await Assert.That(pt.PivotFilters[1].EvaluationOrder).IsEqualTo(-1);
-        await Assert.That(pt.PivotFilters[1].AutoFilterXml).Contains("top10");
+
+        var top10 = pt.PivotFilters[1].AutoFilter.Columns.Single().Criteria as XLTop10Criteria;
+        await Assert.That(top10).IsNotNull();
+        await Assert.That(top10!.Value).IsEqualTo(3D);
     }
 
     /// <summary>
@@ -148,149 +154,15 @@ public class PivotFilterTests
         await Assert.That(definition.Elements<PivotFilters>().Any()).IsFalse();
     }
 
-    private static List<PivotFilter> ReadPivotFilters(MemoryStream saved)
-    {
-        saved.Position = 0;
-        using var doc = SpreadsheetDocument.Open(saved, false);
-        var definition = doc.WorkbookPart!.WorksheetParts
-            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
-            .Single()
-            .PivotTableDefinition;
-
-        return definition.Elements<PivotFilters>()
-            .SelectMany(f => f.Elements<PivotFilter>())
-            .ToList();
-    }
+    private static List<PivotFilter> ReadPivotFilters(MemoryStream saved) =>
+        PivotFilterWorkbook.ReadFilters(saved);
 
     /// <summary>
     /// A minimal workbook whose pivot table carries two filters: a caption filter holding a value
     /// list, and a value filter holding a top-N.
     /// </summary>
-    private static void CreateWorkbookWithPivotFilters(Stream stream)
-    {
-        using var doc = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
-
-        var workbookPart = doc.AddWorkbookPart();
-        workbookPart.Workbook = new Workbook();
-        var sheets = workbookPart.Workbook.AppendChild(new Sheets());
-
-        var dataSheetPart = workbookPart.AddNewPart<WorksheetPart>();
-        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(dataSheetPart), SheetId = 1, Name = "Data" });
-
-        var sheetData = new SheetData();
-        sheetData.Append(CreateRow(1, "Name", "Revenue"));
-        sheetData.Append(CreateNumericRow(2, "Cookies", 500));
-        sheetData.Append(CreateNumericRow(3, "Cake", 800));
-        dataSheetPart.Worksheet = new Worksheet(sheetData);
-
-        var pivotSheetPart = workbookPart.AddNewPart<WorksheetPart>();
-        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(pivotSheetPart), SheetId = 2, Name = "PivotSheet" });
-        pivotSheetPart.Worksheet = new Worksheet(new SheetData());
-
-        var cachePart = workbookPart.AddNewPart<PivotTableCacheDefinitionPart>();
-        var cachePartId = workbookPart.GetIdOfPart(cachePart);
-
-        var cacheDefinition = new PivotCacheDefinition
-        {
-            Id = "rId1",
-            RefreshOnLoad = true,
-            CreatedVersion = 5,
-            RefreshedVersion = 5,
-        };
-        cacheDefinition.AddNamespaceDeclaration("r", OpenXmlConst.RelationshipsNs);
-
-        var cacheSource = new CacheSource { Type = SourceValues.Worksheet };
-        cacheSource.Append(new WorksheetSource { Sheet = "Data", Reference = "A1:B3" });
-        cacheDefinition.Append(cacheSource);
-
-        var cacheFields = new CacheFields();
-
-        var nameField = new CacheField { Name = "Name" };
-        var nameShared = new SharedItems { ContainsSemiMixedTypes = false, ContainsString = true, ContainsNumber = false, Count = 2 };
-        nameShared.Append(new StringItem { Val = "Cookies" });
-        nameShared.Append(new StringItem { Val = "Cake" });
-        nameField.SharedItems = nameShared;
-        cacheFields.Append(nameField);
-
-        var revenueField = new CacheField { Name = "Revenue" };
-        revenueField.SharedItems = new SharedItems
-        {
-            ContainsSemiMixedTypes = false,
-            ContainsString = false,
-            ContainsNumber = true,
-            MinValue = 500,
-            MaxValue = 800,
-        };
-        cacheFields.Append(revenueField);
-
-        cacheFields.Count = 2;
-        cacheDefinition.Append(cacheFields);
-
-        var recordsPart = cachePart.AddNewPart<PivotTableCacheRecordsPart>();
-        var records = new PivotCacheRecords { Count = 2 };
-        records.Append(new PivotCacheRecord(new FieldItem { Val = 0 }, new NumberItem { Val = 500 }));
-        records.Append(new PivotCacheRecord(new FieldItem { Val = 1 }, new NumberItem { Val = 800 }));
-        recordsPart.PivotCacheRecords = records;
-
-        cachePart.PivotCacheDefinition = cacheDefinition;
-
-        var pivotCaches = new PivotCaches();
-        pivotCaches.Append(new PivotCache { CacheId = 0, Id = cachePartId });
-        workbookPart.Workbook.Append(pivotCaches);
-
-        var pivotTablePart = pivotSheetPart.AddNewPart<PivotTablePart>();
-        pivotTablePart.CreateRelationshipToPart(cachePart);
-
-        var pivotTableDef = new PivotTableDefinition
-        {
-            Name = "PivotTable1",
-            CacheId = 0,
-            DataCaption = "Values",
-            CreatedVersion = 5,
-            UpdatedVersion = 5,
-        };
-
-        pivotTableDef.Append(new Location { Reference = "A1:B4", FirstHeaderRow = 1, FirstDataRow = 2, FirstDataColumn = 1 });
-
-        var pivotFields = new PivotFields { Count = 2 };
-        var pf0 = new PivotField { Axis = PivotTableAxisValues.AxisRow, ShowAll = false };
-        var items0 = new Items { Count = 3 };
-        items0.Append(new Item { Index = 0 });
-        items0.Append(new Item { Index = 1 });
-        items0.Append(new Item { ItemType = ItemValues.Default });
-        pf0.Append(items0);
-        pivotFields.Append(pf0);
-        pivotFields.Append(new PivotField { DataField = true, ShowAll = false });
-        pivotTableDef.Append(pivotFields);
-
-        var rowFields = new RowFields { Count = 1 };
-        rowFields.Append(new Field { Index = 0 });
-        pivotTableDef.Append(rowFields);
-
-        var rowItems = new RowItems { Count = 3 };
-        rowItems.Append(new RowItem(new MemberPropertyIndex { Val = 0 }));
-        rowItems.Append(new RowItem(new MemberPropertyIndex { Val = 1 }));
-        rowItems.Append(new RowItem(new MemberPropertyIndex()) { ItemType = ItemValues.Grand });
-        pivotTableDef.Append(rowItems);
-
-        var colItems = new ColumnItems { Count = 1 };
-        colItems.Append(new RowItem(new MemberPropertyIndex()) { ItemType = ItemValues.Grand });
-        pivotTableDef.Append(colItems);
-
-        var dataFields = new DataFields { Count = 1 };
-        dataFields.Append(new DataField { Name = "Sum of Revenue", Field = 1 });
-        pivotTableDef.Append(dataFields);
-
-        pivotTableDef.Append(new PivotTableStyle { Name = "PivotStyleLight16", ShowRowHeaders = true, ShowColumnHeaders = true });
-
-        // The element under test. Schema order puts filters after pivotTableStyleInfo.
-        var filters = new PivotFilters { Count = 2 };
-        filters.Append(BuildCaptionFilter());
-        filters.Append(BuildValueFilter());
-        pivotTableDef.Append(filters);
-
-        pivotTablePart.PivotTableDefinition = pivotTableDef;
-    }
+    private static void CreateWorkbookWithPivotFilters(Stream stream) =>
+        PivotFilterWorkbook.Create(stream, BuildCaptionFilter(), BuildValueFilter());
 
     /// <summary>
     /// A caption filter whose <c>autoFilter</c> holds an explicit value list.
@@ -338,29 +210,5 @@ public class PivotFilterTests
         };
         pivotFilter.Append(autoFilter);
         return pivotFilter;
-    }
-
-    private static Row CreateRow(uint rowIndex, params string[] values)
-    {
-        var row = new Row { RowIndex = rowIndex };
-        for (var i = 0; i < values.Length; i++)
-        {
-            row.Append(new Cell
-            {
-                CellReference = $"{(char)('A' + i)}{rowIndex}",
-                DataType = CellValues.String,
-                CellValue = new CellValue(values[i]),
-            });
-        }
-
-        return row;
-    }
-
-    private static Row CreateNumericRow(uint rowIndex, string name, double value)
-    {
-        var row = new Row { RowIndex = rowIndex };
-        row.Append(new Cell { CellReference = $"A{rowIndex}", DataType = CellValues.String, CellValue = new CellValue(name) });
-        row.Append(new Cell { CellReference = $"B{rowIndex}", DataType = CellValues.Number, CellValue = new CellValue(value) });
-        return row;
     }
 }

--- a/XLibur.Tests/Excel/PivotTables/PivotFilterWorkbook.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotFilterWorkbook.cs
@@ -1,0 +1,236 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using XLibur.Excel;
+using XLibur.Excel.IO;
+
+namespace XLibur.Tests.Excel.PivotTables;
+
+/// <summary>
+/// Builds the smallest workbook a pivot filter can live in, so that a test can put one filter in
+/// and read back what a load and save did to it.
+/// </summary>
+/// <remarks>
+/// Written with the OpenXML SDK rather than XLibur because XLibur has no API for creating pivot
+/// filters — which is the whole reason they only have to survive a round trip.
+/// </remarks>
+internal static class PivotFilterWorkbook
+{
+    /// <summary>
+    /// Load the given filters into XLibur, save, and return the filters as written.
+    /// </summary>
+    internal static List<PivotFilter> RoundTrip(params PivotFilter[] filters)
+    {
+        using var input = new MemoryStream();
+        Create(input, filters);
+        input.Position = 0;
+
+        using var wb = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        wb.SaveAs(output);
+
+        return ReadFilters(output);
+    }
+
+    /// <summary>
+    /// The <c>filterColumn</c> of a filter after a round trip — the element most of the criteria
+    /// tests are about.
+    /// </summary>
+    internal static FilterColumn RoundTripFilterColumn(FilterColumn filterColumn)
+    {
+        var autoFilter = new AutoFilter();
+        autoFilter.Append(filterColumn);
+
+        return RoundTripAutoFilter(autoFilter).Elements<FilterColumn>().Single();
+    }
+
+    /// <summary>
+    /// The <c>autoFilter</c> of a filter after a round trip.
+    /// </summary>
+    internal static AutoFilter RoundTripAutoFilter(AutoFilter autoFilter)
+    {
+        var pivotFilter = new PivotFilter
+        {
+            Field = 0U,
+            Id = 1U,
+            Type = PivotFilterValues.CaptionEqual,
+        };
+        pivotFilter.Append(autoFilter);
+
+        return RoundTrip(pivotFilter).Single().AutoFilter!;
+    }
+
+    internal static List<PivotFilter> ReadFilters(MemoryStream saved)
+    {
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        var definition = doc.WorkbookPart!.WorksheetParts
+            .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
+            .Single()
+            .PivotTableDefinition;
+
+        return definition.Elements<PivotFilters>()
+            .SelectMany(f => f.Elements<PivotFilter>())
+            .ToList();
+    }
+
+    /// <summary>
+    /// A minimal workbook whose single pivot table carries the given filters.
+    /// </summary>
+    internal static void Create(Stream stream, params PivotFilter[] filters)
+    {
+        using var doc = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+        var workbookPart = doc.AddWorkbookPart();
+        workbookPart.Workbook = new Workbook();
+        var sheets = workbookPart.Workbook.AppendChild(new Sheets());
+
+        var dataSheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(dataSheetPart), SheetId = 1, Name = "Data" });
+
+        var sheetData = new SheetData();
+        sheetData.Append(CreateRow(1, "Name", "Revenue"));
+        sheetData.Append(CreateNumericRow(2, "Cookies", 500));
+        sheetData.Append(CreateNumericRow(3, "Cake", 800));
+        dataSheetPart.Worksheet = new Worksheet(sheetData);
+
+        var pivotSheetPart = workbookPart.AddNewPart<WorksheetPart>();
+        sheets.Append(new Sheet { Id = workbookPart.GetIdOfPart(pivotSheetPart), SheetId = 2, Name = "PivotSheet" });
+        pivotSheetPart.Worksheet = new Worksheet(new SheetData());
+
+        var cachePart = workbookPart.AddNewPart<PivotTableCacheDefinitionPart>();
+        var cachePartId = workbookPart.GetIdOfPart(cachePart);
+
+        var cacheDefinition = new PivotCacheDefinition
+        {
+            Id = "rId1",
+            RefreshOnLoad = true,
+            CreatedVersion = 5,
+            RefreshedVersion = 5,
+        };
+        cacheDefinition.AddNamespaceDeclaration("r", OpenXmlConst.RelationshipsNs);
+
+        var cacheSource = new CacheSource { Type = SourceValues.Worksheet };
+        cacheSource.Append(new WorksheetSource { Sheet = "Data", Reference = "A1:B3" });
+        cacheDefinition.Append(cacheSource);
+
+        var cacheFields = new CacheFields();
+
+        var nameField = new CacheField { Name = "Name" };
+        var nameShared = new SharedItems { ContainsSemiMixedTypes = false, ContainsString = true, ContainsNumber = false, Count = 2 };
+        nameShared.Append(new StringItem { Val = "Cookies" });
+        nameShared.Append(new StringItem { Val = "Cake" });
+        nameField.SharedItems = nameShared;
+        cacheFields.Append(nameField);
+
+        var revenueField = new CacheField { Name = "Revenue" };
+        revenueField.SharedItems = new SharedItems
+        {
+            ContainsSemiMixedTypes = false,
+            ContainsString = false,
+            ContainsNumber = true,
+            MinValue = 500,
+            MaxValue = 800,
+        };
+        cacheFields.Append(revenueField);
+
+        cacheFields.Count = 2;
+        cacheDefinition.Append(cacheFields);
+
+        var recordsPart = cachePart.AddNewPart<PivotTableCacheRecordsPart>();
+        var records = new PivotCacheRecords { Count = 2 };
+        records.Append(new PivotCacheRecord(new FieldItem { Val = 0 }, new NumberItem { Val = 500 }));
+        records.Append(new PivotCacheRecord(new FieldItem { Val = 1 }, new NumberItem { Val = 800 }));
+        recordsPart.PivotCacheRecords = records;
+
+        cachePart.PivotCacheDefinition = cacheDefinition;
+
+        var pivotCaches = new PivotCaches();
+        pivotCaches.Append(new PivotCache { CacheId = 0, Id = cachePartId });
+        workbookPart.Workbook.Append(pivotCaches);
+
+        var pivotTablePart = pivotSheetPart.AddNewPart<PivotTablePart>();
+        pivotTablePart.CreateRelationshipToPart(cachePart);
+
+        var pivotTableDef = new PivotTableDefinition
+        {
+            Name = "PivotTable1",
+            CacheId = 0,
+            DataCaption = "Values",
+            CreatedVersion = 5,
+            UpdatedVersion = 5,
+        };
+
+        pivotTableDef.Append(new Location { Reference = "A1:B4", FirstHeaderRow = 1, FirstDataRow = 2, FirstDataColumn = 1 });
+
+        var pivotFields = new PivotFields { Count = 2 };
+        var pf0 = new PivotField { Axis = PivotTableAxisValues.AxisRow, ShowAll = false };
+        var items0 = new Items { Count = 3 };
+        items0.Append(new Item { Index = 0 });
+        items0.Append(new Item { Index = 1 });
+        items0.Append(new Item { ItemType = ItemValues.Default });
+        pf0.Append(items0);
+        pivotFields.Append(pf0);
+        pivotFields.Append(new PivotField { DataField = true, ShowAll = false });
+        pivotTableDef.Append(pivotFields);
+
+        var rowFields = new RowFields { Count = 1 };
+        rowFields.Append(new Field { Index = 0 });
+        pivotTableDef.Append(rowFields);
+
+        var rowItems = new RowItems { Count = 3 };
+        rowItems.Append(new RowItem(new MemberPropertyIndex { Val = 0 }));
+        rowItems.Append(new RowItem(new MemberPropertyIndex { Val = 1 }));
+        rowItems.Append(new RowItem(new MemberPropertyIndex()) { ItemType = ItemValues.Grand });
+        pivotTableDef.Append(rowItems);
+
+        var colItems = new ColumnItems { Count = 1 };
+        colItems.Append(new RowItem(new MemberPropertyIndex()) { ItemType = ItemValues.Grand });
+        pivotTableDef.Append(colItems);
+
+        var dataFields = new DataFields { Count = 1 };
+        dataFields.Append(new DataField { Name = "Sum of Revenue", Field = 1 });
+        pivotTableDef.Append(dataFields);
+
+        pivotTableDef.Append(new PivotTableStyle { Name = "PivotStyleLight16", ShowRowHeaders = true, ShowColumnHeaders = true });
+
+        if (filters.Length > 0)
+        {
+            // Schema order puts filters after pivotTableStyleInfo.
+            var pivotFilters = new PivotFilters { Count = (uint)filters.Length };
+            foreach (var filter in filters)
+                pivotFilters.Append(filter);
+
+            pivotTableDef.Append(pivotFilters);
+        }
+
+        pivotTablePart.PivotTableDefinition = pivotTableDef;
+    }
+
+    private static Row CreateRow(uint rowIndex, params string[] values)
+    {
+        var row = new Row { RowIndex = rowIndex };
+        for (var i = 0; i < values.Length; i++)
+        {
+            row.Append(new Cell
+            {
+                CellReference = $"{(char)('A' + i)}{rowIndex}",
+                DataType = CellValues.String,
+                CellValue = new CellValue(values[i]),
+            });
+        }
+
+        return row;
+    }
+
+    private static Row CreateNumericRow(uint rowIndex, string name, double value)
+    {
+        var row = new Row { RowIndex = rowIndex };
+        row.Append(new Cell { CellReference = $"A{rowIndex}", DataType = CellValues.String, CellValue = new CellValue(name) });
+        row.Append(new Cell { CellReference = $"B{rowIndex}", DataType = CellValues.Number, CellValue = new CellValue(value) });
+        return row;
+    }
+}

--- a/XLibur/Excel/AutoFilters/XLFilterColumn.cs
+++ b/XLibur/Excel/AutoFilters/XLFilterColumn.cs
@@ -17,12 +17,38 @@ internal sealed class XLFilterColumn : IXLFilterColumn, IXLFilteredColumn, IEnum
         _column = column;
     }
 
+    /// <summary>
+    /// The criteria this column was loaded from, kept until the column is changed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The runtime state below is a lossy view of a <c>filterColumn</c>: it has no room for an
+    /// <c>iconFilter</c>, for the button attributes, for <c>extLst</c>, or for the three dozen
+    /// <c>dynamicFilter</c> types beyond above- and below-average. Writing an untouched column
+    /// back from the criteria instead of from that state is what keeps those from being dropped
+    /// by a load and save.
+    /// </para>
+    /// <para>
+    /// Every mutation clears it, so a column the caller has changed is written from what the
+    /// caller asked for, not from what the file used to say.
+    /// </para>
+    /// </remarks>
+    internal XLFilterColumnCriteria? SourceCriteria { get; private set; }
+
+    /// <summary>
+    /// Record the criteria the column was loaded from. Called after the runtime state has been
+    /// populated, because populating it goes through <see cref="AddFilter(XLFilter, bool)"/>,
+    /// which clears the criteria again.
+    /// </summary>
+    internal void SetSourceCriteria(XLFilterColumnCriteria criteria) => SourceCriteria = criteria;
+
     #region IXLFilterColumn Members
 
     public void Clear(bool reapply = true)
     {
         _filters.Clear();
         FilterType = XLFilterType.None;
+        SourceCriteria = null;
         if (reapply)
             _autoFilter.Reapply();
     }
@@ -285,6 +311,7 @@ internal sealed class XLFilterColumn : IXLFilterColumn, IXLFilteredColumn, IEnum
             throw new InvalidOperationException($"{FilterType} filter can have max {maxFilters} conditions.");
 
         _filters.Add(filter);
+        SourceCriteria = null;
         if (reapply)
             _autoFilter.Reapply();
     }
@@ -297,6 +324,10 @@ internal sealed class XLFilterColumn : IXLFilterColumn, IXLFilteredColumn, IEnum
             // correct value, even is cell values changed and avg was stale.
             DynamicValue = GetAverageFilterValue();
             _filters[0].Value = DynamicValue;
+
+            // The recomputed average is what should be saved, so the loaded criteria — which
+            // carry the stale one — no longer describe the column.
+            SourceCriteria = null;
         }
 
         if (FilterType == XLFilterType.TopBottom)

--- a/XLibur/Excel/AutoFilters/XLFilterColumnCriteria.cs
+++ b/XLibur/Excel/AutoFilters/XLFilterColumnCriteria.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace XLibur.Excel.AutoFilters;
+
+/// <summary>
+/// The criteria of one <c>filterColumn</c> (<c>CT_FilterColumn</c>), free of any binding to a
+/// worksheet.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A declarative record of what a filter says, not of what it does. <see cref="XLFilterColumn"/>
+/// is the worksheet-bound counterpart: it evaluates criteria against cells and owns an
+/// <see cref="XLAutoFilter.Range"/>. A pivot table's <c>autoFilter</c> has neither — Excel
+/// applies its criteria to pivot items — so the two share this type rather than the other.
+/// </para>
+/// <para>
+/// Every attribute is carried, including the ones XLibur cannot act on, because the criteria are
+/// written back from here. Anything omitted here is lost on save.
+/// </para>
+/// </remarks>
+internal sealed class XLFilterColumnCriteria
+{
+    /// <summary>
+    /// Zero-based index of the filtered column, relative to the filtered range (<c>colId</c>).
+    /// </summary>
+    internal required uint ColumnId { get; init; }
+
+    /// <summary>
+    /// Whether the filter dropdown button is hidden. Default <c>false</c>.
+    /// </summary>
+    internal bool HiddenButton { get; init; }
+
+    /// <summary>
+    /// Whether the filter dropdown button is shown. Default <c>true</c>.
+    /// </summary>
+    internal bool ShowButton { get; init; } = true;
+
+    /// <summary>
+    /// The criteria themselves — one of the six children the schema allows, or <c>null</c> when
+    /// the column carries none (a valid, if unusual, state: the element then only sets the
+    /// button attributes).
+    /// </summary>
+    internal XLFilterCriteria? Criteria { get; init; }
+
+    /// <summary>
+    /// The <c>extLst</c> child, verbatim, including its element tags. Nothing in XLibur reads
+    /// the extensions, but dropping them would lose whatever a newer Excel put there.
+    /// </summary>
+    internal string? ExtensionListXml { get; init; }
+}

--- a/XLibur/Excel/AutoFilters/XLFilterCriteria.cs
+++ b/XLibur/Excel/AutoFilters/XLFilterCriteria.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+
+namespace XLibur.Excel.AutoFilters;
+
+/// <summary>
+/// One of the six mutually exclusive children a <c>filterColumn</c> may carry. The schema models
+/// them as a choice, so a column has exactly one or none.
+/// </summary>
+internal abstract class XLFilterCriteria
+{
+    private protected XLFilterCriteria()
+    {
+    }
+}
+
+/// <summary>
+/// <c>filters</c> (<c>CT_Filters</c>) — an explicit list of the values to keep, the shape Excel
+/// writes for a tick-box list.
+/// </summary>
+internal sealed class XLValuesFilterCriteria : XLFilterCriteria
+{
+    /// <summary>
+    /// Whether blank values are kept as well. Default <c>false</c>.
+    /// </summary>
+    internal bool Blank { get; init; }
+
+    /// <summary>
+    /// The <c>ST_CalendarType</c> token the date groups are expressed in, e.g. <c>gregorian</c>
+    /// or <c>hijri</c>. Held as the raw token: XLibur does not act on it, and there are a dozen
+    /// values a newer Excel could add to. Default is <c>none</c>, written as absent.
+    /// </summary>
+    internal string? CalendarType { get; init; }
+
+    /// <summary>
+    /// The kept values, as written (<c>filter/@val</c>). Excel compares them against the
+    /// formatted text of a cell, so they are text even for numeric columns.
+    /// </summary>
+    internal IReadOnlyList<string> Values { get; init; } = [];
+
+    /// <summary>
+    /// The kept date groups (<c>dateGroupItem</c>), e.g. "every March".
+    /// </summary>
+    internal IReadOnlyList<XLDateGroupCriteria> DateGroups { get; init; } = [];
+}
+
+/// <summary>
+/// One <c>dateGroupItem</c> — a date truncated to <see cref="Grouping"/>, matching every date
+/// that shares that prefix.
+/// </summary>
+/// <remarks>
+/// The parts are nullable rather than defaulted because the schema makes only <c>year</c> and
+/// <c>dateTimeGrouping</c> required, and a part that was absent must stay absent on save.
+/// </remarks>
+internal sealed class XLDateGroupCriteria
+{
+    internal required XLDateTimeGrouping Grouping { get; init; }
+
+    internal ushort? Year { get; init; }
+
+    internal ushort? Month { get; init; }
+
+    internal ushort? Day { get; init; }
+
+    internal ushort? Hour { get; init; }
+
+    internal ushort? Minute { get; init; }
+
+    internal ushort? Second { get; init; }
+}
+
+/// <summary>
+/// <c>top10</c> (<c>CT_Top10</c>) — keep the highest or lowest N items, or N percent of them.
+/// </summary>
+internal sealed class XLTop10Criteria : XLFilterCriteria
+{
+    /// <summary>
+    /// Whether the top of the range is kept rather than the bottom. Default <c>true</c>.
+    /// </summary>
+    internal bool Top { get; init; } = true;
+
+    /// <summary>
+    /// Whether <see cref="Value"/> is a percentage rather than an item count. Default <c>false</c>.
+    /// </summary>
+    internal bool Percent { get; init; }
+
+    /// <summary>
+    /// The item count or percentage (<c>val</c>). Required by the schema.
+    /// </summary>
+    internal required double Value { get; init; }
+
+    /// <summary>
+    /// The cached cut-off the count resolved to when the filter was last applied
+    /// (<c>filterVal</c>). Optional, and stale as soon as the data changes, so it is preserved
+    /// rather than relied on.
+    /// </summary>
+    internal double? FilterValue { get; init; }
+}
+
+/// <summary>
+/// <c>customFilters</c> (<c>CT_CustomFilters</c>) — up to two comparisons joined by AND or OR.
+/// </summary>
+internal sealed class XLCustomFiltersCriteria : XLFilterCriteria
+{
+    /// <summary>
+    /// Whether the criteria are joined by AND rather than OR. Default <c>false</c>.
+    /// </summary>
+    internal bool And { get; init; }
+
+    internal IReadOnlyList<XLCustomFilterCriterion> Filters { get; init; } = [];
+}
+
+/// <summary>
+/// One <c>customFilter</c> — an operator and the value to compare against.
+/// </summary>
+internal sealed class XLCustomFilterCriterion
+{
+    /// <summary>
+    /// The comparison. Default <see cref="XLFilterOperator.Equal"/>, which Excel treats as a
+    /// wildcard match rather than an equality test.
+    /// </summary>
+    internal XLFilterOperator Operator { get; init; } = XLFilterOperator.Equal;
+
+    /// <summary>
+    /// The value compared against, as written. Optional in the schema, and always text: OOXML has
+    /// no type for it, so a number is stored in its invariant form.
+    /// </summary>
+    internal string? Value { get; init; }
+}
+
+/// <summary>
+/// <c>dynamicFilter</c> (<c>CT_DynamicFilter</c>) — criteria evaluated against the data rather
+/// than fixed, such as "above average" or "this quarter".
+/// </summary>
+internal sealed class XLDynamicFilterCriteria : XLFilterCriteria
+{
+    /// <summary>
+    /// The <c>ST_DynamicFilterType</c> token, e.g. <c>aboveAverage</c> or <c>lastQuarter</c>.
+    /// Held as the raw token rather than <see cref="XLFilterDynamicType"/>, which covers only the
+    /// two average variants: mapping the other three dozen onto it would silently turn
+    /// "this year" into "above average" on save.
+    /// </summary>
+    internal required string Type { get; init; }
+
+    /// <summary>
+    /// The cached value the criteria resolved to — the average, for the average filters.
+    /// </summary>
+    internal double? Value { get; init; }
+
+    /// <summary>
+    /// Upper bound of the cached range, for the date filters that span one.
+    /// </summary>
+    internal double? MaxValue { get; init; }
+
+    /// <summary>
+    /// <see cref="Value"/> as an ISO 8601 date, written by Excel alongside the serial number.
+    /// Preserved as text so it cannot drift from the serial through a parse and reformat.
+    /// </summary>
+    internal string? ValueIso { get; init; }
+
+    /// <summary>
+    /// <see cref="MaxValue"/> as an ISO 8601 date.
+    /// </summary>
+    internal string? MaxValueIso { get; init; }
+}
+
+/// <summary>
+/// <c>colorFilter</c> (<c>CT_ColorFilter</c>) — keep the cells drawn in one colour.
+/// </summary>
+internal sealed class XLColorFilterCriteria : XLFilterCriteria
+{
+    /// <summary>
+    /// Index into the differential formats, which is where the colour itself lives.
+    /// </summary>
+    internal uint? DifferentialFormatId { get; init; }
+
+    /// <summary>
+    /// Whether the fill colour is matched rather than the font colour. Default <c>true</c>.
+    /// </summary>
+    internal bool CellColor { get; init; } = true;
+}
+
+/// <summary>
+/// <c>iconFilter</c> (<c>CT_IconFilter</c>) — keep the cells showing one icon of a conditional
+/// formatting icon set.
+/// </summary>
+/// <remarks>
+/// XLibur cannot evaluate this one: it would have to resolve the conditional format that assigns
+/// the icons first. It is modelled anyway so that a file carrying one survives a round trip.
+/// </remarks>
+internal sealed class XLIconFilterCriteria : XLFilterCriteria
+{
+    /// <summary>
+    /// The <c>ST_IconSetType</c> token, e.g. <c>3TrafficLights1</c>. Required by the schema.
+    /// </summary>
+    internal required string IconSet { get; init; }
+
+    /// <summary>
+    /// Zero-based index of the icon within the set. Absent means "no icon".
+    /// </summary>
+    internal uint? IconId { get; init; }
+}

--- a/XLibur/Excel/EnumConverter.cs
+++ b/XLibur/Excel/EnumConverter.cs
@@ -1148,6 +1148,17 @@ internal static class EnumConverter
         return DynamicFilterMap[value];
     }
 
+    /// <summary>
+    /// The non-throwing form of <see cref="ToXLibur(DynamicFilterValues)"/>.
+    /// <c>ST_DynamicFilterType</c> has around forty values — every relative date period Excel
+    /// offers — and <see cref="XLFilterDynamicType"/> covers the two averages, so a caller
+    /// reading a file has to cope with a value that does not map.
+    /// </summary>
+    public static bool TryToXLibur(this DynamicFilterValues value, out XLFilterDynamicType result)
+    {
+        return DynamicFilterMap.TryGetValue(value, out result);
+    }
+
     public static XLDateTimeGrouping ToXLibur(this DateTimeGroupingValues value)
     {
         return DateTimeGroupingMap[value];

--- a/XLibur/Excel/IO/AutoFilterWriter.cs
+++ b/XLibur/Excel/IO/AutoFilterWriter.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel.AutoFilters;
 using XLibur.Excel.ContentManagers;
-using XLibur.Utils;
 using static XLibur.Excel.XLWorkbook;
 
 namespace XLibur.Excel.IO;
@@ -41,136 +42,149 @@ internal static class AutoFilterWriter
 
         foreach (var (columnNumber, xlFilterColumn) in xlAutoFilter.Columns)
         {
-            var filterColumn = new FilterColumn { ColumnId = (uint)columnNumber - 1 };
-
-            if (xlFilterColumn.FilterType == XLFilterType.None)
+            if (GetCriteria(xlFilterColumn, (uint)columnNumber - 1, context) is not { } criteria)
                 continue;
 
-            PopulateFilterColumn(filterColumn, xlFilterColumn, context);
-            autoFilter.Append(filterColumn);
+            autoFilter.Append(FilterColumnCriteriaWriter.Write(criteria));
         }
 
         if (xlAutoFilter.Sorted)
             AppendSortState(autoFilter, xlAutoFilter, filterRange);
     }
 
-    private static void PopulateFilterColumn(FilterColumn filterColumn, XLFilterColumn xlFilterColumn,
+    /// <summary>
+    /// The criteria to write for one column, or <c>null</c> when it has nothing to say.
+    /// </summary>
+    /// <remarks>
+    /// A column that was loaded and not since changed is written from the criteria it was loaded
+    /// with, so the parts the runtime state cannot hold — an <c>iconFilter</c>, the button
+    /// attributes, <c>extLst</c> — are not lost by a load and save. Once the caller changes the
+    /// column those criteria are dropped, and it is written from what the caller asked for.
+    /// </remarks>
+    private static XLFilterColumnCriteria? GetCriteria(XLFilterColumn xlFilterColumn, uint columnId,
         SaveContext context)
     {
-        switch (xlFilterColumn.FilterType)
+        if (xlFilterColumn.SourceCriteria is { } sourceCriteria)
+            return sourceCriteria;
+
+        if (xlFilterColumn.FilterType == XLFilterType.None)
+            return null;
+
+        return new XLFilterColumnCriteria
         {
-            case XLFilterType.Custom:
-                filterColumn.Append(CreateCustomFilters(xlFilterColumn));
-                break;
-
-            case XLFilterType.TopBottom:
-                filterColumn.Append(CreateTop10Filter(xlFilterColumn));
-                break;
-
-            case XLFilterType.Dynamic:
-                filterColumn.Append(CreateDynamicFilter(xlFilterColumn));
-                break;
-
-            case XLFilterType.Regular:
-                filterColumn.Append(CreateRegularFilters(xlFilterColumn));
-                break;
-
-            case XLFilterType.Color:
-                AppendColorFilter(filterColumn, xlFilterColumn, context);
-                break;
-
-            default:
-                throw new NotSupportedException();
-        }
+            ColumnId = columnId,
+            Criteria = CreateCriteria(xlFilterColumn, context),
+        };
     }
 
-    private static CustomFilters CreateCustomFilters(XLFilterColumn xlFilterColumn)
+    private static XLFilterCriteria? CreateCriteria(XLFilterColumn xlFilterColumn, SaveContext context)
     {
-        var customFilters = new CustomFilters();
+        return xlFilterColumn.FilterType switch
+        {
+            XLFilterType.Custom => CreateCustomFilters(xlFilterColumn),
+            XLFilterType.TopBottom => CreateTop10Filter(xlFilterColumn),
+            XLFilterType.Dynamic => CreateDynamicFilter(xlFilterColumn),
+            XLFilterType.Regular => CreateRegularFilters(xlFilterColumn),
+
+            // A colour whose differential format was never registered has no dxfId to point at,
+            // so the column is written without criteria rather than with a dangling reference.
+            XLFilterType.Color => CreateColorFilter(xlFilterColumn, context),
+            _ => throw new NotSupportedException(),
+        };
+    }
+
+    private static XLCustomFiltersCriteria CreateCustomFilters(XLFilterColumn xlFilterColumn)
+    {
+        var filters = new List<XLCustomFilterCriterion>();
+        var and = false;
+
         foreach (var xlFilter in xlFilterColumn)
         {
-            var filterValue = xlFilter.CustomValue.ToString(CultureInfo.InvariantCulture);
-            var customFilter = new CustomFilter { Val = filterValue };
-
-            if (xlFilter.Operator != XLFilterOperator.Equal)
-                customFilter.Operator = xlFilter.Operator.ToOpenXml();
+            filters.Add(new XLCustomFilterCriterion
+            {
+                Value = xlFilter.CustomValue.ToString(CultureInfo.InvariantCulture),
+                Operator = xlFilter.Operator,
+            });
 
             if (xlFilter.Connector == XLConnector.And)
-                customFilters.And = true;
-
-            customFilters.Append(customFilter);
+                and = true;
         }
 
-        return customFilters;
+        return new XLCustomFiltersCriteria { And = and, Filters = filters };
     }
 
-    private static Top10 CreateTop10Filter(XLFilterColumn xlFilterColumn)
+    private static XLTop10Criteria CreateTop10Filter(XLFilterColumn xlFilterColumn)
     {
-        return new Top10
+        return new XLTop10Criteria
         {
-            Val = xlFilterColumn.TopBottomValue,
-            Percent = OpenXmlHelper.GetBooleanValue(xlFilterColumn.TopBottomType == XLTopBottomType.Percent, false),
-            Top = OpenXmlHelper.GetBooleanValue(xlFilterColumn.TopBottomPart == XLTopBottomPart.Top, true)
+            Value = xlFilterColumn.TopBottomValue,
+            Percent = xlFilterColumn.TopBottomType == XLTopBottomType.Percent,
+            Top = xlFilterColumn.TopBottomPart == XLTopBottomPart.Top,
         };
     }
 
-    private static DynamicFilter CreateDynamicFilter(XLFilterColumn xlFilterColumn)
+    private static XLDynamicFilterCriteria CreateDynamicFilter(XLFilterColumn xlFilterColumn)
     {
-        return new DynamicFilter
+        return new XLDynamicFilterCriteria
         {
-            Type = xlFilterColumn.DynamicType.ToOpenXml(),
-            Val = xlFilterColumn.DynamicValue
+            Type = new EnumValue<DynamicFilterValues>(xlFilterColumn.DynamicType.ToOpenXml()).InnerText!,
+            Value = xlFilterColumn.DynamicValue,
         };
     }
 
-    private static Filters CreateRegularFilters(XLFilterColumn xlFilterColumn)
+    private static XLValuesFilterCriteria CreateRegularFilters(XLFilterColumn xlFilterColumn)
     {
-        var filters = new Filters();
-        foreach (var filter in xlFilterColumn)
-        {
-            if (filter.Value is string s)
-                filters.Append(new Filter { Val = s });
-        }
+        var values = new List<string>();
+        var dateGroups = new List<XLDateGroupCriteria>();
 
         foreach (var filter in xlFilterColumn)
         {
-            if (filter.Value is DateTime time)
-                filters.Append(CreateDateGroupItem(filter, time));
+            switch (filter.Value)
+            {
+                case string text:
+                    values.Add(text);
+                    break;
+
+                case DateTime time:
+                    dateGroups.Add(CreateDateGroup(filter, time));
+                    break;
+            }
         }
 
-        return filters;
+        return new XLValuesFilterCriteria { Values = values, DateGroups = dateGroups };
     }
 
-    private static DateGroupItem CreateDateGroupItem(XLFilter filter, DateTime time)
+    /// <summary>
+    /// A date truncated to the filter's grouping. The parts finer than the grouping are left out
+    /// rather than written as the zeroes the <see cref="DateTime"/> carries, because Excel reads
+    /// a present part as one the filter matches on.
+    /// </summary>
+    private static XLDateGroupCriteria CreateDateGroup(XLFilter filter, DateTime time)
     {
-        var dgi = new DateGroupItem
+        var grouping = filter.DateTimeGrouping;
+        return new XLDateGroupCriteria
         {
+            Grouping = grouping,
             Year = (ushort)time.Year,
-            DateTimeGrouping = filter.DateTimeGrouping.ToOpenXml()
+            Month = grouping >= XLDateTimeGrouping.Month ? (ushort)time.Month : null,
+            Day = grouping >= XLDateTimeGrouping.Day ? (ushort)time.Day : null,
+            Hour = grouping >= XLDateTimeGrouping.Hour ? (ushort)time.Hour : null,
+            Minute = grouping >= XLDateTimeGrouping.Minute ? (ushort)time.Minute : null,
+            Second = grouping >= XLDateTimeGrouping.Second ? (ushort)time.Second : null,
         };
-
-        if (filter.DateTimeGrouping >= XLDateTimeGrouping.Month) dgi.Month = (ushort)time.Month;
-        if (filter.DateTimeGrouping >= XLDateTimeGrouping.Day) dgi.Day = (ushort)time.Day;
-        if (filter.DateTimeGrouping >= XLDateTimeGrouping.Hour) dgi.Hour = (ushort)time.Hour;
-        if (filter.DateTimeGrouping >= XLDateTimeGrouping.Minute) dgi.Minute = (ushort)time.Minute;
-        if (filter.DateTimeGrouping >= XLDateTimeGrouping.Second) dgi.Second = (ushort)time.Second;
-
-        return dgi;
     }
 
-    private static void AppendColorFilter(FilterColumn filterColumn, XLFilterColumn xlFilterColumn,
-        SaveContext context)
+    private static XLColorFilterCriteria? CreateColorFilter(XLFilterColumn xlFilterColumn, SaveContext context)
     {
         var dxfKey = (xlFilterColumn.FilterColor.Key, xlFilterColumn.FilterByCellColor);
-        if (context.ColorFilterDxfIds.TryGetValue(dxfKey, out var dxfId))
+        if (!context.ColorFilterDxfIds.TryGetValue(dxfKey, out var dxfId))
+            return null;
+
+        return new XLColorFilterCriteria
         {
-            var colorFilter = new ColorFilter
-            {
-                FormatId = (uint)dxfId,
-                CellColor = OpenXmlHelper.GetBooleanValue(xlFilterColumn.FilterByCellColor, true),
-            };
-            filterColumn.Append(colorFilter);
-        }
+            DifferentialFormatId = (uint)dxfId,
+            CellColor = xlFilterColumn.FilterByCellColor,
+        };
     }
 
     private static void AppendSortState(AutoFilter autoFilter, XLAutoFilter xlAutoFilter, IXLRange filterRange)

--- a/XLibur/Excel/IO/FilterColumnCriteriaReader.cs
+++ b/XLibur/Excel/IO/FilterColumnCriteriaReader.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+using System.Linq;
+using DocumentFormat.OpenXml.Spreadsheet;
+using XLibur.Excel.AutoFilters;
+using XLibur.Utils;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Reads a <c>filterColumn</c> into <see cref="XLFilterColumnCriteria"/>. The one place that
+/// knows how the criteria are spelled, shared by worksheet autofilters and pivot table filters —
+/// both of which reach the element through the same DOM.
+/// </summary>
+internal static class FilterColumnCriteriaReader
+{
+    internal static XLFilterColumnCriteria Read(FilterColumn filterColumn)
+    {
+        return new XLFilterColumnCriteria
+        {
+            ColumnId = filterColumn.ColumnId?.Value ?? throw PartStructureException.MissingAttribute(),
+            HiddenButton = OpenXmlHelper.GetBooleanValueAsBool(filterColumn.HiddenButton, false),
+            ShowButton = OpenXmlHelper.GetBooleanValueAsBool(filterColumn.ShowButton, true),
+            Criteria = ReadCriteria(filterColumn),
+            ExtensionListXml = filterColumn.GetFirstChild<ExtensionList>()?.OuterXml,
+        };
+    }
+
+    /// <summary>
+    /// The schema models the six children as a choice, so at most one is present. They are tried
+    /// in no particular order; a file with several is malformed either way.
+    /// </summary>
+    private static XLFilterCriteria? ReadCriteria(FilterColumn filterColumn)
+    {
+        if (filterColumn.GetFirstChild<Filters>() is { } filters)
+            return ReadValuesFilter(filters);
+
+        if (filterColumn.GetFirstChild<Top10>() is { } top10)
+            return ReadTop10(top10);
+
+        if (filterColumn.GetFirstChild<CustomFilters>() is { } customFilters)
+            return ReadCustomFilters(customFilters);
+
+        if (filterColumn.GetFirstChild<DynamicFilter>() is { } dynamicFilter)
+            return ReadDynamicFilter(dynamicFilter);
+
+        if (filterColumn.GetFirstChild<ColorFilter>() is { } colorFilter)
+            return ReadColorFilter(colorFilter);
+
+        if (filterColumn.GetFirstChild<IconFilter>() is { } iconFilter)
+            return ReadIconFilter(iconFilter);
+
+        return null;
+    }
+
+    private static XLValuesFilterCriteria ReadValuesFilter(Filters filters)
+    {
+        var values = filters.Elements<Filter>()
+            .Select(filter => filter.Val?.Value)
+            .Where(val => val is not null)
+            .Select(val => val!)
+            .ToList();
+
+        var dateGroups = filters.Elements<DateGroupItem>()
+            .Select(ReadDateGroup)
+            .Where(group => group is not null)
+            .Select(group => group!)
+            .ToList();
+
+        return new XLValuesFilterCriteria
+        {
+            Blank = OpenXmlHelper.GetBooleanValueAsBool(filters.Blank, false),
+            CalendarType = filters.CalendarType?.InnerText,
+            Values = values,
+            DateGroups = dateGroups,
+        };
+    }
+
+    /// <summary>
+    /// Returns <c>null</c> for an item with no grouping. The attribute is required, so its
+    /// absence means the item says nothing about which dates to keep.
+    /// </summary>
+    private static XLDateGroupCriteria? ReadDateGroup(DateGroupItem dateGroupItem)
+    {
+        if (dateGroupItem.DateTimeGrouping is not { HasValue: true } grouping)
+            return null;
+
+        return new XLDateGroupCriteria
+        {
+            Grouping = grouping.Value.ToXLibur(),
+            Year = dateGroupItem.Year?.Value,
+            Month = dateGroupItem.Month?.Value,
+            Day = dateGroupItem.Day?.Value,
+            Hour = dateGroupItem.Hour?.Value,
+            Minute = dateGroupItem.Minute?.Value,
+            Second = dateGroupItem.Second?.Value,
+        };
+    }
+
+    private static XLTop10Criteria ReadTop10(Top10 top10)
+    {
+        return new XLTop10Criteria
+        {
+            Top = OpenXmlHelper.GetBooleanValueAsBool(top10.Top, true),
+            Percent = OpenXmlHelper.GetBooleanValueAsBool(top10.Percent, false),
+            Value = top10.Val?.Value ?? throw PartStructureException.MissingAttribute(),
+            FilterValue = top10.FilterValue?.Value,
+        };
+    }
+
+    private static XLCustomFiltersCriteria ReadCustomFilters(CustomFilters customFilters)
+    {
+        var filters = customFilters.Elements<CustomFilter>()
+            .Select(customFilter => new XLCustomFilterCriterion
+            {
+                Operator = customFilter.Operator is { HasValue: true } op
+                    ? op.Value.ToXLibur()
+                    : XLFilterOperator.Equal,
+                Value = customFilter.Val?.Value,
+            })
+            .ToList();
+
+        return new XLCustomFiltersCriteria
+        {
+            And = OpenXmlHelper.GetBooleanValueAsBool(customFilters.And, false),
+            Filters = filters,
+        };
+    }
+
+    private static XLDynamicFilterCriteria ReadDynamicFilter(DynamicFilter dynamicFilter)
+    {
+        return new XLDynamicFilterCriteria
+        {
+            // The token, not the enum: XLFilterDynamicType covers only the two average variants.
+            Type = dynamicFilter.Type?.InnerText ?? throw PartStructureException.MissingAttribute(),
+            Value = dynamicFilter.Val?.Value,
+            MaxValue = dynamicFilter.MaxVal?.Value,
+            ValueIso = dynamicFilter.ValIso?.InnerText,
+            MaxValueIso = dynamicFilter.MaxValIso?.InnerText,
+        };
+    }
+
+    private static XLColorFilterCriteria ReadColorFilter(ColorFilter colorFilter)
+    {
+        return new XLColorFilterCriteria
+        {
+            DifferentialFormatId = colorFilter.FormatId?.Value,
+            CellColor = OpenXmlHelper.GetBooleanValueAsBool(colorFilter.CellColor, true),
+        };
+    }
+
+    private static XLIconFilterCriteria ReadIconFilter(IconFilter iconFilter)
+    {
+        return new XLIconFilterCriteria
+        {
+            IconSet = iconFilter.IconSet?.InnerText ?? throw PartStructureException.MissingAttribute(),
+            IconId = iconFilter.IconId?.Value,
+        };
+    }
+}

--- a/XLibur/Excel/IO/FilterColumnCriteriaWriter.cs
+++ b/XLibur/Excel/IO/FilterColumnCriteriaWriter.cs
@@ -1,0 +1,174 @@
+using System;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+using XLibur.Excel.AutoFilters;
+using XLibur.Utils;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Writes <see cref="XLFilterColumnCriteria"/> back to a <c>filterColumn</c>. The counterpart of
+/// <see cref="FilterColumnCriteriaReader"/>, and the only place that spells the criteria out, so
+/// the two cannot drift.
+/// </summary>
+internal static class FilterColumnCriteriaWriter
+{
+    internal static FilterColumn Write(XLFilterColumnCriteria criteria)
+    {
+        var filterColumn = new FilterColumn { ColumnId = criteria.ColumnId };
+
+        // Both are written only when they differ from their schema default, so a column Excel
+        // wrote without them comes back without them.
+        if (criteria.HiddenButton)
+            filterColumn.HiddenButton = true;
+
+        if (!criteria.ShowButton)
+            filterColumn.ShowButton = false;
+
+        if (criteria.Criteria is { } childCriteria)
+            filterColumn.Append(WriteCriteria(childCriteria));
+
+        if (criteria.ExtensionListXml is { } extensionListXml)
+            filterColumn.Append(new ExtensionList(extensionListXml));
+
+        return filterColumn;
+    }
+
+    private static OpenXmlElement WriteCriteria(XLFilterCriteria criteria)
+    {
+        return criteria switch
+        {
+            XLValuesFilterCriteria values => WriteValuesFilter(values),
+            XLTop10Criteria top10 => WriteTop10(top10),
+            XLCustomFiltersCriteria customFilters => WriteCustomFilters(customFilters),
+            XLDynamicFilterCriteria dynamicFilter => WriteDynamicFilter(dynamicFilter),
+            XLColorFilterCriteria colorFilter => WriteColorFilter(colorFilter),
+            XLIconFilterCriteria iconFilter => WriteIconFilter(iconFilter),
+            _ => throw new NotSupportedException($"Unexpected filter criteria: {criteria.GetType().Name}."),
+        };
+    }
+
+    private static Filters WriteValuesFilter(XLValuesFilterCriteria criteria)
+    {
+        var filters = new Filters();
+        if (criteria.Blank)
+            filters.Blank = true;
+
+        if (criteria.CalendarType is { } calendarType)
+            SetTokenAttribute(filters, "calendarType", calendarType);
+
+        // Schema order: every filter, then every dateGroupItem.
+        foreach (var value in criteria.Values)
+            filters.Append(new Filter { Val = value });
+
+        foreach (var dateGroup in criteria.DateGroups)
+            filters.Append(WriteDateGroup(dateGroup));
+
+        return filters;
+    }
+
+    private static DateGroupItem WriteDateGroup(XLDateGroupCriteria criteria)
+    {
+        var dateGroupItem = new DateGroupItem { DateTimeGrouping = criteria.Grouping.ToOpenXml() };
+
+        if (criteria.Year is { } year) dateGroupItem.Year = year;
+        if (criteria.Month is { } month) dateGroupItem.Month = month;
+        if (criteria.Day is { } day) dateGroupItem.Day = day;
+        if (criteria.Hour is { } hour) dateGroupItem.Hour = hour;
+        if (criteria.Minute is { } minute) dateGroupItem.Minute = minute;
+        if (criteria.Second is { } second) dateGroupItem.Second = second;
+
+        return dateGroupItem;
+    }
+
+    private static Top10 WriteTop10(XLTop10Criteria criteria)
+    {
+        var top10 = new Top10 { Val = criteria.Value };
+
+        if (!criteria.Top)
+            top10.Top = false;
+
+        if (criteria.Percent)
+            top10.Percent = true;
+
+        if (criteria.FilterValue is { } filterValue)
+            top10.FilterValue = filterValue;
+
+        return top10;
+    }
+
+    private static CustomFilters WriteCustomFilters(XLCustomFiltersCriteria criteria)
+    {
+        var customFilters = new CustomFilters();
+        if (criteria.And)
+            customFilters.And = true;
+
+        foreach (var filter in criteria.Filters)
+        {
+            var customFilter = new CustomFilter();
+            if (filter.Value is { } value)
+                customFilter.Val = value;
+
+            if (filter.Operator != XLFilterOperator.Equal)
+                customFilter.Operator = filter.Operator.ToOpenXml();
+
+            customFilters.Append(customFilter);
+        }
+
+        return customFilters;
+    }
+
+    private static DynamicFilter WriteDynamicFilter(XLDynamicFilterCriteria criteria)
+    {
+        var dynamicFilter = new DynamicFilter();
+        SetTokenAttribute(dynamicFilter, "type", criteria.Type);
+
+        if (criteria.Value is { } value)
+            dynamicFilter.Val = value;
+
+        if (criteria.MaxValue is { } maxValue)
+            dynamicFilter.MaxVal = maxValue;
+
+        // The ISO forms go back as the text they were read as: parsing them into a DateTime and
+        // reformatting would change the precision Excel wrote.
+        if (criteria.ValueIso is { } valueIso)
+            SetTokenAttribute(dynamicFilter, "valIso", valueIso);
+
+        if (criteria.MaxValueIso is { } maxValueIso)
+            SetTokenAttribute(dynamicFilter, "maxValIso", maxValueIso);
+
+        return dynamicFilter;
+    }
+
+    private static ColorFilter WriteColorFilter(XLColorFilterCriteria criteria)
+    {
+        var colorFilter = new ColorFilter();
+        if (criteria.DifferentialFormatId is { } formatId)
+            colorFilter.FormatId = formatId;
+
+        if (!criteria.CellColor)
+            colorFilter.CellColor = false;
+
+        return colorFilter;
+    }
+
+    private static IconFilter WriteIconFilter(XLIconFilterCriteria criteria)
+    {
+        var iconFilter = new IconFilter();
+        SetTokenAttribute(iconFilter, "iconSet", criteria.IconSet);
+
+        if (criteria.IconId is { } iconId)
+            iconFilter.IconId = iconId;
+
+        return iconFilter;
+    }
+
+    /// <summary>
+    /// Set an attribute the SDK types as an enum from its raw token, so a value this build has
+    /// never heard of is written back as it was read rather than dropped.
+    /// </summary>
+    private static void SetTokenAttribute(OpenXmlElement element, string attributeName, string token)
+    {
+        element.SetAttribute(new OpenXmlAttribute(string.Empty, attributeName, string.Empty, token));
+    }
+}

--- a/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -243,11 +243,11 @@ internal static class PivotTableDefinitionPartReader
             // act on it, and a token survives a value a newer Excel introduced.
             var type = pivotFilter.Type?.InnerText ?? throw PartStructureException.MissingAttribute();
 
-            // autoFilter is required by the schema and is a sub-tree in its own right, so it is
-            // carried through verbatim instead of being modelled.
+            // autoFilter is required by the schema and carries the criteria, so a filter without
+            // one says nothing about what it keeps.
             var autoFilter = pivotFilter.AutoFilter ?? throw PartStructureException.ExpectedElementNotFound();
 
-            var xlPivotFilter = new XLPivotFilter(field, id, type, autoFilter.OuterXml)
+            var xlPivotFilter = new XLPivotFilter(field, id, type, ReadAutoFilter(autoFilter))
             {
                 EvaluationOrder = pivotFilter.EvaluationOrder?.Value ?? 0,
                 MemberPropertyField = pivotFilter.MemberPropertyFieldId?.Value,
@@ -260,6 +260,22 @@ internal static class PivotTableDefinitionPartReader
             };
             xlPivotTable.AddPivotFilter(xlPivotFilter);
         }
+    }
+
+    /// <summary>
+    /// Read the <c>autoFilter</c> of a pivot filter. The <c>filterColumn</c> children go through
+    /// the same reader as a worksheet autofilter's, because the element is the same one;
+    /// <c>sortState</c> and <c>extLst</c> are preserved rather than modelled.
+    /// </summary>
+    private static XLPivotAutoFilter ReadAutoFilter(AutoFilter autoFilter)
+    {
+        return new XLPivotAutoFilter
+        {
+            Reference = autoFilter.Reference?.Value,
+            Columns = autoFilter.Elements<FilterColumn>().Select(FilterColumnCriteriaReader.Read).ToList(),
+            SortStateXml = autoFilter.GetFirstChild<SortState>()?.OuterXml,
+            ExtensionListXml = autoFilter.GetFirstChild<ExtensionList>()?.OuterXml,
+        };
     }
 
     private static void LoadConditionalFormats(DocumentFormat.OpenXml.Spreadsheet.ConditionalFormats? conditionalFormats, XLPivotTable xlPivotTable,

--- a/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Extensions;
 using static XLibur.Excel.IO.OpenXmlConst;
 using static XLibur.Excel.XLWorkbook;
@@ -469,13 +470,44 @@ internal static class PivotTableDefinitionPartWriter2
             xml.WriteAttributeOptional("stringValue1", pivotFilter.StringValue1);
             xml.WriteAttributeOptional("stringValue2", pivotFilter.StringValue2);
 
-            // Written back exactly as it was read. See XLPivotFilter.AutoFilterXml.
-            xml.WriteRaw(pivotFilter.AutoFilterXml);
+            WriteAutoFilter(xml, pivotFilter.AutoFilter);
 
             xml.WriteEndElement(); // filter
         }
 
         xml.WriteEndElement(); // filters
+    }
+
+    /// <summary>
+    /// Write the <c>autoFilter</c> child of a pivot filter.
+    /// </summary>
+    /// <remarks>
+    /// Built as a DOM element and streamed into the writer, rather than written attribute by
+    /// attribute, so that the criteria have a single writer shared with worksheet autofilters
+    /// instead of one per part. This part is streamed for the sake of the thousands of items a
+    /// pivot table definition holds; a handful of filters is not where that matters.
+    /// </remarks>
+    private static void WriteAutoFilter(XmlWriter xml, XLPivotAutoFilter pivotAutoFilter)
+    {
+        var autoFilter = new AutoFilter();
+        if (pivotAutoFilter.Reference is { } reference)
+            autoFilter.Reference = reference;
+
+        foreach (var column in pivotAutoFilter.Columns)
+            autoFilter.Append(FilterColumnCriteriaWriter.Write(column));
+
+        // Schema order puts both after the filterColumn children.
+        if (pivotAutoFilter.SortStateXml is { } sortStateXml)
+            autoFilter.Append(new SortState(sortStateXml));
+
+        if (pivotAutoFilter.ExtensionListXml is { } extensionListXml)
+            autoFilter.Append(new ExtensionList(extensionListXml));
+
+        // The SDK writes a detached element with its own prefix, so this goes out as
+        // `x:autoFilter` with a declaration of its own rather than picking up the default
+        // namespace already in scope. Redundant, but the same namespace, and the same shape the
+        // preserved sub-tree produced before it was modelled.
+        autoFilter.WriteTo(xml);
     }
 
     private static void WriteConditionalFormats(XmlWriter xml, XLPivotTable pt)

--- a/XLibur/Excel/IO/WorksheetElementReader.cs
+++ b/XLibur/Excel/IO/WorksheetElementReader.cs
@@ -374,39 +374,69 @@ internal static class WorksheetElementReader
         }
     }
 
+    /// <summary>
+    /// Load the <c>filterColumn</c> elements of an autofilter.
+    /// </summary>
+    /// <remarks>
+    /// Each column is read into <see cref="XLFilterColumnCriteria"/> first, then translated into
+    /// the cell-evaluating runtime state as far as that state can express it. The criteria are
+    /// kept on the column so that the parts it cannot express — an <c>iconFilter</c>, the button
+    /// attributes, <c>extLst</c>, a <c>dynamicFilter</c> type other than the two averages — are
+    /// still there to be written back.
+    /// </remarks>
     internal static void LoadAutoFilterColumns(AutoFilter af, XLAutoFilter autoFilter,
         Dictionary<int, DifferentialFormat>? differentialFormats = null)
     {
         foreach (var filterColumn in af.Elements<FilterColumn>())
         {
-            var column = (int)filterColumn.ColumnId!.Value + 1;
-            var xlFilterColumn = autoFilter.Column(column);
-            if (filterColumn.CustomFilters is { } customFilters)
-                LoadCustomFilters(xlFilterColumn, customFilters);
-            else if (filterColumn.Filters is { } filters)
-                LoadRegularFilters(xlFilterColumn, filters);
-            else if (filterColumn.Top10 is { } top10)
-                LoadTop10Filter(xlFilterColumn, top10);
-            else if (filterColumn.DynamicFilter is { } dynamicFilter)
-                LoadDynamicFilter(xlFilterColumn, filterColumn, dynamicFilter);
-            else if (filterColumn.Elements<ColorFilter>().FirstOrDefault() is { } colorFilter
-                     && differentialFormats is not null)
-                LoadColorFilter(xlFilterColumn, colorFilter, differentialFormats);
+            var criteria = FilterColumnCriteriaReader.Read(filterColumn);
+            var xlFilterColumn = autoFilter.Column((int)criteria.ColumnId + 1);
+
+            switch (criteria.Criteria)
+            {
+                case XLCustomFiltersCriteria customFilters:
+                    LoadCustomFilters(xlFilterColumn, customFilters);
+                    break;
+
+                case XLValuesFilterCriteria values:
+                    LoadRegularFilters(xlFilterColumn, values);
+                    break;
+
+                case XLTop10Criteria top10:
+                    LoadTop10Filter(xlFilterColumn, top10);
+                    break;
+
+                case XLDynamicFilterCriteria dynamicFilter:
+                    LoadDynamicFilter(xlFilterColumn, dynamicFilter);
+                    break;
+
+                case XLColorFilterCriteria colorFilter when differentialFormats is not null:
+                    LoadColorFilter(xlFilterColumn, colorFilter, differentialFormats);
+                    break;
+
+                default:
+                    // An iconFilter, a colour filter with no differential formats to resolve
+                    // against, or no criteria at all. Nothing to evaluate against cells; the
+                    // criteria below are what carry it through a save.
+                    break;
+            }
+
+            xlFilterColumn.SetSourceCriteria(criteria);
         }
     }
 
-    private static void LoadCustomFilters(XLFilterColumn xlFilterColumn, CustomFilters customFilters)
+    private static void LoadCustomFilters(XLFilterColumn xlFilterColumn, XLCustomFiltersCriteria customFilters)
     {
         xlFilterColumn.FilterType = XLFilterType.Custom;
-        var connector = OpenXmlHelper.GetBooleanValueAsBool(customFilters.And, false)
-            ? XLConnector.And
-            : XLConnector.Or;
+        var connector = customFilters.And ? XLConnector.And : XLConnector.Or;
 
-        foreach (var filter in customFilters.OfType<CustomFilter>())
+        foreach (var filter in customFilters.Filters)
         {
-            var op = filter.Operator is not null ? filter.Operator.Value.ToXLibur() : XLFilterOperator.Equal;
-            var filterValue = filter.Val!.Value!;
-            var xlFilter = CreateCustomXLFilter(op, filterValue, connector);
+            // val is optional in the schema, but a comparison without one says nothing.
+            if (filter.Value is not { } filterValue)
+                continue;
+
+            var xlFilter = CreateCustomXLFilter(filter.Operator, filterValue, connector);
             xlFilterColumn.AddFilter(xlFilter);
         }
     }
@@ -427,26 +457,23 @@ internal static class WorksheetElementReader
         }
     }
 
-    private static void LoadRegularFilters(XLFilterColumn xlFilterColumn, Filters filters)
+    private static void LoadRegularFilters(XLFilterColumn xlFilterColumn, XLValuesFilterCriteria values)
     {
         xlFilterColumn.FilterType = XLFilterType.Regular;
-        foreach (var filter in filters.OfType<Filter>())
+        foreach (var value in values.Values)
         {
-            xlFilterColumn.AddFilter(XLFilter.CreateRegularFilter(filter.Val!.Value!));
+            xlFilterColumn.AddFilter(XLFilter.CreateRegularFilter(value));
         }
 
-        foreach (var dateGroupItem in filters.OfType<DateGroupItem>())
+        foreach (var dateGroup in values.DateGroups)
         {
-            LoadDateGroupItem(xlFilterColumn, dateGroupItem);
+            LoadDateGroupItem(xlFilterColumn, dateGroup);
         }
     }
 
-    private static void LoadDateGroupItem(XLFilterColumn xlFilterColumn, DateGroupItem dateGroupItem)
+    private static void LoadDateGroupItem(XLFilterColumn xlFilterColumn, XLDateGroupCriteria dateGroupItem)
     {
-        if (dateGroupItem.DateTimeGrouping is null || !dateGroupItem.DateTimeGrouping.HasValue)
-            return;
-
-        var xlGrouping = dateGroupItem.DateTimeGrouping.Value.ToXLibur();
+        var xlGrouping = dateGroupItem.Grouping;
         var year = 1900;
         var month = 1;
         var day = 1;
@@ -482,41 +509,47 @@ internal static class WorksheetElementReader
         }
     }
 
-    private static bool TryGetDatePart(UInt16Value? value, ref int result)
+    private static bool TryGetDatePart(ushort? value, ref int result)
     {
-        if (value?.HasValue ?? false)
+        if (value is { } part)
         {
-            result = value.Value;
+            result = part;
             return true;
         }
 
         return false;
     }
 
-    private static void LoadTop10Filter(XLFilterColumn xlFilterColumn, Top10 top10)
+    private static void LoadTop10Filter(XLFilterColumn xlFilterColumn, XLTop10Criteria top10)
     {
         xlFilterColumn.FilterType = XLFilterType.TopBottom;
-        xlFilterColumn.TopBottomType = OpenXmlHelper.GetBooleanValueAsBool(top10.Percent, false)
-            ? XLTopBottomType.Percent
-            : XLTopBottomType.Items;
-        var takeTop = OpenXmlHelper.GetBooleanValueAsBool(top10.Top, true);
-        xlFilterColumn.TopBottomPart = takeTop ? XLTopBottomPart.Top : XLTopBottomPart.Bottom;
+        xlFilterColumn.TopBottomType = top10.Percent ? XLTopBottomType.Percent : XLTopBottomType.Items;
+        xlFilterColumn.TopBottomPart = top10.Top ? XLTopBottomPart.Top : XLTopBottomPart.Bottom;
 
         // Value contains how many percent or items, so it can only be int.
         // Filter value is optional, so we don't rely on it.
-        var percentsOrItems = (int)top10.Val!.Value;
+        var percentsOrItems = (int)top10.Value;
         xlFilterColumn.TopBottomValue = percentsOrItems;
-        xlFilterColumn.AddFilter(XLFilter.CreateTopBottom(takeTop, percentsOrItems));
+        xlFilterColumn.AddFilter(XLFilter.CreateTopBottom(top10.Top, percentsOrItems));
     }
 
-    private static void LoadDynamicFilter(XLFilterColumn xlFilterColumn, FilterColumn filterColumn,
-        DynamicFilter dynamicFilter)
+    /// <summary>
+    /// Set up the runtime state for a <c>dynamicFilter</c>, if it is one of the two types the
+    /// runtime state can express.
+    /// </summary>
+    /// <remarks>
+    /// <c>ST_DynamicFilterType</c> has around forty values — every relative date period Excel
+    /// offers — while <see cref="XLFilterDynamicType"/> has the two averages. The rest are left
+    /// unevaluated rather than forced onto one of the two, and survive the save through the
+    /// criteria kept on the column.
+    /// </remarks>
+    private static void LoadDynamicFilter(XLFilterColumn xlFilterColumn, XLDynamicFilterCriteria dynamicFilter)
     {
+        if (!TryGetDynamicType(dynamicFilter.Type, out var dynamicType))
+            return;
+
         xlFilterColumn.FilterType = XLFilterType.Dynamic;
-        var dynamicType = dynamicFilter.Type is { } dynamicFilterType
-            ? dynamicFilterType.Value.ToXLibur()
-            : XLFilterDynamicType.AboveAverage;
-        var dynamicValue = filterColumn.DynamicFilter!.Val!.Value;
+        var dynamicValue = dynamicFilter.Value ?? double.NaN;
 
         xlFilterColumn.DynamicType = dynamicType;
         xlFilterColumn.DynamicValue = dynamicValue;
@@ -524,14 +557,28 @@ internal static class WorksheetElementReader
             dynamicType == XLFilterDynamicType.AboveAverage));
     }
 
-    private static void LoadColorFilter(XLFilterColumn xlFilterColumn, ColorFilter colorFilter,
+    private static bool TryGetDynamicType(string token, out XLFilterDynamicType dynamicType)
+    {
+        var value = new EnumValue<DynamicFilterValues> { InnerText = token };
+        if (value.HasValue && value.Value.TryToXLibur(out dynamicType))
+            return true;
+
+        dynamicType = default;
+        return false;
+    }
+
+    private static void LoadColorFilter(XLFilterColumn xlFilterColumn, XLColorFilterCriteria colorFilter,
         Dictionary<int, DifferentialFormat> differentialFormats)
     {
+        // dxfId is optional, and without it there is no colour to match on.
+        if (colorFilter.DifferentialFormatId is not { } dxfId)
+            return;
+
         xlFilterColumn.FilterType = XLFilterType.Color;
-        var byCellColor = OpenXmlHelper.GetBooleanValueAsBool(colorFilter.CellColor, true);
+        var byCellColor = colorFilter.CellColor;
         xlFilterColumn.FilterByCellColor = byCellColor;
 
-        var formatId = (int)colorFilter.FormatId!.Value;
+        var formatId = (int)dxfId;
         if (differentialFormats.TryGetValue(formatId, out var dxf))
         {
             var filterColorValue = ResolveFilterColor(dxf, byCellColor);

--- a/XLibur/Excel/PivotTables/XLPivotAutoFilter.cs
+++ b/XLibur/Excel/PivotTables/XLPivotAutoFilter.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using XLibur.Excel.AutoFilters;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// The <c>autoFilter</c> child of a pivot table filter (<c>CT_AutoFilter</c>) — the criteria that
+/// say what the filter actually does.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Despite the shared element type, this is not a worksheet autofilter: it is a criteria record
+/// Excel applies to pivot items, so it hides no rows and its <see cref="Reference"/> does not
+/// describe any. That is why it holds <see cref="XLFilterColumnCriteria"/> rather than an
+/// <see cref="XLAutoFilter"/>, which owns a live range and evaluates against cells.
+/// </para>
+/// <para>
+/// <c>sortState</c> and <c>extLst</c> are carried verbatim. Sorting is modelled elsewhere in
+/// XLibur far more narrowly than <c>CT_SortState</c> allows, and pivot filters do not appear to
+/// use it in practice, so preserving the sub-tree beats modelling it badly.
+/// </para>
+/// </remarks>
+internal sealed class XLPivotAutoFilter
+{
+    /// <summary>
+    /// The <c>ref</c> attribute. Optional, and not a range XLibur reads anything from.
+    /// </summary>
+    internal string? Reference { get; init; }
+
+    /// <summary>
+    /// The <c>filterColumn</c> children. Empty is legal, if pointless.
+    /// </summary>
+    internal IReadOnlyList<XLFilterColumnCriteria> Columns { get; init; } = [];
+
+    /// <summary>
+    /// The <c>sortState</c> child, verbatim, including its element tags.
+    /// </summary>
+    internal string? SortStateXml { get; init; }
+
+    /// <summary>
+    /// The <c>extLst</c> child, verbatim, including its element tags.
+    /// </summary>
+    internal string? ExtensionListXml { get; init; }
+}

--- a/XLibur/Excel/PivotTables/XLPivotFilter.cs
+++ b/XLibur/Excel/PivotTables/XLPivotFilter.cs
@@ -12,21 +12,18 @@ namespace XLibur.Excel;
 /// </para>
 /// <para>
 /// XLibur has no API for creating or interpreting these yet, so the type exists to carry them
-/// through a load/save unchanged. The attributes are modelled because they are the part anyone
-/// exposing an API would need; <see cref="AutoFilterXml"/> is kept verbatim because
-/// <c>CT_AutoFilter</c> is a whole sub-tree of its own (<c>filterColumn</c> with any of
-/// <c>filters</c>, <c>top10</c>, <c>customFilters</c>, <c>dynamicFilter</c>, <c>colorFilter</c>
-/// or <c>iconFilter</c>) and modelling it would be a large surface with nothing reading it.
+/// through a load/save unchanged. The attributes here say which field the filter applies to and
+/// what kind it is; <see cref="AutoFilter"/> holds the criteria themselves.
 /// </para>
 /// </remarks>
 internal sealed class XLPivotFilter
 {
-    internal XLPivotFilter(uint field, uint id, string type, string autoFilterXml)
+    internal XLPivotFilter(uint field, uint id, string type, XLPivotAutoFilter autoFilter)
     {
         Field = field;
         Id = id;
         Type = type;
-        AutoFilterXml = autoFilterXml;
+        AutoFilter = autoFilter;
     }
 
     /// <summary>
@@ -48,10 +45,10 @@ internal sealed class XLPivotFilter
     internal string Type { get; }
 
     /// <summary>
-    /// The <c>autoFilter</c> child, verbatim, including its element tags. Required by the
-    /// schema, so every filter has one.
+    /// The criteria — what the filter actually keeps. Required by the schema, so every filter
+    /// has one.
     /// </summary>
-    internal string AutoFilterXml { get; }
+    internal XLPivotAutoFilter AutoFilter { get; }
 
     /// <summary>
     /// Order the filter is evaluated in relative to the other filters. Default <c>0</c>.

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -109,7 +109,7 @@ its own period runs from this release.
 |------|---------|------|--------|
 | #1 | 7 | Bug — empty data validations written with empty `sqref` | **Merged** — [#290](https://github.com/XLibur/XLibur/pull/290) |
 | #2 | 10 | Feature — pivot `chartFormats` round trip | **Merged** — [#294](https://github.com/XLibur/XLibur/pull/294) |
-| #3 | 11 | Feature — pivot `filters` round trip | Not started |
+| #3 | 11 | Feature — pivot `filters` round trip | **Merged** — [#300](https://github.com/XLibur/XLibur/pull/300); `autoFilter` modelled rather than preserved as a string in [#301](https://github.com/XLibur/XLibur/issues/301) |
 | #4 | 2, 4 | Correctness — structured references in the dependency tree | In review — [#297](https://github.com/XLibur/XLibur/pull/297) |
 | #5 | 3 | Perf — register data-table formulas in the dependency tree | **Closed, will not do** — see below |
 | #6 | 1 | Perf — cache parsed reference addresses | **Merged** — [#286](https://github.com/XLibur/XLibur/pull/286) |


### PR DESCRIPTION
Closes #301, taking **Option A**: extract a sheet-free criteria model shared by worksheet autofilters and pivot table filters.

## The problem

#300 preserved a pivot filter's `autoFilter` as a verbatim string. Nothing could read what a filter did, a filter could be carried but not built or reasoned about, and the raw XML was written back with `WriteRaw` without ever being validated.

## Why the worksheet model could not just be reused

`XLAutoFilter` is a live `IXLRange` whose `XLFilter`s carry `Func<IXLCell, XLFilterColumn, bool>` predicates. A pivot filter's `autoFilter` is a declarative criteria record Excel applies to pivot items — no range, no cells to evaluate. So rather than drag a range and cell predicates into a context with neither, the criteria are split out from the worksheet binding and both sides use them:

- `XLFilterColumnCriteria` — `CT_FilterColumn`, including `hiddenButton`/`showButton` and `extLst`
- `XLFilterCriteria` and its six variants — `filters`, `top10`, `customFilters`, `dynamicFilter`, `colorFilter`, `iconFilter`
- `FilterColumnCriteriaReader` / `FilterColumnCriteriaWriter` — one reader and one writer, shared, so the two cannot drift
- `XLPivotAutoFilter` replaces `XLPivotFilter.AutoFilterXml`

`XLAutoFilter` keeps `Range`, `HiddenRows` and the predicates on top, unchanged.

## Not a fidelity regression — an improvement

The risk the issue called out was that a partial model would be worse than the string. Two things address it:

**The runtime state is a lossy view of the element.** It has no room for an `iconFilter`, the button attributes, `extLst`, or the `dynamicFilter` types beyond the two averages. So a worksheet column that has not been changed is **written back from the criteria it was loaded with**. Every mutation (`Clear`, `AddFilter`, and `Refresh` when it recomputes a dynamic average) drops them, so an edit is never silently discarded.

**Worksheets gain fidelity they did not have.** `iconFilter`, `hiddenButton`, `showButton` and `filterColumn/extLst` were previously dropped on load and lost on save. They now survive.

**A load crash is fixed.** `ST_DynamicFilterType` has ~40 values; `EnumConverter.DynamicFilterMap` has two. Loading a worksheet with `dynamicFilter type="thisMonth"` threw `KeyNotFoundException`. The token is now carried rather than mapped, so the file loads and the filter survives. `TryToXLibur` is added alongside the throwing `ToXLibur`.

`sortState` and `extLst` on `CT_AutoFilter` are preserved verbatim on the pivot side. `XLAutoFilter` models sorting far more narrowly than `CT_SortState` allows, and pivot filters do not appear to use it, so preserving the sub-tree beats modelling it badly.

## Acceptance criteria

1. **Everything that round-trips today still round-trips** — including `iconFilter`, `hiddenButton`/`showButton` and `extLst`. Covered for pivot filters and, newly, for worksheets.
2. **A test per `filterColumn` child** — `PivotFilterCriteriaTests` covers all six, plus the date-group form of `filters`, the button attributes, both `extLst` positions, `ref`, `sortState`, a column with no criteria, and several columns at once.
3. **Opens in Excel without a repair prompt** — I cannot drive Excel here. The closest automatic check is in place instead: `EveryFilterKindTogether_ProducesASchemaValidPackage` builds a workbook carrying one filter of every kind, round-trips it, and asserts `OpenXmlValidator` reports nothing. **Worth a manual Excel check before merge.**
4. **Public API** — no change. The model is `internal` throughout; `IXLAutoFilter` and `IXLFilterColumn` are untouched, `PublicAPI.*.txt` needs no edit, and there is nothing for the release notes.

## Behaviour change worth knowing

Attributes sitting at their schema default are now written as absent, so an input `top="1"` comes back omitted. Same meaning to Excel, and it matches what the worksheet writer already did. One assertion in `PivotFilterTests` was updated to read the effective value rather than require the attribute.

## Pre-existing bug found, not fixed here

The schema-validation test surfaced this: `CT_Filters` is a choice — `filter*` **or** `dateGroupItem*`, never both — but `AutoFilterWriter.CreateRegularFilters` appends both to one `filters` element. So

```csharp
column.AddFilter("Cookies", false);
column.AddDateGroupFilter(new DateTime(2024, 3, 17), XLDateTimeGrouping.Year, false);
```

produces schema-invalid output. I confirmed it reproduces with the original writer logic, which this PR preserves unchanged. Fixing it means deciding what the API should do when both are asked for, which is a separate call from this issue — happy to raise it as one.

## Verification

- Full suite green on **net8.0** and **net10.0**: 11,701 tests, 0 failures, 4 pre-existing skips.
- Whole solution builds clean, 0 warnings (`TreatWarningsAsErrors`).
- 20 new tests: 13 in `PivotFilterCriteriaTests`, 7 in `AutoFilterRoundTripTests`.

`docs/todos.md` task #3 was still marked "Not started" although #300 merged it; updated to reflect that and this follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preservation of Excel auto-filter settings when workbooks are opened and saved.
  * Preserved value, date, top/bottom, custom, dynamic, color, and icon filter criteria.
  * Maintained filter buttons, extensions, sort state, and related worksheet metadata.
  * Improved pivot-table filter round-tripping and schema validity.
  * Added safer handling for unsupported or incomplete dynamic and color filters.
* **Documentation**
  * Updated project tracking to reflect completed filter support work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->