### PR TITLE
perf(shift): skip the formula parse a shift cannot reach

### DIFF
--- a/XLibur.Tests/Excel/Ranges/FormulaShiftFilterTests.cs
+++ b/XLibur.Tests/Excel/Ranges/FormulaShiftFilterTests.cs
@@ -1,0 +1,272 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Ranges;
+
+/// <summary>
+/// Pins the pre-filter that lets the shift pass skip a formula without parsing it: a formula whose
+/// furthest shiftable reference stops above (or left of) the shifted region cannot be rewritten by
+/// that shift, so <c>XLCellFormula.MaxShiftableRow</c>/<c>MaxShiftableColumn</c> is consulted before
+/// <c>XLCellFormulaShifter</c> is asked to do the work.
+/// <para>
+/// Note which direction of error each test can catch. A bound that is too <em>large</em> costs a parse
+/// and nothing else — the shifter re-derives the real answer and leaves the formula alone — so no test
+/// here would notice one. A bound that is too <em>small</em> strands a formula that should have moved,
+/// which is silent data corruption, and that is what every test below is aimed at. Deleting the filter
+/// outright leaves them all green; tightening it wrongly does not.
+/// </para>
+/// </summary>
+public class FormulaShiftFilterTests
+{
+    [Test]
+    public async Task ReferenceBelowDeletionIsShifted()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").FormulaA1 = "SUM(A100:C100)";
+
+        ws.Row(50).Delete();
+
+        await Assert.That(ws.Cell("D1").FormulaA1).IsEqualTo("SUM(A99:C99)");
+    }
+
+    [Test]
+    public async Task ReferenceAboveDeletionIsUntouched()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").FormulaA1 = "SUM(A10:C10)";
+
+        ws.Row(50).Delete();
+
+        await Assert.That(ws.Cell("D1").FormulaA1).IsEqualTo("SUM(A10:C10)");
+    }
+
+    /// <summary>
+    /// The boundary the filter compares against. A reference ending exactly on the first deleted row is
+    /// inside the deletion, not above it, so it must still be rewritten — an off-by-one that used
+    /// <c>&lt;=</c> instead of <c>&lt;</c> would strand this.
+    /// </summary>
+    [Test]
+    public async Task ReferenceEndingOnTheFirstDeletedRowIsShifted()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").FormulaA1 = "SUM(A5:A50)";
+
+        ws.Row(50).Delete();
+
+        await Assert.That(ws.Cell("D1").FormulaA1).IsEqualTo("SUM(A5:A49)");
+    }
+
+    /// <summary>
+    /// The case the cached bound is most likely to get wrong: after the first shift the formula is a new
+    /// instance whose bound was carried over rather than re-derived, and the second shift reads that
+    /// carried value. A carry that under-estimates would leave the third rewrite undone.
+    /// </summary>
+    [Test]
+    public async Task RepeatedDeletionsKeepShiftingTheSameFormula()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").FormulaA1 = "SUM(A100:C100)";
+
+        ws.Row(10).Delete();
+        ws.Row(10).Delete();
+        ws.Row(10).Delete();
+
+        await Assert.That(ws.Cell("D1").FormulaA1).IsEqualTo("SUM(A97:C97)");
+    }
+
+    /// <summary>
+    /// Repeated deletions walking <em>up</em> toward the reference. Each delete leaves the reference
+    /// closer to the deletion point, so a carried bound that drifted low would stop the rewrite partway.
+    /// </summary>
+    [Test]
+    public async Task DeletionsApproachingTheReferenceKeepShiftingIt()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").FormulaA1 = "A20";
+
+        for (var row = 15; row >= 10; row--)
+            ws.Row(row).Delete();
+
+        await Assert.That(ws.Cell("D1").FormulaA1).IsEqualTo("A14");
+    }
+
+    /// <summary>
+    /// A reference on another sheet. The bound deliberately ignores which sheet a reference names, so a
+    /// formula parked on Sheet2 still shifts when Sheet1 is edited beneath it.
+    /// </summary>
+    [Test]
+    public async Task CrossSheetReferenceIsShiftedWhenTheOtherSheetIsEdited()
+    {
+        using var wb = new XLWorkbook();
+        var source = wb.AddWorksheet("Source");
+        var consumer = wb.AddWorksheet("Consumer");
+        consumer.Cell("A1").FormulaA1 = "Source!A100";
+
+        source.Row(50).Delete();
+
+        await Assert.That(consumer.Cell("A1").FormulaA1).IsEqualTo("Source!A99");
+    }
+
+    [Test]
+    public async Task AbsoluteReferenceBelowDeletionIsShifted()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").FormulaA1 = "$A$100";
+
+        ws.Row(50).Delete();
+
+        await Assert.That(ws.Cell("D1").FormulaA1).IsEqualTo("$A$99");
+    }
+
+    [Test]
+    public async Task DeletingTheReferencedRowsProducesRefError()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").FormulaA1 = "A100";
+
+        ws.Range("A100:A100").Delete(XLShiftDeletedCells.ShiftCellsUp);
+
+        await Assert.That(ws.Cell("D1").FormulaA1).IsEqualTo("#REF!");
+    }
+
+    /// <summary>
+    /// A whole-column reference names no rows, so its row extent is the whole sheet and no row shift can
+    /// ever filter it out. Excel leaves such a reference alone, which is also what the shifter decides —
+    /// the point here is that the filter does not reach that conclusion on its own by short-circuiting.
+    /// </summary>
+    [Test]
+    public async Task WholeColumnReferenceSurvivesRowDeletion()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").FormulaA1 = "SUM(B:B)";
+
+        ws.Row(50).Delete();
+
+        await Assert.That(ws.Cell("D1").FormulaA1).IsEqualTo("SUM(B:B)");
+    }
+
+    /// <summary>
+    /// A formula whose text contains no reference at all still has to shift as a <em>cell</em>, and the
+    /// filter must not interfere with that — it only skips rewriting the text.
+    /// </summary>
+    [Test]
+    public async Task ReferencelessFormulaMovesWithItsCell()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D100").FormulaA1 = "1+2";
+
+        ws.Row(50).Delete();
+
+        await Assert.That(ws.Cell("D99").FormulaA1).IsEqualTo("1+2");
+        await Assert.That(ws.Cell("D100").FormulaA1).IsEqualTo(string.Empty);
+    }
+
+    /// <summary>
+    /// An array formula with no references still owns a range that has to be relocated by the shift, so
+    /// array formulas opt out of the filter entirely rather than being skipped on an empty bound.
+    /// </summary>
+    [Test]
+    public async Task ArrayFormulaRangeRelocatesWhenTextHasNoReferences()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Range("D100:D102").FormulaArrayA1 = "1+2";
+
+        ws.Row(50).Delete();
+
+        await Assert.That(ws.Cell("D99").HasArrayFormula).IsTrue();
+        await Assert.That(ws.Cell("D101").HasArrayFormula).IsTrue();
+        await Assert.That(ws.Cell("D102").HasArrayFormula).IsFalse();
+    }
+
+    [Test]
+    public async Task ColumnReferenceRightOfDeletionIsShifted()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").FormulaA1 = "SUM(J5:L5)";
+
+        ws.Column(5).Delete();
+
+        await Assert.That(ws.Cell("A1").FormulaA1).IsEqualTo("SUM(I5:K5)");
+    }
+
+    [Test]
+    public async Task ColumnReferenceLeftOfDeletionIsUntouched()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").FormulaA1 = "SUM(B5:C5)";
+
+        ws.Column(20).Delete();
+
+        await Assert.That(ws.Cell("A1").FormulaA1).IsEqualTo("SUM(B5:C5)");
+    }
+
+    [Test]
+    public async Task RepeatedColumnDeletionsKeepShiftingTheSameFormula()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").FormulaA1 = "J5";
+
+        ws.Column(5).Delete();
+        ws.Column(5).Delete();
+
+        await Assert.That(ws.Cell("A1").FormulaA1).IsEqualTo("H5");
+    }
+
+    /// <summary>
+    /// Inserting rows uses the same filter with the sign reversed.
+    /// </summary>
+    [Test]
+    public async Task ReferenceBelowInsertionIsShifted()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").FormulaA1 = "SUM(A100:C100)";
+
+        ws.Row(50).InsertRowsAbove(3);
+
+        await Assert.That(ws.Cell("D1").FormulaA1).IsEqualTo("SUM(A103:C103)");
+    }
+
+    [Test]
+    public async Task ReferenceAboveInsertionIsUntouched()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").FormulaA1 = "SUM(A10:C10)";
+
+        ws.Row(50).InsertRowsAbove(3);
+
+        await Assert.That(ws.Cell("D1").FormulaA1).IsEqualTo("SUM(A10:C10)");
+    }
+
+    /// <summary>
+    /// A sheet rename rewrites the formula text, which drops the cached bound. If it did not, a formula
+    /// renamed and then shifted would be measured against a bound derived from text it no longer has.
+    /// </summary>
+    [Test]
+    public async Task ShiftAfterSheetRenameStillRewritesTheReference()
+    {
+        using var wb = new XLWorkbook();
+        var source = wb.AddWorksheet("Source");
+        var consumer = wb.AddWorksheet("Consumer");
+        consumer.Cell("A1").FormulaA1 = "Source!A100";
+
+        source.Name = "Renamed";
+        source.Row(50).Delete();
+
+        await Assert.That(consumer.Cell("A1").FormulaA1).IsEqualTo("Renamed!A99");
+    }
+}

