### PR TITLE
refactor(sonar): clean up the test helpers, samples and dense expressions

### DIFF
--- a/XLibur.Fonts.SixLabors.Examples/FontEngine/UsingSixLaborsFontsV2.cs
+++ b/XLibur.Fonts.SixLabors.Examples/FontEngine/UsingSixLaborsFontsV2.cs
@@ -7,7 +7,7 @@ namespace XLibur.Fonts.SixLabors.Examples.FontEngine;
 /// Demonstrates using SixLabors.Fonts 2.x as the font engine for text measurement.
 /// Install the XLibur.Fonts.SixLabors NuGet package to use this.
 /// </summary>
-public class UsingSixLaborsFontsV2
+public static class UsingSixLaborsFontsV2
 {
     public static void Create(string filePath)
     {

--- a/XLibur.Report.Benchmarks/ReportData.cs
+++ b/XLibur.Report.Benchmarks/ReportData.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Report.Benchmarks;
@@ -49,7 +49,7 @@ public static class ReportData
     public static List<ReportRow> Rows(int count)
     {
         var rows = new List<ReportRow>(count);
-        var start = new DateTime(2026, 1, 1);
+        var start = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         for (var i = 0; i < count; i++)
         {

--- a/XLibur.Report.Examples/AnnualSalesReport.cs
+++ b/XLibur.Report.Examples/AnnualSalesReport.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using XLibur.Excel;
@@ -144,7 +144,7 @@ public sealed class AnnualSalesReport : ReportExample
     {
         template.AddVariable("Company", "Contoso Horticultural Supplies");
         template.AddVariable("Year", 2026);
-        template.AddVariable("RunOn", new DateTime(2026, 7, 30).ToString("d MMMM yyyy"));
+        template.AddVariable("RunOn", new DateTime(2026, 7, 30, 0, 0, 0, DateTimeKind.Utc).ToString("d MMMM yyyy"));
         template.AddVariable("StrongLine", 500);
         template.AddVariable("WeakLine", 100);
         template.AddVariable("Sales", SalesData.Sales());

--- a/XLibur.Report.Examples/EverythingAtOnce.cs
+++ b/XLibur.Report.Examples/EverythingAtOnce.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using XLibur.Excel;
@@ -213,7 +213,7 @@ public sealed class EverythingAtOnce : ReportExample
 
         template.AddVariable("Company", "Contoso Ltd");
         template.AddVariable("Year", 2026);
-        template.AddVariable("RunOn", new DateTime(2026, 7, 30).ToString("d MMMM yyyy"));
+        template.AddVariable("RunOn", new DateTime(2026, 7, 30, 0, 0, 0, DateTimeKind.Utc).ToString("d MMMM yyyy"));
         template.AddVariable("Target", 300m);
         template.AddVariable("Items", sales);
         template.AddVariable("Rows", sales);

--- a/XLibur.Report.Examples/SalesData.cs
+++ b/XLibur.Report.Examples/SalesData.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace XLibur.Report.Examples;
@@ -61,7 +61,7 @@ public static class SalesData
             Product = product,
             Quantity = quantity,
             UnitPrice = unitPrice,
-            SoldOn = new DateTime(2026, 3, day),
+            SoldOn = new DateTime(2026, 3, day, 0, 0, 0, DateTimeKind.Utc),
             IsExport = export,
         };
 }

--- a/XLibur.Report.Tests/ExampleSmokeTests.cs
+++ b/XLibur.Report.Tests/ExampleSmokeTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -34,7 +34,7 @@ public class ExampleSmokeTests
     /// </summary>
     private static bool ExpectsErrors(string name) => name == new ErrorsAreReportedNotThrown().Name;
 
-    private static IReadOnlyList<ExampleRun> RunAll()
+    private static List<ExampleRun> RunAll()
     {
         var directory = Path.Combine(Path.GetTempPath(), "XLiburReportExamples", Guid.NewGuid().ToString("N"));
 

--- a/XLibur.Report.Tests/Infrastructure/GoldenFile.cs
+++ b/XLibur.Report.Tests/Infrastructure/GoldenFile.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -49,7 +49,7 @@ public static class GoldenFile
         throw new GoldenFileMismatchException(Describe(fixture.Name, differences, actualPath, expectedPath));
     }
 
-    private static IXLWorkbook LoadTemplate(ReportFixture fixture)
+    private static XLWorkbook LoadTemplate(ReportFixture fixture)
     {
         using var stream = ReportResources.OpenTemplate(fixture.Name);
         return new XLWorkbook(stream);

--- a/XLibur.Report.Tests/Infrastructure/WorkbookComparerTests.cs
+++ b/XLibur.Report.Tests/Infrastructure/WorkbookComparerTests.cs
@@ -7,7 +7,7 @@ namespace XLibur.Report.Tests.Infrastructure;
 
 public class WorkbookComparerTests
 {
-    private static IXLWorkbook Sheet(Action<IXLWorksheet> build, string name = "Report")
+    private static XLWorkbook Sheet(Action<IXLWorksheet> build, string name = "Report")
     {
         var workbook = new XLWorkbook();
         build(workbook.AddWorksheet(name));

--- a/XLibur.Report.Tests/Ranges/HorizontalRangeTests.cs
+++ b/XLibur.Report.Tests/Ranges/HorizontalRangeTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using XLibur.Excel;
@@ -21,7 +21,7 @@ public class HorizontalRangeTests
     /// A range over B4:C6 with the labels down column A. Column B repeats — product, quantity and a
     /// spare line — and column C is the options column.
     /// </summary>
-    private static IXLWorkbook Template(string c4 = "<<Horizontal>>", string c5 = "", string c6 = "")
+    private static XLWorkbook Template(string c4 = "<<Horizontal>>", string c5 = "", string c6 = "")
     {
         var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Report");

--- a/XLibur.Report.Tests/Ranges/RangeExpansionTests.cs
+++ b/XLibur.Report.Tests/Ranges/RangeExpansionTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -23,7 +23,7 @@ public class RangeExpansionTests
     /// Builds a sheet whose rows <paramref name="dataRows"/> are named <c>Items</c>, with the row
     /// after them acting as the options row.
     /// </summary>
-    private static IXLWorkbook TemplateWithItemsRange(
+    private static XLWorkbook TemplateWithItemsRange(
         Action<IXLWorksheet> build,
         int firstRow = 1,
         int dataRows = 1,

--- a/XLibur.Report.Tests/Rewriting/ChartRewritingTests.cs
+++ b/XLibur.Report.Tests/Rewriting/ChartRewritingTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -26,7 +26,7 @@ public class ChartRewritingTests
     /// A sheet whose rows 3 (data) and 4 (options) are named <c>Items</c>, with a column chart
     /// plotting the quantity column against the product column.
     /// </summary>
-    private static IXLWorkbook Template(string valueReferences = "Report!$B$3:$B$3", string? categoryReferences = "Report!$A$3:$A$3")
+    private static XLWorkbook Template(string valueReferences = "Report!$B$3:$B$3", string? categoryReferences = "Report!$A$3:$A$3")
     {
         var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Report");

--- a/XLibur.Report.Tests/Rewriting/PicturePlacementTests.cs
+++ b/XLibur.Report.Tests/Rewriting/PicturePlacementTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -27,7 +27,7 @@ public class PicturePlacementTests
         .ToList();
 
     /// <summary>Rows 3 and 4 are the bound range; the picture is anchored at A8, below it.</summary>
-    private static IXLWorkbook Template(string anchor)
+    private static XLWorkbook Template(string anchor)
     {
         var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Report");

--- a/XLibur.Report.Tests/Tags/CultureBoundOrderingTests.cs
+++ b/XLibur.Report.Tests/Tags/CultureBoundOrderingTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -56,7 +56,7 @@ public class CultureBoundOrderingTests
     /// A two-column range over A3:B4 — the first column holding <paramref name="expression"/>, the
     /// second a quantity — with row 4 the options row.
     /// </summary>
-    private static IXLWorkbook Template(string expression, string optionsA, string optionsB = "")
+    private static XLWorkbook Template(string expression, string optionsA, string optionsB = "")
     {
         var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Report");

--- a/XLibur.Report.Tests/Tags/GroupTagTests.cs
+++ b/XLibur.Report.Tests/Tags/GroupTagTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using XLibur.Excel;
@@ -23,7 +23,7 @@ public class GroupTagTests
     /// Builds a four-column range over A3:D4 — region, category, product, quantity — where row 3 is
     /// the data row and row 4 the options row.
     /// </summary>
-    private static IXLWorkbook Template(string a = "", string b = "", string c = "", string d = "")
+    private static XLWorkbook Template(string a = "", string b = "", string c = "", string d = "")
     {
         var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Report");

--- a/XLibur.Report.Tests/Tags/IfTagTests.cs
+++ b/XLibur.Report.Tests/Tags/IfTagTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using XLibur.Excel;
@@ -20,7 +20,7 @@ public class IfTagTests
     /// <paramref name="c3"/> lands in a repeated row, anything for the row-4 arguments in the options
     /// row.
     /// </summary>
-    private static IXLWorkbook Template(string c3 = "", string a4 = "", string b4 = "", string c4 = "")
+    private static XLWorkbook Template(string c3 = "", string a4 = "", string b4 = "", string c4 = "")
     {
         var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Report");

--- a/XLibur.Report.Tests/Tags/TagBehaviourTests.cs
+++ b/XLibur.Report.Tests/Tags/TagBehaviourTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -20,7 +20,7 @@ public class TagBehaviourTests
     /// Builds a two-column range over A3:B4, where row 3 is the data row and row 4 the options row
     /// holding <paramref name="optionsA"/> and <paramref name="optionsB"/>.
     /// </summary>
-    private static IXLWorkbook Template(string optionsA = "", string optionsB = "")
+    private static XLWorkbook Template(string optionsA = "", string optionsB = "")
     {
         var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Report");

--- a/XLibur.Report.Tests/XLTemplateTests.cs
+++ b/XLibur.Report.Tests/XLTemplateTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,7 +9,7 @@ namespace XLibur.Report.Tests;
 
 public class XLTemplateTests
 {
-    private static IXLWorkbook WorkbookWith(params (string Address, string Text)[] cells)
+    private static XLWorkbook WorkbookWith(params (string Address, string Text)[] cells)
     {
         var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Report");

--- a/XLibur.Tests/Excel/Comments/ThreadedCommentReviewTests.cs
+++ b/XLibur.Tests/Excel/Comments/ThreadedCommentReviewTests.cs
@@ -1,14 +1,15 @@
-using System;
+﻿using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.Comments;
 
-public class ThreadedCommentReviewTests
+public partial class ThreadedCommentReviewTests
 {
     [Test]
     public async Task Deleting_a_thread_that_has_been_shifted_clears_the_right_cell()
@@ -124,7 +125,7 @@ public class ThreadedCommentReviewTests
             using (var reader = new StreamReader(entry.Open(), Encoding.UTF8))
                 xml = reader.ReadToEnd();
 
-            xml = System.Text.RegularExpressions.Regex.Replace(xml, " dT=\"[^\"]*\"", string.Empty);
+            xml = TimestampAttribute().Replace(xml, string.Empty);
 
             using var stream = entry.Open();
             stream.SetLength(0);
@@ -150,4 +151,9 @@ public class ThreadedCommentReviewTests
         using var reader = new StreamReader(entryStream, Encoding.UTF8);
         return reader.ReadToEnd();
     }
+
+    // The threaded-comment timestamp is written at save time, so it has to come out before two
+    // saves of the same workbook can be compared.
+    [GeneratedRegex(" dT=\"[^\"]*\"")]
+    private static partial Regex TimestampAttribute();
 }

--- a/XLibur.Tests/Excel/Styles/XLColorAutomaticTests.cs
+++ b/XLibur.Tests/Excel/Styles/XLColorAutomaticTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using XLibur.Excel;
 using System.Threading.Tasks;
 
@@ -13,7 +14,7 @@ namespace XLibur.Tests.Excel.Styles;
 /// picker. The application resolves the actual color from the context it is used in, so it must not
 /// be pinned to a concrete value on save.
 /// </summary>
-public class XLColorAutomaticTests
+public partial class XLColorAutomaticTests
 {
     [Test]
     public async Task Automatic_IsTheFirstColorType()
@@ -99,8 +100,7 @@ public class XLColorAutomaticTests
 
     private static async Task<string> FontsBlock(string stylesXml)
     {
-        var match = System.Text.RegularExpressions.Regex.Match(stylesXml, "<x:fonts.*?</x:fonts>",
-            System.Text.RegularExpressions.RegexOptions.Singleline);
+        var match = FontsBlockPattern().Match(stylesXml);
         await Assert.That(match.Success).IsTrue().Because($"No <fonts> block in styles.xml.\n\n{stylesXml}");
         return match.Value;
     }
@@ -198,4 +198,7 @@ public class XLColorAutomaticTests
 
         return ms.ToArray();
     }
+
+    [GeneratedRegex("<x:fonts.*?</x:fonts>", RegexOptions.Singleline)]
+    private static partial Regex FontsBlockPattern();
 }

--- a/XLibur/Excel/CalcEngine/Functions/Distributions.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Distributions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using XLibur.Excel.CalcEngine.Functions;
 using static XLibur.Excel.CalcEngine.Functions.SampleStatistics;
@@ -598,7 +598,12 @@ internal static class Distributions
             return XLMath.GammaP(alpha, x / beta);
 
         if (x == 0)
-            return alpha < 1 ? XLError.NumberInvalid : alpha == 1 ? 1 / beta : 0d;
+            return alpha switch
+            {
+                < 1 => XLError.NumberInvalid,
+                1 => 1 / beta,
+                _ => 0d,
+            };
 
         var logDensity = (alpha - 1) * Math.Log(x) - x / beta - alpha * Math.Log(beta) - XLMath.LnGamma(alpha);
         return Math.Exp(logDensity);

--- a/XLibur/Excel/CalcEngine/Functions/Regression.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Regression.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using XLibur.Excel.CalcEngine.Functions;
 using static XLibur.Excel.CalcEngine.Functions.SampleStatistics;
@@ -948,13 +948,11 @@ internal static class Regression
     {
         flag = false;
         error = default;
-        if (!value.TryPickScalar(out var scalar, out _))
+        if (!value.TryPickScalar(out var scalar, out _)
+            && !value.ImplicitIntersection(ctx).TryPickScalar(out scalar, out _))
         {
-            if (!value.ImplicitIntersection(ctx).TryPickScalar(out scalar, out _))
-            {
-                error = XLError.IncompatibleValue;
-                return false;
-            }
+            error = XLError.IncompatibleValue;
+            return false;
         }
 
         if (scalar.IsBlank)

--- a/XLibur/Excel/CalcEngine/Functions/Statistical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Statistical.cs
@@ -848,9 +848,11 @@ internal static class Statistical
         if (numbers[below] < x && below + 1 < numbers.Count)
             position += (x - numbers[below]) / (numbers[below + 1] - numbers[below]);
 
+        // A single observation has no spread to place x within, so it ranks at the top.
+        var inclusiveRank = numbers.Count > 1 ? position / (numbers.Count - 1) : 1d;
         var rank = exclusive
             ? (position + 1) / (numbers.Count + 1)
-            : numbers.Count > 1 ? position / (numbers.Count - 1) : 1d;
+            : inclusiveRank;
 
         if (exclusive && (rank <= 0 || rank >= 1))
             return XLError.NoValueAvailable;

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -290,11 +290,10 @@ internal static partial class XLCellFormulaShifter
         /// </remarks>
         private string Render(SymbolRange range, ReferenceArea shifted, string? sheet, bool destroyed)
         {
-            var body = destroyed
-                ? RefErrorText
-                : SourceIsRange(range)
-                    ? string.Concat(shifted.First.GetDisplayStringA1(), ":", shifted.Second.GetDisplayStringA1())
-                    : shifted.First.GetDisplayStringA1();
+            var reference = SourceIsRange(range)
+                ? string.Concat(shifted.First.GetDisplayStringA1(), ":", shifted.Second.GetDisplayStringA1())
+                : shifted.First.GetDisplayStringA1();
+            var body = destroyed ? RefErrorText : reference;
 
             if (sheet is null)
                 return body;

--- a/XLibur/Excel/PageSetup/XLHeaderFooter.cs
+++ b/XLibur/Excel/PageSetup/XLHeaderFooter.cs
@@ -35,8 +35,6 @@ internal sealed class XLHeaderFooter : IXLHeaderFooter
 
     public string GetText(XLHFOccurrence occurrence)
     {
-        //if (innerTexts.ContainsKey(occurrence)) return innerTexts[occurrence];
-
         var leftText = Left.GetText(occurrence);
         var centerText = Center.GetText(occurrence);
         var rightText = Right.GetText(occurrence);

--- a/XLibur/Excel/PageSetup/XLPageSetup.cs
+++ b/XLibur/Excel/PageSetup/XLPageSetup.cs
@@ -198,18 +198,6 @@ internal sealed class XLPageSetup : IXLPageSetup
         ColumnBreaks.Sort();
     }
 
-    //public void SetPageBreak(IXLRange range, XLPageBreakLocations breakLocation)
-    //{
-    //    switch (breakLocation)
-    //    {
-    //        case XLPageBreakLocations.AboveRange: RowBreaks.Add(range.Internals.Worksheet.Row(range.RowNumber)); break;
-    //        case XLPageBreakLocations.BelowRange: RowBreaks.Add(range.Internals.Worksheet.Row(range.RowCount())); break;
-    //        case XLPageBreakLocations.LeftOfRange: ColumnBreaks.Add(range.Internals.Worksheet.Column(range.ColumnNumber)); break;
-    //        case XLPageBreakLocations.RightOfRange: ColumnBreaks.Add(range.Internals.Worksheet.Column(range.ColumnCount())); break;
-    //        default: throw new NotImplementedException();
-    //    }
-    //}
-
     public IXLPageSetup SetPageOrientation(XLPageOrientation value) { PageOrientation = value; return this; }
     public IXLPageSetup SetPagesWide(int value) { PagesWide = value; return this; }
     public IXLPageSetup SetPagesTall(int value) { PagesTall = value; return this; }

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -1549,8 +1549,13 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
             return;
         }
 
-        var paneRow = sr > 0 ? (target.RowNumber <= sr ? sr + 1 : target.RowNumber) : 1;
-        var paneColumn = sc > 0 ? (target.ColumnNumber <= sc ? sc + 1 : target.ColumnNumber) : 1;
+        var paneRow = PaneStart(sr, target.RowNumber);
+        var paneColumn = PaneStart(sc, target.ColumnNumber);
+
+        // With no split the pane starts at the first row/column; with one, it starts just past the
+        // split unless the target already sits below it.
+        static int PaneStart(int split, int index) =>
+            split > 0 ? (index <= split ? split + 1 : index) : 1;
 
         SheetView.PaneTopLeftCellAddress = new XLAddress(this, paneRow, paneColumn,
             fixedRow: false, fixedColumn: false);

--- a/docs/sonar.md
+++ b/docs/sonar.md
@@ -1,4 +1,4 @@
-# SonarQube issues — XLibur_XLibur
+﻿# SonarQube issues — XLibur_XLibur
 
 - Server: https://sonarcloud.io
 - Filters: impactSeverities=`MEDIUM`, issueStatuses=`OPEN,CONFIRMED`
@@ -42,7 +42,7 @@ taken from the local build.
 | `CA1859` | 19 | Tighten to the concrete type where the member is not public API |
 | `CA1510` | 9 | `ArgumentNullException.ThrowIfNull` |
 | `S3358` | 5 | Lift the inner ternary into a named local |
-| `S125` | 4 | Delete the commented-out code |
+| `S125` | 2 | Delete the commented-out code — the other 2 are prose, not code |
 | `S6562` | 4 | Pass `DateTimeKind` explicitly in sample data |
 | `CA2249` | 4 | `string.Contains` |
 | `CA1806` | 3 | Make the tolerated-parse fallback explicit |
@@ -53,8 +53,8 @@ taken from the local build.
 | `SYSLIB1045` | 2 | `[GeneratedRegex]` partial method |
 | `S1066`, `S1118`, `S4581`, `CA1513`, `CA1845`, `CA1846` | 1 each | Mechanical |
 
-`CA1822` was triaged as a fix and reversed on inspection — see its entry. That makes the
-split **67 fix / 83 ignore**.
+Three entries were triaged as fixes and reversed once the code was read — one `CA1822`
+and two `S125`. Each says so in its own entry. The final split is **65 fix / 85 ignore**.
 
 **The one real defect.** `XLPictures.ValidateMembersAndComputeBounds(List<XLPicture> members)`
 throws `ArgumentException` with the literal `paramName` `"pictures"`, which is not a
@@ -114,7 +114,7 @@ Stacked pull requests, each branching from the one before:
 
 ### 2. Remove this commented out code.
 - Location: `XLibur.Benchmarks/Program.cs:14`
-- Rule: `csharpsquid:S125` — Sections of code should not be commented out
+- **Status:** IGNORE - FALSE POSITIVE on inspection: the flagged lines are prose describing the benchmark modes, not commented-out code.
 - **Status:** FIX - delete the commented-out code.
 - Link: https://sonarcloud.io/project/issues?id=XLibur_XLibur&open=AZ-jJ36vmmYrCxinzLl-
 - Fix guidance: see rule `csharpsquid:S125` below.
@@ -1103,7 +1103,7 @@ Stacked pull requests, each branching from the one before:
 
 ### 125. Remove this commented out code.
 - Location: `XLibur/Excel/Cells/XLCellFormulaShifter.cs:212`
-- Rule: `csharpsquid:S125` — Sections of code should not be commented out
+- **Status:** IGNORE - FALSE POSITIVE on inspection: the flagged lines are prose describing how row deletion clamps a reference, not commented-out code.
 - **Status:** FIX - delete the commented-out code.
 - Link: https://sonarcloud.io/project/issues?id=XLibur_XLibur&open=AZ-nMDZv--pWpbX2ie1c
 - Fix guidance: see rule `csharpsquid:S125` below.


### PR DESCRIPTION
Stacked on #330. The largest of the fix PRs, and the least risky — most of it is test and sample code.

- **`CA1859` (tests, 12).** Test helpers return the workbook type they actually build rather than `IXLWorkbook`. The `Generate` helpers still take the interface, so nothing else moved.
- **`SYSLIB1045` (2).** Two ad-hoc `Regex` calls become `[GeneratedRegex]` partial methods.
- **`S125` (2 of 4).** Two blocks of genuinely dead code go: a commented-out early return in `XLHeaderFooter.GetText`, and a commented-out `SetPageBreak` in `XLPageSetup`.
- **`S6562` (4)** — sample `DateTime`s state their kind. **`S1118` (1)** — the SixLabors example class becomes static. **`S1066` (1)** — one mergeable guard in `Regression.TryGetBoolean`.

## `S3358` — five nested ternaries

Worth calling out because "extract the nested ternary" can easily make code worse. Each of these reads better afterwards rather than merely differently:

- The gamma density three-way on `alpha` becomes a `switch` expression.
- The percentile rank and the shifted-reference body each lift their inner branch into a named local.
- The pane origin in `XLWorksheet` becomes a local function used by both axes, replacing two parallel nested ternaries with one named rule.

## Two more reversals

Two of the four `S125` findings turned out to be **false positives** — the flagged lines are prose describing benchmark modes and describing how row deletion clamps a reference, not commented-out code. Both are recorded as such in `docs/sonar.md`, and the suppressions are not needed since nothing is there to delete.

With the `CA1822` reversal in PR 4, the final split is **65 fix / 85 ignore**.

Build clean; full suite **24538 passed, 0 failed**.