### PR TITLE
refactor(sonar): use the framework throw helpers and string.Contains

### DIFF
--- a/XLibur.Report.DynamicLinq/DynamicLinqExpressionEngine.cs
+++ b/XLibur.Report.DynamicLinq/DynamicLinqExpressionEngine.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -112,15 +112,8 @@ public sealed class DynamicLinqExpressionEngine : IExpressionEngine
     /// <inheritdoc />
     public object? Evaluate(string expression, ExpressionScope scope)
     {
-        if (expression is null)
-        {
-            throw new ArgumentNullException(nameof(expression));
-        }
-
-        if (scope is null)
-        {
-            throw new ArgumentNullException(nameof(scope));
-        }
+        ArgumentNullException.ThrowIfNull(expression);
+        ArgumentNullException.ThrowIfNull(scope);
 
         var names = Flatten(scope);
 
@@ -130,15 +123,8 @@ public sealed class DynamicLinqExpressionEngine : IExpressionEngine
     /// <inheritdoc />
     public string Interpolate(string text, ExpressionScope scope)
     {
-        if (text is null)
-        {
-            throw new ArgumentNullException(nameof(text));
-        }
-
-        if (scope is null)
-        {
-            throw new ArgumentNullException(nameof(scope));
-        }
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(scope);
 
         var names = Flatten(scope);
         var result = new StringBuilder(text.Length);

--- a/XLibur.Report/Expressions/ExpressionScope.cs
+++ b/XLibur.Report/Expressions/ExpressionScope.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Report.Expressions;
@@ -29,10 +29,7 @@ public sealed class ExpressionScope
     /// </summary>
     public ExpressionScope(IEnumerable<KeyValuePair<string, object?>> values, ExpressionScope? parent = null)
     {
-        if (values is null)
-        {
-            throw new ArgumentNullException(nameof(values));
-        }
+        ArgumentNullException.ThrowIfNull(values);
 
         _values = new Dictionary<string, object?>(StringComparer.Ordinal);
         foreach (var pair in values)

--- a/XLibur.Report/Expressions/ScribanExpressionEngine.cs
+++ b/XLibur.Report/Expressions/ScribanExpressionEngine.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -62,10 +62,7 @@ public sealed class ScribanExpressionEngine : IExpressionEngine
             throw new ArgumentException("A function name is required.", nameof(name));
         }
 
-        if (function is null)
-        {
-            throw new ArgumentNullException(nameof(function));
-        }
+        ArgumentNullException.ThrowIfNull(function);
 
         _functions.Import(name, function);
     }
@@ -92,10 +89,7 @@ public sealed class ScribanExpressionEngine : IExpressionEngine
     /// <inheritdoc />
     public object? Evaluate(string expression, ExpressionScope scope)
     {
-        if (expression is null)
-        {
-            throw new ArgumentNullException(nameof(expression));
-        }
+        ArgumentNullException.ThrowIfNull(expression);
 
         var template = GetTemplate(_expressionCache, expression, expression, ExpressionLexerOptions);
         return Run(template, expression, scope, static (t, ctx) => t.Evaluate(ctx));
@@ -104,10 +98,7 @@ public sealed class ScribanExpressionEngine : IExpressionEngine
     /// <inheritdoc />
     public string Interpolate(string text, ExpressionScope scope)
     {
-        if (text is null)
-        {
-            throw new ArgumentNullException(nameof(text));
-        }
+        ArgumentNullException.ThrowIfNull(text);
 
         var template = GetTemplate(_textCache, text, text, lexerOptions: null);
         return Run(template, text, scope, static (t, ctx) => t.Render(ctx)) ?? string.Empty;

--- a/XLibur.Report/Rewriting/SheetReference.cs
+++ b/XLibur.Report/Rewriting/SheetReference.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using XLibur.Excel;
 
@@ -40,7 +40,7 @@ internal readonly record struct SheetReference(
         var span = text!.Trim();
 
         // A multi-area reference is written as a parenthesised, comma-separated list.
-        if (span.IndexOf(',') >= 0 || span.IndexOf('(') >= 0)
+        if (span.Contains(',') || span.Contains('('))
         {
             return false;
         }
@@ -156,7 +156,7 @@ internal readonly record struct SheetReference(
         var unquoted = text[..separator];
 
         // A 3-D reference spans sheets; there is no single sheet to match it against.
-        if (unquoted.IndexOf(':') >= 0)
+        if (unquoted.Contains(':'))
         {
             return false;
         }

--- a/XLibur.Report/XLTemplate.cs
+++ b/XLibur.Report/XLTemplate.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
@@ -117,10 +117,7 @@ public sealed class XLTemplate : IXLTemplate
     /// <inheritdoc />
     public void AddVariable(object value)
     {
-        if (value is null)
-        {
-            throw new ArgumentNullException(nameof(value));
-        }
+        ArgumentNullException.ThrowIfNull(value);
 
         ThrowIfDisposed();
 
@@ -203,9 +200,6 @@ public sealed class XLTemplate : IXLTemplate
 
     private void ThrowIfDisposed()
     {
-        if (_disposed)
-        {
-            throw new ObjectDisposedException(nameof(XLTemplate));
-        }
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 }

--- a/XLibur/Excel/CalcEngine/NumberParser.cs
+++ b/XLibur/Excel/CalcEngine/NumberParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 
 namespace XLibur.Excel.CalcEngine;
@@ -108,7 +108,7 @@ internal static class NumberParser
     private static bool ContainsCurrencySymbol(string text, CultureInfo culture)
     {
         var symbol = culture.NumberFormat.CurrencySymbol;
-        return symbol.Length > 0 && text.IndexOf(symbol, StringComparison.Ordinal) >= 0;
+        return symbol.Length > 0 && text.Contains(symbol, StringComparison.Ordinal);
     }
 
     private static int IndexOfFirstDigit(string text)


### PR DESCRIPTION
Stacked on #328.

Mechanical, and the smallest PR in the stack.

- **`CA1510` (9).** Nine `if (x is null) throw new ArgumentNullException(nameof(x));` blocks become `ArgumentNullException.ThrowIfNull(x)`.
- **`CA1513` (1).** `XLTemplate.ThrowIfDisposed` becomes `ObjectDisposedException.ThrowIf(_disposed, this)` — matching the form already used in `StreamingPackageWriter` and `XLStreamingWorkbook`, rather than the `typeof(...)` overload.
- **`CA2249` (3).** Three `IndexOf(...) >= 0` tests become `Contains`, which is what they were asking.

Behaviour is unchanged — the guards throw the same exception types on the same inputs. The only observable difference is the `ObjectName` on the disposed exception, and the one test covering it asserts the type, not the name.

Net effect is 51 lines removed for 19 added.

Build clean; full suite **24538 passed, 0 failed**.