--- a/XLibur/Excel/CalcEngine/Visitors/FormulaExtent.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/FormulaExtent.cs
@@ -1,0 +1,116 @@
+using ClosedXML.Parser;
+
+namespace XLibur.Excel.CalcEngine.Visitors;
+
+/// <summary>
+/// How far down and to the right a formula's <em>shiftable</em> references reach.
+/// <para>
+/// A row or column shift can only rewrite a reference whose extent reaches into the shifted region,
+/// so a formula whose furthest reference stops short of the shift start cannot be edited by it. That
+/// makes this extent a sound pre-filter for the shift pass, which otherwise parses every formula in
+/// the workbook on every structural edit just to discover it had nothing to do.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Only the reference kinds the shifter rewrites are measured — plain <c>A1</c> and single-sheet
+/// <c>Sheet1!A1</c> — matching <c>XLCellFormulaShifter</c>'s collector exactly. 3D, bang, external,
+/// defined-name and structured references are never rewritten, so they widen nothing.
+/// <para>
+/// The extent deliberately ignores which sheet a reference names. A formula on one sheet can refer to
+/// the sheet being shifted, and resolving that here would mean caching a per-sheet answer that a sheet
+/// rename invalidates. Taking the maximum across all sheets over-approximates, which only ever costs a
+/// parse that turns out to be unnecessary — it can never skip a formula that needed shifting.
+/// </para>
+/// </remarks>
+internal readonly struct FormulaExtent
+{
+    /// <summary>The largest row any shiftable reference reaches.</summary>
+    internal int MaxRow { get; private init; }
+
+    /// <summary>The largest column any shiftable reference reaches.</summary>
+    internal int MaxColumn { get; private init; }
+
+    /// <summary>
+    /// Measures <paramref name="formulaA1"/>. A formula the parser rejects — an external workbook
+    /// reference, say — reports the whole sheet, so it always reaches the shifter and its legacy
+    /// fallback rather than being filtered out on a failed parse.
+    /// </summary>
+    internal static FormulaExtent Of(string formulaA1)
+    {
+        if (string.IsNullOrWhiteSpace(formulaA1))
+            return new FormulaExtent { MaxRow = 0, MaxColumn = 0 };
+
+        var collector = new ExtentCollector();
+        try
+        {
+            FormulaParser<object?, object?, ExtentCollector>.CellFormulaA1(
+                FormulaTransformation.ProtectStructuredRefColons(formulaA1, out _),
+                collector,
+                ExtentVisitor.Instance);
+        }
+        catch
+        {
+            return Unbounded;
+        }
+
+        return new FormulaExtent { MaxRow = collector.MaxRow, MaxColumn = collector.MaxColumn };
+    }
+
+    private static FormulaExtent Unbounded => new()
+    {
+        MaxRow = XLHelper.MaxRowNumber,
+        MaxColumn = XLHelper.MaxColumnNumber,
+    };
+
+    /// <summary>
+    /// Mutable accumulator threaded through the parse as the visitor's context.
+    /// </summary>
+    private sealed class ExtentCollector
+    {
+        internal int MaxRow { get; private set; }
+
+        internal int MaxColumn { get; private set; }
+
+        internal void Widen(ReferenceArea reference)
+        {
+            var first = reference.First;
+            var second = reference.Second;
+
+            // An axis the reference does not name spans the whole sheet: the rows of B:D are every
+            // row, which is exactly why a whole-row shift reaches it.
+            MaxRow = first.RowType == ReferenceAxisType.None
+                ? XLHelper.MaxRowNumber
+                : Max(MaxRow, first.RowValue, second.RowValue);
+
+            MaxColumn = first.ColumnType == ReferenceAxisType.None
+                ? XLHelper.MaxColumnNumber
+                : Max(MaxColumn, first.ColumnValue, second.ColumnValue);
+        }
+
+        private static int Max(int current, int a, int b)
+        {
+            if (a > current)
+                current = a;
+
+            return b > current ? b : current;
+        }
+    }
+
+    private sealed class ExtentVisitor : CollectVisitor<ExtentCollector>
+    {
+        internal static readonly ExtentVisitor Instance = new();
+
+        public override object? Reference(ExtentCollector context, SymbolRange range, ReferenceArea reference)
+        {
+            context.Widen(reference);
+            return null;
+        }
+
+        public override object? SheetReference(ExtentCollector context, SymbolRange range, string sheet,
+            ReferenceArea reference)
+        {
+            context.Widen(reference);
+            return null;
+        }
+    }
+}

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -1148,6 +1148,16 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
 
         if (formula.Type == FormulaType.Normal)
         {
+            // A formula whose furthest reference stops above the shifted region cannot be rewritten
+            // by this shift, so skip the parse the shifter would otherwise pay to discover that.
+            // Dynamic arrays are excluded: their spill footprint is relocated below even when the
+            // formula text is untouched, and so is an array's stored Range further down.
+            if (!formula.IsDynamicArray &&
+                formula.MaxShiftableRow < shiftedRange.RangeAddress.FirstAddress.RowNumber)
+            {
+                return;
+            }
+
             var shiftedNormal = XLCellFormulaShifter.ShiftFormulaRows(formula.A1, Worksheet, shiftedRange, rowsShifted);
 
             if (formula.IsDynamicArray)
@@ -1158,7 +1168,12 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
             }
 
             if (!string.Equals(shiftedNormal, formula.A1, StringComparison.Ordinal))
