### PR TITLE
fix(names): resolve a structured reference in a defined name the way the calc engine does

### DIFF
--- a/XLibur.Tests/Excel/NamedRanges/DefinedNameStructuredReferenceTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/DefinedNameStructuredReferenceTests.cs
@@ -1,0 +1,163 @@
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.NamedRanges;
+
+/// <summary>
+/// What <see cref="IXLDefinedName.Ranges"/> answers for a name whose formula is a structured
+/// reference (<c>=Sales[Amount]</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The area is resolved when it is asked for, through the same
+/// <c>StructuredReferenceResolver</c> that evaluation and the dependency tree use, so a name
+/// honours the <c>#Headers</c> / <c>#Totals</c> / <c>#All</c> specifiers and a column span rather
+/// than always answering with the first column's data.
+/// </para>
+/// <para>
+/// The two-specifier form Excel writes as <c>Sales[[#Headers],[#Data]]</c> is not covered: it
+/// throws inside ClosedXML.Parser while the formula is being parsed, before any of this is
+/// reached, so it is not something resolution can answer for either way. The resolver does handle
+/// the combination once a formula carrying it parses.
+/// </para>
+/// </remarks>
+public class DefinedNameStructuredReferenceTests
+{
+    /// <summary>
+    /// A table at <c>A1:C4</c> — headers <c>A1:C1</c>, data <c>A2:C3</c>, totals <c>A4:C4</c>.
+    /// </summary>
+    private static XLWorkbook TableBook()
+    {
+        var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = "Product";
+        ws.Cell("B1").Value = "Amount";
+        ws.Cell("C1").Value = "Tax";
+        ws.Cell("A2").Value = "Widget";
+        ws.Cell("B2").Value = 10;
+        ws.Cell("C2").Value = 1;
+        ws.Cell("A3").Value = "Gadget";
+        ws.Cell("B3").Value = 20;
+        ws.Cell("C3").Value = 2;
+        ws.Range("A1:C3").CreateTable("Sales").SetShowTotalsRow(true);
+        return wb;
+    }
+
+    private static string[] RangesOf(XLWorkbook wb, string formula) =>
+        wb.DefinedNames.Add("Probe", formula).Ranges
+            .Select(r => r.RangeAddress.ToString())
+            .ToArray();
+
+    [Test]
+    [Arguments("Sales[Amount]", "B2:B3")]
+    [Arguments("Sales[[#Data],[Amount]]", "B2:B3")]
+    [Arguments("Sales[[#Headers],[Amount]]", "B1:B1")]
+    [Arguments("Sales[[#Totals],[Amount]]", "B4:B4")]
+    [Arguments("Sales[[#All],[Amount]]", "B1:B4")]
+    public async Task AnAreaSpecifierSelectsThatPartOfTheColumn(string formula, string expected)
+    {
+        using var wb = TableBook();
+
+        await Assert.That(RangesOf(wb, formula)).IsEquivalentTo(new[] { expected });
+    }
+
+    /// <summary>A column span covers every column between its ends, not just the first.</summary>
+    [Test]
+    [Arguments("Sales[[Amount]:[Tax]]", "B2:C3")]
+    [Arguments("Sales[[Product]:[Tax]]", "A2:C3")]
+    [Arguments("Sales[[#Headers],[Amount]:[Tax]]", "B1:C1")]
+    public async Task AColumnSpanCoversItsWholeWidth(string formula, string expected)
+    {
+        using var wb = TableBook();
+
+        await Assert.That(RangesOf(wb, formula)).IsEquivalentTo(new[] { expected });
+    }
+
+    /// <summary>
+    /// A reference naming no column covers the table's full width. These used to resolve to
+    /// nothing at all.
+    /// </summary>
+    [Test]
+    [Arguments("Sales[#All]", "A1:C4")]
+    [Arguments("Sales[#Data]", "A2:C3")]
+    [Arguments("Sales[#Headers]", "A1:C1")]
+    [Arguments("Sales[#Totals]", "A4:C4")]
+    public async Task AWholeTableReferenceCoversTheTable(string formula, string expected)
+    {
+        using var wb = TableBook();
+
+        await Assert.That(RangesOf(wb, formula)).IsEquivalentTo(new[] { expected });
+    }
+
+    /// <summary>
+    /// A name Excel would show as <c>#REF!</c> yields no range rather than throwing. Reachable
+    /// from an ordinary load — a workbook whose table or column has since been renamed — so
+    /// reading the property must not be able to fail.
+    /// </summary>
+    [Test]
+    [Arguments("Sales[NoSuchColumn]")]
+    [Arguments("NoSuchTable[Amount]")]
+    [Arguments("Sales[[NoSuchColumn]:[Tax]]")]
+    public async Task AReferenceThatCannotResolveYieldsNoRange(string formula)
+    {
+        using var wb = TableBook();
+
+        await Assert.That(RangesOf(wb, formula)).IsEmpty();
+    }
+
+    /// <summary>
+    /// A defined name has no anchoring cell, so <c>[@Column]</c> — which means "this row" — has no
+    /// row to mean. It resolves to nothing rather than guessing one.
+    /// </summary>
+    [Test]
+    public async Task AThisRowReferenceYieldsNoRange()
+    {
+        using var wb = TableBook();
+
+        await Assert.That(RangesOf(wb, "Sales[@Amount]")).IsEmpty();
+    }
+
+    /// <summary>Several references in one formula each contribute their own range.</summary>
+    [Test]
+    public async Task EveryReferenceInTheFormulaContributes()
+    {
+        using var wb = TableBook();
+
+        await Assert.That(RangesOf(wb, "SUM(Sales[Amount], Sales[Tax])"))
+            .IsEquivalentTo(new[] { "B2:B3", "C2:C3" });
+    }
+
+    /// <summary>The resolved area follows the table, rather than being fixed when the name was added.</summary>
+    [Test]
+    public async Task TheAreaFollowsTheTableWhenItGrows()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = "Amount";
+        ws.Cell("A2").Value = 10;
+        ws.Cell("A3").Value = 20;
+        var table = ws.Range("A1:A3").CreateTable("Sales");
+
+        var name = wb.DefinedNames.Add("Probe", "Sales[Amount]");
+        await Assert.That(name.Ranges.Single().RangeAddress.ToString()).IsEqualTo("A2:A3");
+
+        ws.Cell("A4").Value = 30;
+        table.Resize(ws.Range("A1:A4"));
+
+        await Assert.That(name.Ranges.Single().RangeAddress.ToString()).IsEqualTo("A2:A4");
+    }
+
+    /// <summary>A table with no totals row has no totals to point at.</summary>
+    [Test]
+    public async Task TotalsOfATableWithoutATotalsRowYieldNoRange()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Cell("A1").Value = "Amount";
+        ws.Cell("A2").Value = 10;
+        ws.Range("A1:A2").CreateTable("Sales");
+
+        await Assert.That(RangesOf(wb, "Sales[#Totals]")).IsEmpty();
+    }
+}

