### PR TITLE
perf(rows): delete a set of rows in one formula pass

### DIFF
--- a/XLibur.Tests/Excel/Ranges/BatchRowDeleteTests.cs
+++ b/XLibur.Tests/Excel/Ranges/BatchRowDeleteTests.cs
@@ -1,0 +1,289 @@
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Ranges;
+
+/// <summary>
+/// Covers deleting a set of whole rows in one call, where the set need not be contiguous.
+/// <para>
+/// The batched path re-points every formula once against the whole set of deleted rows instead of once
+/// per row, so the thing worth pinning is that it lands in the same place the row-at-a-time path does.
+/// Several tests assert exactly that equivalence rather than a hand-computed answer, because the
+/// row-at-a-time path is the definition of correct here and a hand-computed expectation would just be a
+/// second chance to get the same arithmetic wrong.
+/// </para>
+/// </summary>
+public class BatchRowDeleteTests
+{
+    [Test]
+    public async Task ScatteredDeleteMatchesRowAtATimeDelete()
+    {
+        using var perRow = Build(60, out var a);
+        using var batched = Build(60, out var b);
+        var targets = Enumerable.Range(1, 20).Select(i => i * 3).Reverse().ToList();
+
+        foreach (var row in targets)
+            a.Row(row).Delete();
+
+        b.Rows(Spec(targets)).Delete();
+
+        for (var row = 1; row <= 60; row++)
+        {
+            await Assert.That(b.Cell(row, 4).FormulaA1).IsEqualTo(a.Cell(row, 4).FormulaA1);
+            await Assert.That(b.Cell(row, 1).GetString()).IsEqualTo(a.Cell(row, 1).GetString());
+        }
+    }
+
+    [Test]
+    public async Task ContiguousDeleteMatchesRowAtATimeDelete()
+    {
+        using var perRow = Build(40, out var a);
+        using var batched = Build(40, out var b);
+        var targets = new[] { 12, 11, 10, 9, 8 };
+
+        foreach (var row in targets)
+            a.Row(row).Delete();
+
+        b.Rows("8:12").Delete();
+
+        for (var row = 1; row <= 40; row++)
+            await Assert.That(b.Cell(row, 4).FormulaA1).IsEqualTo(a.Cell(row, 4).FormulaA1);
+    }
+
+    /// <summary>
+    /// Runs and singletons in the same call. The set is split into contiguous runs and removed furthest
+    /// down first, so a mis-ordered split shows up as rows going missing from the wrong places.
+    /// </summary>
+    [Test]
+    public async Task MixedRunsAndSingletonsMatchRowAtATimeDelete()
+    {
+        using var perRow = Build(40, out var a);
+        using var batched = Build(40, out var b);
+        var targets = new[] { 30, 21, 20, 19, 12, 5, 4 };
+
+        foreach (var row in targets)
+            a.Row(row).Delete();
+
+        b.Rows(Spec(targets)).Delete();
+
+        for (var row = 1; row <= 40; row++)
+        {
+            await Assert.That(b.Cell(row, 1).GetString()).IsEqualTo(a.Cell(row, 1).GetString());
+            await Assert.That(b.Cell(row, 4).FormulaA1).IsEqualTo(a.Cell(row, 4).FormulaA1);
+        }
+    }
+
+    [Test]
+    public async Task ScatteredDeleteShiftsRowsUpByTheCountRemovedAboveThem()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        for (var row = 1; row <= 10; row++)
+            ws.Cell(row, 1).Value = row;
+
+        ws.Rows("2:2,5:5,8:8").Delete();
+
+        // 1,3,4,6,7,9,10 survive and close up in order.
+        var expected = new[] { 1, 3, 4, 6, 7, 9, 10 };
+        for (var i = 0; i < expected.Length; i++)
+            await Assert.That(ws.Cell(i + 1, 1).GetValue<int>()).IsEqualTo(expected[i]);
+
+        await Assert.That(ws.Cell(8, 1).IsEmpty()).IsTrue();
+    }
+
+    /// <summary>
+    /// A reference spanning the deleted rows loses exactly the rows deleted inside it, and the rows
+    /// deleted above it move the whole thing up.
+    /// </summary>
+    [Test]
+    public async Task ReferenceSpanningDeletedRowsShrinksByTheRowsRemovedInsideIt()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("E1").FormulaA1 = "SUM(A10:A20)";
+
+        ws.Rows("2:2,12:12,15:15").Delete();
+
+        // One row deleted above the reference moves it up by one; two deleted inside shorten it.
+        await Assert.That(ws.Cell("E1").FormulaA1).IsEqualTo("SUM(A9:A17)");
+    }
+
+    /// <summary>
+    /// Only the reference is destroyed, not the call around it, so the surviving text is
+    /// <c>SUM(#REF!)</c> — which is also what deleting the rows one at a time produces.
+    /// </summary>
+    [Test]
+    public async Task ReferenceEntirelyInsideTheDeletedSetBecomesRefError()
+    {
+        using var batched = new XLWorkbook();
+        var b = batched.AddWorksheet();
+        b.Cell("E1").FormulaA1 = "SUM(A10:A12)";
+        b.Rows("10:12").Delete();
+
+        using var perRow = new XLWorkbook();
+        var a = perRow.AddWorksheet();
+        a.Cell("E1").FormulaA1 = "SUM(A10:A12)";
+        a.Row(12).Delete();
+        a.Row(11).Delete();
+        a.Row(10).Delete();
+
+        await Assert.That(b.Cell("E1").FormulaA1).IsEqualTo("SUM(#REF!)");
+        await Assert.That(b.Cell("E1").FormulaA1).IsEqualTo(a.Cell("E1").FormulaA1);
+    }
+
+    [Test]
+    public async Task ReferenceAboveEveryDeletedRowIsUntouched()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("E1").FormulaA1 = "SUM(A2:A5)";
+
+        ws.Rows("10:10,20:20,30:30").Delete();
+
+        await Assert.That(ws.Cell("E1").FormulaA1).IsEqualTo("SUM(A2:A5)");
+    }
+
+    [Test]
+    public async Task FormulaOnAnotherSheetIsRepointedByTheBatchedDelete()
+    {
+        using var wb = new XLWorkbook();
+        var source = wb.AddWorksheet("Source");
+        var consumer = wb.AddWorksheet("Consumer");
+        consumer.Cell("A1").FormulaA1 = "SUM(Source!A10:A20)";
+
+        source.Rows("2:2,12:12,15:15").Delete();
+
+        await Assert.That(consumer.Cell("A1").FormulaA1).IsEqualTo("SUM(Source!A9:A17)");
+    }
+
+    /// <summary>
+    /// An array formula carries a stored range that only the per-cell shift relocates, so a workbook
+    /// containing one takes the row-at-a-time path. The batched call must still produce the same answer.
+    /// </summary>
+    [Test]
+    public async Task ArrayFormulaWorkbookFallsBackAndStillShifts()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Range("F20:F22").FormulaArrayA1 = "1+2";
+        ws.Cell("E1").FormulaA1 = "SUM(A10:A20)";
+
+        ws.Rows("2:2,12:12").Delete();
+
+        await Assert.That(ws.Cell("E1").FormulaA1).IsEqualTo("SUM(A9:A18)");
+        await Assert.That(ws.Cell("F18").HasArrayFormula).IsTrue();
+        await Assert.That(ws.Cell("F20").HasArrayFormula).IsTrue();
+        await Assert.That(ws.Cell("F21").HasArrayFormula).IsFalse();
+    }
+
+    /// <summary>
+    /// The row map collapses duplicates and sorts, so a caller handing over rows in any order — or the
+    /// same row twice — gets the same result as a clean ascending set.
+    /// </summary>
+    [Test]
+    public async Task UnsortedAndDuplicatedRowsDeleteEachRowOnce()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        for (var row = 1; row <= 10; row++)
+            ws.Cell(row, 1).Value = row;
+
+        ws.Rows("8:8,2:2,8:8,5:5,2:2").Delete();
+
+        var expected = new[] { 1, 3, 4, 6, 7, 9, 10 };
+        for (var i = 0; i < expected.Length; i++)
+            await Assert.That(ws.Cell(i + 1, 1).GetValue<int>()).IsEqualTo(expected[i]);
+    }
+
+    [Test]
+    public async Task RowPropertiesFollowTheSurvivingRows()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        for (var row = 1; row <= 10; row++)
+            ws.Cell(row, 1).Value = row;
+
+        ws.Row(7).Height = 33;
+
+        ws.Rows("2:2,5:5").Delete();
+
+        // Row 7 loses two rows above it and becomes row 5.
+        await Assert.That(ws.Cell(5, 1).GetValue<int>()).IsEqualTo(7);
+        await Assert.That(ws.Row(5).Height).IsEqualTo(33);
+    }
+
+    [Test]
+    public async Task DefinedNameShiftsAcrossAScatteredDelete()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        ws.Range("A10:A20").AddToNamed("Block", XLScope.Workbook);
+
+        ws.Rows("2:2,12:12,15:15").Delete();
+
+        await Assert.That(wb.DefinedName("Block").RefersTo).IsEqualTo("Data!$A$9:$A$17");
+    }
+
+    [Test]
+    public async Task MergedRangeShiftsAcrossAScatteredDelete()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Range("A10:B11").Merge();
+
+        ws.Rows("2:2,5:5").Delete();
+
+        await Assert.That(ws.MergedRanges.Single().RangeAddress.ToString()).IsEqualTo("A8:B9");
+    }
+
+    [Test]
+    public async Task LiveRangeShiftsAcrossAScatteredDelete()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var tracked = ws.Range("A10:A20");
+
+        ws.Rows("2:2,12:12,15:15").Delete();
+
+        await Assert.That(tracked.RangeAddress.ToString()).IsEqualTo("A9:A17");
+    }
+
+    /// <summary>
+    /// The values a batched delete leaves behind must still recalculate, i.e. the formulas it rewrote
+    /// are marked dirty rather than keeping the cached result of the pre-delete layout.
+    /// </summary>
+    [Test]
+    public async Task FormulasRecalculateAfterABatchedDelete()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        for (var row = 1; row <= 10; row++)
+            ws.Cell(row, 1).Value = row * 100;
+
+        ws.Cell("C1").FormulaA1 = "A8";
+        await Assert.That(ws.Cell("C1").GetValue<int>()).IsEqualTo(800);
+
+        ws.Rows("2:2,4:4").Delete();
+
+        // A8 became A6, which now holds what was in row 8 -> 800 still, but via the moved cell.
+        await Assert.That(ws.Cell("C1").FormulaA1).IsEqualTo("A6");
+        await Assert.That(ws.Cell("C1").GetValue<int>()).IsEqualTo(800);
+    }
+
+    private static string Spec(System.Collections.Generic.IEnumerable<int> rows)
+        => string.Join(",", rows.Select(r => $"{r}:{r}"));
+
+    private static XLWorkbook Build(int rows, out IXLWorksheet ws)
+    {
+        var wb = new XLWorkbook();
+        ws = wb.AddWorksheet("Sheet1");
+        for (var row = 1; row <= rows; row++)
+        {
+            ws.Cell(row, 1).Value = $"r{row}";
+            ws.Cell(row, 4).FormulaA1 = $"SUM(A{row}:C{row})";
+        }
+
+        return wb;
+    }
+}

