### PR TITLE
refactor(crypto): drive the package-decrypt loop by the counter it actually tests

### DIFF
--- a/XLibur/Excel/IO/Encryption/Agile/AgileCrypto.cs
+++ b/XLibur/Excel/IO/Encryption/Agile/AgileCrypto.cs
@@ -180,7 +180,10 @@ internal static class AgileCrypto
         var plaintext = new byte[declaredLength];
         var written = 0;
 
-        for (var segmentIndex = 0; written < declaredLength; segmentIndex++)
+        // The loop ends when the declared content has been recovered, not when the segments run
+        // out — a trailing segment can carry padding past the declared length.
+        var segmentIndex = 0;
+        while (written < declaredLength)
         {
             var offset = prefixLength + segmentIndex * SegmentLength;
             var segmentLength = Math.Min(SegmentLength, encryptedPackage.Length - offset);
@@ -203,6 +206,7 @@ internal static class AgileCrypto
             written += copyLength;
 
             CryptographicOperations.ZeroMemory(decrypted);
+            segmentIndex++;
         }
 
         if (written != declaredLength)


### PR DESCRIPTION
Stack 1/7 — SonarQube quality-issue sweep. Base: `main`.

Fixes `csharpsquid:S1994` at `XLibur/Excel/IO/Encryption/Agile/AgileCrypto.cs:183`.

`DecryptPackage` walked the encrypted segments with a `for` whose stop condition tested `written` against the declared content length while its incrementer advanced `segmentIndex`. Two unrelated quantities in the one clause: the loop reads as though the index bounds it, which is not what stops it.

Rewritten as a `while` over the condition that genuinely terminates the loop, with the segment index advanced in the body alongside the other per-segment state.

Behaviour is unchanged — both early exits already left via `break`, so neither ever reached the incrementer.

Verified: solution builds clean (0 warnings), full suite 11724 tests / 0 failed.