+            {
                 FormulaA1 = shiftedNormal;
+                Formula?.SeedShiftedExtentFrom(
+                    formula, shiftedRange.RangeAddress.FirstAddress.RowNumber, rowsShifted, shiftRows: true);
+            }
+
             return;
         }
 
@@ -1192,6 +1207,13 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
 
         if (formula.Type == FormulaType.Normal)
         {
+            // See ShiftFormulaRows for why this filter is sound and why dynamic arrays opt out.
+            if (!formula.IsDynamicArray &&
+                formula.MaxShiftableColumn < shiftedRange.RangeAddress.FirstAddress.ColumnNumber)
+            {
+                return;
+            }
+
             var shiftedNormal = XLCellFormulaShifter.ShiftFormulaColumns(formula.A1, Worksheet, shiftedRange, columnsShifted);
 
             if (formula.IsDynamicArray)
@@ -1202,7 +1224,12 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
             }
 
             if (!string.Equals(shiftedNormal, formula.A1, StringComparison.Ordinal))
+            {
                 FormulaA1 = shiftedNormal;
+                Formula?.SeedShiftedExtentFrom(
+                    formula, shiftedRange.RangeAddress.FirstAddress.ColumnNumber, columnsShifted, shiftRows: false);
+            }
+
             return;
         }
 