--- a/XLibur.Tests/Excel/Ranges/RowDeletionMapTests.cs
+++ b/XLibur.Tests/Excel/Ranges/RowDeletionMapTests.cs
@@ -1,0 +1,106 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Ranges;
+
+/// <summary>
+/// Unit tests for the row map a batched delete is built on.
+/// <para>
+/// <see cref="BatchRowDeleteTests"/> covers the observable behaviour, but two properties here are
+/// invisible from outside and would degrade silently. Run coalescing is one: emitting singletons
+/// instead of runs is still <em>correct</em>, just one structural pass per row instead of per run,
+/// which is most of what the batching is for. The edge-mapping asymmetry is the other.
+/// </para>
+/// </summary>
+public class RowDeletionMapTests
+{
+    [Test]
+    public async Task ConsecutiveRowsCoalesceIntoOneRun()
+    {
+        var map = XLRowDeletionMap.Create([8, 9, 10, 11, 12])!;
+
+        var runs = map.GetRunsBottomUp();
+
+        await Assert.That(runs.Count).IsEqualTo(1);
+        await Assert.That(runs[0]).IsEqualTo((8, 12));
+    }
+
+    /// <summary>
+    /// Runs come out furthest down the sheet first: a run has to be removed before the runs above it
+    /// move, or their row numbers stop meaning what the map says.
+    /// </summary>
+    [Test]
+    public async Task RunsAreEmittedBottomUp()
+    {
+        var map = XLRowDeletionMap.Create([4, 5, 12, 19, 20, 21, 30])!;
+
+        var runs = map.GetRunsBottomUp();
+
+        await Assert.That(runs).IsEquivalentTo([(30, 30), (19, 21), (12, 12), (4, 5)]);
+    }
+
+    [Test]
+    public async Task UnsortedInputWithDuplicatesCollapses()
+    {
+        var map = XLRowDeletionMap.Create([12, 4, 5, 4, 12])!;
+
+        await Assert.That(map.Count).IsEqualTo(3);
+        await Assert.That(map.FirstDeletedRow).IsEqualTo(4);
+        await Assert.That(map.GetRunsBottomUp()).IsEquivalentTo([(12, 12), (4, 5)]);
+    }
+
+    [Test]
+    public async Task EmptyInputProducesNoMap()
+    {
+        await Assert.That(XLRowDeletionMap.Create([])).IsNull();
+    }
+
+    /// <summary>
+    /// The two edges are counted differently on purpose. A range's top slides up by the rows deleted
+    /// strictly above it; its bottom also loses the rows deleted inside it. Mapping both ends the same
+    /// way would leave a range that spans a deleted row too long by exactly that count.
+    /// </summary>
+    [Test]
+    public async Task TopAndBottomEdgesMapDifferentlyAcrossAnInteriorDeletion()
+    {
+        var map = XLRowDeletionMap.Create([2, 12, 15])!;
+
+        // A10:A20 -> one row gone above it, two gone inside it.
+        await Assert.That(map.MapFirst(10)).IsEqualTo(9);
+        await Assert.That(map.MapLast(20)).IsEqualTo(17);
+    }
+
+    [Test]
+    public async Task RowsAboveEveryDeletionAreUnmoved()
+    {
+        var map = XLRowDeletionMap.Create([10, 20, 30])!;
+
+        await Assert.That(map.MapFirst(5)).IsEqualTo(5);
+        await Assert.That(map.MapLast(9)).IsEqualTo(9);
+    }
+
+    /// <summary>
+    /// A range wholly inside the deletion maps to an inverted pair, which is how the shifter recognises
+    /// a reference the deletion destroyed.
+    /// </summary>
+    [Test]
+    public async Task FullySwallowedRangeMapsToAnInvertedPair()
+    {
+        var map = XLRowDeletionMap.Create([10, 11, 12])!;
+
+        await Assert.That(map.MapLast(12)).IsLessThan(map.MapFirst(10));
+    }
+
+    /// <summary>
+    /// A deleted row shares its mapped position with the first survivor below it — the survivor moves
+    /// into the space the deleted row left.
+    /// </summary>
+    [Test]
+    public async Task DeletedRowMapsToWhereItsSuccessorLands()
+    {
+        var map = XLRowDeletionMap.Create([5])!;
+
+        await Assert.That(map.MapFirst(5)).IsEqualTo(5);
+        await Assert.That(map.MapFirst(6)).IsEqualTo(5);
+    }
+}