--- a/XLibur.Tests/Excel/NamedRanges/DefinedNameStructuredReferenceTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/DefinedNameStructuredReferenceTests.cs
@@ -128,6 +128,42 @@ public class DefinedNameStructuredReferenceTests
             .IsEquivalentTo(new[] { "B2:B3", "C2:C3" });
     }
 
+    /// <summary>
+    /// Structured references and ordinary sheet references are gathered by separate passes, so a
+    /// formula holding both has to come back with both.
+    /// </summary>
+    /// <remarks>
+    /// A sheet reference keeps the fixed markers it was written with, while a structured reference
+    /// is resolved to the area the table currently covers and so has none.
+    /// </remarks>
+    [Test]
+    public async Task AStructuredReferenceAndASheetReferenceBothContribute()
+    {
+        using var wb = TableBook();
+
+        await Assert.That(RangesOf(wb, "SUM(Sales[Amount], Data!$A$10:$A$11)"))
+            .IsEquivalentTo(new[] { "B2:B3", "$A$10:$A$11" });
+    }
+
+    /// <summary>
+    /// A structured reference that cannot resolve does not make the name invalid. Deliberate:
+    /// <see cref="IXLDefinedName.IsValid"/> reports a <c>#REF!</c> written into the formula, and it
+    /// is what <c>ValidNamedRanges()</c> filters on — which the IO writers and XLibur.Report's range
+    /// binder both consume. A name that survives a load and save today has to keep surviving one.
+    /// </summary>
+    [Test]
+    [Arguments("NoSuchTable[Amount]")]
+    [Arguments("Sales[NoSuchColumn]")]
+    public async Task AnUnresolvableReferenceLeavesTheNameValid(string formula)
+    {
+        using var wb = TableBook();
+        var name = wb.DefinedNames.Add("Probe", formula);
+
+        await Assert.That(name.Ranges).IsEmpty();
+        await Assert.That(name.IsValid).IsTrue();
+        await Assert.That(wb.DefinedNames.ValidNamedRanges().Any(n => n.Name == "Probe")).IsTrue();
+    }
+
     /// <summary>The resolved area follows the table, rather than being fixed when the name was added.</summary>
     [Test]
     public async Task TheAreaFollowsTheTableWhenItGrows()

