### PR TITLE
fix(report): match a defined name to its variable the way Excel matches names

### DIFF
--- a/XLibur.Report.Tests/Ranges/DefinedNameScopeTests.cs
+++ b/XLibur.Report.Tests/Ranges/DefinedNameScopeTests.cs
@@ -3,19 +3,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using XLibur.Excel;
-using XLibur.Report.Ranges;
 
 namespace XLibur.Report.Tests.Ranges;
 
 /// <summary>
-/// Which defined names bind when more than one of them shares a name.
+/// Which defined names bind when more than one of them shares a name, and how a name is matched to
+/// the variable it selects.
 /// </summary>
 /// <remarks>
 /// Excel scopes a defined name either to the workbook or to one sheet, and the same name may be
 /// declared once per sheet on top of a workbook-wide one. Binding follows those rules: every
 /// sheet-scoped name binds, and a workbook-scoped name binds except on a sheet that declares its
 /// own. Every range named <c>Items</c> reads the <c>Items</c> variable, which is what a template
-/// repeating one section per sheet wants.
+/// repeating one section per sheet wants — and it reads it whatever case the name is typed in,
+/// because that is the one namespace Excel keeps names in.
 /// </remarks>
 public class DefinedNameScopeTests
 {
@@ -121,13 +122,9 @@ public class DefinedNameScopeTests
 
     /// <summary>
     /// Excel holds defined names in one case-insensitive namespace, so a sheet-scoped <c>items</c>
-    /// shadows a workbook-scoped <c>ITEMS</c>.
+    /// shadows a workbook-scoped <c>ITEMS</c> — and both spellings select the <c>Items</c> variable,
+    /// which is what makes the shadowing observable through a template at all.
     /// </summary>
-    /// <remarks>
-    /// Driven through the binder rather than through a template, because a template matches its
-    /// variables case-sensitively: neither spelling would find an <c>Items</c> variable, so both
-    /// blocks would come out unbound and the two answers would be indistinguishable.
-    /// </remarks>
     [Test]
     public async Task ShadowingComparesNamesTheWayExcelDoes()
     {
@@ -136,15 +133,81 @@ public class DefinedNameScopeTests
         workbook.DefinedNames.Add("ITEMS", TemplateBlock(sheet, 1));
         sheet.DefinedNames.Add("items", TemplateBlock(sheet, 5));
 
-        var variables = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["Items"] = ThreeItems(),
-        };
+        var result = Generate(workbook, ThreeItems());
 
-        var bound = RangeBinder.Resolve(workbook, variables, new TemplateErrors());
+        await Assert.That(result.ParsingErrors).IsEmpty();
 
-        await Assert.That(bound.Count).IsEqualTo(1);
-        await Assert.That(bound[0].Area.FirstRow).IsEqualTo(5);
+        // The shadowed block never expanded, so nothing below it moved.
+        await Assert.That(sheet.Cell("A5").Value.GetText()).IsEqualTo("Widget");
+        await Assert.That(sheet.Cell("A7").Value.GetText()).IsEqualTo("Doohickey");
+        await Assert.That(sheet.Cell("A1").IsEmpty()).IsTrue();
+    }
+
+    /// <summary>
+    /// The case from issue #308. A defined name is an Excel identifier, written in Excel's name box
+    /// and held in Excel's case-insensitive namespace, so the case it is typed in does not decide
+    /// whether it finds its variable. It used to: the block was left unbound and rendered blank,
+    /// with nothing in <see cref="XLGenerateResult.ParsingErrors"/> to say why.
+    /// </summary>
+    [Test]
+    [Arguments("ITEMS")]
+    [Arguments("items")]
+    [Arguments("iTeMs")]
+    public async Task ADefinedNameFindsItsVariableWhateverCaseItIsTypedIn(string definedName)
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Report");
+        workbook.DefinedNames.Add(definedName, TemplateBlock(sheet, 1));
+
+        var result = Generate(workbook, ThreeItems());
+
+        await Assert.That(result.ParsingErrors).IsEmpty();
+        await Assert.That(sheet.Cell("A1").Value.GetText()).IsEqualTo("Widget");
+        await Assert.That(sheet.Cell("A3").Value.GetText()).IsEqualTo("Doohickey");
+    }
+
+    /// <summary>
+    /// A template holding two variables that differ only by case keeps the one the name spells
+    /// exactly, so no template that binds today binds anything different.
+    /// </summary>
+    [Test]
+    public async Task AnExactMatchWinsOverOneDifferingOnlyByCase()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Report");
+        workbook.DefinedNames.Add("Items", TemplateBlock(sheet, 1));
+
+        using var template = new XLTemplate(workbook);
+        template.AddVariable("items", ThreeItems());
+        template.AddVariable("Items", ThreeItems().Take(1).ToList());
+        var result = template.Generate();
+
+        await Assert.That(result.ParsingErrors).IsEmpty();
+        await Assert.That(sheet.Cell("A1").Value.GetText()).IsEqualTo("Widget");
+        await Assert.That(sheet.Cell("A2").IsEmpty()).IsTrue();
+    }
+
+    /// <summary>
+    /// Two variables differing only by case, and a name spelling neither of them: the one case a
+    /// case-insensitive match has no answer for. Binding either would be binding whichever the
+    /// dictionary yielded first, so the name is reported instead and nothing binds.
+    /// </summary>
+    [Test]
+    public async Task VariablesDifferingOnlyByCaseAreReportedRatherThanGuessedAt()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Report");
+        workbook.DefinedNames.Add("ITEMS", TemplateBlock(sheet, 1));
+
+        using var template = new XLTemplate(workbook);
+        template.AddVariable("Items", ThreeItems());
+        template.AddVariable("items", ThreeItems());
+        var result = template.Generate();
+
+        await Assert.That(result.HasErrors).IsTrue();
+        await Assert.That(result.ParsingErrors.Count).IsEqualTo(1);
+        await Assert.That(result.ParsingErrors[0].Message).Contains("'ITEMS'");
+        await Assert.That(result.ParsingErrors[0].Message).Contains("differ only by case");
     }
 
     /// <summary>