--- a/XLibur/Excel/Cells/XLCellFormula.cs
+++ b/XLibur/Excel/Cells/XLCellFormula.cs
@@ -467,6 +467,18 @@ internal sealed class XLCellFormula
     /// on the next shift, which is the parse the filter exists to avoid.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// The batch counterpart of <see cref="SeedShiftedExtentFrom(XLCellFormula,int,int,bool)"/>. The
+    /// bound is the furthest row a reference reaches, so it maps like the bottom edge of one.
+    /// </summary>
+    internal void SeedShiftedExtentFrom(XLCellFormula source, XLRowDeletionMap map)
+    {
+        if (source._maxShiftableRow == 0)
+            return;
+
+        _maxShiftableRow = Math.Clamp(map.MapLast(source._maxShiftableRow), 1, XLHelper.MaxRowNumber);
+    }
+
     /// <param name="source">The formula this one replaces.</param>
     /// <param name="shiftStart">First row (or column) of the shifted region.</param>
     /// <param name="shift">Signed shift; negative for a deletion.</param>

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -34,6 +34,55 @@ internal static partial class XLCellFormulaShifter
         int columnsShifted)
         => Shift(formulaA1, worksheetInAction, shiftedRange, columnsShifted, ShiftAxis.Column);
 
+    /// <summary>
+    /// Re-points a formula for the deletion of a whole set of rows at once, rather than one contiguous
+    /// block at a time.
+    /// </summary>
+    /// <remarks>
+    /// The block overload cannot express a scattered deletion, so callers had to run it once per row —
+    /// which is a parse of every formula in the workbook per row. Here the whole set is one mapping and
+    /// one parse.
+    /// <para>
+    /// Only whole-row deletions come through here, so the cross-axis containment test the block path
+    /// applies is vacuous: a whole-row deletion spans every column and therefore spans every reference.
+    /// </para>
+    /// </remarks>
+    internal static string ShiftFormulaRows(string formulaA1, XLWorksheet worksheetInAction, string shiftedSheetName,
+        XLRowDeletionMap map)
+    {
+        if (string.IsNullOrWhiteSpace(formulaA1))
+            return string.Empty;
+
+        var parseable = FormulaTransformation.ProtectStructuredRefColons(formulaA1, out var wasProtected);
+        var plan = new ShiftPlan(shiftedSheetName, worksheetInAction.Name, parseable, map);
+        try
+        {
+            FormulaParser<object?, object?, ShiftPlan>.CellFormulaA1(parseable, plan, ShiftCollector.Instance);
+        }
+        catch (Exception)
+        {
+            // The block path degrades to the regex implementation here. There is no batch regex
+            // shifter, so fall back to applying the runs one at a time, which is what the caller would
+            // have done anyway. Correctness first; this is the rare formula, not the common one.
+            var shiftedByRuns = formulaA1;
+            foreach (var (firstRow, lastRow) in map.GetRunsBottomUp())
+            {
+                var runRange = (XLRange)worksheetInAction.Workbook.Worksheet(shiftedSheetName)
+                    .Range(firstRow, 1, lastRow, XLHelper.MaxColumnNumber);
+                shiftedByRuns = ShiftFormulaRowsLegacy(
+                    shiftedByRuns, worksheetInAction, runRange, -(lastRow - firstRow + 1));
+            }
+
+            return shiftedByRuns;
+        }
+
+        if (!plan.HasEdits)
+            return formulaA1;
+
+        var shifted = plan.Apply(parseable);
+        return wasProtected ? shifted.Replace(FormulaTransformation.ColonPlaceholder, ':') : shifted;
+    }
+
     private static string Shift(string formulaA1, XLWorksheet worksheetInAction, XLRange shiftedRange, int shift,
         ShiftAxis axis)
     {
@@ -111,30 +160,72 @@ internal static partial class XLCellFormulaShifter
     /// <summary>
     /// The shift being applied, plus the replacement spans collected for it.
     /// </summary>
-    private sealed class ShiftPlan(
-        string shiftedSheetName,
-        string formulaSheetName,
-        string formula,
-        XLRange shiftedRange,
-        int shift,
-        ShiftAxis axis)
+    private sealed class ShiftPlan
     {
         private const string RefErrorText = "#REF!";
 
-        private readonly int _shiftFirstRow = shiftedRange.RangeAddress.FirstAddress.RowNumber;
-        private readonly int _shiftLastRow = shiftedRange.RangeAddress.LastAddress.RowNumber;
-        private readonly int _shiftFirstColumn = shiftedRange.RangeAddress.FirstAddress.ColumnNumber;
-        private readonly int _shiftLastColumn = shiftedRange.RangeAddress.LastAddress.ColumnNumber;
+        private readonly string _shiftedSheetName;
+        private readonly string _formulaSheetName;
+        private readonly string _formula;
+        private readonly int _shift;
+        private readonly ShiftAxis _axis;
+
+        private readonly int _shiftFirstRow;
+        private readonly int _shiftLastRow;
+        private readonly int _shiftFirstColumn;
+        private readonly int _shiftLastColumn;
+
+        /// <summary>
+        /// Set for a scattered whole-row deletion, in which case it — not
+        /// <see cref="_shift"/> — decides where each reference edge lands.
+        /// </summary>
+        private readonly XLRowDeletionMap? _rowMap;
 
         private List<Edit>? _edits;
+
+        internal ShiftPlan(
+            string shiftedSheetName,
+            string formulaSheetName,
+            string formula,
+            XLRange shiftedRange,
+            int shift,
+            ShiftAxis axis)
+        {
+            _shiftedSheetName = shiftedSheetName;
+            _formulaSheetName = formulaSheetName;
+            _formula = formula;
+            _shift = shift;
+            _axis = axis;
+            _shiftFirstRow = shiftedRange.RangeAddress.FirstAddress.RowNumber;
+            _shiftLastRow = shiftedRange.RangeAddress.LastAddress.RowNumber;
+            _shiftFirstColumn = shiftedRange.RangeAddress.FirstAddress.ColumnNumber;
+            _shiftLastColumn = shiftedRange.RangeAddress.LastAddress.ColumnNumber;
+        }
+
+        /// <summary>
+        /// A whole-row deletion of an arbitrary set of rows. The shifted region spans every column, so
+        /// the cross-axis bounds are the whole sheet.
+        /// </summary>
+        internal ShiftPlan(string shiftedSheetName, string formulaSheetName, string formula, XLRowDeletionMap map)
+        {
+            _shiftedSheetName = shiftedSheetName;
+            _formulaSheetName = formulaSheetName;
+            _formula = formula;
+            _axis = ShiftAxis.Row;
+            _rowMap = map;
+            _shiftFirstRow = map.FirstDeletedRow;
+            _shiftLastRow = XLHelper.MaxRowNumber;
+            _shiftFirstColumn = 1;
+            _shiftLastColumn = XLHelper.MaxColumnNumber;
+        }
 
         internal bool HasEdits => _edits is { Count: > 0 };
 
         internal void Visit(SymbolRange range, ReferenceArea reference, string? sheet)
         {
             // An unqualified reference resolves against the sheet its formula sits on.
-            var referencedSheet = sheet ?? formulaSheetName;
-            if (!XLHelper.SheetComparer.Equals(referencedSheet, shiftedSheetName))
+            var referencedSheet = sheet ?? _formulaSheetName;
+            if (!XLHelper.SheetComparer.Equals(referencedSheet, _shiftedSheetName))
                 return;
 
             if (!TryShiftReference(reference, out var shifted, out var destroyed))
@@ -184,9 +275,9 @@ internal static partial class XLCellFormulaShifter
             if (IsConfinedToOtherAxis(first, second))
                 return false;
 
-            var (refFirst, refLast) = Extent(first, second, axis);
-            var (crossFirst, crossLast) = Extent(first, second, Other(axis));
-            var (shiftCrossFirst, shiftCrossLast) = axis == ShiftAxis.Row
+            var (refFirst, refLast) = Extent(first, second, _axis);
+            var (crossFirst, crossLast) = Extent(first, second, Other(_axis));
+            var (shiftCrossFirst, shiftCrossLast) = _axis == ShiftAxis.Row
                 ? (_shiftFirstColumn, _shiftLastColumn)
                 : (_shiftFirstRow, _shiftLastRow);
 
@@ -195,19 +286,32 @@ internal static partial class XLCellFormulaShifter
             if (crossFirst < shiftCrossFirst || crossLast > shiftCrossLast)
                 return false;
 
-            var shiftStart = axis == ShiftAxis.Row ? _shiftFirstRow : _shiftFirstColumn;
+            var shiftStart = _axis == ShiftAxis.Row ? _shiftFirstRow : _shiftFirstColumn;
             if (refLast < shiftStart)
                 return false;
 
             int newFirst, newLast;
-            if (shift > 0)
+            if (_rowMap is not null)
             {
-                newFirst = refFirst >= shiftStart ? refFirst + shift : refFirst;
-                newLast = refLast + shift;
+                // The top slides up by the rows deleted above it; the bottom also loses the rows
+                // deleted inside the reference. An inverted result means the deletion swallowed it.
+                newFirst = _rowMap.MapFirst(refFirst);
+                newLast = _rowMap.MapLast(refLast);
+
+                if (newLast < newFirst)
+                {
+                    destroyed = true;
+                    return true;
+                }
+            }
+            else if (_shift > 0)
+            {
+                newFirst = refFirst >= shiftStart ? refFirst + _shift : refFirst;
+                newLast = refLast + _shift;
             }
             else
             {
-                var deleted = -shift;
+                var deleted = -_shift;
                 var shiftEnd = shiftStart + deleted - 1;
 
                 // Rows above the deletion keep their number; rows below move up by the deleted count;
@@ -225,7 +329,7 @@ internal static partial class XLCellFormulaShifter
                 }
             }
 
-            var max = axis == ShiftAxis.Row ? XLHelper.MaxRowNumber : XLHelper.MaxColumnNumber;
+            var max = _axis == ShiftAxis.Row ? XLHelper.MaxRowNumber : XLHelper.MaxColumnNumber;
             newFirst = Math.Clamp(newFirst, 1, max);
             newLast = Math.Clamp(newLast, 1, max);
 
@@ -233,8 +337,8 @@ internal static partial class XLCellFormulaShifter
                 return false;
 
             shifted = new ReferenceArea(
-                WithExtent(first, newFirst, axis),
-                WithExtent(second, newLast, axis));
+                WithExtent(first, newFirst, _axis),
+                WithExtent(second, newLast, _axis));
             return true;
         }
 #pragma warning restore S3776
