### PR TITLE
chore(sonar): mark the accepted cognitive-complexity findings in code

### DIFF
--- a/XLibur.Report/Ranges/GroupRenderer.cs
+++ b/XLibur.Report/Ranges/GroupRenderer.cs
@@ -203,6 +203,7 @@ internal sealed class GroupRenderer
     /// how the levels nest. Because the ordering is stable, whatever <c>&lt;&lt;Sort&gt;&gt;</c>
     /// already decided survives as the order within each group.
     /// </remarks>
+#pragma warning disable S3776 // Building one ordering across all levels; the first level seeds it and the rest chain
     private static (IReadOnlyList<object?> Items, object?[][] Keys) Order(
         List<GroupLevel> levels,
         IReadOnlyList<object?> items,
@@ -263,6 +264,7 @@ internal sealed class GroupRenderer
 
         return (orderedItems, orderedKeys);
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// Finds each level's runs of consecutive items sharing a key — a run being one group.
@@ -541,6 +543,7 @@ internal sealed class GroupRenderer
     /// Gives the block its outline: data rows at the innermost level, each subtotal row one level
     /// out from the rows it covers, so that collapsing a level in Excel leaves its totals showing.
     /// </summary>
+#pragma warning disable S3776 // Outline levels, collapsing and summary position are three independent passes
     private void Outline(IXLWorksheet sheet, List<Run> runs, List<Run> subtotalled, int[] itemFirstRow, int dataRowCount)
     {
         // Excel allows eight outline levels. A template with more still generates; it just stops
@@ -588,6 +591,7 @@ internal sealed class GroupRenderer
                 : XLOutlineSummaryVLocation.Bottom;
         }
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// Merges a group's repeated label cells into one, which is the point of grouping a column the

--- a/XLibur.Report/Rewriting/SheetReference.cs
+++ b/XLibur.Report/Rewriting/SheetReference.cs
@@ -102,6 +102,7 @@ internal readonly record struct SheetReference(
     /// Separates the sheet name from the area, understanding the quoting Excel uses for a name that
     /// contains a space or a punctuation mark.
     /// </summary>
+#pragma warning disable S3776 // Quoted and unquoted sheet names are two separate, flat parses
     private static bool TrySplitSheet(string text, out string? sheetName, out string area)
     {
         sheetName = null;
@@ -164,6 +165,7 @@ internal readonly record struct SheetReference(
         area = text[(separator + 1)..];
         return area.Length > 0;
     }
+#pragma warning restore S3776
 
     /// <summary>Parses <c>$B$3</c>, <c>B3</c> and the mixed forms into row and column numbers.</summary>
     private static bool TryParseCell(string text, out int row, out int column)

--- a/XLibur/Excel/CalcEngine/CalcContext.cs
+++ b/XLibur/Excel/CalcEngine/CalcContext.cs
@@ -116,6 +116,7 @@ internal sealed class CalcContext : IStructuredReferenceScope
         CancellationToken.ThrowIfCancellationRequested();
     }
 
+#pragma warning disable S3776 // One cell-read contract: spill anchors, clean cells, single-sheet recalc, recursive eval
     internal ScalarValue GetCellValue(XLWorksheet? sheet, int rowNumber, int columnNumber)
     {
         sheet ??= Worksheet;
@@ -172,6 +173,7 @@ internal sealed class CalcContext : IStructuredReferenceScope
 
         throw new GettingDataException(new SheetPoint(sheet.SheetId, new Point(rowNumber, columnNumber)));
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// This method goes over slices and returns a value for each non-blank cell. Because it is using

--- a/XLibur/Excel/CalcEngine/DependencyTree.cs
+++ b/XLibur/Excel/CalcEngine/DependencyTree.cs
@@ -53,6 +53,7 @@ internal sealed class DependencyTree
 
     internal bool IsEmpty => _sheetTrees.All(sheetTree => sheetTree.Value.IsEmpty) && _dependencies.Count == 0;
 
+#pragma warning disable S3776 // One branch per formula kind, each documented; splitting would separate them from the walk
     internal static DependencyTree CreateFrom(XLWorkbook workbook)
     {
         var tree = new DependencyTree();
@@ -109,6 +110,7 @@ internal sealed class DependencyTree
 
         return tree;
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// Add a formula to the dependency tree.

--- a/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -418,6 +418,7 @@ internal static class DateAndTime
     /// Read the <c>weekend</c> argument of the .INTL functions: either one of the numbered codes, or
     /// a seven-character string of 0s and 1s running Monday to Sunday where 1 marks a weekend day.
     /// </summary>
+#pragma warning disable S3776 // The weekend argument has two spellings -- a numbered code or a seven-character mask
     private static bool TryGetWeekendMask(CalcContext ctx, in AnyValue value, out int mask, out XLError error)
     {
         mask = 0;
@@ -476,6 +477,7 @@ internal static class DateAndTime
         error = default;
         return true;
     }
+#pragma warning restore S3776
 
     /// <summary>Day of the week of a serial date as a bit index, 0 = Monday … 6 = Sunday.</summary>
     private static int WeekdayBit(int serialDate) => (WeekdayCalc(serialDate) + 5) % 7;
@@ -552,6 +554,7 @@ internal static class DateAndTime
         return total;
     }
 
+#pragma warning disable S3776 // Four optional-argument guards ahead of one day-stepping loop
     private static AnyValue WorkdayIntl(CalcContext ctx, Span<AnyValue> args)
     {
         if (!TryGetDate(ctx, ToScalar(ctx, args[0]), out var startDate, out var startError))
@@ -587,6 +590,7 @@ internal static class DateAndTime
 
         return date;
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// Reduce an argument of the .INTL functions to the single value it expects. Only the holidays

--- a/XLibur/Excel/CalcEngine/Functions/Distributions.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Distributions.cs
@@ -205,6 +205,7 @@ internal static class Distributions
     /// the shape of the ranges: a two-dimensional table has (rows−1)(columns−1), a single row or
     /// column has one less than its length.
     /// </summary>
+#pragma warning disable S3776 // A double loop over paired cells; the guards inside it are the function's error contract
     private static AnyValue ChiSqTest(CalcContext ctx, Span<AnyValue> args)
     {
         if (!args[0].TryPickCollectionArray(out var actual, ctx) ||
@@ -242,6 +243,7 @@ internal static class Distributions
 
         return XLMath.GammaQ(degreesOfFreedom / 2.0, statistic / 2);
     }
+#pragma warning restore S3776
 
     private static bool IsValidDegreesOfFreedom(double degreesOfFreedom)
         => degreesOfFreedom >= 1 && degreesOfFreedom < 1e10;

--- a/XLibur/Excel/CalcEngine/Functions/DynamicArray.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DynamicArray.cs
@@ -59,6 +59,7 @@ internal static class DynamicArray
     /// Append the arguments along one axis. The other axis grows to the widest (or tallest)
     /// argument, and the arguments that fall short are padded with <c>#N/A</c>.
     /// </summary>
+#pragma warning disable S3776 // Measure the arguments, then fill; both walks are flat and sequential
     private static AnyValue Stack(CalcContext ctx, Span<AnyValue> args, bool vertically)
     {
         var parts = new List<Array>(args.Length);
@@ -91,6 +92,7 @@ internal static class DynamicArray
 
         return Orient(new ConstArray(data), !vertically);
     }
+#pragma warning restore S3776
 
     #endregion
 
@@ -106,6 +108,7 @@ internal static class DynamicArray
     /// TOROW/TOCOL(array, [ignore], [scan_by_column]) — read every value in scan order, optionally
     /// skipping blanks (1), errors (2) or both (3), and lay the result out along a single axis.
     /// </summary>
+#pragma warning disable S3776 // Optional-argument guards ahead of one filtered walk; already reduced from 21
     private static AnyValue Flatten(CalcContext ctx, Span<AnyValue> args, bool intoRow)
     {
         if (!args[0].TryPickCollectionArray(out var array, ctx))
@@ -147,6 +150,7 @@ internal static class DynamicArray
 
         return Orient(new ConstArray(data), intoRow);
     }
+#pragma warning restore S3776
 
     private static AnyValue WrapRows(CalcContext ctx, Span<AnyValue> args)
         => Wrap(ctx, args, intoRows: true);
@@ -208,6 +212,7 @@ internal static class DynamicArray
     /// CHOOSEROWS/CHOOSECOLS(array, num1, …) — pick lines out of the array in the order asked for,
     /// repeats included. A negative index counts back from the end.
     /// </summary>
+#pragma warning disable S3776 // One index-validation rule applied over two argument shapes
     private static AnyValue Choose(CalcContext ctx, Span<AnyValue> args, bool byRow)
     {
         if (!args[0].TryPickCollectionArray(out var array, ctx))
@@ -252,6 +257,7 @@ internal static class DynamicArray
 
         return Orient(BuildRows(source, selected), !byRow);
     }
+#pragma warning restore S3776
 
     #endregion
 
@@ -406,6 +412,7 @@ internal static class DynamicArray
         return new ConstArray(data);
     }
 
+#pragma warning disable S3776 // Argument guards, then a linear group-by over rows; each stage is flat
     private static AnyValue Unique(CalcContext ctx, Span<AnyValue> args)
     {
         if (!args[0].TryPickCollectionArray(out var array, ctx))
@@ -467,6 +474,7 @@ internal static class DynamicArray
 
         return Orient(new ConstArray(result), byColumn);
     }
+#pragma warning restore S3776
 
     private static AnyValue Sort(CalcContext ctx, Span<AnyValue> args)
     {
@@ -503,6 +511,7 @@ internal static class DynamicArray
         return Orient(BuildRows(source, order), byColumn);
     }
 
+#pragma warning disable S3776 // Parsing the (by_array, [order]) pairs is one loop with one comparator
     private static AnyValue SortBy(CalcContext ctx, Span<AnyValue> args)
     {
         if (!args[0].TryPickCollectionArray(out var array, ctx))
@@ -552,7 +561,9 @@ internal static class DynamicArray
 
         return BuildRows(array, indices);
     }
+#pragma warning restore S3776
 
+#pragma warning disable S3776 // Mask-shape detection then one mask walk; already reduced from 27
     private static AnyValue Filter(CalcContext ctx, Span<AnyValue> args)
     {
         if (!args[0].TryPickCollectionArray(out var array, ctx))
@@ -591,7 +602,9 @@ internal static class DynamicArray
 
         return Orient(BuildRows(source, kept), !filterRows);
     }
+#pragma warning restore S3776
 
+#pragma warning disable S3776 // Six optional arguments to validate before one lookup; already reduced from 23
     private static AnyValue XLookup(CalcContext ctx, Span<AnyValue> args)
     {
         if (!TryScalarArg(ctx, args[0], out var lookupValue))
@@ -634,6 +647,7 @@ internal static class DynamicArray
 
         return Orient(new ConstArray(line), !vertical);
     }
+#pragma warning restore S3776
 
     private static AnyValue XMatch(CalcContext ctx, Span<AnyValue> args)
     {
@@ -664,6 +678,7 @@ internal static class DynamicArray
     /// 2 wildcard) and search modes (1 first-to-last, -1 last-to-first; binary modes fall back to a
     /// linear scan, which is correct if slower).
     /// </summary>
+#pragma warning disable S3776 // Four match modes over one scan; the modes are the specification
     private static int FindMatch(Array array, bool vertical, ScalarValue target, int matchMode, int searchMode)
     {
         var length = vertical ? array.Height : array.Width;
@@ -707,6 +722,7 @@ internal static class DynamicArray
 
         return best;
     }
+#pragma warning restore S3776
 
     private static ScalarValue Element(Array array, bool vertical, int index)
         => vertical ? array[index, 0] : array[0, index];

--- a/XLibur/Excel/CalcEngine/Functions/Financial.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Financial.cs
@@ -215,6 +215,7 @@ internal static class Financial
         return XLError.NumberInvalid;
     }
 
+#pragma warning disable S3776 // Six scalar arguments to read before one Newton iteration
     private static AnyValue Rate(CalcContext ctx, Span<AnyValue> args)
     {
         // RATE(nper, pmt, pv, [fv], [type], [guess]) - solved iteratively. All arguments are scalars.
@@ -256,6 +257,7 @@ internal static class Financial
 
         return XLError.NumberInvalid;
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// The time-value-of-money residual: <c>pv·(1+rate)^nper + pmt·(1+rate·type)·((1+rate)^nper−1)/rate + fv</c>,
@@ -755,6 +757,7 @@ internal static class Financial
         return XNpvOf(rate, schedule);
     }
 
+#pragma warning disable S3776 // Newton with a documented bisection fallback; the convergence tests are the algorithm
     private static AnyValue XIrr(CalcContext ctx, Span<AnyValue> args)
     {
         // XIRR(values, dates, [guess]) — the rate at which XNPV of the schedule is zero.
@@ -807,6 +810,7 @@ internal static class Financial
         // Newton wandered off; fall back to bisecting a bracket found by scanning outwards.
         return XIrrByBisection(schedule);
     }
+#pragma warning restore S3776
 
     private static AnyValue XIrrByBisection(List<(double Amount, double Days)> schedule)
     {
@@ -860,6 +864,7 @@ internal static class Financial
     /// first date. The two arguments must hold the same number of cells and no date may fall before
     /// the first one.
     /// </summary>
+#pragma warning disable S3776 // Two symmetric collection walks with error propagation, then one pairing check
     private static bool TryCollectSchedule(CalcContext ctx, in AnyValue valuesArg, in AnyValue datesArg, out List<(double Amount, double Days)> schedule, out XLError error)
     {
         schedule = null!;
@@ -923,6 +928,7 @@ internal static class Financial
         schedule = result;
         return true;
     }
+#pragma warning restore S3776
 
     #endregion
 

--- a/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
@@ -1020,6 +1020,7 @@ internal static class MathTrig
     /// Functions 1..13 take any number of ranges; 14..19 take one array and a k, because they pick
     /// a position within a single ordered set.
     /// </summary>
+#pragma warning disable S3776 // AGGREGATE dispatches nineteen functions; the switch arms are the specification
     private static AnyValue Aggregate(CalcContext ctx, Span<AnyValue> args)
     {
         if (!TryGetAggregateArgument(ctx, args[0], out var functionArgument, out var functionError))
@@ -1080,6 +1081,7 @@ internal static class MathTrig
             _ => Statistical.QuartileExclusive(numbers, k),
         };
     }
+#pragma warning restore S3776
 
     /// <summary>Read one of AGGREGATE's scalar arguments — the function number, the options or the k.</summary>
     private static bool TryGetAggregateArgument(CalcContext ctx, in AnyValue value, out double number, out XLError error)

--- a/XLibur/Excel/CalcEngine/Functions/Regression.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Regression.cs
@@ -552,6 +552,7 @@ internal static class Regression
         return BuildStatistics(design, constant, coefficients, row);
     }
 
+#pragma warning disable S3776 // Optional new_x handling ahead of one prediction loop
     private static AnyValue Predict(CalcContext ctx, Span<AnyValue> args, bool exponential)
     {
         // TREND(known_y, [known_x], [new_x], [const]) — the flag sits one place later than in LINEST.
@@ -599,6 +600,7 @@ internal static class Regression
 
         return new ConstArray(data);
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// Read known_y and known_x into a design matrix. When known_x is left out the predictor is the
@@ -716,6 +718,7 @@ internal static class Regression
     /// Read a block of predictor values. <paramref name="expected"/> is the number of predictors to
     /// insist on, or zero to take whatever the block holds.
     /// </summary>
+#pragma warning disable S3776 // Orientation fixup and shape validation ahead of one read loop
     private static bool TryReadPredictors(CalcContext ctx, Array array, int expected, bool vertical, out double[,] x, out int observations, out XLError error)
     {
         error = default;
@@ -754,6 +757,7 @@ internal static class Regression
 
         return true;
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// Solve the normal equations XᵀX·β = Xᵀy. <paramref name="constant"/> false pins the intercept
@@ -829,6 +833,7 @@ internal static class Regression
     /// degrees of freedom, then the regression and residual sums of squares. The cells to the right
     /// of the short rows are <c>#N/A</c>, as Excel leaves them.
     /// </summary>
+#pragma warning disable S3776 // The five-row LINEST statistics block; the arithmetic is flat and sequential
     private static AnyValue BuildStatistics(in Design design, bool constant, double[] coefficients, double[] reportedRow)
     {
         var width = design.Predictors + 1;
@@ -873,6 +878,7 @@ internal static class Regression
 
         return new ConstArray(data);
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// Standard errors of the coefficients, in the same reversed order as the coefficients: the

--- a/XLibur/Excel/CalcEngine/Functions/Statistical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Statistical.cs
@@ -808,6 +808,7 @@ internal static class Statistical
     /// and exclusive flavours: inclusive spreads the n values over 0…1, exclusive over
     /// 1/(n+1)…n/(n+1). The result is truncated, not rounded, to <c>significance</c> decimals.
     /// </summary>
+#pragma warning disable S3776 // Argument guards, then the inclusive/exclusive rank rules PERCENTRANK is defined by
     private static AnyValue PercentRank(CalcContext ctx, Span<AnyValue> args, bool exclusive)
     {
         if (!TryGetNumbers(ctx, args[0], out var numbers, out var arrayError))
@@ -857,6 +858,7 @@ internal static class Statistical
         var scale = Math.Pow(10, significance);
         return Math.Truncate(rank * scale) / scale;
     }
+#pragma warning restore S3776
 
     private static AnyValue Quartile(CalcContext ctx, AnyValue arrayParam, double quartParam)
     {

--- a/XLibur/Excel/CalcEngine/Functions/Text.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Text.cs
@@ -167,6 +167,7 @@ internal static class Text
     /// forms. Like ASC, real Excel only does this when the authoring language is East Asian; the
     /// mapping is applied unconditionally here, which is what makes DBCS(ASC(x)) an identity.
     /// </summary>
+#pragma warning disable S3776 // Half-width katakana recombination then a flat per-character mapping
     private static ScalarValue Dbcs(CalcContext ctx, string text)
     {
         const char dakuten = 'ﾞ';
@@ -209,6 +210,7 @@ internal static class Text
 
         return sb.ToString();
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// The half-width to full-width katakana mapping, derived by running every full-width katakana
@@ -303,6 +305,7 @@ internal static class Text
     /// TEXTSPLIT(text, col_delimiter, [row_delimiter], [ignore_empty], [match_mode], [pad_with]) —
     /// split into a grid, rows first and then columns within each row, and pad the short rows.
     /// </summary>
+#pragma warning disable S3776 // Six optional arguments to read before splitting; each guard is independent
     private static AnyValue TextSplit(CalcContext ctx, Span<AnyValue> args)
     {
         if (!TryGetText(ctx, args[0], out var text, out var textError))
@@ -356,6 +359,7 @@ internal static class Text
 
         return new ConstArray(data);
     }
+#pragma warning restore S3776
 
     /// <summary>Split on any of the delimiters; no delimiters at all leaves the text in one piece.</summary>
     private static List<string> Split(string text, List<string> delimiters, bool ignoreCase, bool ignoreEmpty)
@@ -387,6 +391,7 @@ internal static class Text
     /// match at the same place the longer one wins, so splitting on both "&lt;br&gt;" and "&lt;b&gt;"
     /// does not leave a stray "r&gt;".
     /// </summary>
+#pragma warning disable S3776 // Longest-match-wins delimiter scan; the tie-breaking is the point of the method
     private static List<(int Start, int Length)> FindDelimiters(string text, List<string> delimiters, bool ignoreCase)
     {
         var comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
@@ -422,6 +427,7 @@ internal static class Text
 
         return matches;
     }
+#pragma warning restore S3776
 
     /// <summary>Read a delimiter argument, which Excel lets you write as an array of alternatives.</summary>
     private static bool TryGetDelimiters(CalcContext ctx, in AnyValue value, out List<string> delimiters, out XLError error)
@@ -540,6 +546,7 @@ internal static class Text
         return Render(ctx, ToScalar(ctx, args[0]), strict);
     }
 
+#pragma warning disable S3776 // Concise and strict rendering differ only in separators, chosen inline per position
     private static AnyValue ArrayToText(CalcContext ctx, Span<AnyValue> args)
     {
         if (!TryGetFormat(ctx, args, 1, out var strict, out var formatError))
@@ -573,6 +580,7 @@ internal static class Text
 
         return sb.ToString();
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// Read the shared <c>format</c> argument of VALUETOTEXT and ARRAYTOTEXT: 0 is the concise form

--- a/XLibur/Excel/CalcEngine/Functions/XLMath.cs
+++ b/XLibur/Excel/CalcEngine/Functions/XLMath.cs
@@ -304,6 +304,7 @@ public static class XLMath
     /// on the CDF, with the bracket it has narrowed so far as a fallback whenever a step would jump
     /// outside it — the density vanishes in both tails, where Newton alone would run away.
     /// </summary>
+#pragma warning disable S3776 // Newton on the gamma CDF with bracket fallbacks; the guards are the numerics
     internal static double InverseGammaP(double p, double a)
     {
         if (p <= 0)
@@ -343,6 +344,7 @@ public static class XLMath
 
         return x;
     }
+#pragma warning restore S3776
 
     private static double InverseGammaInitialGuess(double p, double a)
     {

--- a/XLibur/Excel/CalcEngine/NumberParser.cs
+++ b/XLibur/Excel/CalcEngine/NumberParser.cs
@@ -36,6 +36,7 @@ internal static class NumberParser
     /// leftmost group may be shorter than its group size, which is why the groups can't be validated
     /// until they have all been seen.
     /// </summary>
+#pragma warning disable S3776 // Group sizes are validated right-to-left with the leftmost group exempt
     private static bool HasValidGroupSeparators(string text, CultureInfo culture)
     {
         var format = culture.NumberFormat;
@@ -76,6 +77,7 @@ internal static class NumberParser
 
         return true;
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// Group sizes are listed from the right, and the last one repeats for everything further left.

--- a/XLibur/Excel/CalcEngine/ScalarValue.cs
+++ b/XLibur/Excel/CalcEngine/ScalarValue.cs
@@ -462,6 +462,7 @@ internal readonly struct ScalarValue
         serialDateTime = default;
         return false;
 
+#pragma warning disable S3776 // Every split point of 'date time' has to be tried; the guards are the search
         static bool TryParseDateWithOverflowTime(string text, CultureInfo culture, out double serialDateTime)
         {
             serialDateTime = default;
@@ -494,6 +495,7 @@ internal readonly struct ScalarValue
 
             return false;
         }
+#pragma warning restore S3776
 
         // Whether the culture writes '3/1' as the first of March or the third of January.
         static bool IsMonthBeforeDay(CultureInfo c)

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -170,6 +170,7 @@ internal static partial class XLCellFormulaShifter
         /// </summary>
         /// <returns><c>false</c> when the shift leaves the reference untouched, in which case the
         /// original text is kept verbatim rather than re-rendered.</returns>
+#pragma warning disable S3776 // Insert and delete each have their own clamping rules, documented inline
         private bool TryShiftReference(ReferenceArea reference, out ReferenceArea shifted, out bool destroyed)
         {
             shifted = reference;
@@ -236,6 +237,7 @@ internal static partial class XLCellFormulaShifter
                 WithExtent(second, newLast, axis));
             return true;
         }
+#pragma warning restore S3776
 
         /// <summary>
         /// A reference that names only the axis we are not shifting: <c>3:5</c> during a column shift,

--- a/XLibur/Excel/Coordinates/XLAreaList.cs
+++ b/XLibur/Excel/Coordinates/XLAreaList.cs
@@ -79,6 +79,7 @@ internal sealed class XLAreaList : IEnumerable<Area>
     /// Appends the pieces one area breaks into when <paramref name="insertedArea"/> pushes it down.
     /// An area can survive whole, be extended, or be cut into an above/left/right/shifted set.
     /// </summary>
+#pragma warning disable S3776 // Splitting one area against an insertion; already reduced from 32
     private static void AddShiftedDown(Area originalArea, Area insertedArea, List<Area> result)
     {
         if (originalArea.HasFullColumnHeight)
@@ -153,6 +154,7 @@ internal sealed class XLAreaList : IEnumerable<Area>
             result.Add(cutToWidth);
         }
     }
+#pragma warning restore S3776
 
     internal XLAreaList InsertAndShiftRight(Area insertedArea)
     {

--- a/XLibur/Excel/IO/ChartFormatting.cs
+++ b/XLibur/Excel/IO/ChartFormatting.cs
@@ -583,6 +583,7 @@ internal static class ChartFormatting
     /// Applies the assigned axis properties onto an existing <c>c:catAx</c> or <c>c:valAx</c>, leaving
     /// its tick marks, label positions, line and text formatting as they were.
     /// </summary>
+#pragma warning disable S3776 // One independent, flat block per assigned axis property
     internal static void PatchAxis(OpenXmlCompositeElement? axis, XLChartAxis model)
     {
         var assigned = model.AssignedFormat;
@@ -634,7 +635,9 @@ internal static class ChartFormatting
         if (model.IsValueAxis)
             PatchAxisUnits(axis, model, assigned);
     }
+#pragma warning restore S3776
 
+#pragma warning disable S3776 // One independent, flat block per assigned scaling property
     private static void PatchScaling(
         OpenXmlCompositeElement axis, XLChartAxis model, XLChartAxisFormat assigned)
     {
@@ -681,6 +684,7 @@ internal static class ChartFormatting
                 InsertOrdered(scaling, new C.MinAxisValue { Val = model.Min.Value }, ScalingChildOrder);
         }
     }
+#pragma warning restore S3776
 
     private static void PatchAxisUnits(
         OpenXmlCompositeElement axis, XLChartAxis model, XLChartAxisFormat assigned)
@@ -968,6 +972,7 @@ internal static class ChartFormatting
         OpenXmlCompositeElement groupElement, XLChartDataLabels labels, XLChartType chartType) =>
         PatchDataLabels(groupElement, labels, chartType, groupLevel: true);
 
+#pragma warning disable S3776 // One independent, flat block per assigned data-label property
     private static void PatchDataLabels(
         OpenXmlCompositeElement parent, XLChartDataLabels labels, XLChartType chartType, bool groupLevel)
     {
@@ -1022,6 +1027,7 @@ internal static class ChartFormatting
         if ((assigned & XLDataLabelsFormat.ShowPercentage) != 0)
             SetLabelFlag<C.ShowPercent>(dataLabels, labels.ShowPercentage);
     }
+#pragma warning restore S3776
 
     private static void SetLabelFlag<TFlag>(C.DataLabels dataLabels, bool value)
         where TFlag : OpenXmlLeafElement, new()
@@ -1272,6 +1278,7 @@ internal static class ChartFormatting
             shapeProperties.Append(fill);
     }
 
+#pragma warning disable S3776 // Create-or-update outline, then one flat block per assigned property
     private static void SetOutline(
         C.ChartShapeProperties shapeProperties, XLChartSeries series, XLChartSeriesFormat assigned)
     {
@@ -1307,6 +1314,7 @@ internal static class ChartFormatting
                 outline.InsertAt(new A.SolidFill(BuildColor(series.LineColor)), 0);
         }
     }
+#pragma warning restore S3776
 
     private static bool IsFillElement(OpenXmlElement element) =>
         element is A.NoFill or A.SolidFill or A.GradientFill or A.BlipFill or A.PatternFill or A.GroupFill;

--- a/XLibur/Excel/IO/SharedStringReader.cs
+++ b/XLibur/Excel/IO/SharedStringReader.cs
@@ -77,6 +77,7 @@ internal static class SharedStringReader
         return [];
     }
 
+#pragma warning disable S3776 // A hand-rolled XmlReader walk; the node-type tests are the parser
     private static SharedStringEntry[] ReadSst(XmlReader reader)
     {
         // Pre-allocate from the sst's uniqueCount attribute to avoid resize+copy for large tables.
@@ -126,6 +127,7 @@ internal static class SharedStringReader
 
         return entries;
     }
+#pragma warning restore S3776
 
     private static int ReadUniqueCount(XmlReader reader)
     {

--- a/XLibur/Excel/IO/TextSerializer.cs
+++ b/XLibur/Excel/IO/TextSerializer.cs
@@ -9,6 +9,7 @@ namespace XLibur.Excel.IO;
 
 internal static class TextSerializer
 {
+#pragma warning disable S3776 // Runs, phonetic runs and phonetic properties are three independent optional sections
     internal static void WriteRichTextElements(XmlWriter w, XLImmutableRichText richText, SaveContext context)
     {
         if (richText.Runs.Count == 0)
@@ -69,6 +70,7 @@ internal static class TextSerializer
             w.WriteEndElement(); // phoneticPr
         }
     }
+#pragma warning restore S3776
 
     internal static void WriteRun(XmlWriter w, XLImmutableRichText richText, XLImmutableRichText.RichTextRun run)
     {

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -448,6 +448,7 @@ internal static class WorksheetSheetDataReader
             reader.Skip();
     }
 
+#pragma warning disable S3776 // Shared, array and dynamic-array formulas are decided by flat, documented tests
     private static XLCellFormula? SetCellFormulaXml(XmlReader reader, XLWorksheet ws, Point cellAddress,
         Dictionary<uint, string> sharedFormulasR1C1, uint? cellMetaIndex, HashSet<uint>? dynamicArrayCmIndexes)
     {
@@ -518,6 +519,7 @@ internal static class WorksheetSheetDataReader
 
         return formula;
     }
+#pragma warning restore S3776
 
     /// <summary>
     /// Loads a classic or dynamic array formula from a master <c>&lt;f t="array"&gt;</c> cell.


### PR DESCRIPTION
Stack 8/8 — SonarQube quality-issue sweep. Base: `sonar/regression-collection-helpers` (#323).

Closes out the sweep. The S3776 threshold stays at the default 15 (changing it needs a SonarCloud quality-profile edit that is not available on this plan), so the findings that will not be refactored are marked in code instead.

## What is suppressed

**40 methods**, each with `#pragma warning disable S3776 // <reason>` stating why it is accepted — matching the convention already in `WorkbookStylesPartWriter.cs`. Per method rather than per file, so a genuinely complex method added later is still reported.

They are overwhelmingly one shape: a flat chain of `if (!TryGetX(...)) return error;` argument guards in a calc-engine function, or a run of independent `if ((assigned & Flag) != 0) { clear; set }` blocks in the chart writer. Nesting depth one, no interleaving, each line independently readable. `Distributions.ChiSqTest` scores 16 against a limit of 15 and is a textbook double loop.

## Four of them are honest partial results

These are methods the earlier PRs in this stack already improved, which remain over the limit. Their markers say so, so nobody re-treads the ground expecting a clean win:

| Method | Before | Now |
|---|---|---|
| `XLAreaList.AddShiftedDown` | 32 | 17 |
| `DynamicArray.Filter` | 27 | 18 |
| `DynamicArray.XLookup` | 23 | 17 |
| `DynamicArray.Flatten` | 21 | 17 |

## Verified, not assumed

Built against `SonarAnalyzer.CSharp` with a `SonarLint.xml` supplying the `threshold` parameter — which reproduces exactly what SonarCloud reports through the scanner, since `dotnet sonarscanner begin/end` wraps the Roslyn build. **40 findings before, 0 after.**

That measurement also corrected two things worth knowing:
- S3776 is a *parameterized* rule, so it is inert in the analyzer package unless a `SonarLint.xml` supplies the threshold and the severity is enabled. Anyone reproducing this locally needs both.
- The finding originally reported at `WorksheetSheetDataReader.cs:415` is `SetCellFormulaXml`, not `LoadCellContentXml`.

The scaffolding is deliberately **not** committed: it would add the analyzer to every build, and `TreatWarningsAsErrors` would then promote several hundred unrelated Sonar rules to errors.

Verified: `dotnet build XLibur.slnx` clean (0 warnings), XLibur suite 11724 tests / 0 failed, XLibur.Report suite 481 tests / 0 failed.