### PR TITLE
docs(specs): shapes & text boxes, shared DrawingML infrastructure, picture styling

### DIFF
--- a/docs/specs/15-shapes-and-text-boxes.md
+++ b/docs/specs/15-shapes-and-text-boxes.md
@@ -1,0 +1,544 @@
+# Spec 15 — Shapes & Text Boxes (DrawingML `xdr:sp`)
+
+**Area:** Feature + Compatibility
+**Effort:** L (2–3 weeks, after spec 16)
+**Dependencies:** **Hard dependency on [spec 16](16-drawingml-infrastructure.md)** — the anchor
+factory, the shared `ShapePropertiesWriter`, the text-body primitives, and the XML change-set harness
+all come from there and must land first. Task 4 here modifies `PictureWriter.WriteDrawings`
+orchestration, so it conflicts with any in-flight work in `XLibur/Excel/IO/PictureWriter.cs`.
+**Status:** Proposed
+
+## Summary
+
+XLibur cannot create a drawing shape of any kind. `IXLPictures.Add` takes images only, `IXLCharts.Add`
+takes charts, and there is no third option — a caller who wants a floating text box, a callout, or an
+arrow on a worksheet has to drop out of XLibur and hand-write `xdr:sp` into the saved package. Shapes
+that already exist in a loaded file survive a round trip verbatim, but they are invisible to the model:
+their text cannot be read, let alone changed.
+
+This spec adds a first-class shape model — `ws.Shapes` — covering preset geometries that can carry
+text, with a text box being the rectangle preset. Shapes read from a file are loaded into the model and
+**patched in place** on save, so everything XLibur does not model (effects, 3-D, gradient fills,
+hyperlinks, adjust handles) keeps surviving untouched.
+
+## Decisions taken before writing this spec
+
+| Question | Decision | Consequence |
+|---|---|---|
+| Object-model width | **Preset shapes, all text-capable**; text box is the rectangle preset | One writer, one anchor path, no breaking rename when ellipses/callouts arrive |
+| Existing shapes in loaded files | **Read into the model and patch in place** (spec 10's chart approach) | Highest fidelity; needs dirty-tracking and its own fixture corpus |
+| Text content model | **Paragraph-aware** (`IXLTextBody` → paragraphs → runs), not `IXLRichText` | True mapping of `a:txBody`; per-paragraph alignment expressible; a second rich-text-shaped model to maintain |
+| Formatting depth in v1 | **Core set** — solid/no fill, line colour/width/dash, run fonts, horizontal + vertical alignment, wrap, picture-style anchoring | Rotation, auto-fit, insets, gradients, shadows deferred (see [Out of scope](#out-of-scope-for-v1)) |
+| Shared infrastructure (2026-08-01 review) | **Split into [spec 16](16-drawingml-infrastructure.md)**, landing first; property-layer extraction is **full** (setters move, value-only signatures), not primitives-only | This spec consumes; it does not refactor `ChartFormatting`/`AddPictureAnchor` itself |
+| Run font API (2026-08-01 review) | **Narrow `IXLShapeTextFont`**, not `IXLFontBase` — the spreadsheet-font contract has members (`Shadow`, `FontFamilyNumbering`, `FontCharSet`, `FontScheme`, accounting underlines) with no clean `a:rPr` mapping | Honest per-property assignment tracking; not the familiar base type cells/comments use |
+| Creation defaults (2026-08-01 review) | **Mirror Excel's authored XML** — capture from fixtures, emit as static boilerplate | New shapes look native in Excel; slightly more writer output |
+| Spec-16 review follow-ups (2026-08-01) | Text-body primitives are extracted **here, in task 2** (not in 16 — abstraction shaped by the real consumer); task 3 **extends** the shared layer with `a:noFill`/`a:prstDash`, operations charts never perform | 16 stays strictly behaviour-preserving; the new operations are gated by this spec's change-set tests |
+
+## Current state
+
+Verified against the tree at `dfd5f49b` (2026-08-01).
+
+**No creation path.**
+- `XLibur/Excel/Drawings/IXLPictures.cs:10-20` — six `Add` overloads, all image sources.
+- `XLibur/Excel/Drawings/IXLDrawing.cs` — despite the general name, `IXLDrawing<T>` is the **VML**
+  styling model for comments/notes (`XLibur/Excel/IO/VmlDrawingPartWriter.cs:160`,
+  `DrawingPartReader.LoadTextBox` at `DrawingPartReader.cs:283`). It has nothing to do with DrawingML
+  and must not be extended to cover worksheet shapes.
+- `IXLWorksheet` exposes `Charts` (`XLibur/Excel/IXLWorksheet.cs:393`) and `Pictures` (line 536). No
+  third drawing collection.
+
+**Existing shapes are preserved but opaque.**
+- Read: `DrawingPartReader.LoadDrawings` (`DrawingPartReader.cs:55-88`) walks
+  `WorksheetDrawing.ChildElements`; an anchor with no image rel id is skipped outright
+  (`DrawingPartReader.cs:74-77`, comment: *"we're probably dealing with a TextBox (or another shape)"*).
+- Save: `PictureWriter.RemoveEmptyDrawingPart` (`PictureWriter.cs:127-148`) deliberately keeps the
+  DrawingsPart alive when `WorksheetDrawing.HasChildren`, precisely so non-picture shapes are not
+  dropped. Save reopens the original package and rewrites only modelled parts, so the shape XML is
+  carried through unmodified (the mechanism `docs/round-trip-fidelity.md` documents).
+- Regression coverage exists: `XLibur.Tests/Excel/Drawings/PictureTests.cs:41-69` loads
+  `TryToLoad/textbox_shapemissing_onload_2377.xlsx` and asserts the `OneCellAnchor` and its `TEXTBOX`
+  text survive save. **This test must stay green** — it is the contract this spec must not regress.
+
+**The anchor machinery already exists and is reusable.**
+- `PictureWriter.AddPictureAnchor` (`PictureWriter.cs:197-391`) builds all three anchor forms —
+  `AbsoluteAnchor` (FreeFloating), `TwoCellAnchor` (MoveAndSize), `OneCellAnchor` (Move) — from
+  `XLPicturePlacement` plus pixel geometry, converting through `ConvertToEnglishMetricUnits`. The
+  marker/extent construction is identical for a shape; only the `xdr:pic` child differs.
+- Non-visual drawing property ids are allocated as `max(existing) + 1` (`PictureWriter.cs:236-239`).
+- `RebaseNonVisualDrawingPropertiesIds` (`PictureWriter.cs:755`) renumbers every id in the drawing. It
+  is already skipped when the drawing contains a group shape, because renumbering breaks connector
+  `a:stCxn/@id` references (`PictureWriter.cs:33-38`). The same hazard applies to shapes.
+
+**Precedent to copy for patch-in-place.**
+`XLibur/Excel/IO/ChartPatcher.cs:11-31` states the contract spec 10 settled on: XLibur never regenerates
+XML it read, edits are patched into the loaded DOM, and only properties the caller actually assigned are
+written (`XLChartSeries.AssignedFormat`, `XLChartSeries.cs:156-198`). Chart formatting properties are
+nullable — `XLColor? FillColor`, `double? LineWidthPt` (`IXLChartSeries.cs:51-67`) — with null meaning
+"not assigned, don't emit". Shapes follow the same two rules.
+
+## OOXML background
+
+A shape anchor holds an `xdr:sp` instead of an `xdr:pic`:
+
+```xml
+<xdr:twoCellAnchor>
+  <xdr:from>…</xdr:from><xdr:to>…</xdr:to>
+  <xdr:sp macro="" textlink="">
+    <xdr:nvSpPr>
+      <xdr:cNvPr id="2" name="TextBox 1"/>
+      <xdr:cNvSpPr txBox="1"/>            <!-- txBox="1" marks it a text box -->
+    </xdr:nvSpPr>
+    <xdr:spPr>
+      <a:xfrm><a:off x="0" y="0"/><a:ext cx="1905000" cy="571500"/></a:xfrm>
+      <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+      <a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>   <!-- or <a:noFill/> -->
+      <a:ln w="9525"><a:solidFill><a:srgbClr val="000000"/></a:solidFill>
+                     <a:prstDash val="dash"/></a:ln>
+    </xdr:spPr>
+    <xdr:txBody>
+      <a:bodyPr vertOverflow="clip" wrap="square" anchor="ctr" rtlCol="0"/>
+      <a:lstStyle/>
+      <a:p>
+        <a:pPr algn="ctr"/>
+        <a:r><a:rPr lang="en-US" sz="1100" b="1"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>
+             <a:latin typeface="Calibri"/></a:rPr><a:t>Hello</a:t></a:r>
+      </a:p>
+    </xdr:txBody>
+  </xdr:sp>
+  <xdr:clientData/>
+</xdr:twoCellAnchor>
+```
+
+Points that drive the design:
+
+- **A text box is not a distinct element.** It is `prstGeom prst="rect"` plus `cNvSpPr/@txBox="1"`.
+  Excel's Insert ▸ Text Box writes exactly that, and also defaults to `<a:noFill/>` on `spPr` for
+  *shapes* but a white fill for text boxes drawn from the ribbon — the writer must emit explicitly what
+  the model says rather than relying on defaults, because theme style inheritance (`xdr:style`) is not
+  modelled.
+- **Geometry lives in two places.** The anchor (`from`/`to` markers, or `pos`/`ext`) positions the shape
+  on the sheet; `spPr/a:xfrm` positions it in the shape's own space. For an ungrouped shape Excel writes
+  `off x=0 y=0` and `ext` equal to the anchor extent — mirroring what `AddPictureAnchor` already does
+  for pictures (`PictureWriter.cs:269-275`).
+- **Text formatting is per-run**, in `a:rPr` — a DrawingML font description (`sz` in hundredths of a
+  point, `b`/`i`/`u`, `a:solidFill`, `a:latin typeface`), *not* the spreadsheet `<font>` element.
+  Comments reuse `IXLFontBase` legitimately because comment rich text uses the spreadsheet font
+  schema; `a:rPr` does not, which is why runs get their own narrow font interface (below) instead.
+- **`a:ln/@w` is EMU**, not points: `w = pt * 12700`.
+- **`a:prstDash` values** (`solid`, `dot`, `dash`, `lgDash`, `dashDot`, `lgDashDot`, `lgDashDotDot`,
+  `sysDash`, `sysDot`, `sysDashDot`, `sysDashDotDot`) are DrawingML's own set. The existing
+  `XLDashStyle`/`XLLineStyle` enums are **VML** enums used by comment styling
+  (`EnumConverter.cs:359-366`, `PublicAPI.Shipped.txt:662-674`); reusing them would force a lossy
+  round trip. This spec adds `XLLineDashStyle` mapping 1:1 onto `a:prstDash`.
+
+## Design
+
+### Public surface
+
+New folder `XLibur/Excel/Drawings/Shapes/`. Everything below goes into `PublicAPI.Unshipped.txt`.
+
+```csharp
+// Collection — reachable as IXLWorksheet.Shapes
+public interface IXLShapes : IEnumerable<IXLShape>
+{
+    int Count { get; }
+
+    IXLTextBox AddTextBox(string text, IXLCell topLeft);
+    IXLTextBox AddTextBox(string text, int left, int top);        // free-floating, pixels
+    IXLShape   Add(XLShapeType type, IXLCell topLeft);
+    IXLShape   Add(XLShapeType type, int left, int top);
+    IXLShape   AddPreset(string presetGeometry, IXLCell topLeft); // escape hatch: raw a:prstGeom/@prst
+
+    IXLShape Shape(string name);
+    bool TryGetShape(string name, out IXLShape? shape);
+    bool Contains(string name);
+    void Delete(string name);
+    void Delete(IXLShape shape);
+}
+
+public interface IXLShape
+{
+    int Id { get; }                       // xdr:cNvPr/@id
+    string Name { get; set; }
+    XLShapeType ShapeType { get; }
+    string PresetGeometry { get; }        // the raw prst value, for shapes added via AddPreset
+    IXLWorksheet Worksheet { get; }
+
+    // Geometry — pixels, matching IXLPicture
+    int Left { get; set; }
+    int Top { get; set; }
+    int Width { get; set; }
+    int Height { get; set; }
+    XLPicturePlacement Placement { get; set; }
+    IXLCell TopLeftCell { get; }
+    IXLCell BottomRightCell { get; }
+
+    // Core formatting — null means "not assigned, leave whatever is in the file"
+    XLColor? FillColor { get; set; }
+    bool NoFill { get; set; }
+    XLColor? LineColor { get; set; }
+    double? LineWidthPt { get; set; }
+    XLLineDashStyle? LineDash { get; set; }
+    bool NoLine { get; set; }
+
+    IXLTextBody TextBody { get; }
+
+    IXLShape MoveTo(int left, int top);
+    IXLShape MoveTo(IXLCell cell);
+    IXLShape MoveTo(IXLCell cell, int xOffset, int yOffset);
+    IXLShape MoveTo(IXLCell fromCell, IXLCell toCell);
+    IXLShape WithSize(int width, int height);
+    IXLShape WithPlacement(XLPicturePlacement value);
+    void Delete();
+}
+
+/// <summary>A shape whose geometry is <c>rect</c> and whose <c>cNvSpPr/@txBox</c> is 1.</summary>
+public interface IXLTextBox : IXLShape
+{
+    /// <summary>Whole-body text; paragraphs joined by <c>\n</c>. Setting it replaces the body.</summary>
+    string Text { get; set; }
+}
+```
+
+Text body, paragraph-aware:
+
+```csharp
+public interface IXLTextBody : IEnumerable<IXLTextParagraph>
+{
+    int Count { get; }
+    IXLTextParagraph this[int index] { get; }
+    IXLTextParagraph AddParagraph(string text = "");
+    void Clear();
+
+    string Text { get; set; }                          // convenience over the paragraph list
+    XLTextVerticalAlignment VerticalAlignment { get; set; }   // a:bodyPr/@anchor
+    bool WrapText { get; set; }                               // a:bodyPr/@wrap (square | none)
+}
+
+public interface IXLTextParagraph : IEnumerable<IXLTextRun>
+{
+    XLTextAlignment Alignment { get; set; }            // a:pPr/@algn — l | ctr | r | just | dist
+    IXLTextRun AddText(string text);                   // returns the run, so formatting chains
+    string Text { get; }                               // concatenated run text
+    int Count { get; }
+    IXLTextRun this[int index] { get; }
+}
+
+/// <summary>
+/// Font properties of a DrawingML text run. Deliberately narrower than <see cref="IXLFontBase"/>:
+/// every member here maps cleanly onto <c>a:rPr</c>, and nothing is promised that DrawingML cannot
+/// express (no <c>Shadow</c> bool, no accounting underlines, no <c>FontFamilyNumbering</c>/
+/// <c>FontCharSet</c>/<c>FontScheme</c>). All nullable: null = not assigned, inherit/preserve.
+/// </summary>
+public interface IXLShapeTextFont
+{
+    bool? Bold { get; set; }                           // a:rPr/@b
+    bool? Italic { get; set; }                         // a:rPr/@i
+    XLShapeTextUnderline? Underline { get; set; }      // a:rPr/@u — None | Single | Double
+    bool? Strikethrough { get; set; }                  // a:rPr/@strike
+    double? FontSize { get; set; }                     // a:rPr/@sz, hundredths of a point in XML
+    XLColor? FontColor { get; set; }                   // a:rPr/a:solidFill
+    string? FontName { get; set; }                     // a:rPr/a:latin/@typeface
+}
+
+public interface IXLTextRun : IXLShapeTextFont
+{
+    string Text { get; set; }
+    IXLTextRun SetBold(bool value = true);             // fluent setters mirroring the properties
+    IXLTextRun SetItalic(bool value = true);
+    IXLTextRun SetFontSize(double value);
+    IXLTextRun SetFontColor(XLColor value);
+    IXLTextRun SetFontName(string value);
+}
+```
+
+New enums: `XLShapeType` (curated: `TextBox`, `Rectangle`, `RoundedRectangle`, `Ellipse`, `Triangle`,
+`RightArrow`, `LeftArrow`, `UpArrow`, `DownArrow`, `Line`, `RoundedCallout`, `WedgeRectCallout`,
+`Diamond`, `Pentagon`, `Chevron`, `Star5`, `Can`, `Cloud`, `Custom`), `XLLineDashStyle`,
+`XLTextAlignment`, `XLTextVerticalAlignment`, `XLShapeTextUnderline`.
+
+Name semantics follow `XLPictures` exactly: lookups are case-insensitive, `Delete(string)` removes
+*all* matches, and names are not required to be unique — loaded files legitimately contain duplicates
+(Excel permits them; copy-paste produces them). `Shape(name)` returns the first match in drawing
+order; code that needs a specific shape among duplicates enumerates and matches on `Id`.
+
+Usage:
+
+```csharp
+ws.Shapes.AddTextBox("Draft — do not circulate", ws.Cell("B2"))
+         .WithSize(220, 60);
+
+var callout = ws.Shapes.Add(XLShapeType.WedgeRectCallout, ws.Cell("E4"));
+callout.FillColor = XLColor.LightYellow;
+callout.LineColor = XLColor.Black;
+callout.LineWidthPt = 1.5;
+callout.TextBody.VerticalAlignment = XLTextVerticalAlignment.Center;
+var p = callout.TextBody.AddParagraph();
+p.Alignment = XLTextAlignment.Center;
+p.AddText("Revised ").SetBold();
+p.AddText("2026-08-01");
+```
+
+### Design rules
+
+1. **`XLPicturePlacement` is reused, not duplicated — for creation.** The three placements map to
+   exactly the same three anchor forms, and a parallel `XLShapePlacement` with identical members would
+   be a second name for one concept. The type name is a wart inherited from the picture API; it is not
+   worth a breaking rename. Document it on `IXLShape.Placement`. Two limits, both consequences of
+   patch-in-place: (a) on read, the anchor form maps to a placement the way `LoadPicturePlacement`
+   does for pictures (`DrawingPartReader.cs:524-543`), but `twoCellAnchor/@editAs`
+   (`oneCell`/`absolute`) has no representation in the enum and is simply preserved untouched; (b)
+   **setting `Placement` on a loaded shape throws `NotSupportedException` in v1** — changing placement
+   means replacing the anchor *element type*, which is anchor regeneration, not patching, and would
+   discard `editAs` and anything else on the anchor XLibur does not model. Geometry edits stay within
+   the existing anchor form.
+2. **Null means unassigned.** Following `IXLChartSeries`, a `null` formatting property is never written.
+   A shape loaded from a file whose fill nobody touched keeps whatever fill XML it had — including
+   gradients and pictures fills this spec does not model. `NoFill`/`NoLine` are the explicit way to say
+   "remove it".
+3. **Assignment is tracked, per property.** `XLShape` carries an `AssignedProperties` flags enum, set by
+   the setters, mirroring `XLChartSeries.AssignedFormat`. The patcher writes only flagged properties.
+   A shape nobody edited is not touched at all.
+4. **New shapes are generated; loaded shapes are patched.** Never regenerate a loaded `xdr:sp`.
+5. **`AddPreset` is the escape hatch.** DrawingML has ~190 preset geometries; the enum covers the ones
+   people ask for and `AddPreset("moon")` covers the rest. `ShapeType` reads back `Custom` for those,
+   with the raw string on `PresetGeometry`.
+6. **Text boxes are shapes.** `AddTextBox` is `Add(XLShapeType.TextBox, …)` plus `txBox="1"`;
+   `IXLTextBox` adds only the `Text` convenience. A shape loaded with `txBox="1"` materialises as
+   `IXLTextBox`.
+7. **Creation defaults mirror Excel's own authored XML.** "Null is never written" governs *edits to
+   loaded shapes*; a *new* shape with nothing assigned must not emit bare `prstGeom` — with no fill,
+   no line and no `xdr:style`, rendering is renderer-defined and the shape can be invisible. Instead
+   the writer emits, as static boilerplate captured from Excel-authored fixtures: for **text boxes**,
+   what Insert ▸ Text Box writes (white/`lt1` fill, thin black line, plus its `xdr:style` block); for
+   **preset shapes**, the ribbon's default (`xdr:style` referencing theme accent1 fills/lines, no
+   explicit fill in `spPr`). The exact XML is copied from the fixture during task 4, not paraphrased
+   from memory. Assigned properties then override the boilerplate through the normal path. Model
+   read-back of an untouched new shape reports the defaults as unassigned (`null`), matching how a
+   theme-styled loaded shape reads.
+8. **Edit granularity matches model granularity.** Every setter mutates the narrowest element that
+   holds its value and touches nothing else: `IXLTextRun.Text` rewrites `a:t` and leaves that run's
+   `a:rPr` (theme font, `lang`, per-run effects) exactly as it was; `IXLTextParagraph.Alignment` writes
+   `a:pPr/@algn` and no sibling; `LineWidthPt` sets `a:ln/@w` on the *existing* `a:ln`, keeping its
+   `a:headEnd`/`a:tailEnd`/`a:miter` children. Only `IXLTextBody.Text` (the wholesale setter) and
+   `Clear()` rebuild the paragraph list, and both are documented as destructive — that is what the
+   caller asked for. This rule is what makes [failure mode 2](#the-three-ways-patching-loses-data)
+   impossible by construction rather than by test, and it is the rule that has to hold as v2 adds
+   rotation, insets and effects. (Referenced below as "design rule 8".)
+9. **DrawingML property writes go through the shared layer.** Shapes do not get their own copy of
+   fill/line/ordering logic (spec 16's `ShapePropertiesWriter`, extended by task 3), and text edits go
+   through the `TextBodyPrimitives` task 2 extracts (`endParaRPr` stays last, `rPr`-preserving run
+   replacement). Shape code never manipulates `spPr` children or `a:p` run-level structure directly.
+10. **Save never touches a clean drawing.** The OpenXML SDK re-serializes a part merely because its DOM
+   was materialised — stated in the codebase itself at `PictureWriter.cs:138-140`. So on save, if a
+   sheet has no added, edited or deleted shape, shape code must not access `WorksheetDrawing` at all;
+   the part passes through byte-identical. This also improves the current behaviour:
+   `RemoveEmptyDrawingPart` today probes `WorksheetDrawing.HasChildren` even on shape-only sheets, and
+   with shapes modelled, `Shapes.Count > 0` short-circuits that probe before it can materialise the
+   DOM.
+
+### The three ways patching loses data
+
+Patch-in-place buys fidelity, and the whole of it can be given back by a careless writer. Naming the
+failure modes, because tasks 4–7 exist to close them and acceptance criterion 3 exists to prove it:
+
+1. **Sibling loss.** Edit the text, lose the shadow. Cheap to avoid — a patcher that only touches
+   assigned properties never goes near `spPr` when the edit was to `txBody` — and correspondingly cheap
+   to *test*, which is the trap: a naive implementation passes a sibling-level assertion. This is the
+   least of the three and must not be mistaken for the gate.
+2. **In-place loss.** The damage happens inside the element being edited: rebuilding an `a:p` to change
+   a word discards the run's `a:rPr`; rebuilding `a:ln` to set a width drops the arrowheads that were
+   inside it. Design rule 8 is the answer; no sibling-level test detects it.
+3. **Structural invalidity.** `CT_ShapeProperties` is a *sequence* (`a:xfrm`, geometry, fill, `a:ln`,
+   `a:effectLst`, 3-D, `a:extLst`) and the SDK does not reorder children on `Append`. Fills are a
+   *choice* group, so setting a colour over an `a:gradFill` means replacing it, not adding beside it.
+   Get either wrong and Excel shows a repair prompt. `validate: true` (criterion 5) catches most of it.
+
+### The shared DrawingML layer (spec 16)
+
+All three failure modes are already solved once in the codebase, in chart-specific form, and
+**[spec 16](16-drawingml-infrastructure.md) extracts the property layer before this spec starts**: the
+fill/outline/ordering logic from `ChartFormatting.cs:1251-1348` (plus `BuildColor`/`MapSchemeColor`,
+which already write theme colours) becomes `DrawingML/ShapePropertiesWriter` — fills as a choice
+group, `a:ln` mutated in place, sequence order via `InsertAfterLastOf` and its predicates;
+`xdr:sp/spPr` and a chart's `c:spPr` are the same schema type, `a:CT_ShapeProperties`. The layer takes
+plain values, never flags masks — this spec's `AssignedProperties` enum stays in its own patcher,
+which decides *whether* to write; the layer decides *how*.
+
+Two pieces deliberately land in *this* spec, not 16:
+
+- **Text-body primitives (task 2).** The paragraph-editing rules inside `SetRichText`
+  (`ChartFormatting.cs:257-287` — `rPr`-preserving run replacement, `endParaRPr`-stays-last,
+  `IsRunLevel`) are extracted into `DrawingML/TextBodyPrimitives` here, where their second consumer
+  actually exists to shape the abstraction; the chart title path is moved onto them in the same PR,
+  with the chart tests still gating.
+- **New operations (task 3).** Charts never emit an explicit `a:noFill` and never write `a:prstDash`,
+  so `NoFill`/`NoLine`/`LineDash` are *extensions* of the shared layer, not extractions — added here
+  under this spec's change-set tests, keeping 16 strictly behaviour-preserving. (Shared with
+  [spec 17](17-picture-styling.md), which needs the same two operations and the `XLLineDashStyle`
+  enum for picture borders — whichever spec lands first adds them, the other rebases.)
+
+### Read path
+
+New `XLibur/Excel/IO/ShapeReader.cs`, called from `DrawingPartReader.LoadDrawings` at the point where
+the `imgId == null` branch currently `continue`s (`DrawingPartReader.cs:74-77`):
+
+- Anchor contains `xdr:sp` → build an `XLShape`, capture geometry from the anchor (markers/extent →
+  pixels), preset from `spPr/a:prstGeom/@prst`, `txBox` flag, fill/line where they are the simple forms
+  this spec models (`a:solidFill` holding `a:srgbClr` *or* `a:schemeClr`, `a:noFill`, `a:ln` with
+  `w`/`prstDash`), and the text body from `a:txBody`. Anything else — theme colours, gradients, effects — is left unread and unflagged, so
+  it is preserved by rule 2.
+- **The shape must record its identity, not a DOM handle.** The load package is disposed when
+  `LoadSheets` returns (`XLibur/Excel/XLWorkbook_Load.cs:37`) and save *reopens* the package
+  (`docs/round-trip-fidelity.md:11`), so an `OpenXmlElement` captured at read time is attached to a
+  closed package and is useless to the patcher. `XLShape` therefore stores the `cNvPr/@id` it was read
+  with, and `ShapePatcher` re-locates the `xdr:sp` in the reopened drawing by that id — the same way
+  `ChartPatcher.ResolvePart` and `PictureWriter.GetAnchorFromImageId` re-find their targets. This makes
+  id stability load-bearing, which is a second reason the rebase guard below is not optional.
+- **Duplicate ids make a shape read-only.** The schema requires `cNvPr/@id` uniqueness per drawing,
+  but real files (copy-paste bugs, other producers) violate it, and an id-keyed patcher would then
+  edit the wrong shape. On load, if an id occurs more than once, every shape carrying it is loaded
+  for reading but marked unpatchable: any setter on it throws `InvalidOperationException` naming the
+  duplicate id. Deleting such a shape is also refused. Rare, explicit, and safe beats silently
+  corrupting someone's drawing.
+- On read, the anchor form maps to a `Placement` exactly as `LoadPicturePlacement` does for pictures
+  (`DrawingPartReader.cs:524-543`); `editAs` and other unmodelled anchor attributes are untouched.
+- Nothing is re-serialized on read; `WorksheetDrawing` is already materialised for every sheet with a
+  drawing part today.
+- Anchors holding `xdr:cxnSp` (connectors), `xdr:graphicFrame`, or `xdr:grpSp` keep the current
+  behaviour: not loaded, preserved verbatim. Shapes *inside* a group are out of scope for v1 (as
+  grouped pictures were, initially).
+
+### Write path
+
+New `XLibur/Excel/IO/ShapeWriter.cs` + `ShapePatcher.cs`, orchestrated from `PictureWriter.WriteDrawings`
+(renaming that entry point to `DrawingWriter.WriteDrawings` is optional; keep the call order —
+deletions, then pictures, then shapes, then `RemoveEmptyDrawingPart`).
+
+- **Clean sheets are never touched** (design rule 10): the shape pass runs only when the sheet has an
+  added, edited or deleted shape, so an unedited drawing part passes through byte-identical.
+- **New shapes** (no loaded id): build the anchor via spec 16's `DrawingAnchorFactory`, append
+  `xdr:sp` with the Excel-mirroring boilerplate of rule 7, allocate the id as `max(existing) + 1`.
+  Assigned properties are then written by the *same* shared layer the patcher uses, so there is one
+  implementation of "write a fill", not two.
+- **Loaded shapes**: `ShapePatcher` re-locates the `xdr:sp` by its recorded id and writes only assigned
+  properties — geometry into the anchor markers and `a:xfrm`, fill/line through spec 16's
+  `ShapePropertiesWriter`, and text at run/paragraph granularity per design rule 8 using the
+  text-body primitives. A body is rebuilt only when `IXLTextBody.Text` or `Clear()` was called.
+- **Deleted shapes**: remove the whole anchor, matching `ProcessDeletedPicturesAndGroups`.
+- An empty text body is written the way Excel writes it — `a:bodyPr`, `a:lstStyle`, and one `a:p`
+  holding only an `a:endParaRPr` — never omitted and never an `a:p` with a zero-length run.
+- **`RebaseNonVisualDrawingPropertiesIds` must not run when the drawing contains any `xdr:sp`.** The
+  existing guard (`PictureWriter.cs:33-38`) only checks for group shapes; extend it. Renumbering ids
+  under a connector that references a shape by id produces a file Excel repairs.
+- `RemoveEmptyDrawingPart` gains `xlWorksheet.Shapes.Count == 0` to its condition, and the DrawingsPart
+  is created on demand for a sheet whose first drawing is a shape.
+
+### Where the model lives
+
+`XLWorksheet` gains `Shapes` alongside `Pictures`/`Charts`, constructed in the same place, backed by
+`XLShapes : IXLShapes` holding a `List<XLShape>` plus a `Deleted` list — the `XLPictures` shape exactly
+(`XLibur/Excel/Drawings/XLPictures.cs:10-41`). Shapes take no part in row/column shifting in v1, matching
+pictures.
+
+## Work plan
+
+Spec 16 (anchor factory, `ShapePropertiesWriter`, text-body primitives, change-set harness) is a
+prerequisite for everything below and is planned separately.
+
+| # | Task | Size | Depends on |
+|---|------|------|-----------|
+| 1 | **Model + collection**: `IXLShape`, `IXLShapes`, `IXLTextBox`, `XLShapeType`, `XLLineDashStyle`, `IXLShapeTextFont`, geometry/placement, `ws.Shapes` wiring, public API files. No IO. | M | — |
+| 2 | **Text body model + primitives extraction**: `IXLTextBody`/`IXLTextParagraph`/`IXLTextRun` + `a:txBody` ⇄ model mapping (`a:rPr` ⇄ `IXLShapeTextFont`, `sz` in 1/100 pt, `a:latin`), run/paragraph-granular writes per design rule 8. Extracts `DrawingML/TextBodyPrimitives` from `SetRichText` (`ChartFormatting.cs:257-287`) and moves the chart title path onto them in the same PR — chart tests and spec 16's goldens gate the move. | M | 1 |
+| 3 | **Core formatting**: map fill, line, alignment and wrap onto spec 16's `ShapePropertiesWriter`, plus the assigned-property flags; **extend** the layer with the operations charts never perform — explicit `a:noFill` emission and `a:prstDash` — under this spec's change-set tests. | S–M | 1 |
+| 4 | **`ShapeWriter`** for new shapes + save orchestration (drawing part creation, Excel-mirroring creation boilerplate from fixtures, id allocation, rebase guard, `RemoveEmptyDrawingPart` short-circuit, clean-sheet no-touch rule). | M | 1, 2, 3 |
+| 5 | **`ShapeReader`** — load `xdr:sp` anchors into the model, recording each shape's `cNvPr/@id` for re-location, anchor-form → `Placement` mapping, duplicate-id read-only marking. | M | 1, 2, 3 |
+| 6 | **`ShapePatcher`** — assigned-property-only writes into loaded shapes, re-located by id. | M | 4, 5 |
+| 7 | **Tests + fixture corpus** (see acceptance criteria), built on spec 16's harness. Excel-authored fixtures into `XLibur.Tests/Resource/`. | M | 4, 5, 6 |
+| 8 | **Docs**: a `docs-website/docs/shapes.md` page, and an update to `docs/round-trip-fidelity.md` recording that shapes are now modelled and what still passes through opaquely. | S | 7 |
+
+Parallelisation: tasks 1/2/3 are one workstream, splittable by interface boundary. Tasks 4 and 5 are
+independent of each other once 1–3 land; 6 needs both.
+
+## Acceptance criteria
+
+1. `ws.Shapes.AddTextBox("Hello", ws.Cell("B2")).WithSize(200, 60)` on a new workbook produces a file
+   that **Excel 365 opens with no repair prompt** (manual check recorded in the PR), showing the text at
+   the specified geometry.
+2. Every member of `XLShapeType` can be added, saved, reloaded by XLibur, and reads back with its type,
+   geometry, fill, line and text intact — as a data-driven test over the enum.
+3. **Fidelity under edit** — three tiers on spec 16's change-set harness. Tiers 2–3 are stated in
+   *canonical* terms, not bytes, deliberately: materialising a part's DOM re-serializes it even with no
+   modifications (`PictureWriter.cs:138-140`), so once one shape on a sheet is patched, the whole part
+   is rewritten and only canonical comparison is meaningful. Tier 1 alone demands bytes, which design
+   rule 10 makes achievable. Tier 3 is the one with teeth; tiers 1 and 2 are passed by implementations
+   that fail tier 3.
+   1. *Untouched.* Load an Excel-authored fixture with a gradient-filled, shadowed, rotated text box and
+      save without edits → drawing part **byte-identical** (the clean-sheet no-touch rule).
+   2. *Cross-area edit.* Change the text only → the canonical change set inside `spPr` is **empty**:
+      gradient, shadow and rotation all still present and untouched.
+   3. *In-area edit* — change set equals *exactly* the intended nodes; nothing else added, dropped or
+      reordered. (a) Change one run's text → that run's `a:rPr` is unchanged and its sibling runs are
+      untouched. (b) Set `FillColor` on the gradient-filled shape → the `a:gradFill` is *replaced*, not
+      duplicated or left beside the new `a:solidFill`; `a:ln` and `a:effectLst` are unchanged; the
+      `spPr` child order is still schema-valid. (c) Set `LineWidthPt` on a shape whose `a:ln` carries
+      arrowheads → `a:headEnd`/`a:tailEnd` survive.
+4. **No regression**: full suite green on net8.0/net9.0/net10.0, and
+   `XLibur.Tests/Excel/Drawings/PictureTests.cs:41-69` still passes unmodified — an untouched text box
+   in a loaded file still round-trips with its anchor and text intact (that test asserts structure and
+   `InnerText`, not bytes; the byte-level guarantee is tier 1 above).
+5. Saving with `validate: true` produces zero schema errors for every shape the API can emit, including
+   `AddPreset` with an arbitrary valid `prst` value.
+6. A drawing containing a connector that references shapes by id round-trips with those ids unchanged
+   (the rebase guard).
+7. **No cost when unused**: the write benchmark on a workbook with no shapes shows no time or
+   allocation regression beyond noise; on a loaded workbook whose shapes nobody edited, no sheet's
+   `WorksheetDrawing` DOM is materialised by shape code (design rule 10) and the drawing parts pass
+   through byte-identical. Sheets where one shape *was* edited re-serialize as a whole; the unedited
+   sibling shapes on them are asserted canonically identical, not byte-identical.
+8. Every new shape the API creates carries the Excel-mirroring boilerplate of rule 7 — verified by
+   comparing a created text box and a created preset shape against their Excel-authored fixture
+   counterparts on the harness, with only geometry, ids and text expected to differ.
+
+## Risks
+
+- **Excel's tolerance for a hand-built `xdr:sp` is narrower than for `xdr:pic`.** `xdr:txBody` without
+  `a:bodyPr` triggers a repair prompt in some builds. (An `a:p` with no run is fine — it is what Excel
+  itself writes for an empty body, closed by `a:endParaRPr`; see the write path.) The gate is the
+  manual open-in-Excel check; mirror byte-for-byte what Excel writes for a freshly inserted text box
+  (author a fixture, inspect the part, copy its element order and attribute set — rule 7 makes this
+  the source of the creation boilerplate anyway).
+- **Theme-derived formatting.** Excel writes an `xdr:style` block referencing theme fills/lines for
+  ribbon-inserted shapes. This spec neither reads nor writes `xdr:style`, so a shape whose colour
+  comes only from it reports `FillColor == null`. Setting `FillColor` writes an explicit
+  `a:solidFill` into `spPr`, which correctly wins over `xdr:style` — and theme *values* are fine on
+  the write side, since the layer's `BuildColor` already emits `a:schemeClr` for
+  `XLColorType.Theme`. The reader should likewise read `a:solidFill/a:schemeClr` in `spPr` as a
+  theme `XLColor`, not just `srgbClr`; the remaining asymmetry (style-block-only colours read as
+  null) needs documenting.
+- **Text measurement.** Nothing auto-sizes: a shape is exactly the extent it was given, and long text
+  overflows or clips per `wrap`. `SixLabors.Fonts` could measure it, but auto-fit is deferred (and the
+  library must not be upgraded — see `CLAUDE.md`).
+- **Id collisions in real files.** Patching is keyed on `cNvPr/@id`; duplicates (illegal but seen in
+  the wild) are handled by the read-only marking in the read path, but the detection itself must be
+  cheap — one pass over loaded ids per sheet, no DOM re-walk at save time.
+- **Mixed picture+shape sheets change picture behaviour subtly.** Extending the rebase guard means
+  sheets holding both a picture and a shape no longer get their nvPr ids renumbered on save (today
+  they do — the guard only checks for group shapes). This is a fix, not a regression, but it is an
+  observable output change for such files and needs a test pinning it.
+- **Group membership.** A shape inside `xdr:grpSp` is not loaded; if a user deletes a *picture* from a
+  group the existing code already refuses to dismantle it (`PictureWriter.cs:63-67`). Keep the same
+  posture for shapes and state it in the docs rather than half-supporting it.
+
+## Out of scope for v1
+
+Rotation and flips (`a:xfrm/@rot`, `@flipH`, `@flipV`), auto-fit (`spAutoFit`/`normAutofit`), text
+insets (`lIns`/`tIns`/`rIns`/`bIns`), vertical/rotated text (`bodyPr/@vert`), gradient/picture/pattern
+fills, shadows and other `a:effectLst` content, 3-D, bullets and numbering, hyperlinks on shapes, z-order
+manipulation, connectors and their routing, custom geometry (`a:custGeom`), grouping shapes with each
+other or with pictures, `CopyTo`/`Duplicate` across sheets, cell-linked shape text (`xdr:sp/@textlink`),
+form controls and ActiveX (VML/legacy — a different mechanism entirely), and shape participation in
+row/column insert/delete shifting.
+
+Each of these is additive: the model, the assigned-property flags and the patcher are all designed so a
+later spec can extend them without changing what v1 emits.

--- a/docs/specs/16-drawingml-infrastructure.md
+++ b/docs/specs/16-drawingml-infrastructure.md
@@ -1,0 +1,132 @@
+# Spec 16 — Shared DrawingML Infrastructure
+
+**Area:** Architecture + Refactor
+**Effort:** S–M (~1 week)
+**Dependencies:** None. Conflicts with any in-flight work in `XLibur/Excel/IO/ChartFormatting.cs`
+(spec 10's territory) and `XLibur/Excel/IO/PictureWriter.cs`. Spec 10's open 3D follow-on lives in
+`ChartWriter.cs` and does **not** conflict with this spec.
+**Status:** Proposed. **Hard prerequisite for spec 15** (shapes & text boxes).
+
+## Summary
+
+Spec 15 needs machinery that already exists in the codebase in chart- or picture-specific form:
+anchor construction, schema-correct DrawingML property writing, and a way to prove an edit changed
+exactly what it meant to. Extracting it is refactoring of *shipped* behaviour — spec 10's chart
+formatting and the picture save path — and deserves its own gate rather than landing interleaved with
+new-feature PRs. This spec does only that: one new test instrument plus two behaviour-preserving
+refactors, each a self-contained PR, each gated by a green suite and golden fixtures.
+
+Who this serves, honestly: **spec 15 is the primary consumer.** The secondary value is real but
+smaller — the change-set harness permanently strengthens the existing chart-patch tests, and any
+future chart-*formatting* work inherits one correct DrawingML ordering implementation instead of
+risking a second. (An earlier draft claimed spec 10's open 3D-chart follow-on as a consumer; that gap
+is chart *group element* emission in `ChartWriter.cs` — see `AppendBar3DChart`,
+`ChartWriter.cs:740` — and is unrelated to this layer.)
+
+## Scope boundary: extraction only
+
+This spec adds **no new DrawingML capability**. Operations spec 15 needs that charts never perform —
+emitting an explicit `a:noFill` (chart code removes fills and stops; it never writes one), writing
+`a:prstDash` (chart series don't model dash at all) — are **not** added here, because the whole
+contract of this spec is "behaviour-preserving, gated by the existing suite", and the existing suite
+cannot gate operations it never exercises. Spec 15's task 3 extends the layer with those operations
+under its own change-set tests. If a PR in this spec adds a code path the chart and picture suites
+don't reach, it is out of scope by definition.
+
+## Why these extractions are justified (and what their risk is)
+
+`xdr:sp/spPr` and a chart series' `c:spPr` are the **same schema type** — `a:CT_ShapeProperties`. The
+rules for writing into it are subtle and already implemented once, correctly, in `ChartFormatting`:
+
+- Fills are a *choice* group — setting a colour over an `a:gradFill` means removing the whole group
+  first (`SetFill`, `ChartFormatting.cs:1263`, via `IsFillElement`), not appending beside it.
+- The type is a *sequence* — `a:xfrm`, geometry, fill, `a:ln`, `a:effectLst`, 3-D, `a:extLst` — and
+  the SDK does not order children for you (`InsertAfterLastOf`, line 1334, plus the
+  `IsAfterFill`/`IsAfterOutline`/`IsEffectOrLater` predicates).
+- Existing elements are mutated in place, never rebuilt — `SetOutline` (line 1282) edits the `a:ln`
+  that is there, so unmodeled children (arrowheads, miter) survive.
+
+A second implementation of these rules for shapes is how the two copies drift. The decision (taken
+with the project owner, 2026-08-01) is **full extraction**: the setters move, not just the predicates.
+
+The honest cost: this is *not* a mechanical move. The current signatures are chart-coupled —
+`SetOutline(C.ChartShapeProperties, XLChartSeries, XLChartSeriesFormat)` takes the series and its
+flags enum, and `EnsureShapeProperties` positions `spPr` after `C.SeriesText`/`C.Order`/`C.Index`,
+which is knowledge about the *chart parent's* sequence, meaningless for other hosts. The extraction
+therefore redesigns working code, under these rules:
+
+1. **The shared layer takes values, never masks.** Its signatures are of the form "set fill to X",
+   "clear fill", "ensure outline exists, correctly placed" — plain nullable values and explicit
+   operations. `XLChartSeriesFormat` stays in `ChartFormatting`; spec 15's `AssignedProperties` flags
+   stay in its patcher. Callers decide *whether* to write; the layer decides *how*. If a flags enum
+   appears in a shared-layer signature, the abstraction has failed.
+2. **Parent positioning stays with the parent.** `EnsureShapeProperties`' knowledge of where `spPr`
+   sits inside a chart series element remains chart-side; `xdr:sp` never needs an equivalent because
+   `spPr` is a *required* child of `CT_Shape`. The shared layer operates *within* an `spPr` it is
+   handed.
+3. **Colour building moves with the setters.** `BuildColor`/`MapSchemeColor`
+   (`ChartFormatting.cs:742-748`) are part of "write a fill" and are outside the setter line range —
+   they move too. They already handle theme colours (`A.SchemeColor` for `XLColorType.Theme`), so the
+   layer's consumers get theme-colour writing for free.
+4. **Behaviour-preserving, proven twice.** The chart formatting and picture tests pass unmodified,
+   and output is byte-identical against golden fixtures captured from the pre-refactor code
+   (task 1's corpus).
+
+What does **not** move: the in-place paragraph-editing rules inside `SetRichText`
+(`ChartFormatting.cs:257-287` — `rPr`-preserving run replacement, `endParaRPr`-stays-last,
+`IsRunLevel`). They are the right bones for spec 15's text patching, but their only real consumer
+today is the chart title path, and shaping a shared abstraction against spec 15's still-on-paper text
+model is premature (decision 2026-08-01). **Spec 15's task 2 performs that extraction** when the
+second consumer exists, relocating the rules into `DrawingML/` with the chart tests still gating.
+
+## Current state
+
+Verified against the tree at `dfd5f49b` (2026-08-01).
+
+- **Anchor construction**: `PictureWriter.AddPictureAnchor` (`PictureWriter.cs:197-391`) builds all
+  three anchor forms — `AbsoluteAnchor` (FreeFloating), `TwoCellAnchor` (MoveAndSize), `OneCellAnchor`
+  (Move) — as three near-identical inline blocks differing only in the `xdr:pic` payload and marker
+  sources. Marker fallbacks default to A1 (`PictureWriter.cs:284-301`).
+- **Property writing**: `ChartFormatting.cs:1251-1348` (setters, predicates, ordered insertion) plus
+  `BuildColor`/`MapSchemeColor` at 742-748, consumed by the series patching path (`ChartPatcher`).
+- **Test instrument**: chart-patch tests assert selected properties of the output XML. Nothing asserts
+  "this edit changed *only* these nodes", which is the property patch-in-place actually promises.
+
+## Work plan
+
+The harness lands **first** — it is the gate the two refactors are measured with.
+
+| # | Task | Size | Gate |
+|---|------|------|------|
+| 1 | **XML change-set harness + golden corpus.** (a) Canonicalize a part before and after an operation (namespace-aware; attribute order and insignificant whitespace normalized) and assert the change set equals exactly an expected node set — nothing else added, dropped, or reordered. (b) Golden fixtures: capture the current code's save output for every chart fixture exercised by the formatting tests plus a representative multi-picture save, committed with a green test asserting current output matches golden — this is what lets the later refactor PRs prove byte-identity, since a test cannot run pre-refactor code after the fact. (c) Retrofit two existing chart-patch tests (one fill edit, one title edit) to change-set assertions. | M | Retrofitted tests pass and demonstrably fail when a deliberate extra mutation is introduced; golden test green on unmodified code. |
+| 2 | **`DrawingAnchorFactory`** — extract anchor construction from `PictureWriter.AddPictureAnchor`: (placement, pixel geometry / markers, child element) → `AbsoluteAnchor`/`OneCellAnchor`/`TwoCellAnchor`, EMU conversion included. The A1 marker fallbacks move with it and are documented as part of the factory's contract, since future callers (spec 15) inherit them silently. `PictureWriter` becomes a caller. | S | Full picture test suite green; golden byte-identity holds. |
+| 3 | **`IO/DrawingML/ShapePropertiesWriter`** — full extraction of `SetFill`/`SetOutline`/`BuildColor`/`MapSchemeColor`/ordering predicates/`InsertAfterLastOf`/`AppendBeforeExtensionList` under the redesign rules above, over `OpenXmlCompositeElement`. `ChartFormatting` keeps thin mask-driven adapters and its parent-positioning logic. No new operations (see scope boundary). | M | Chart formatting tests green, unmodified; golden byte-identity holds. |
+
+Tasks 2 and 3 are independent of each other once 1 lands.
+
+## Acceptance criteria
+
+1. No public API change: `PublicAPI.Unshipped.txt` untouched (everything added is `internal`).
+2. Full suite green on net8.0/net9.0/net10.0 after each PR, with no test modified except the two
+   deliberately retrofitted in task 1.
+3. Golden byte-identity: every fixture in task 1's corpus saves byte-identically after tasks 2 and 3.
+   Any diff is a finding to investigate, never noise to re-baseline without a written explanation.
+4. No flags enum (`XLChartSeriesFormat` or any successor) appears in a `DrawingML/` signature.
+5. The harness absorbs the SDK's serialization quirks: a part whose DOM **was materialised and
+   re-serialized** with no model edits canonicalizes to an **empty change set** (mere DOM loading
+   re-serializes — see the comment at `PictureWriter.cs:138-140`; this criterion is what makes the
+   harness usable for spec 15's fidelity tiers).
+6. Scope boundary held: the extracted layer's observable capability set is unchanged — no operation
+   exists in `DrawingML/` that the chart and picture suites do not exercise.
+
+## Risks
+
+- **This refactors shipped spec-10 behaviour for the benefit of code that does not exist yet.** The
+  mitigation is structural: each task is a separate behaviour-preserving PR gated by suite + goldens,
+  landed before spec 15 writes a line against it. If spec 15 is later descoped, the harness and the
+  single-implementation ordering layer still pay for themselves in future chart-formatting work.
+- **The value-only redesign may surface latent chart bugs** — e.g. an edit order the mask-driven code
+  happened to make unobservable. The golden corpus (criterion 3) is the tripwire.
+- **Canonicalization is deceptively hard** (namespace prefixes, `xml:space`, attribute ordering, the
+  SDK's own normalization). Task 1 is sized M for this reason and its "deliberately broken mutation"
+  check exists to prove the harness detects what it claims to.

--- a/docs/specs/17-picture-styling.md
+++ b/docs/specs/17-picture-styling.md
@@ -1,0 +1,274 @@
+# Spec 17 — Picture Styling & Round-Trip Fidelity (`IXLPicture`)
+
+**Area:** Feature + Compatibility (and a fidelity **defect fix**)
+**Effort:** M–L (2–3 weeks, after spec 16)
+**Dependencies:** **Hard dependency on [spec 16](16-drawingml-infrastructure.md)**
+(`ShapePropertiesWriter`, `DrawingAnchorFactory`, change-set harness). Shares two shared-layer
+extensions with [spec 15](15-shapes-and-text-boxes.md) — see [Interplay](#interplay-with-specs-15-and-16).
+Conflicts with spec 15 in `XLibur/Excel/IO/PictureWriter.cs` (both rework its save orchestration);
+run them sequentially in either order, not concurrently.
+**Status:** Proposed
+
+## Summary
+
+`IXLPicture` models geometry and placement only — no border, fill, rotation, flip, transparency,
+shadow, recolor, crop, or brightness/contrast. But the gap is worse than "missing API": **the picture
+save path destroys existing styling.** Every save rebuilds every picture's anchor from scratch with a
+hardcoded `spPr` and `blipFill`, so a loaded file whose pictures were rotated, bordered, shadowed,
+recolored or cropped in Excel silently loses all of it the first time XLibur saves the workbook. The
+"preservation by default" story in `docs/round-trip-fidelity.md` does not apply here, because
+preservation only covers what XLibur does *not* rewrite — and pictures are rewritten.
+
+This spec (a) moves loaded pictures to **patch-in-place**, closing the destruction for modelled and
+unmodelled styling alike, and (b) adds the styling model: border, fill, rotation, flip, transparency,
+shadow, recolor, crop, brightness/contrast.
+
+## Decisions taken before writing this spec (2026-08-01)
+
+| Question | Decision | Consequence |
+|---|---|---|
+| Loaded-picture write path | **Patch-in-place** (charts/spec-10 and shapes/spec-15 approach), replacing wholesale regeneration | Fixes destruction of *unmodelled* content too (effects, adjust data); needs dirty-tracking; placement changes need an explicit fallback (below) |
+| Recolor model | **Preset enum** — `None`, `Grayscale`, `Sepia`, `Washout`, `BlackAndWhite`, plus read-only `Custom` | Matches Excel's gallery; arbitrary duotones read as `Custom` and are preserved, not editable |
+| Shadow depth | **Single outer shadow** — colour, transparency, blur, distance, angle (`a:outerShdw`) | Excel's whole preset gallery is parameter values of this one element; inner/perspective shadows stay preserved-unmodelled |
+| Extra scope | **Crop (`a:srcRect`) and brightness/contrast (`a:lum`) included** | Both are destroyed today; both are cheap once `blipFill` is patched rather than rebuilt |
+
+## Current state
+
+Verified against the tree at `dfd5f49b` (2026-08-01).
+
+**The model has no styling.** `IXLPicture` (`XLibur/Excel/Drawings/IXLPicture.cs`) exposes geometry,
+placement, name, format, group membership. `XLPicture` stores nothing beyond that.
+
+**The reader reads no styling.** `DrawingPartReader.LoadPictureFromAnchor` / `LoadPictureTransform` /
+`LoadPicturePlacement` (`DrawingPartReader.cs`) read offsets, extents and markers. `a:xfrm/@rot`,
+`@flipH`/`@flipV`, `a:ln`, `a:effectLst`, `a:srcRect`, and every `a:blip` child effect are ignored.
+
+**The writer destroys styling on save.** `PictureWriter.AddPictureAnchor` (`PictureWriter.cs:197-391`)
+locates each picture's existing anchor by image rel id (`GetAnchorFromImageId`, line 223) and
+**replaces it** (`AttachAnchor`, line 395) with a freshly built anchor whose `spPr` is hardcoded to a
+plain `Transform2D` + `PresetGeometry rect` (lines 269-275) and whose `blipFill` is hardcoded to
+`Blip + Stretch(FillRectangle)` (lines 261-267). Consequences, all silent:
+
+- rotation, flips → gone (`a:xfrm` rebuilt without `@rot`/`@flipH`/`@flipV`);
+- border, shadow, any effect → gone (`a:ln`/`a:effectLst` never emitted);
+- crop → gone (`a:srcRect` replaced by `Stretch`);
+- transparency/recolor/brightness → gone (`a:blip` rebuilt bare);
+- the image binary is re-fed on every save (`FeedData`, line 220) even when untouched.
+
+The only pictures spared are grouped ones — `UpdateGroupedPicture` patches the `xdr:pic` in place —
+and anchors hosting a group (the guard at lines 229-230).
+
+**What exists to build on.** Spec 16 provides the anchor factory, the `ShapePropertiesWriter` (fills,
+outlines, ordering — `xdr:pic/spPr` is the same `a:CT_ShapeProperties` as shapes and charts), the
+change-set harness with golden fixtures, and `BuildColor` with theme-colour support. Spec 15's design
+rules 2/3/8/10 (null = unassigned; per-property assignment flags; edit granularity matches model
+granularity; never touch a clean drawing) apply here verbatim and are not restated.
+
+## OOXML background
+
+Everything this spec models lives in two places inside `xdr:pic`:
+
+```xml
+<xdr:pic>
+  <xdr:nvPicPr>…</xdr:nvPicPr>
+  <xdr:blipFill>
+    <a:blip r:embed="rId1">
+      <a:alphaModFix amt="65000"/>          <!-- transparency: 100% - amt/1000 -->
+      <a:grayscl/>                          <!-- recolor: grayscale -->
+      <!-- or <a:duotone><a:prstClr val="black"/><a:schemeClr val="…"/></a:duotone> (sepia/washout) -->
+      <!-- or <a:biLevel thresh="50000"/> (black & white) -->
+      <a:lum bright="20000" contrast="-10000"/>  <!-- brightness/contrast, thousandths of a % -->
+    </a:blip>
+    <a:srcRect l="10000" t="0" r="25000" b="0"/> <!-- crop, thousandths of a % per edge -->
+    <a:stretch><a:fillRect/></a:stretch>
+  </xdr:blipFill>
+  <xdr:spPr>
+    <a:xfrm rot="1200000" flipH="1">…</a:xfrm>   <!-- rotation in 60,000ths of a degree -->
+    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+    <a:solidFill>…</a:solidFill>                 <!-- fill: shows behind transparent image regions -->
+    <a:ln w="19050">…</a:ln>                     <!-- border -->
+    <a:effectLst><a:outerShdw blurRad="50800" dist="38100" dir="2700000" …/></a:effectLst>
+  </xdr:spPr>
+</xdr:pic>
+```
+
+Points that drive the design:
+
+- **`spPr` styling is exactly the shapes/charts problem** — border, fill, shadow and the `a:xfrm`
+  attributes go through spec 16's layer (plus the extensions below). Element order in `spPr` and the
+  fill choice group are already solved there.
+- **`blipFill` styling is new territory** — the `a:blip` child effects are a *sequence of effects*
+  applied in order, and Excel is sensitive to their order (`alphaModFix` before recolor before `lum`
+  as it writes them). This needs its own small writer with the same in-place discipline.
+- **Rotation does not change the anchor.** Excel keeps the anchor/extent of the unrotated picture and
+  rotates about the centre; `Width`/`Height`/`Left`/`Top` keep meaning the unrotated box. Same for
+  flips. No bounding-box recomputation.
+- **Recolor presets are fixed effect patterns**: Grayscale = `a:grayscl`; Black & white =
+  `a:biLevel thresh="50000"`; Sepia and Washout = `a:duotone` with specific colour pairs Excel always
+  uses. The reader maps those exact patterns back to the enum; any other pattern reads `Custom`.
+
+## Design
+
+### Public surface (additions to `IXLPicture`)
+
+Flat nullable properties with per-property assignment tracking, following `IXLChartSeries` and spec
+15's `IXLShape` — null means "not assigned, leave whatever the file has":
+
+```csharp
+// Border — same vocabulary as IXLShape
+XLColor? BorderColor { get; set; }
+double? BorderWidthPt { get; set; }
+XLLineDashStyle? BorderDash { get; set; }         // shared enum with spec 15
+bool NoBorder { get; set; }
+
+// Fill behind transparent image regions
+XLColor? FillColor { get; set; }
+bool NoFill { get; set; }
+
+// Orientation
+double? Rotation { get; set; }                     // degrees, clockwise; a:xfrm/@rot
+bool? FlipHorizontal { get; set; }
+bool? FlipVertical { get; set; }
+
+// Image effects
+double? Transparency { get; set; }                 // 0–100 %, a:blip/a:alphaModFix
+XLPictureRecolor? Recolor { get; set; }            // None|Grayscale|Sepia|Washout|BlackAndWhite; Custom read-only
+double? Brightness { get; set; }                   // −100…100 %, a:lum/@bright
+double? Contrast { get; set; }                     // −100…100 %, a:lum/@contrast
+
+// Crop — thousandths-of-a-percent per edge in XML, exposed as 0–100 %
+XLCrop? Crop { get; set; }                         // readonly record struct: Left, Top, Right, Bottom
+
+// Shadow — single outer shadow
+XLPictureShadow? Shadow { get; set; }              // record: Color, TransparencyPct, BlurPt, DistancePt, AngleDeg
+```
+
+New types: `XLPictureRecolor` enum, `XLCrop` and `XLPictureShadow` readonly record structs. Setting
+`Recolor` to `Custom` throws (`Custom` is a read-back value only). Setting any property marks it
+assigned; `null` assignment (e.g. `Rotation = null`) after a prior assignment means "remove the
+modelled value on save" for removable elements and is defined per property in the implementation
+notes of the PR — the chart precedent (`SetOutline`'s width handling) applies.
+
+`Duplicate`/`CopyTo` copy assigned styling and, for loaded pictures, the unmodelled anchor content
+they carry (the copy is a clone of the patched anchor, not a regeneration).
+
+### Write path rework — patch-in-place
+
+`AddPictureAnchor`'s replace-always behaviour is retired for loaded pictures:
+
+- **Clean sheets are never touched** (spec 15's design rule 10, extended to pictures): if no picture
+  on the sheet was added, edited, deleted, re-imaged or re-placed, the shape/picture pass does not
+  materialise `WorksheetDrawing` and does not re-feed image binaries. This is a behavioural
+  *improvement* — today every picture sheet is rewritten and every image re-fed on every save.
+- **Loaded, edited pictures are patched**: located by image rel id (the existing
+  `GetAnchorFromImageId` mechanism), geometry written into the *existing* anchor's markers/extents,
+  `spPr` styling through the shared layer, `blipFill` styling through the new `BlipEffectsWriter`.
+  Unassigned properties and unmodelled content are untouched.
+- **The image binary is re-fed only when the stream changed** (new-picture or an explicit image
+  replacement), not on every save.
+- **New pictures** are generated via spec 16's `DrawingAnchorFactory` exactly as today, with assigned
+  styling written through the same two writers — one implementation of each write, as in spec 15.
+- **Placement change is the documented fallback to regeneration.** Changing `Placement` on a loaded
+  picture changes the anchor *element type*, which cannot be patched. Unlike shapes (spec 15 throws),
+  pictures have always supported this and callers rely on it — so it stays supported, implemented as
+  regeneration of that one anchor with all *modelled* styling carried over, and documented as the one
+  path where unmodelled anchor content is lost. A test pins exactly this semantics.
+- **`RebaseNonVisualDrawingPropertiesIds` is retired for existing drawings.** Wholesale renumbering
+  is incompatible with patch-in-place (and spec 15 already forbids it when shapes exist). It runs
+  only when the entire drawing part is new. Behaviour change pinned by test.
+
+### Read path
+
+`LoadPictureFromAnchor` additionally reads, into unassigned model state (visible via the getters,
+flagged only when the *user* sets them — mirroring spec 15's loaded-shape read): rotation/flips from
+`a:xfrm`; border from `a:ln` (colour incl. `schemeClr`, width, `prstDash`); fill from `spPr`
+`solidFill`/`noFill`; transparency from `alphaModFix`; recolor by pattern-matching the known preset
+effect shapes (else `Custom`); brightness/contrast from `a:lum`; crop from `a:srcRect`; shadow from a
+sole `a:outerShdw` (any other effect content → shadow reads null, is preserved).
+
+### `BlipEffectsWriter` (new, `IO/DrawingML/`)
+
+The `blipFill` counterpart of `ShapePropertiesWriter`: in-place, ordered writes of `a:alphaModFix`,
+recolor effects, and `a:lum` inside the existing `a:blip`, plus `a:srcRect` maintenance beside the
+existing fill-mode element (never replacing an existing `a:tile`/`a:stretch` choice). Effect order
+mirrors what Excel writes, captured from fixtures. Lives in the shared layer because a future spec
+(in-cell images, shape picture-fills) can reuse it; until then its only consumer is this spec, so it
+is *created here with this spec's tests*, not in spec 16 (16 is extraction-only).
+
+## Interplay with specs 15 and 16
+
+- **From 16 (required):** `ShapePropertiesWriter`, `DrawingAnchorFactory`, harness + goldens.
+- **Shared with 15, first-lander adds them:** the `a:noFill`-emission and `a:prstDash` operations in
+  the shared layer, and the `XLLineDashStyle` enum. Both specs state this; whichever merges second
+  rebases on the other's version.
+- **Added here, reusable by shapes later:** the `a:outerShdw` write operation and the
+  `a:xfrm` `@rot`/`@flipH`/`@flipV` attribute patching (attribute-only edits on an existing `a:xfrm`,
+  offsets untouched). Spec 15 deferred shadow/rotation for shapes; when a shapes v2 picks them up,
+  the layer operations already exist.
+- **Conflict:** both 15 (task 4) and this spec rework `PictureWriter` orchestration. Sequential, not
+  concurrent; either order works, second one rebases.
+
+## Work plan
+
+| # | Task | Size | Depends on |
+|---|------|------|-----------|
+| 1 | **Patch-in-place rework, no new API** — the fidelity fix alone: clean-sheet no-touch, patch geometry into existing anchors, conditional image re-feed, placement-change regeneration fallback, rebase retirement. Existing picture suite green; new harness-based tests prove an Excel-styled picture round-trips untouched (this fails on main today). | M | spec 16 |
+| 2 | **Model + API**: properties, assignment flags, `XLPictureRecolor`/`XLCrop`/`XLPictureShadow`, public API files, `Duplicate`/`CopyTo` semantics. No IO. | S–M | — |
+| 3 | **`spPr` styling writes**: border/fill via the shared layer (adding `noFill`/`prstDash` ops if spec 15 has not already), rotation/flip attribute patching, `outerShdw` operation. | M | 1, 2 |
+| 4 | **`BlipEffectsWriter`**: transparency, recolor presets, brightness/contrast, crop — in-place and ordered. | M | 1, 2 |
+| 5 | **Reader**: all modelled properties incl. recolor pattern-matching to presets. | S–M | 2 |
+| 6 | **Tests + fixtures**: Excel-authored pictures covering every property and combinations (rotated+cropped+shadowed), recolor gallery fixtures for pattern-matching, change-set assertions throughout, manual opens-clean-in-Excel checks recorded. | M | 3, 4, 5 |
+| 7 | **Docs**: picture styling page in `docs-website/`, and a correction to `docs/round-trip-fidelity.md` — it must state that picture styling was destroyed before this spec and is preserved/modelled after. | S | 6 |
+
+Task 1 is deliberately standalone and PR-able first: it is the defect fix, valuable with zero new API,
+and it is the risky part — everything after it is additive.
+
+## Acceptance criteria
+
+1. **The headline fix:** an Excel-authored workbook whose picture is rotated, flipped, bordered,
+   shadowed, recolored, cropped and brightness-adjusted survives load → save → reopen with all of it
+   intact — byte-identical drawing part when nothing was edited (clean-sheet rule), canonical-identical
+   `xdr:pic` when only sheet content elsewhere changed. **This fails on main today** and the test
+   asserting it is the spec's reason to exist.
+2. Geometry-only edit (`MoveTo`/`WithSize`) on a styled loaded picture → change set is exactly the
+   anchor markers/extents (+ `a:xfrm` off/ext); every styling element untouched.
+3. Each modelled property: set via API → save (`validate: true`, zero errors) → reload → reads back;
+   the full matrix opens clean in Excel 365 (manual check recorded in the PR).
+4. Recolor: the four presets written by XLibur are element-identical to Excel's gallery output
+   (fixture comparison); Excel-authored presets read back as the right enum member; an arbitrary
+   duotone reads `Custom`, cannot be assigned, and survives save untouched.
+5. Placement change on a loaded picture: regenerates that anchor, carries all modelled styling,
+   drops unmodelled content — pinned by an explicit test and stated in the docs.
+6. Image binaries are not re-fed for pictures whose stream did not change; unedited picture sheets
+   are not rewritten at all. Write benchmark shows no regression; a save of a loaded
+   many-pictures workbook with no edits gets measurably cheaper (record the numbers in the PR).
+7. Full suite green on net8.0/net9.0/net10.0; grouped-picture and group-creation tests unmodified.
+
+## Risks
+
+- **Task 1 changes shipped save behaviour for every workbook with pictures.** Anchors that were
+  regenerated (normalized) every save are now passed through. Files that depended on regeneration to
+  *repair* odd anchors — if any exist — would surface as regressions. The existing picture suite plus
+  golden fixtures over the picture test resources are the gate; run the full
+  `TryToLoad` corpus through load-save as a sweep.
+- **Anchor-form geometry patching.** Writing `MoveTo` into an existing `TwoCellAnchor` means
+  recomputing from/to markers against current column widths/row heights — the regeneration path did
+  this from scratch; the patch path must produce the same markers. Reuse the exact marker computation,
+  assert equivalence in tests.
+- **`a:blip` effect ordering.** The effect sequence is order-sensitive and underdocumented; mirror
+  Excel-authored fixtures, and keep unrecognized effect elements exactly where they are relative to
+  the ones being edited.
+- **Recolor pattern-matching brittleness.** Sepia/Washout duotone colour pairs must match what current
+  Excel writes; older files may differ slightly and will read `Custom` — acceptable (preserved), but
+  document it.
+- **Rotation and `editAs` interplay.** A rotated picture in a `TwoCellAnchor` whose row/column sizes
+  change renders differently across anchor semantics; XLibur does not recompute anything — same
+  posture as Excel, stated in docs.
+
+## Out of scope for v1
+
+Preset 3-D/bevel/glow/soft-edge effects, artistic effects (`a14:imgLayer`), picture styles gallery
+(`xdr:style` on pictures), inner/perspective shadows (preserved, not modelled), tile fill mode
+authoring (`a:tile` preserved if present), image replacement API (re-point `ImageStream` exists
+already; a richer API is separate), per-picture hyperlinks (`a:hlinkClick` — preserved), and
+compression/DPI-resampling of image binaries.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,6 +1,6 @@
 # XLibur Improvement Roadmap
 
-Fourteen prioritized, self-contained specs covering features, compatibility, architecture, and performance (memory + read/write times). Each spec is written to be handed to an independent agent/model: it states the problem with measured numbers, points at the exact files, prescribes a design, breaks the work into PR-sized tasks, and defines measurable acceptance criteria.
+Seventeen prioritized, self-contained specs covering features, compatibility, architecture, and performance (memory + read/write times). Each spec is written to be handed to an independent agent/model: it states the problem with measured numbers, points at the exact files, prescribes a design, breaks the work into PR-sized tasks, and defines measurable acceptance criteria.
 
 Specs 01–10 are the original top-ten set; spec 11 is a follow-on that came out of implementing spec 03 (see below).
 
@@ -24,6 +24,41 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 12 | [Report templating (`XLibur.Report`)](12-report-templating.md) | Feature · Arch | L | ✅ **Done** (see Results; gauge corpus not ported) | 11 tasks; 4/5/6/10 parallel after 3 |
 | 13 | [Public core surface for `XLibur.Report`](13-report-core-public-api.md) | Arch · API · Packaging | M | Proposed | Tasks 1 and 2 independent |
 | 14 | [`Clear`/`CopyTo` scalability](14-clear-copyto-scalability.md) | Perf (edit) · Correctness | S | Proposed ([#271](https://github.com/XLibur/XLibur/issues/271)) | Task 1 first; 2/3/4 independent |
+| 15 | [Shapes & text boxes](15-shapes-and-text-boxes.md) | Feature · Compat | L | Proposed (**needs 16 first**) | 1–3 one stream; then 4/5 parallel |
+| 16 | [Shared DrawingML infrastructure](16-drawingml-infrastructure.md) | Arch · Refactor | S–M | Proposed | 3 PRs; harness first, then 2/3 independent |
+| 17 | [Picture styling & fidelity](17-picture-styling.md) | Feature · Compat · **Defect** | M–L | Proposed (**needs 16 first**) | Task 1 (fidelity fix) first and standalone; 3/4/5 parallel after 2 |
+
+Spec 15 closes the last hole in the drawing surface: XLibur can add pictures and charts but no shape of
+any kind, so a floating text box, callout or arrow cannot be created at all. Shapes that already exist in
+a file do survive a round trip — save reopens the original package and rewrites only modelled parts, the
+same mechanism `docs/round-trip-fidelity.md` documents — but they are invisible to the model, so their
+text can be neither read nor changed. 15 adds `ws.Shapes` over DrawingML `xdr:sp` with a paragraph-aware
+text model, and follows spec 10's chart precedent: new shapes are generated, loaded shapes are **patched
+in place** so unmodelled XML (gradients, effects, theme styles) keeps surviving untouched.
+
+Spec 16 was split out of 15 by review (2026-08-01): the machinery 15 needs already exists in chart- and
+picture-specific form, and extracting it is refactoring of *shipped* behaviour that deserves its own
+gate rather than landing interleaved with feature PRs. 16 delivers three internal pieces, harness
+first: an XML change-set test harness with golden fixtures (proven by retrofitting two chart tests);
+the anchor factory out of `PictureWriter.AddPictureAnchor`; and the DrawingML
+fill/line/colour/element-ordering layer out of `ChartFormatting` — `xdr:sp/spPr` and a chart's `spPr`
+are the same schema type, and one implementation of it beats two — with value-only signatures so
+neither side's assigned-flags enum leaks in. 16 is strictly extraction: operations charts never
+perform (`a:noFill` emission, `a:prstDash`) and the `SetRichText` paragraph-editing primitives are
+added/extracted by 15 itself, where their real consumer shapes the code and its tests gate it.
+**15 hard-depends on 16.** (Spec 10's open 3D follow-on is unrelated — that gap is chart group
+emission in `ChartWriter.cs`, not this layer.)
+
+Spec 17 started as "add the missing picture styling" and turned into a defect report: the picture save
+path **destroys existing styling**. `PictureWriter.AddPictureAnchor` replaces every picture's anchor on
+every save with a hardcoded `spPr` and `blipFill`, so rotation, borders, shadows, recolors and crops
+authored in Excel are silently lost the first time XLibur saves the file — the round-trip-fidelity
+guarantee never covered pictures, because it only protects what XLibur does not rewrite. 17's task 1 is
+the standalone fix (patch-in-place for loaded pictures, clean sheets untouched, image binaries no longer
+re-fed every save); the styling model — border, fill, rotation/flip, transparency, single outer shadow,
+recolor presets, crop, brightness/contrast — builds on top of it through spec 16's shared layer plus a
+new `BlipEffectsWriter`. **17 hard-depends on 16** and conflicts with 15 in `PictureWriter.cs`
+(sequential, either order).
 
 Spec 13 came out of preparing `XLibur.Report` to version independently of core. Report reads core
 internals through an `InternalsVisibleTo` grant, which is safe only while the two ship as one
@@ -124,7 +159,7 @@ to RelocateRange probing the range repository for XLRow instances that are never
 **Read spec 02's Results section before starting 03** — it corrects 03's number-formatting task
 and describes an allocation technique that applies to the rest of the IO layer.
 
-Conflict map: 01↔03 (`SheetDataWriter`), 04↔08 (evaluation stack / `CalcContext`), 07 waves B↔C (`Statistical.cs`). Everything else is disjoint. **Spec 05 must rebase onto spec 11**: 11's Task 4 rewrote bulk style propagation (`XLStylizedBase.ModifyStyle` / `SetStyle`), which is 05's territory.
+Conflict map: 01↔03 (`SheetDataWriter`), 04↔08 (evaluation stack / `CalcContext`), 07 waves B↔C (`Statistical.cs`), 16↔any chart-*formatting* work (`ChartFormatting.cs` — 16 extracts its DrawingML property layer; spec 10's open 3D follow-on is in `ChartWriter.cs` and does not conflict), 15→16 and 17→16 (hard dependencies), 15↔17 (`PictureWriter.cs` save orchestration — sequential, either order), 15↔17 also share the shared-layer `noFill`/`prstDash` ops and `XLLineDashStyle` (first lander adds them). Everything else is disjoint. **Spec 05 must rebase onto spec 11**: 11's Task 4 rewrote bulk style propagation (`XLStylizedBase.ModifyStyle` / `SetStyle`), which is 05's territory.
 
 ## Ground rules for implementing agents
 


### PR DESCRIPTION
Docs only — three new specs and the index. No code changes.

Started from the question "does XLibur support adding text boxes?" (it does not — `IXLPictures.Add` takes images, `IXLCharts.Add` takes charts, and there is no third option). Planning that out surfaced two further pieces of work, so the result is three specs rather than one.

All claims are grounded against the tree at `dfd5f49b`, with file:line references throughout.

## Spec 15 — Shapes & text boxes

Adds `ws.Shapes` over DrawingML `xdr:sp`: preset geometries that can all carry text, with a text box being the rectangle preset. New shapes are generated; shapes loaded from a file are **patched in place**, so unmodelled XML (gradients, effects, theme styles) keeps surviving untouched — the contract spec 10 settled on for charts.

Design decisions recorded in the spec: paragraph-aware text model (not `IXLRichText`), a narrow `IXLShapeTextFont` rather than `IXLFontBase` (the spreadsheet font contract has members `a:rPr` cannot express), creation defaults mirroring Excel's own authored XML, and core formatting only for v1.

## Spec 16 — Shared DrawingML infrastructure

**Hard prerequisite for 15 and 17.** Extraction only, no new capability:

- XML change-set test harness with golden fixtures, proven by retrofitting two chart-patch tests
- `DrawingAnchorFactory` out of `PictureWriter.AddPictureAnchor`
- `ShapePropertiesWriter` out of `ChartFormatting` — `xdr:sp/spPr` and a chart's `c:spPr` are the same schema type (`a:CT_ShapeProperties`), and the choice-group/sequence-ordering rules are already implemented correctly there once

Split out of 15 during review because it refactors *shipped* behaviour (spec 10's chart formatting, the picture save path) and deserves its own gate rather than landing interleaved with feature PRs. Value-only signatures keep either side's assigned-flags enum out of the shared layer.

## Spec 17 — Picture styling & fidelity

Asked for as "add the missing `IXLPicture` styling"; the audit found a defect underneath it.

`PictureWriter.AddPictureAnchor` locates each picture's existing anchor and **replaces** it with a freshly built one whose `spPr` is a hardcoded `Transform2D` + `PresetGeometry rect` and whose `blipFill` is a hardcoded `Blip + Stretch`. So rotation, borders, shadows, recolors, crops and brightness adjustments authored in Excel are silently destroyed the first time XLibur saves the file, and every image binary is re-fed on every save. The round-trip-fidelity guarantee never covered this, because it only protects parts XLibur does not rewrite.

Task 1 is therefore the standalone fix with zero new API (patch-in-place, clean sheets untouched, conditional image re-feed), with a test that fails on `main` today. The styling model — border, fill, rotation/flip, transparency, single outer shadow, recolor presets, crop, brightness/contrast — builds on top.

## Sequencing

```
16  →  15  (shapes)
    →  17  (pictures)
```

15 and 17 both rework `PictureWriter` orchestration and both need the same two shared-layer operations (`a:noFill` emission, `a:prstDash`) plus `XLLineDashStyle` — sequential in either order, second one rebases. Both specs say so. Spec 10's open 3D follow-on lives in `ChartWriter.cs` and does **not** conflict with 16.

The conflict map and index in `docs/specs/README.md` are updated accordingly.