--- a/XLibur/Excel/Cells/XLCellFormula.cs
+++ b/XLibur/Excel/Cells/XLCellFormula.cs
@@ -50,6 +50,17 @@ internal sealed class XLCellFormula
     private FormulaExtra? _extra;
 
     /// <summary>
+    /// Cached value behind <see cref="MaxShiftableRow"/>; <c>0</c> means "not computed yet"
+    /// (no reference can have row 0, so it is unambiguous as a sentinel).
+    /// </summary>
+    private int _maxShiftableRow;
+
+    /// <summary>
+    /// Cached value behind <see cref="MaxShiftableColumn"/>. See <see cref="_maxShiftableRow"/>.
+    /// </summary>
+    private int _maxShiftableColumn;
+
+    /// <summary>
     /// Is this formula clean, i.e. evaluated against the workbook's current edit epoch?
     /// </summary>
     internal bool IsClean(XLWorkbook wb) => _evalEpoch == wb.EditEpoch;
@@ -356,6 +367,33 @@ internal sealed class XLCellFormula
     }
 
     /// <summary>
+    /// The lowest row a row-shift can start at and still rewrite something in this formula, i.e. the
+    /// largest row any shiftable reference reaches. A row deletion or insertion starting below this
+    /// cannot produce an edit, so the shift can be skipped without parsing.
+    /// <para>
+    /// Computed once and cached, because the shift pass asks the same question of every formula in
+    /// the workbook on every structural edit, and the answer only changes when <see cref="A1"/> does.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// "Shiftable" means the reference kinds <c>XLCellFormulaShifter</c> actually rewrites — plain and
+    /// single-sheet references. Everything else (3D, bang, external, defined names, structured
+    /// references) is left alone by the shifter, so it contributes no bound. A formula the parser
+    /// rejects reports <see cref="XLHelper.MaxRowNumber"/>, which never filters, so it still reaches
+    /// the shifter's legacy fallback.
+    /// </remarks>
+    internal int MaxShiftableRow => _maxShiftableRow != 0
+        ? _maxShiftableRow
+        : _maxShiftableRow = FormulaExtent.Of(A1).MaxRow;
+
+    /// <summary>
+    /// The column counterpart of <see cref="MaxShiftableRow"/>.
+    /// </summary>
+    internal int MaxShiftableColumn => _maxShiftableColumn != 0
+        ? _maxShiftableColumn
+        : _maxShiftableColumn = FormulaExtent.Of(A1).MaxColumn;
+
+    /// <summary>
     /// Get a lazy initialized AST for the formula.
     /// </summary>
     /// <param name="engine">Engine to parse the formula into AST, if necessary.</param>
