### PR TITLE
docs: explain TUnit "zero tests ran" and exit code 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,45 @@ Solution uses `.slnx` format (modern MSBuild Solution Extension).
   finds 0 tests. Tracked upstream at stryker-mutator/stryker-net#3094. `stryker-config.json`
   and the tool manifest are left in place for when support lands.
 
+### "Zero tests ran" / exit code 5 — filter syntax, not a broken suite
+
+`dotnet test` reports an unknown runner option as `Zero tests ran` + `Exit code: 5` and
+swallows the real message. Nothing is wrong with discovery; the argument was rejected before
+any test ran. Run the built test executable directly to see the truth:
+
+```
+XLibur.Tests/bin/Debug/net10.0/XLibur.Tests.exe --filter Foo
+  -> Unknown option '--filter'
+```
+
+Distinguish the two exit codes:
+
+- **Exit 5 = invalid command line.** A VSTest-era option was passed. `--filter`,
+  `--logger`, `--collect` and `--blame` do **not** exist on this runner.
+- **Exit 8 = zero tests genuinely matched.** The filter is valid but selected nothing.
+
+**Filtering uses `--treenode-filter`, not `--filter`:**
+
+```
+dotnet test XLibur.Tests/XLibur.Tests.csproj -f net10.0 --treenode-filter "/*/*/PivotFilterCriteriaTests/*"
+```
+
+The path is `/Assembly/Namespace/Class/Test`; `*` wildcards each segment.
+
+Other notes:
+
+- Pass `-f net10.0`. The test projects multi-target `net8.0;net10.0`, so an unfiltered run
+  executes the whole suite twice.
+- MSBuild options still work — `-v n`, `--no-build`, `-c Release` are handled by the
+  `dotnet test` wrapper and never reach the runner.
+- **Do not filter at solution level.** `dotnet test XLibur.slnx --treenode-filter ...` exits 8
+  even when every selected test passes, because the other six test projects each match zero
+  tests. Neither `--minimum-expected-tests 0` nor `--zero-tests-policy` suppresses it (valid
+  values are `allow-skipped` and `strict` — there is no `ignore`). Name the specific
+  `.csproj` instead.
+- `--diagnostic` writes a `log_*.diag` file when the cause is still unclear.
+- See also https://tunit.dev/docs/troubleshooting/
+
 ## Key Dependencies
 
 - **DocumentFormat.OpenXml** 3.4.1 - Core OpenXML implementation ([source](https://github.com/dotnet/Open-XML-SDK))


### PR DESCRIPTION
When an unknown runner option is passed, `dotnet test` reports it as `Zero tests ran` with `Exit code: 5` and swallows the real message. That reads like a broken suite, but discovery never happened — the argument was rejected first. Running the test executable directly shows what actually went wrong:

```
$ XLibur.Tests/bin/Debug/net10.0/XLibur.Tests.exe --filter "FullyQualifiedName~PivotFilterCriteria"
Unknown option '--filter'
```

This adds a troubleshooting subsection to the Testing section of `CLAUDE.md`.

## What it documents

- **Exit 5 vs exit 8.** 5 is an invalid command line; 8 is a valid filter that matched nothing. Only the second one is about tests.
- **`--treenode-filter`, not `--filter`.** The VSTest-era `--filter`, `--logger`, `--collect` and `--blame` do not exist on Microsoft.Testing.Platform. Path format is `/Assembly/Namespace/Class/Test`.
- **Pass `-f net10.0`.** The test projects multi-target `net8.0;net10.0`, so an unfiltered run executes the suite twice.
- **MSBuild options are still fine.** `-v n`, `--no-build` and `-c Release` are handled by the `dotnet test` wrapper and never reach the runner.
- **Do not filter at solution level.** `dotnet test XLibur.slnx --treenode-filter ...` exits 8 even when every selected test passes, because the other six test projects each match zero tests.

## Verification

Each claim was checked against the current tree rather than inferred:

| Command | Result |
|---|---|
| `--filter "FullyQualifiedName~..."` | exit 5, `Unknown option` |
| `--logger:...` / `--collect:...` / `--blame` | exit 5 |
| `-v n` | exit 0 |
| `--treenode-filter "/*/*/PivotFilterCriteriaTests/*"` | exit 0, 14/14 passed |
| `--treenode-filter "/*/*/NoSuchClass/*"` | exit 8 |
| solution-level with filter | exit 8, despite `total: 28, failed: 0` |

Both suppression flags for the solution-level case were tried and neither works, so the doc says to name the specific `.csproj` instead: `--zero-tests-policy ignore` is not a valid value (only `allow-skipped` and `strict` exist), and `--minimum-expected-tests 0` still exits 8.

Consistent with the causes listed at https://tunit.dev/docs/troubleshooting/ — its other entries (missing TUnit package, stray `Microsoft.NET.Test.Sdk`, non-`Exe` output) were checked across every `.csproj` and do not apply here.

Docs only; no code or test changes.