--- a/XLibur/Excel/CalcEngine/Visitors/FormulaReferences.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/FormulaReferences.cs
@@ -12,13 +12,6 @@ namespace XLibur.Excel.CalcEngine.Visitors;
 /// </summary>
 internal sealed class FormulaReferences
 {
-    private readonly string _formula;
-
-    private FormulaReferences(string formula)
-    {
-        _formula = formula;
-    }
-
     /// <summary>
     /// Is there a <c>#REF!</c> anywhere in the formula?
     /// </summary>
@@ -34,11 +27,16 @@ internal sealed class FormulaReferences
     /// </summary>
     internal HashSet<XLSheetReference> SheetReferences { get; } = [];
 
-    private HashSet<(string Table, string Column, string Symbol)> StructuredReferences { get; } = new();
+    /// <summary>
+    /// Structured references (<c>Sales[Amount]</c>) found in the formula, kept as written rather
+    /// than as areas: a table can be resized, renamed or deleted after the formula was parsed, so
+    /// the area a reference covers is only true at the moment it is asked for.
+    /// </summary>
+    private HashSet<StructuredReference> StructuredReferences { get; } = new();
 
     internal static FormulaReferences ForFormula(string formula)
     {
-        var references = new FormulaReferences(formula);
+        var references = new FormulaReferences();
         FormulaParser<object?, object?, FormulaReferences>.CellFormulaA1(formula, references,
             CollectRefsFactory.Instance);
         return references;
@@ -61,13 +59,68 @@ internal sealed class FormulaReferences
             }
         }
 
-        foreach (var (tableName, column, _) in StructuredReferences)
+        if (StructuredReferences.Count > 0)
         {
-            if (workbook.TryGetTable(tableName, out var table))
-                list.Add(table.DataRange!.Column(column));
+            var scope = new DefinedNameScope(workbook, anchor);
+            foreach (var reference in StructuredReferences)
+            {
+                // A reference that does not resolve today — an unknown table, a column since
+                // renamed — contributes no range, the same answer an unknown table has always
+                // given. Excel shows such a name as #REF! rather than refusing the workbook, and
+                // whatever later restores the table makes the name resolve again.
+                if (!StructuredReferenceResolver.TryResolve(scope, reference.ToNode(), out var sheet, out var area, out _))
+                    continue;
+
+                list.Add(sheet.Range(area.TopRow, area.LeftColumn, area.BottomRow, area.RightColumn));
+            }
         }
 
         return list;
+    }
+
+    /// <summary>
+    /// A structured reference as the formula wrote it. A value type so that the same reference
+    /// written twice in one formula counts once.
+    /// </summary>
+    /// <remarks>
+    /// Only references naming a table are collected — <see cref="CollectRefsFactory"/> does not
+    /// override the table-less or external-workbook overloads — so <see cref="Table"/> is never
+    /// null and <see cref="IStructuredReferenceScope.Worksheet"/> is never reached.
+    /// </remarks>
+    private readonly record struct StructuredReference(
+        string Table,
+        StructuredReferenceArea Area,
+        string? FirstColumn,
+        string? LastColumn)
+    {
+        internal StructuredReferenceNode ToNode() => new(null, Table, Area, FirstColumn, LastColumn);
+    }
+
+    /// <summary>
+    /// The formula location a defined name can offer the resolver.
+    /// </summary>
+    /// <remarks>
+    /// A defined name is not written in a cell, so it has no formula location of its own and the
+    /// caller's anchor stands in for one. That only matters to <c>[@Column]</c>, which needs a row
+    /// to mean anything: against the default anchor it lands outside the table's data and resolves
+    /// to no range, which is the right answer for a name Excel would show as <c>#VALUE!</c>.
+    /// </remarks>
+    private readonly struct DefinedNameScope : IStructuredReferenceScope
+    {
+        public DefinedNameScope(XLWorkbook workbook, Point anchor)
+        {
+            Workbook = workbook;
+            FormulaPoint = anchor;
+        }
+
+        public XLWorkbook Workbook { get; }
+
+        public Point FormulaPoint { get; }
+
+        /// <inheritdoc />
+        /// <remarks>Read only for a table-less reference, which is never collected.</remarks>
+        public XLWorksheet Worksheet =>
+            throw new InvalidOperationException("A defined name has no sheet to resolve a table-less reference against.");
     }
 
     /// <summary>
@@ -100,10 +153,7 @@ internal sealed class FormulaReferences
             StructuredReferenceArea area,
             string? firstColumn, string? lastColumn)
         {
-            // TODO: Temporary placeholder, extract range detection from CalculationVisitor
-            if (firstColumn is not null)
-                context.StructuredReferences.Add((table, firstColumn,
-                    context._formula.Substring(range.Start, range.End - range.Start)));
+            context.StructuredReferences.Add(new StructuredReference(table, area, firstColumn, lastColumn));
 
             return base.StructureReference(context, range, table, area, firstColumn, lastColumn);
         }


