### PR TITLE
refactor(patterns): separate a quadrant's own-ranges sweep from the recursive walk

### DIFF
--- a/XLibur/Excel/Patterns/Quadrant.cs
+++ b/XLibur/Excel/Patterns/Quadrant.cs
@@ -323,29 +323,7 @@ internal class Quadrant
         if (_subtreeCount == 0)
             return 0;
 
-        var count = 0;
-
-        if (_ranges != null)
-        {
-            List<IXLRangeAddress>? keysToRemove = null;
-            foreach (var range in _ranges.Values)
-            {
-                if (!predicate(range))
-                    continue;
-
-                (keysToRemove ??= new List<IXLRangeAddress>()).Add(range.RangeAddress);
-                removed.Add(range);
-            }
-
-            if (keysToRemove != null)
-            {
-                foreach (var keyToRemove in keysToRemove)
-                {
-                    if (_ranges.Remove(keyToRemove))
-                        count++;
-                }
-            }
-        }
+        var count = RemoveOwnRanges(predicate, removed);
 
         var children = Children;
         if (children != null)
@@ -355,6 +333,39 @@ internal class Quadrant
         }
 
         _subtreeCount -= count;
+        return count;
+    }
+
+    /// <summary>
+    /// Removes this quadrant's own matching ranges, appending them to <paramref name="removed"/>, and
+    /// returns how many went. The matches are collected before any are removed because the dictionary
+    /// cannot be modified while its values are being enumerated.
+    /// </summary>
+    private int RemoveOwnRanges(Predicate<IXLAddressable> predicate, List<IXLAddressable> removed)
+    {
+        if (_ranges == null)
+            return 0;
+
+        List<IXLRangeAddress>? keysToRemove = null;
+        foreach (var range in _ranges.Values)
+        {
+            if (!predicate(range))
+                continue;
+
+            (keysToRemove ??= new List<IXLRangeAddress>()).Add(range.RangeAddress);
+            removed.Add(range);
+        }
+
+        if (keysToRemove == null)
+            return 0;
+
+        var count = 0;
+        foreach (var keyToRemove in keysToRemove)
+        {
+            if (_ranges.Remove(keyToRemove))
+                count++;
+        }
+
         return count;
     }
 


### PR DESCRIPTION
Stack 3/7 — SonarQube quality-issue sweep. Base: `sonar/area-list-per-area-transforms` (#318).

Fixes `csharpsquid:S3776` at `XLibur/Excel/Patterns/Quadrant.cs:318` — scored **19** against a limit of 15.

`RemoveAllInto` did two unrelated jobs: remove this quadrant's own matching ranges, and recurse into the children. The first is a collect-then-delete dance — the dictionary cannot be modified while its values are being enumerated — which sat four levels deep inside the second.

Moved into `RemoveOwnRanges`, where the reason for the two passes can be stated where it applies. `RemoveAllInto` is now the walk it is named after: skip empty subtrees, take this quadrant, recurse, adjust the count.

Pure restructuring; no behaviour change.

Verified: builds clean, full suite 11724 tests / 0 failed.