@@ -383,6 +421,7 @@ internal sealed class XLCellFormula
             return;
 
         A1 = newA1;
+        InvalidateExtent();
         MarkExplicitlyDirty();
     }
 
@@ -397,8 +436,73 @@ internal sealed class XLCellFormula
         if (res != a1)
         {
             A1 = res;
+            InvalidateExtent();
             MarkExplicitlyDirty();
         }
+    }
+
+    /// <summary>
+    /// Drops the cached <see cref="MaxShiftableRow"/>/<see cref="MaxShiftableColumn"/>. Must be
+    /// called from every place that assigns <see cref="A1"/> after construction.
+    /// </summary>
+    private void InvalidateExtent()
+    {
+        _maxShiftableRow = 0;
+        _maxShiftableColumn = 0;
+    }
+
+    /// <summary>
+    /// Seeds this formula's cached extent from the formula it was shifted out of, instead of
+    /// re-deriving it by parsing text that was just parsed by the shifter.
+    /// </summary>
+    /// <remarks>
+    /// A shift moves every reference it touches by the same rule, so the predecessor's bound moved by
+    /// that rule bounds the successor. The result is only ever an over-estimate — a reference clamped
+    /// onto the edge of a deleted block lands below it — and over-estimating is the safe direction:
+    /// the filter that reads this skips a formula only when the bound falls short of the shift, so a
+    /// bound that is too large costs a parse and never a missed rewrite.
+    /// <para>
+    /// Carrying the bound rather than recomputing it is what keeps the filter from being a pessimism
+    /// on sheets where formulas really do move: without it every rewritten formula pays a fresh parse
+    /// on the next shift, which is the parse the filter exists to avoid.
+    /// </para>
+    /// </remarks>
+    /// <param name="source">The formula this one replaces.</param>
+    /// <param name="shiftStart">First row (or column) of the shifted region.</param>
+    /// <param name="shift">Signed shift; negative for a deletion.</param>
+    /// <param name="shiftRows"><c>true</c> for a row shift, <c>false</c> for a column shift.</param>
+    internal void SeedShiftedExtentFrom(XLCellFormula source, int shiftStart, int shift, bool shiftRows)
+    {
+        var sourceBound = shiftRows ? source._maxShiftableRow : source._maxShiftableColumn;
+
+        // Nothing cached on the source means nothing to carry: leave this formula to compute its own
+        // bound on first use.
+        if (sourceBound == 0)
+            return;
+
+        int bound;
+        if (sourceBound < shiftStart)
+        {
+            bound = sourceBound;
+        }
+        else if (shift >= 0)
+        {
+            bound = sourceBound + shift;
+        }
+        else
+        {
+            // A reference that survives moves up by the deleted count; one swallowed by the deletion
+            // collapses onto the row above it. Neither can exceed this.
+            bound = Math.Max(sourceBound + shift, shiftStart - 1);
+        }
+
+        var max = shiftRows ? XLHelper.MaxRowNumber : XLHelper.MaxColumnNumber;
+        bound = Math.Clamp(bound, 1, max);
+
+        if (shiftRows)
+            _maxShiftableRow = bound;
+        else
+            _maxShiftableColumn = bound;
     }
 
     internal XLCellFormula GetMovedTo(Point origin, Point destination)

