### PR TITLE
chore(sonar): mark the accepted findings where they are, with the reason

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,23 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+# Analyzer rules that are right about library code and wrong about test code.
+# These fire only under SonarCloud's analyzer configuration, not the normal build.
+# See docs/sonar.md for the finding-by-finding reasoning.
+[{XLibur.Tests,XLibur.Report.Tests,XLibur.Fonts.SixLabors.Tests,XLibur.Fonts.SkiaSharp.Tests}/**.cs]
+
+# CA1861: hoist a constant array argument into a static readonly field. In a test the array
+# literal IS the case under test and belongs beside its assertion; moving 58 of them to fields
+# trades readability for one avoided allocation per test.
+dotnet_diagnostic.CA1861.severity = none
+
+# TUnit0057: a hook may take an AssemblyHookContext. Ours have no use for it, and adding an
+# unused parameter to silence an informational suggestion is worse than the suggestion.
+dotnet_diagnostic.TUnit0057.severity = none
+
+# TUnitAssertions0016: IsEqualTo on a collection compares by reference. Area is a readonly
+# struct with IEquatable value equality that also enumerates points, so the premise does not
+# hold; IsEquivalentTo would compare point sequences instead of the area, which is the weaker
+# and wrong assertion.
+dotnet_diagnostic.TUnitAssertions0016.severity = none

--- a/XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs
@@ -299,8 +299,10 @@ public class OpenXmlWorkbookBenchmarks
         WriteRowEnd(writer);
     }
 
+#pragma warning disable S107 // The benchmark mirrors the raw OpenXML write it measures; grouping the arguments would measure the grouping
     private void WriteFormattedDataRow(OpenXmlWriter writer, Span<char> cellRef, int row, int i, int idx,
         bool applyFormatting, List<string> sstEntries, Dictionary<string, int> sstMap)
+#pragma warning restore S107
     {
         WriteRowStart(writer, row);
 

--- a/XLibur.Report.Examples/Program.cs
+++ b/XLibur.Report.Examples/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -91,6 +91,7 @@ public static class Program
     {
         var names = new List<string>();
 
+#pragma warning disable S127 // --out consumes the following argument, so the index advances twice
         for (var i = 0; i < args.Length; i++)
         {
             if (args[i].StartsWith("--", StringComparison.Ordinal))
@@ -106,6 +107,7 @@ public static class Program
 
             names.Add(args[i]);
         }
+#pragma warning restore S127
 
         return names;
     }

--- a/XLibur.Report/Ranges/RangeExpander.cs
+++ b/XLibur.Report/Ranges/RangeExpander.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel;
 using XLibur.Excel.ConditionalFormats;
@@ -208,6 +208,7 @@ internal sealed class RangeExpander
         return RangeAxis.Vertical;
     }
 
+#pragma warning disable S107 // One field per piece of expansion state; a parameter object here is the same list behind a name
     private ProcessingContext Context(
         IXLWorksheet sheet,
         RangeAxis axis,
@@ -220,6 +221,7 @@ internal sealed class RangeExpander
         Dictionary<int, string> lineExpressions,
         List<OptionTag> tags,
         GroupOptions groupOptions) =>
+#pragma warning restore S107
         new(
             sheet,
             RangeAxis.Range(sheet, axis.Slots(area, firstSlot, lastSlot)),

--- a/XLibur.Report/Tags/OptionTag.cs
+++ b/XLibur.Report/Tags/OptionTag.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using XLibur.Excel;
 using XLibur.Report.Expressions;
 
@@ -71,6 +71,7 @@ public abstract class OptionTag
 /// </summary>
 public sealed class ProcessingContext
 {
+#pragma warning disable S107 // One field per piece of processing state; a parameter object here is the same list behind a name
     internal ProcessingContext(
         IXLWorksheet worksheet,
         IXLRange generatedRange,
@@ -84,6 +85,7 @@ public sealed class ProcessingContext
         IReadOnlyList<OptionTag> tags,
         List<Rewriting.PivotRequest> pendingPivots,
         bool grandTotalsDisabled = false)
+#pragma warning restore S107
     {
         Tags = tags;
         PendingPivots = pendingPivots;

--- a/XLibur/Excel/CalcEngine/Functions/DynamicArray.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DynamicArray.cs
@@ -708,6 +708,7 @@ internal static class DynamicArray
             if (compare == 0)
                 return i;
 
+#pragma warning disable S1871 // The two arms are the two match modes; one condition would hide that
             if (matchMode == -1 && compare < 0 && (best == -1 || comparer.Compare(value, bestValue) > 0))
             {
                 best = i;
@@ -718,6 +719,7 @@ internal static class DynamicArray
                 best = i;
                 bestValue = value;
             }
+#pragma warning restore S1871
         }
 
         return best;

--- a/XLibur/Excel/CalcEngine/Functions/Financial.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Financial.cs
@@ -373,7 +373,9 @@ internal static class Financial
     /// for, so consecutive slices add up to the whole and a full-life run charges exactly
     /// <c>cost - salvage</c>.
     /// </summary>
+#pragma warning disable S107 // VDB takes seven arguments in Excel; the eighth is the calc context
     private static ScalarValue Vdb(CalcContext ctx, double cost, double salvage, double life, double startPeriod, double endPeriod, double factor, bool noSwitch)
+#pragma warning restore S107
     {
         if (startPeriod < 0 || endPeriod < startPeriod || endPeriod > life || cost < 0 || salvage > cost || factor <= 0)
             return XLError.NumberInvalid;

--- a/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -6,6 +6,11 @@ namespace XLibur.Excel.CalcEngine.Functions;
 /// <summary>
 /// A collection of adapter functions from a more a generic formula function to more specific ones.
 /// </summary>
+// S2234 is suppressed for the whole file. Every adapter forwards its locals arg0..argN-1 to a
+// Func<> whose own generic parameters the framework names arg1..argN, so the rule matches them by
+// name and reports a transposition that is not there. The calls are positionally correct and the
+// calc-engine tests over these functions cover it.
+#pragma warning disable S2234 // Func<> names its generics arg1..argN; our locals are arg0..argN-1
 internal static class SignatureAdapter
 {
     #region Signature adapters
@@ -1335,3 +1340,4 @@ internal static class SignatureAdapter
     }
     #endregion
 }
+#pragma warning restore S2234

--- a/XLibur/Excel/CalcEngine/Functions/Text.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Text.cs
@@ -168,6 +168,7 @@ internal static class Text
     /// mapping is applied unconditionally here, which is what makes DBCS(ASC(x)) an identity.
     /// </summary>
 #pragma warning disable S3776 // Half-width katakana recombination then a flat per-character mapping
+#pragma warning disable S127 // The extra i++ consumes the second half of a combining pair
     private static ScalarValue Dbcs(CalcContext ctx, string text)
     {
         const char dakuten = 'ﾞ';
@@ -211,6 +212,8 @@ internal static class Text
         return sb.ToString();
     }
 #pragma warning restore S3776
+
+#pragma warning restore S127
 
     /// <summary>
     /// The half-width to full-width katakana mapping, derived by running every full-width katakana

--- a/XLibur/Excel/Charts/XLChartAxis.cs
+++ b/XLibur/Excel/Charts/XLChartAxis.cs
@@ -176,6 +176,7 @@ internal sealed class XLChartAxis : IXLChartAxis
     /// Seeds the properties from an existing chart part without marking them as assigned, so that an
     /// axis nobody edited is never written back.
     /// </summary>
+#pragma warning disable S107 // One parameter per axis attribute read from the chart part
     internal void SeedLoaded(
         string? title,
         string? numberFormat,
@@ -188,6 +189,7 @@ internal sealed class XLChartAxis : IXLChartAxis
         XLAxisOrientation orientation,
         bool logScale,
         double logBase)
+#pragma warning restore S107
     {
         _title = title;
         _numberFormat = numberFormat;

--- a/XLibur/Excel/Charts/XLChartSeries.cs
+++ b/XLibur/Excel/Charts/XLChartSeries.cs
@@ -171,6 +171,7 @@ internal sealed class XLChartSeries : IXLChartSeries
     /// marking them as assigned by the caller. Values seeded this way are never written back, so a
     /// chart nobody edited keeps its original XML byte for byte.
     /// </summary>
+#pragma warning disable S107 // One parameter per series format attribute read from the chart part
     internal void SeedLoadedFormat(
         XLColor? fillColor,
         XLColor? lineColor,
@@ -180,6 +181,7 @@ internal sealed class XLChartSeries : IXLChartSeries
         XLColor? markerFillColor,
         bool smooth,
         bool useSecondaryAxis)
+#pragma warning restore S107
     {
         _fillColor = fillColor;
         _lineColor = lineColor;

--- a/XLibur/Excel/IO/DrawingPartReader.cs
+++ b/XLibur/Excel/IO/DrawingPartReader.cs
@@ -151,8 +151,10 @@ internal static class DrawingPartReader
             LoadGroupRecursive(nested, drawingsPart, ws, scaleX, scaleY, offsetX, offsetY);
     }
 
+#pragma warning disable S107 // One parameter per drawing anchor attribute
     private static void LoadGroupedPicture(Xdr.Picture pic, DrawingsPart drawingsPart, XLWorksheet ws,
         double scaleX, double scaleY, double offsetX, double offsetY, uint? groupId, long groupKey)
+#pragma warning restore S107
     {
         var embed = pic.BlipFill?.Blip?.Embed?.Value;
         if (embed == null)

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -24,6 +24,7 @@ internal static class WorksheetSheetDataReader
     /// <summary>
     /// Loop-invariant parameters for sheet data reading.
     /// </summary>
+#pragma warning disable S107 // One field per piece of sheet-read context
     internal readonly struct SheetDataReadContext(
         StylesheetData styles,
         XLWorksheet worksheet,
@@ -33,6 +34,7 @@ internal static class WorksheetSheetDataReader
         Dictionary<XLNumberFormatValue, XLDataType> numberDataTypeCache,
         bool use1904DateSystem,
         HashSet<uint>? dynamicArrayCmIndexes = null)
+#pragma warning restore S107
     {
         public readonly StylesheetData Styles = styles;
         public readonly XLWorksheet Worksheet = worksheet;
@@ -408,9 +410,11 @@ internal static class WorksheetSheetDataReader
         return new CellProperties(styleIndex, cellRef, dataType, showPhonetic, cellMetaIndex, valueMetaIndex, hasMisc);
     }
 
+#pragma warning disable S107 // One parameter per cell attribute read from sheetData
     private static void LoadCellContentXml(XmlReader reader, in SheetDataReadContext context,
         CellValues dataType, Point cellAddress, XLStyleValue cellStyleValue,
         XLWorksheet ws, XLCellsCollection cellsCollection, uint? cellMetaIndex)
+#pragma warning restore S107
     {
         // Positioned on the first child of <c> (an Element) or on </c> (an EndElement).
         var formula = IsMainElement(reader, "f")
@@ -551,9 +555,11 @@ internal static class WorksheetSheetDataReader
         return arrayFormula;
     }
 
+#pragma warning disable S107 // One parameter per data-table formula attribute
     private static XLCellFormula LoadDataTableFormulaXml(string refAttr, string? r1Attr, string? r2Attr,
         bool is2D, bool input1Deleted, bool input2Deleted, bool isRowDataTable,
         Point cellAddress, FormulaSlice formulaSlice)
+#pragma warning restore S107
     {
         var dataTableArea = Area.Parse(refAttr);
         var input1 = r1Attr is not null ? Point.Parse(r1Attr) : throw MissingRequiredAttr("r1");
@@ -746,10 +752,12 @@ internal static class WorksheetSheetDataReader
     /// bypassing <see cref="XLCell"/> allocation and <c>CalcEngine.MarkDirty</c>.
     /// An <see cref="XLCell"/> is only created for the rare rich-text shared-string path.
     /// </summary>
+#pragma warning disable S107 // One parameter per cell attribute needed to set the value
     internal static void SetCellValue(CellValues dataType, ReadOnlySpan<char> cellValue,
         XLCellsCollection cellsCollection, Point cellAddress, XLStyleValue cellStyleValue,
         XLWorksheet ws, SharedStringEntry[]? sharedStrings, bool inline,
         Dictionary<XLNumberFormatValue, XLDataType>? numberDataTypeCache = null)
+#pragma warning restore S107
     {
         // Number and SharedString are the bulk of any sheet and parse straight from the characters.
         // String keeps the text, so it materializes one either way. Error and Date are rare enough

--- a/XLibur/Excel/Streaming/XLStreamingWorkbook.cs
+++ b/XLibur/Excel/Streaming/XLStreamingWorkbook.cs
@@ -154,7 +154,9 @@ public sealed class XLStreamingWorkbook : IDisposable
     /// The writer interns the style's value at the point of use, so one instance can be
     /// reconfigured and handed to later rows without disturbing the rows already written.
     /// </remarks>
+#pragma warning disable CA1822 // Public API: making this static would break every caller
     public IXLStyle CreateStyle() => XLStyle.CreateEmptyStyle();
+#pragma warning restore CA1822
 
     /// <summary>
     /// Add a worksheet and make it the one being written. Any worksheet still open is completed


### PR DESCRIPTION
Stacked on #331. Last in the stack.

The 85 findings not worth fixing are recorded against the code, so they are not re-triaged from scratch the next time someone reads the report.

## 65 are test-only — scoped off in `.editorconfig`

One `.editorconfig` section for the four test projects, each rule carrying its reason, rather than 65 pragmas:

- **`CA1861` (58).** Wants inline array arguments hoisted into `static readonly` fields. In a test the array literal is the case under test and belongs beside its assertion; hoisting 58 of them trades readability for one avoided allocation per test run. Verified all 58 are in test projects before scoping it this way.
- **`TUnit0057` (4).** Wants an `AssemblyHookContext` parameter our hooks have no use for. Adding an unused parameter to silence an informational suggestion is worse than the suggestion.
- **`TUnitAssertions0016` (3).** Reads `Area` as a collection compared by reference. It is a `readonly struct : IEquatable<Area>, IEnumerable<Point>` with `Equals` and `GetHashCode`, so the premise does not hold; `IsEquivalentTo` would assert the point sequence rather than the area.

These fire only under SonarCloud analyzer configuration, not the normal build — `.editorconfig` severities are what SonarCloud reads.

## The rest are per-method pragmas

Matching the convention from `68487738` — per method, so a genuinely new violation is still reported:

- **`S107` (11).** OOXML readers, writers and context structs carrying one parameter per attribute. A parameter object renames the problem rather than solving it. **These locations were found by counting parameters, not taken from the export** — its line numbers predate the `WorksheetSheetDataReader` refactor and no longer point at the right methods. `S107` does not reproduce from the NuGet analyzer even with a `SonarLint.xml` supplying its threshold, so measurement was not an option here.
- **`S2234` (3).** Suppressed for `SignatureAdapter` as a whole rather than per method, because every adapter in the file trips the same false positive: `Func<>` names its generics `arg1..argN` while the locals are `arg0..argN-1`.
- **`S127` (2)** — two loops that advance the index deliberately. **`S1871` (1)** — the two XLOOKUP match-mode arms; one merged condition would hide that. **`CA1822` (1)** — the public `CreateStyle` that cannot become static without breaking callers, reversed in PR 4.

Build clean; full suite **24538 passed, 0 failed**.