### PR DESCRIPTION
Actions the `// TODO: Temporary placeholder, extract range detection from CalculationVisitor` in `FormulaReferences.CollectRefsFactory.StructureReference`.

## The TODO was still live, and the work it asked for is already done

`StructuredReferenceResolver` was extracted at some point and is shared by `CalculationVisitor` (which evaluates the reference) and `DependenciesVisitor` (which registers it as a precedent). It handles every `#Headers` / `#Data` / `#Totals` / `#All` / `#ThisRow` combination, column spans, and reversed corners. `FormulaReferences` is the one caller that never got migrated, so this migrates it rather than reimplementing anything.

`FormulaReferences` is used only by `XLDefinedName`, so the blast radius is defined names whose `RefersTo` is a structured reference (`=Sales[Amount]`).

## What was wrong

The old code stored `(table, firstColumn)` and resolved by hand as `table.DataRange!.Column(column)` — the data column, whatever the reference actually said. Measured against a `Sales` table at `A1:C4` (headers `A1:C1`, data `A2:C3`, totals `A4:C4`):

| Formula | Before | After |
|---|---|---|
| `Sales[Amount]` | `B2:B3` | `B2:B3` (unchanged) |
| `Sales[[Amount]:[Tax]]` | `B2:B3` | `B2:C3` |
| `Sales[[#Headers],[Amount]]` | `B2:B3` | `B1:B1` |
| `Sales[[#Totals],[Amount]]` | `B2:B3` | `B4:B4` |
| `Sales[[#All],[Amount]]` | `B2:B3` | `B1:B4` |
| `Sales[#Data]` | *(no ranges)* | `A2:C3` |
| `Sales[#All]` | *(no ranges)* | `A1:C4` |
| `Sales[NoSuchColumn]` | **throws `ArgumentOutOfRangeException`** | *(no ranges)* |
| `NoSuchTable[Amount]` | *(no ranges)* | *(no ranges)* |

The throw is the one that could bite a caller: it escapes `IXLDefinedName.Ranges`, a property getter, and it is reachable from ordinary data — load a workbook whose table column has since been renamed. `IsValid` gives no warning, since `ContainsRefError` only tracks a literal `#REF!` in the formula text.

`Sales[Amount]` — the overwhelmingly common form — resolves identically, so the change is narrower than the table makes it look.

## Design

- **Stored as written, resolved on demand.** A table can be resized, renamed or deleted after the formula was parsed, so the area is only true at the moment `Ranges` is asked. Kept in a `readonly record struct` rather than as `StructuredReferenceNode` so that value equality still collapses the same reference written twice in one formula, which the old tuple did.
- **Unresolvable means no range.** Matches what an unknown table already did and what `DependenciesVisitor` does for the same case. Nothing throws. `IsValid` is deliberately left alone: it feeds `ValidNamedRanges()`, which the IO writers and `XLibur.Report`'s `RangeBinder` both filter on, so making a broken reference invalidate the name would quietly change which names survive a round trip. Worth considering separately, not here.
- **`DefinedNameScope`** supplies the resolver's `IStructuredReferenceScope`. A defined name has no anchoring cell, so the caller's existing `anchor` stands in as `FormulaPoint`; that only matters to `[@Column]`, which lands outside the data against the default anchor and so resolves to nothing — the right answer for a name Excel shows as `#VALUE!`. `Worksheet` throws as unreachable: only a table-less reference reads it, and `CollectRefsFactory` does not override the table-less or external-workbook overloads, so one is never collected.
- **Dead code removed:** the `_formula` field and the `Symbol` element of the old tuple were written but never read — `GetExternalRanges` discarded `Symbol` with `_`.

## Tests

`XLibur.Tests/Excel/NamedRanges/DefinedNameStructuredReferenceTests.cs`, 19 cases covering the table above plus `[@Column]`, several references in one formula, a totals reference against a table with no totals row, and that the area follows the table when it is resized.

There was no existing coverage of `IXLDefinedName.Ranges` for a structured reference at all, which is how the wrong answers went unnoticed.

## Pre-existing, not addressed here

`Sales[[#Headers],[#Data]]` — the two-specifier form Excel writes — throws `IndexOutOfRangeException` from inside `ClosedXML.Parser` while the formula is being parsed, before any of this code is reached. I verified it reproduces on unmodified `main`, so it is upstream and out of scope. `StructuredReferenceResolver` already handles the `Headers | Data` combination, so the resolution side is ready if the parser is fixed. Noted in the test class remarks. Happy to raise it upstream against ClosedXML.Parser if wanted.

## Verified

`11700` core tests (4 skipped) and `472` report tests pass; solution builds clean under `TreatWarningsAsErrors`.