@@ -246,7 +350,7 @@ internal static partial class XLCellFormulaShifter
         /// </summary>
         private bool IsConfinedToOtherAxis(RowCol first, RowCol second)
         {
-            return axis == ShiftAxis.Row
+            return _axis == ShiftAxis.Row
                 ? first.RowType == ReferenceAxisType.None && second.RowType == ReferenceAxisType.None
                 : first.ColumnType == ReferenceAxisType.None && second.ColumnType == ReferenceAxisType.None;
         }
@@ -313,7 +417,7 @@ internal static partial class XLCellFormulaShifter
         /// </summary>
         private bool SourceIsRange(SymbolRange range)
         {
-            var text = formula.AsSpan(range.Start, range.Length);
+            var text = _formula.AsSpan(range.Start, range.Length);
             var separator = text.LastIndexOf('!');
             if (separator >= 0)
                 text = text[(separator + 1)..];

--- a/XLibur/Excel/Ranges/XLRangeBase.cs
+++ b/XLibur/Excel/Ranges/XLRangeBase.cs
@@ -1080,7 +1080,18 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
         mergeToDelete.ForEach(m => Worksheet.Internals.MergedRanges.Remove(m));
     }
 
-    public void Delete(XLShiftDeletedCells shiftDeleteCells)
+    public void Delete(XLShiftDeletedCells shiftDeleteCells) => Delete(shiftDeleteCells, shiftFormulas: true);
+
+    /// <summary>
+    /// Deletes the range, optionally skipping the formula pass.
+    /// </summary>
+    /// <param name="shiftDeleteCells">Which way the surviving cells close the gap.</param>
+    /// <param name="shiftFormulas">
+    /// <c>false</c> only for <see cref="XLRowBatchDelete"/>, which re-points every formula once against
+    /// the whole set of deleted rows before removing them run by run. Running the per-run pass as well
+    /// would be both wasted work and wrong, since the formulas already hold their final text.
+    /// </param>
+    internal void Delete(XLShiftDeletedCells shiftDeleteCells, bool shiftFormulas)
     {
         var numberOfRows = RowCount();
         var numberOfColumns = ColumnCount();
@@ -1089,18 +1100,20 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
 
         Worksheet.SparklineGroups.Remove(this);
 
-        IXLRange shiftedRangeFormula = Worksheet.Range(
-            RangeAddress.FirstAddress.RowNumber,
-            RangeAddress.FirstAddress.ColumnNumber,
-            RangeAddress.LastAddress.RowNumber,
-            RangeAddress.LastAddress.ColumnNumber);
+        if (shiftFormulas)
+        {
+            IXLRange shiftedRangeFormula = Worksheet.Range(
+                RangeAddress.FirstAddress.RowNumber,
+                RangeAddress.FirstAddress.ColumnNumber,
+                RangeAddress.LastAddress.RowNumber,
+                RangeAddress.LastAddress.ColumnNumber);
 
-        // Shift formulas first
-        XLFormulaShiftPass.Run(
-            Worksheet.Workbook,
-            (XLRange)shiftedRangeFormula,
-            shiftDeleteCells == XLShiftDeletedCells.ShiftCellsUp,
-            shiftDeleteCells == XLShiftDeletedCells.ShiftCellsUp ? -numberOfRows : -numberOfColumns);
+            XLFormulaShiftPass.Run(
+                Worksheet.Workbook,
+                (XLRange)shiftedRangeFormula,
+                shiftDeleteCells == XLShiftDeletedCells.ShiftCellsUp,
+                shiftDeleteCells == XLShiftDeletedCells.ShiftCellsUp ? -numberOfRows : -numberOfColumns);
+        }
 
         // Range to shift...
         var columnModifier = 0;

--- a/XLibur/Excel/Ranges/XLRowBatchDelete.cs
+++ b/XLibur/Excel/Ranges/XLRowBatchDelete.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.Linq;
+using XLibur.Excel.Coordinates;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// Deletes a set of whole rows — contiguous or not — re-pointing every formula once for the whole set
+/// rather than once per row.
+/// </summary>
+/// <remarks>
+/// Deleting rows one at a time makes the formula pass, which visits every formula in the workbook, run
+/// once per deleted row. On a sheet with a formula per row that is the dominant cost of the whole
+/// operation and it grows quadratically: 1,333 deletes over 2,667 surviving formulas is 3.6M parses,
+/// nearly all of which conclude that nothing needed changing.
+/// <para>
+/// Here the rows become one <see cref="XLRowDeletionMap"/>, every formula is re-pointed against it in a
+/// single pass, and only then are the rows removed run by run with the per-run formula pass switched
+/// off. The removal itself is still per-run — the live ranges, conditional formats, data validations,
+/// merges, page breaks and hyperlinks all still shift a block at a time, which is correct because those
+/// shifts compose, just not yet batched.
+/// </para>
+/// </remarks>
+internal static class XLRowBatchDelete
+{
+    internal static void Delete(XLWorksheet worksheet, IEnumerable<int> rowNumbers)
+    {
+        var map = XLRowDeletionMap.Create(rowNumbers);
+        if (map is null)
+            return;
+
+        var batched = CanBatch(worksheet.Workbook);
+        if (batched)
+            ShiftAllFormulas(worksheet.Workbook, worksheet.Name, map);
+
+        foreach (var (firstRow, lastRow) in map.GetRunsBottomUp())
+        {
+            var range = (XLRange)worksheet.Range(firstRow, 1, lastRow, XLHelper.MaxColumnNumber);
+            range.Delete(XLShiftDeletedCells.ShiftCellsUp, shiftFormulas: !batched);
+
+            for (var row = lastRow; row >= firstRow; row--)
+                worksheet.DeleteRow(row);
+        }
+    }
+
+    /// <summary>
+    /// Whether the composite pass can stand in for the per-run passes.
+    /// </summary>
+    /// <remarks>
+    /// Array, data-table and dynamic-array formulas carry a stored range or a spill footprint that the
+    /// per-cell shift relocates as a side effect of re-pointing the text. The composite pass rewrites
+    /// text only, so a workbook containing any of them keeps the per-run path — correctness over speed,
+    /// and the case is rare enough that the scan to detect it is cheaper than the work it guards.
+    /// </remarks>
+    private static bool CanBatch(XLWorkbook workbook)
+    {
+        foreach (var sheet in workbook.WorksheetsInternal)
+        {
+            var enumerator = sheet.Internals.CellsCollection.FormulaSlice.GetForwardEnumerator(Area.Full);
+            while (enumerator.MoveNext())
+            {
+                var formula = enumerator.Current;
+                if (formula.Type != FormulaType.Normal || formula.IsDynamicArray)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void ShiftAllFormulas(XLWorkbook workbook, string shiftedSheetName, XLRowDeletionMap map)
+    {
+        var firstDeletedRow = map.FirstDeletedRow;
+
+        foreach (var sheet in workbook.WorksheetsInternal)
+        {
+            var cellsCollection = sheet.Internals.CellsCollection;
+
+            // Materialise the points first: rewriting a formula replaces the entry at its own point,
+            // and mutating a slice while its enumerator is live is not a contract the slice offers.
+            var points = new List<Point>();
+            var enumerator = cellsCollection.FormulaSlice.GetForwardEnumerator(Area.Full);
+            while (enumerator.MoveNext())
+                points.Add(enumerator.Point);
+
+            foreach (var point in points)
+            {
+                var cell = cellsCollection.GetCell(point);
+                var formula = cell.Formula;
+
+                // Same pre-filter the per-run pass uses: a formula whose furthest reference stops above
+                // every deleted row cannot be rewritten by any of them.
+                if (formula is null || formula.MaxShiftableRow < firstDeletedRow)
+                    continue;
+
+                var shifted = XLCellFormulaShifter.ShiftFormulaRows(formula.A1, sheet, shiftedSheetName, map);
+                if (string.Equals(shifted, formula.A1, System.StringComparison.Ordinal))
+                    continue;
+
+                cell.FormulaA1 = shifted;
+                cell.Formula?.SeedShiftedExtentFrom(formula, map);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The rows an <see cref="IXLRows"/> covers, grouped by the sheet they live on.
+    /// </summary>
+    internal static IEnumerable<IGrouping<IXLWorksheet, int>> GroupBySheet(IEnumerable<IXLRow> rows)
+        => rows.GroupBy(r => r.Worksheet, r => r.RowNumber());
+}

--- a/XLibur/Excel/Ranges/XLRowDeletionMap.cs
+++ b/XLibur/Excel/Ranges/XLRowDeletionMap.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+
+namespace XLibur.Excel;
+
+/// <summary>
+/// Where every row of a sheet ends up after a set of whole rows is deleted in one go.
+/// </summary>
+/// <remarks>
+/// Deleting scattered rows one at a time makes every consumer of a shift — most expensively the
+/// formula pass — run once per row. This collapses the whole set into a single mapping so they can
+/// run once instead.
+/// <para>
+/// A reference spanning rows <c>[a, b]</c> becomes <c>[MapFirst(a), MapLast(b)]</c>. The two ends are
+/// counted differently on purpose: the top of a range slides up by the rows deleted strictly above it,
+/// while the bottom also loses the rows deleted inside it. When the deletion swallows the range
+/// entirely the mapped bottom lands above the mapped top, which is how a destroyed reference is
+/// detected.
+/// </para>
+/// </remarks>
+internal sealed class XLRowDeletionMap
+{
+    /// <summary>Deleted row numbers, ascending and distinct.</summary>
+    private readonly int[] _deleted;
+
+    private XLRowDeletionMap(int[] deleted)
+    {
+        _deleted = deleted;
+    }
+
+    /// <summary>The number of rows this map deletes.</summary>
+    internal int Count => _deleted.Length;
+
+    /// <summary>The first deleted row; the lowest row number any reference can be affected from.</summary>
+    internal int FirstDeletedRow => _deleted[0];
+
+    /// <summary>
+    /// Builds a map from an arbitrary collection of row numbers. Duplicates collapse and order does
+    /// not matter, so callers may hand over rows in whatever order they gathered them.
+    /// </summary>
+    /// <returns><c>null</c> when nothing would be deleted.</returns>
+    internal static XLRowDeletionMap? Create(IEnumerable<int> rows)
+    {
+        var sorted = new SortedSet<int>(rows);
+        if (sorted.Count == 0)
+            return null;
+
+        var deleted = new int[sorted.Count];
+        sorted.CopyTo(deleted);
+        return new XLRowDeletionMap(deleted);
+    }
+
+    /// <summary>
+    /// Splits the deleted rows into contiguous runs, furthest down the sheet first. Consumers that
+    /// still work a block at a time need this order: a run must be removed before the runs above it
+    /// move, or their row numbers stop meaning what the map says they mean.
+    /// </summary>
+    internal List<(int FirstRow, int LastRow)> GetRunsBottomUp()
+    {
+        var runs = new List<(int, int)>();
+        for (var i = _deleted.Length - 1; i >= 0; i--)
+        {
+            var last = _deleted[i];
+            while (i > 0 && _deleted[i - 1] == _deleted[i] - 1)
+                i--;
+
+            runs.Add((_deleted[i], last));
+        }
+
+        return runs;
+    }
+
+    /// <summary>
+    /// Where the top of a range lands: its own row less the rows deleted strictly above it. A row that
+    /// is itself deleted maps to the position its first surviving successor takes.
+    /// </summary>
+    internal int MapFirst(int row) => row - CountBelow(row);
+
+    /// <summary>
+    /// Where the bottom of a range lands: its own row less every deleted row at or above it, so rows
+    /// deleted from inside the range shorten it.
+    /// </summary>
+    internal int MapLast(int row) => row - CountAtOrBelow(row);
+
+    /// <summary>Deleted rows strictly less than <paramref name="row"/>.</summary>
+    private int CountBelow(int row)
+    {
+        var index = Array.BinarySearch(_deleted, row);
+        return index >= 0 ? index : ~index;
+    }
+
+    /// <summary>Deleted rows less than or equal to <paramref name="row"/>.</summary>
+    private int CountAtOrBelow(int row)
+    {
+        var index = Array.BinarySearch(_deleted, row);
+        return index >= 0 ? index + 1 : ~index;
+    }
+}

--- a/XLibur/Excel/Rows/XLRows.cs
+++ b/XLibur/Excel/Rows/XLRows.cs
@@ -76,11 +76,11 @@ internal sealed class XLRows : XLStylizedBase, IXLRows, IXLStylized
                 list.Add(r.RowNumber());
             }
 
+            // One batched delete per sheet rather than one delete per row. The rows need not be
+            // contiguous: XLRowBatchDelete folds the whole set into a single row map so the formula
+            // pass, which visits every formula in the workbook, runs once instead of once per row.
             foreach (var kp in toDelete)
-            {
-                foreach (var r in kp.Value.OrderByDescending(r => r))
-                    kp.Key.Row(r).Delete();
-            }
+                XLRowBatchDelete.Delete((XLWorksheet)kp.Key, kp.Value);
         }
     }
 


### PR DESCRIPTION
**Stacked on #347** — review that first; the diff here is against it.

## The problem

`IXLRows.Delete()` looped `Row(r).Delete()` over its rows, so every consumer of a
shift ran once per row — most expensively the formula pass, which visits every
formula in the workbook. Deleting every 3rd row of a 4000-row sheet is 1,333
passes over 2,667 formulas.

It did not batch even a *contiguous* block: `ws.Rows(1000, 2332).Delete()`
measured the same as the manual loop, while one equivalent `Range.Delete()` took
5 ms.

## What changed

The rows become one `XLRowDeletionMap` and every formula is re-pointed against
the whole set in a single pass. A reference maps its two edges differently — the
top slides up by the rows deleted strictly above it, the bottom also loses the
rows deleted *inside* it — and an inverted result is how a destroyed reference is
recognised. The rows are then removed run by run with the per-run formula pass
switched off, contiguous rows coalescing into one run.

## Numbers

Every 3rd row of an N-row sheet with a `SUM` per row:

| | row-at-a-time | batched |
|---|---:|---:|
| 4000 rows / 1333 deletes | 2650 ms / 2714 MB | **732 ms / 257 MB** |
| 8000 rows / 2666 deletes | 10687 ms / 10847 MB | **2923 ms / 1002 MB** |

Against `main` before #347: **6.3x faster, 17x fewer allocations.**

## Still quadratic — but the reason has moved

Allocations still go ~4x per doubling. The formula term is gone; what remains is
the per-run removal — live ranges, conditional formats, data validations, merges,
page breaks, hyperlinks, and the cell compaction, which now dominates. Those
shifts compose, so per-run is correct; batching them is the next step and a
larger one (it touches every one of those consumers).

For reference, the floor: one contiguous `Range.Delete()` of the same row count
is 5 ms.

## Scope and escape hatches

- A workbook holding an **array, data-table or dynamic-array** formula keeps the
  row-at-a-time path. Those carry a stored range or spill footprint that the
  per-cell shift relocates as a side effect of rewriting text, and the composite
  pass rewrites text only.
- Formulas the parser rejects fall back to applying the runs one at a time
  through the legacy regex shifter, since there is no batch regex path.

## Testing

- `XLibur.Tests` 11,764 pass / 4 pre-existing skips; `XLibur.Report.Tests` 481 pass.
- `BatchRowDeleteTests` asserts the batched path lands where the row-at-a-time
  path does, cell by cell, rather than against hand-computed answers — the old
  path is the definition of correct here. Also covers defined names, merges, live
  ranges, row properties, cross-sheet references, the array-formula fallback, and
  unsorted/duplicate input.
- `RowDeletionMapTests` pins two properties invisible from outside: run
  coalescing (degrading it stays *correct*, just undoes the batching, so no
  behavioural test would catch it) and the edge-mapping asymmetry.
- Mutation-verified: mapping both reference edges the same way fails a test.