--- a/XLibur.Report.Tests/Ranges/RangeExpansionTests.cs
+++ b/XLibur.Report.Tests/Ranges/RangeExpansionTests.cs
@@ -386,6 +386,37 @@ public class RangeExpansionTests
         await Assert.That(workbook.Worksheet("Report").Cell("A3").Value.GetText()).IsEqualTo("Doohickey");
     }
 
+    /// <summary>
+    /// Where an underscore name stops being an Excel identifier. Its first segment picks a variable,
+    /// so it matches the way Excel matches a name; the segments after it are read off the object as
+    /// the C# members they are, and match exactly.
+    /// </summary>
+    [Test]
+    [Arguments("ORDER_Lines", "Doohickey")]
+    [Arguments("order_Lines", "Doohickey")]
+    [Arguments("Order_lines", null)]
+    [Arguments("Order_LINES", null)]
+    public async Task OnlyAnUnderscoreNamesFirstSegmentIgnoresCase(string name, string? expected)
+    {
+        using var workbook = TemplateWithItemsRange(ws => ws.Cell("A1").Value = "{{ item.Product }}", name: name);
+
+        using var template = new XLTemplate(workbook);
+        template.AddVariable("Order", new Order { Lines = ThreeItems() });
+        var result = template.Generate();
+
+        await Assert.That(result.ParsingErrors).IsEmpty();
+
+        var cell = workbook.Worksheet("Report").Cell("A3");
+        if (expected is null)
+        {
+            await Assert.That(cell.IsEmpty()).IsTrue();
+        }
+        else
+        {
+            await Assert.That(cell.Value.GetText()).IsEqualTo(expected);
+        }
+    }
+
     [Test]
     public async Task DefinedNamesWithNoMatchingVariableAreLeftAlone()
     {

--- a/XLibur.Report/Ranges/RangeBinder.cs
+++ b/XLibur.Report/Ranges/RangeBinder.cs
@@ -22,6 +22,11 @@ namespace XLibur.Report.Ranges;
 /// template may declare the same name once per sheet — <c>Q1!Items</c> and <c>Q2!Items</c> — and
 /// have every one of them bind. See <see cref="EnumerateNames"/>.
 /// </para>
+/// <para>
+/// A name is then matched to its variable the way Excel matches names, without regard to case. That
+/// is the boundary at which an Excel identifier becomes a C# one, and matching stops being
+/// case-insensitive on the other side of it. See <see cref="TryGetVariable"/>.
+/// </para>
 /// </remarks>
 internal static class RangeBinder
 {
@@ -38,7 +43,7 @@ internal static class RangeBinder
 
         foreach (var definedName in EnumerateNames(workbook))
         {
-            if (!TryResolveItems(definedName.Name, variables, out var items))
+            if (!TryResolveItems(definedName.Name, variables, errors, out var items))
             {
                 continue;
             }
@@ -137,11 +142,12 @@ internal static class RangeBinder
     private static bool TryResolveItems(
         string name,
         IReadOnlyDictionary<string, object?> variables,
+        TemplateErrors errors,
         out IReadOnlyList<object?>? items)
     {
         items = null;
 
-        if (!TryResolveValue(name, variables, out var value))
+        if (!TryResolveValue(name, variables, errors, out var value))
         {
             return false;
         }
@@ -159,9 +165,10 @@ internal static class RangeBinder
     private static bool TryResolveValue(
         string name,
         IReadOnlyDictionary<string, object?> variables,
+        TemplateErrors errors,
         out object? value)
     {
-        if (variables.TryGetValue(name, out value))
+        if (TryGetVariable(name, name, variables, errors, out value))
         {
             return true;
         }
@@ -173,7 +180,7 @@ internal static class RangeBinder
         }
 
         var segments = name.Split('_');
-        if (!variables.TryGetValue(segments[0], out var current) || current is null)
+        if (!TryGetVariable(name, segments[0], variables, errors, out var current) || current is null)
         {
             return false;
         }
@@ -189,6 +196,74 @@ internal static class RangeBinder
 
         value = current;
         return true;
+    }
+
+    /// <summary>Finds the variable a defined name selects.</summary>
+    /// <param name="definedName">The whole name, for the error message.</param>
+    /// <param name="name">The name to look up — the whole of it, or a path's first segment.</param>
+    /// <param name="variables">The template's variables.</param>
+    /// <param name="errors">Collects an ambiguous match.</param>
+    /// <param name="value">The variable's value, when one was found.</param>
+    /// <remarks>
+    /// <para>
+    /// Excel holds defined names in one case-insensitive namespace, so a template author who types
+    /// <c>ITEMS</c> in the name box has named the same thing as the variable added as <c>Items</c>,
+    /// and it binds. An exact match still wins, so nothing that binds today binds anything
+    /// different; the case-insensitive pass runs only when there is nothing exact to find.
+    /// </para>
+    /// <para>
+    /// The boundary stops here. The property segments of <c>Customer_Orders</c> are read by
+    /// <see cref="ReadMember"/>, and every name inside <c>{{ }}</c> by the expression engine, as the
+    /// C# members they are: <c>item.Price</c> and <c>item.price</c> stay different names.
+    /// </para>
+    /// <para>
+    /// Two variables differing only by case are the one case with no answer — nothing is exact, and
+    /// picking either would be picking whichever the dictionary happened to yield first — so the
+    /// name is reported and left unbound.
+    /// </para>
+    /// </remarks>
+    private static bool TryGetVariable(
+        string definedName,
+        string name,
+        IReadOnlyDictionary<string, object?> variables,
+        TemplateErrors errors,
+        out object? value)
+    {
+        if (variables.TryGetValue(name, out value))
+        {
+            return true;
+        }
+
+        string? matched = null;
+
+        foreach (var variable in variables)
+        {
+            if (!StringComparer.OrdinalIgnoreCase.Equals(variable.Key, name))
+            {
+                continue;
+            }
+
+            if (matched is not null)
+            {
+                // Say which part of the name did the matching, because for a property path it is the
+                // first segment rather than the whole of it.
+                var through = string.Equals(definedName, name, StringComparison.Ordinal)
+                    ? string.Empty
+                    : $" (through its first segment '{name}')";
+
+                errors.Add(new TemplateError(
+                    $"Defined name '{definedName}'{through} matches the variables '{matched}' and " +
+                    $"'{variable.Key}', which differ only by case. Rename one of them, or spell the name to " +
+                    "match one of them exactly."));
+                value = null;
+                return false;
+            }
+
+            matched = variable.Key;
+            value = variable.Value;
+        }
+
+        return matched is not null;
     }
 
     /// <summary>Reads a property, field or dictionary entry by name.</summary>

--- a/docs/report-templating.md
+++ b/docs/report-templating.md
@@ -97,6 +97,21 @@ entirely.
 Defined names may address a property path with an underscore: a name `Order_Lines` binds
 `order.Lines` where `Order` is the bound variable.
 
+### Name case
+
+A defined name is an Excel identifier, and Excel keeps names in one case-insensitive namespace, so the
+case a name is typed in does not decide which variable it finds. `Items`, `ITEMS` and `items` all
+select the variable added as `Items`.
+
+That holds at the name only. Everything inside `{{ }}` is C#, and matches case-**sensitively**:
+`item.Price` and `item.price` are different names. An underscore name sits astride the two — its first
+segment picks a variable, so `ORDER_Lines` binds `Order.Lines`, while the segments after it are
+properties and must be spelled as the type spells them, so `Order_lines` binds nothing.
+
+A template holding two variables that differ only by case — `AddVariable("Items", …)` and
+`AddVariable("items", …)` — keeps both, and a name spelling one of them exactly gets that one. A name
+spelling neither is genuinely ambiguous: it binds nothing and is reported in `ParsingErrors`.
+
 ### Name scope
 
 Names bind under Excel's own scoping. A name scoped to a **sheet** may be declared once per sheet, and
@@ -108,8 +123,9 @@ Q2!Items → Q2!A2:C3
 ```
 
 A name scoped to the **workbook** binds everywhere except on a sheet that declares its own name of that
-name, which shadows it there and nowhere else. Shadowing is silent: it is what Excel does, so it is not
-reported as a template error.
+name, which shadows it there and nowhere else — and the two names are compared the way Excel compares
+them, so a sheet-scoped `items` shadows a workbook-scoped `ITEMS`. Shadowing is silent: it is what
+Excel does, so it is not reported as a template error.
 
 The name is what selects the variable, so all the ranges above read `Items`. To bind two sheets to
 different data, give the ranges different names.


### PR DESCRIPTION
Closes #308, implementing **Option A** — case-insensitive matching at the defined-name boundary only, exact match first.

## What was wrong

Excel holds defined names in one case-insensitive namespace, and XLibur agrees: `XLDefinedNames` keys on `XLHelper.NameComparer`, which is `StringComparer.OrdinalIgnoreCase`. `RangeBinder` was the one place that then looked the name up in the `StringComparer.Ordinal` dictionary `XLTemplate` keeps its variables in.

So a name typed `ITEMS` never found the variable added as `Items`. `TryResolveItems` returned false, no `BoundRange` was created, and the block fell through to the pre-expansion pass — where `item` is not in scope, so the cells rendered blank. Nothing reached `ParsingErrors`, so `HasErrors` was `false` and the report looked like it had worked.

```csharp
workbook.DefinedNames.Add("ITEMS", sheet.Range("A1:C2"));
template.AddVariable("Items", items);
// before: A1 blank, result.HasErrors == false
// after:  A1 == "Widget"
```

The same applied to the underscore property-path form, whose first segment went through the same lookup.

## What changed

One method. `RangeBinder.TryGetVariable` now sits between the defined name and the variables, and both the whole-name lookup and a path's first segment go through it:

| Defined name | Variable | Before | After |
|---|---|---|---|
| `Items` | `Items` | binds | binds (unchanged) |
| `ITEMS` / `items` / `iTeMs` | `Items` | **blank, no error** | binds |
| `Items` | `Items` **and** `items` | binds `Items` | binds `Items` (unchanged) |
| `ITEMS` | `Items` **and** `items` | blank, no error | reported, unbound |
| `ORDER_Lines` / `order_Lines` | `Order.Lines` | blank, no error | binds |
| `Order_lines` / `Order_LINES` | `Order.Lines` | blank, no error | blank, no error (unchanged) |

It probes exactly first and scans case-insensitively only on a miss, so **nothing that binds today binds anything different** — the new path is reachable only where the old one returned nothing. The scan walks a dictionary holding a handful of variables and never runs when the caller's dictionary is already case-insensitive, because `TryGetValue` finds it first.

### Where the boundary stops

A defined name is an Excel identifier — written in Excel's name box, held in Excel's namespace — and only then used to pick a variable. That is the one place the two naming systems meet, and it is the only thing this touches. Untouched:

- **`ReadMember`** still walks a property path with case-sensitive `GetProperty`, so `Order_lines` binds nothing. An underscore name sits astride the boundary: its first segment is an Excel name, the rest are C# members.
- **`ExpressionScope`** still matches with `StringComparer.Ordinal`, where `item.Price` and `item.price` being different names is the documented contract and Scriban agrees.
- **`XLTemplate._variables`** stays `Ordinal`, so `AddVariable("Items", …)` and `AddVariable("items", …)` remain two variables — the blast radius that made Option B unattractive.

### The ambiguous case

Exact-first settles `ITEMS` against `Items`. It leaves one residue the issue did not decide: two variables differing only by case, and a name spelling neither. Enumeration order would pick one arbitrarily, so this records a `TemplateError` and binds nothing:

> Defined name 'ITEMS' matches the variables 'Items' and 'items', which differ only by case. Rename one of them, or spell the name to match one of them exactly.

It needs no warning severity — nothing binds, so it is a real error — and it cannot fire on a template that works today, since a name matching one of them exactly takes that one and never reaches the scan. For a property path the message says which segment did the matching, because there it is `Order` rather than `Order_Lines`.

## Tests

`DefinedNameScopeTests` gains the issue's repro across three spellings, an exact-match-wins case, and the ambiguity case. `ShadowingComparesNamesTheWayExcelDoes` goes back to being driven through a template rather than calling `RangeBinder.Resolve` directly — as #308 anticipated, it only did that because neither spelling could find its variable, and the remark saying so is gone.

`RangeExpansionTests.OnlyAnUnderscoreNamesFirstSegmentIgnoresCase` pins both halves of the boundary with the four path cases from the table.

I checked these are not vacuous: with the binder reverted and the tests left in place, 5 of the 11 scope tests and 2 of the 4 underscore cases fail.

## Docs

`docs/report-templating.md` gains a **Name case** section under Bound ranges covering all three rules — the name ignores case, `{{ }}` does not, and an underscore name is half of each. The Name scope section now says shadowing compares names Excel's way, so a sheet-scoped `items` shadows a workbook-scoped `ITEMS`. `RangeBinder`'s class remarks say the same, since they described *which* names bind but not how they are matched.

## Verified

`481` report tests pass on net8.0 and net10.0; solution builds clean under `TreatWarningsAsErrors`.
