### PR TITLE
fix(sonar): correct the findings that describe real defects

### DIFF
--- a/XLibur.Report.Tests/Rewriting/SheetReferenceTests.cs
+++ b/XLibur.Report.Tests/Rewriting/SheetReferenceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using XLibur.Report.Rewriting;
 
@@ -7,7 +8,11 @@ public class SheetReferenceTests
 {
     private static SheetReference Parse(string text)
     {
-        SheetReference.TryParse(text, out var reference);
+        // Every case here is a reference the parser is expected to accept. Failing loudly beats
+        // returning a default that turns into a baffling assertion failure further down.
+        if (!SheetReference.TryParse(text, out var reference))
+            throw new ArgumentException($"'{text}' did not parse as a sheet reference.", nameof(text));
+
         return reference;
     }
 

--- a/XLibur.Report/Ranges/RangeExpander.cs
+++ b/XLibur.Report/Ranges/RangeExpander.cs
@@ -105,7 +105,7 @@ internal sealed class RangeExpander
 
         // Captured before anything moves: the rules are re-pointed afterwards from the template's
         // original geometry.
-        var templateFormats = CaptureConditionalFormats(sheet, axis, area, firstSlot, dataLastSlot);
+        var templateFormats = CaptureConditionalFormats(sheet, axis, firstSlot, dataLastSlot);
         var formatsBeforeExpansion = new HashSet<IXLConditionalFormat>(
             sheet.ConditionalFormats,
             ReferenceEqualityComparer.Instance);
@@ -475,7 +475,6 @@ internal sealed class RangeExpander
     private static List<CapturedConditionalFormat> CaptureConditionalFormats(
         IXLWorksheet sheet,
         RangeAxis axis,
-        RangeArea area,
         int dataFirstSlot,
         int dataLastSlot)
     {

--- a/XLibur/Excel/CalcEngine/Functions/Financial.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Financial.cs
@@ -536,7 +536,7 @@ internal static class Financial
         var total = 0d;
         for (var period = Math.Ceiling(startPeriod); period <= Math.Truncate(endPeriod); period++)
         {
-            var interest = InterestOfPeriod(rate, period, numberOfPayments, presentValue, type, pmt);
+            var interest = InterestOfPeriod(rate, period, presentValue, type, pmt);
             total += principal ? pmt - interest : interest;
         }
 
@@ -544,7 +544,7 @@ internal static class Financial
     }
 
     /// <summary>Interest portion of a single annuity payment; the IPMT calculation without the argument checks.</summary>
-    private static double InterestOfPeriod(double rate, double period, double numberOfPayments, double presentValue, double type, double pmt)
+    private static double InterestOfPeriod(double rate, double period, double presentValue, double type, double pmt)
     {
         // Payment one of an annuity-due carries no interest — the payment is made before any accrues.
         if (type != 0 && period == 1)

--- a/XLibur/Excel/Drawings/XLPictures.cs
+++ b/XLibur/Excel/Drawings/XLPictures.cs
@@ -242,17 +242,17 @@ internal sealed class XLPictures : IXLPictures, IEnumerable<XLPicture>
         return members;
     }
 
-    private (long MinX, long MinY, long MaxX, long MaxY) ValidateMembersAndComputeBounds(List<XLPicture> members)
+    private (long MinX, long MinY, long MaxX, long MaxY) ValidateMembersAndComputeBounds(List<XLPicture> pictures)
     {
         var wb = _worksheet.Workbook;
         long minX = long.MaxValue, minY = long.MaxValue, maxX = long.MinValue, maxY = long.MinValue;
 
-        foreach (var member in members)
+        foreach (var member in pictures)
         {
             if (!ReferenceEquals(member.Worksheet, _worksheet))
-                throw new ArgumentException("All pictures must belong to this worksheet.", "pictures");
+                throw new ArgumentException("All pictures must belong to this worksheet.", nameof(pictures));
             if (member.IsInGroup)
-                throw new ArgumentException($"Picture '{member.Name}' is already in a group.", "pictures");
+                throw new ArgumentException($"Picture '{member.Name}' is already in a group.", nameof(pictures));
             if (member.Placement != XLPicturePlacement.FreeFloating)
                 throw new NotSupportedException(
                     $"Only free-floating pictures can be grouped; '{member.Name}' is '{member.Placement}'. Call MoveTo(left, top) first.");

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -213,7 +213,9 @@ internal static class WorksheetSheetDataReader
             switch (localName)
             {
                 case "r":
-                    TryParseOoxmlNonNegativeInt(value, out rowIndex);
+                    // A malformed r leaves rowIndex at zero, which the caller reads as "no r" and
+                    // resolves to the next sequential row. Discarding the result is the behaviour.
+                    _ = TryParseOoxmlNonNegativeInt(value, out rowIndex);
                     break;
                 case "ht":
                     height = double.Parse(value, NumberStyles.Float, XLHelper.ParseCulture);
@@ -380,7 +382,9 @@ internal static class WorksheetSheetDataReader
                     cellRef = Point.Parse(value);
                     break;
                 case "s":
-                    TryParseOoxmlNonNegativeInt(value, out styleIndex);
+                    // A malformed s leaves styleIndex at zero, the default style. Discarding the
+                    // result is the behaviour.
+                    _ = TryParseOoxmlNonNegativeInt(value, out styleIndex);
                     break;
                 case "t":
                     dataType = ParseCellDataType(value);

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -881,7 +881,7 @@ public partial class XLWorkbook
         if (!string.IsNullOrEmpty(value))
             return Guid.TryParse(value, out guid);
 
-        guid = default;
+        guid = Guid.Empty;
         return false;
     }
 


### PR DESCRIPTION
Stacked on #327. Review that one first.

The findings in this PR are the ones that describe something actually wrong, rather than a style preference.

## The defect

`XLPictures.ValidateMembersAndComputeBounds(List<XLPicture> members)` threw `ArgumentException` with the literal `paramName` `"pictures"` — not a parameter of that method. A caller catching it and reading `ParamName` got a name it could not map to anything. The parameter is renamed to match the public entry point and the throws use `nameof`, so the name stays true if either changes. Reported twice, as `CA2208` and `S3928`.

## Unused parameters (`S1172`)

`InterestOfPeriod` took `numberOfPayments` and never used it; `CaptureConditionalFormats` took `area` and never used it. Both private, both verified unused before removal — a parameter that is ignored implies the value matters when it does not.

## Dropped `TryParse` results (`CA1806`)

Three sites, and they are not the same case:

- `WorksheetSheetDataReader` drops the result at two attribute reads. That is deliberate and already documented — a malformed `r` resolves to the next sequential row, a malformed `s` to the default style. Behaviour unchanged; the discard is now explicit with the reason, so it no longer reads as an oversight.
- `SheetReferenceTests.Parse` also dropped one, but there every case is a reference the parser must accept. That one now throws, so a parser regression names itself instead of surfacing as a baffling assertion against a default value.

## `S4581`

`XLWorkbook_Load` assigned `default` to an `out Guid`. `Guid.Empty` says the same thing without reading as an oversight.

## Verification

Build clean; full suite **24538 passed, 0 failed** across all four test projects on net8.0 and net10.0.

One unrelated observation while running this: an earlier full-suite run reported a single failure that did not reproduce on any subsequent run, and I did not capture which test it was. Flagging it rather than leaving it unsaid — it is not something this PR touches, and given the suite shares temp files and the calc engine serially, an intermittent is plausible.