--- a/XLibur/Excel/Ranges/XLFormulaShiftPass.cs
+++ b/XLibur/Excel/Ranges/XLFormulaShiftPass.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// Re-points the formulas of every worksheet in a workbook after a row or column shift.
+/// </summary>
+/// <remarks>
+/// Every worksheet is visited, not just the shifted one, because a formula on any sheet may refer to
+/// the sheet being shifted; <c>XLCellFormulaShifter</c> is what decides which references that shift
+/// actually reaches.
+/// <para>
+/// The walk is over the formula slice rather than over used cells. The cell-level enumeration visited
+/// every used cell in the sheet and materialised an <c>XLCell</c> facade for each — through a 16-slot
+/// direct-mapped cache that a linear scan defeats — only to discard the ones with no formula. The
+/// formula slice already knows where the formulas are, so a value-only sheet costs nothing here.
+/// </para>
+/// </remarks>
+internal static class XLFormulaShiftPass
+{
+    internal static void Run(XLWorkbook workbook, XLRange shiftedRange, bool shiftRows, int shift)
+    {
+        // Array and data-table formulas share one instance across every cell of their range and must
+        // be shifted exactly once; the set is shared across sheets because the pass is.
+        var processedArrayFormulas = new HashSet<XLCellFormula>();
+
+        foreach (var sheet in workbook.WorksheetsInternal)
+        {
+            var cellsCollection = sheet.Internals.CellsCollection;
+            var enumerator = cellsCollection.FormulaSlice.GetForwardEnumerator(Coordinates.Area.Full);
+
+            // Materialise the points first. The shift writes back into the same slice (a rewritten
+            // normal formula is a new XLCellFormula instance at the same point), and mutating a slice
+            // while its enumerator is live is not a contract the slice offers.
+            var points = new List<Coordinates.Point>();
+            while (enumerator.MoveNext())
+                points.Add(enumerator.Point);
+
+            foreach (var point in points)
+            {
+                var cell = cellsCollection.GetCell(point);
+                if (shiftRows)
+                    cell.ShiftFormulaRows(shiftedRange, shift, processedArrayFormulas);
+                else
+                    cell.ShiftFormulaColumns(shiftedRange, shift, processedArrayFormulas);
+            }
+        }
+    }
+}

--- a/XLibur/Excel/Ranges/XLRangeBase.cs
+++ b/XLibur/Excel/Ranges/XLRangeBase.cs
@@ -1096,21 +1096,11 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
             RangeAddress.LastAddress.ColumnNumber);
 
         // Shift formulas first
-        var processedArrayFormulas = new HashSet<XLCellFormula>();
-        foreach (var cell in Worksheet
-                     .Workbook
-                     .Worksheets
-                     .Cast<XLWorksheet>()
-                     .SelectMany(ws => ws
-                         .Internals
-                         .CellsCollection
-                         .GetCells(c => c.HasFormula)))
-        {
-            if (shiftDeleteCells == XLShiftDeletedCells.ShiftCellsUp)
-                cell.ShiftFormulaRows((XLRange)shiftedRangeFormula, numberOfRows * -1, processedArrayFormulas);
-            else
-                cell.ShiftFormulaColumns((XLRange)shiftedRangeFormula, numberOfColumns * -1, processedArrayFormulas);
-        }
+        XLFormulaShiftPass.Run(
+            Worksheet.Workbook,
+            (XLRange)shiftedRangeFormula,
+            shiftDeleteCells == XLShiftDeletedCells.ShiftCellsUp,
+            shiftDeleteCells == XLShiftDeletedCells.ShiftCellsUp ? -numberOfRows : -numberOfColumns);
 
         // Range to shift...
         var columnModifier = 0;

--- a/XLibur/Excel/Ranges/XLRangeInsertHelper.cs
+++ b/XLibur/Excel/Ranges/XLRangeInsertHelper.cs
@@ -51,13 +51,7 @@ internal static class XLRangeInsertHelper
 
     private static void ShiftFormulasForColumns(XLRangeBase range, int numberOfColumns)
     {
-        var asRange = range.AsRange();
-        var processedArrayFormulas = new HashSet<XLCellFormula>();
-        foreach (var ws in range.Worksheet.Workbook.WorksheetsInternal)
-        {
-            foreach (var cell in ws.Internals.CellsCollection.GetCells(c => c.Formula is not null))
-                cell.ShiftFormulaColumns(asRange, numberOfColumns, processedArrayFormulas);
-        }
+        XLFormulaShiftPass.Run(range.Worksheet.Workbook, range.AsRange(), shiftRows: false, numberOfColumns);
     }
 
     private static void ShiftColumnWidths(XLRangeBase range, bool onlyUsedCells, int numberOfColumns)
@@ -164,13 +158,7 @@ internal static class XLRangeInsertHelper
 
     private static void ShiftFormulasForRows(XLRangeBase range, int numberOfRows)
     {
-        var asRange = range.AsRange();
-        var processedArrayFormulas = new HashSet<XLCellFormula>();
-        foreach (var ws in range.Worksheet.Workbook.WorksheetsInternal)
-        {
-            foreach (var cell in ws.Internals.CellsCollection.GetCells(c => c.Formula is not null))
-                cell.ShiftFormulaRows(asRange, numberOfRows, processedArrayFormulas);
-        }
+        XLFormulaShiftPass.Run(range.Worksheet.Workbook, range.AsRange(), shiftRows: true, numberOfRows);
     }
 
     private static void ShiftRowHeights(XLRangeBase range, bool onlyUsedCells, int numberOfRows)


### PR DESCRIPTION
A row or column shift asks every formula in the workbook to re-point itself, and
the shifter can only answer by parsing. On a sheet where the edit reaches
nothing, that is a full parse per formula per edit — which is why deleting rows
one at a time is dominated by formula work rather than by moving cells.

## What changed

**Cache how far a formula reaches.** `FormulaExtent` measures only the reference
kinds `XLCellFormulaShifter` actually rewrites (plain and single-sheet), so 3D,
bang, external, defined-name and structured references widen nothing. A formula
whose furthest reference stops above the shifted region cannot be edited by it,
so the parse is skipped outright.

The bound is *carried* through a shift rather than re-derived. Without that,
every rewritten formula pays a fresh parse on the next edit — the first cut was
a 36% regression on formulas that do move (7219 ms -> 9794 ms) before
`SeedShiftedExtentFrom` was added. Over-approximating is the safe direction: the
filter skips only when the bound falls short, so a loose bound costs a parse and
never a missed rewrite.

**Walk the formula slice, not every used cell.** The old pass visited every used
cell and materialised an `XLCell` facade for each — through a 16-slot
direct-mapped cache that a linear scan defeats — only to discard the ones with
no formula. The three near-identical copies of that scan collapse into
`XLFormulaShiftPass`.

Array, data-table and dynamic-array formulas opt out of the filter: their stored
`Range` and spill footprint are relocated by the shift even when the formula
text is untouched.

## Numbers

Deleting every 3rd row of a 4000-row sheet with a `SUM` per row:

| | before | after |
|---|---:|---:|
| 4000 rows / 1333 deletes | 4613 ms / 4373 MB | **2716 ms / 2701 MB** |
| 8000 rows / 2666 deletes | 19595 ms / 17481 MB | **10839 ms / 10793 MB** |

Isolated, 1333 deletes over 4000 formula cells:

| | before | after |
|---|---:|---:|
| formulas the shift cannot reach | 3718 ms / 2773 MB | **255 ms / 538 MB** |
| formulas the shift does rewrite | 7219 ms / 7125 MB | 6518 ms / 7251 MB |

## What this is not

A constant-factor win, **not** a complexity change. Repeated single-row deletes
stay quadratic — allocations still go 4x per doubling — because the rewrites
they trigger are real: a formula in `D3000` genuinely must be re-pointed each
time a row above it goes. The filter removes the parse-and-find-nothing half of
the work; only one composite shift can remove the other half. That is a
follow-up.

Because the filter helps only the half it can reach, the win depends on delete
direction: bottom-up (most survivors above each delete) gets ~1.8x, top-down
gets ~1.34x.

## Testing

- `XLibur.Tests` 11,741 pass / 4 pre-existing skips; `XLibur.Report.Tests` 481 pass.
- New `FormulaShiftFilterTests` (17 cases) targets the only dangerous direction —
  a bound too *small*, which strands a formula that should have moved. Verified
  non-vacuous by mutation: changing the boundary `<` to `<=` fails 2 tests, and
  making the carry-forward under-estimate fails 2 others.