### PR TITLE
perf(rows): compact cells by row, once, for a batched delete

### DIFF
--- a/XLibur.Tests/Excel/Ranges/BatchRowDeleteCompactionTests.cs
+++ b/XLibur.Tests/Excel/Ranges/BatchRowDeleteCompactionTests.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Ranges;
+
+/// <summary>
+/// Covers the batched delete's cell compaction, which moves whole rows in one pass instead of moving
+/// cells a block at a time.
+/// <para>
+/// The compaction bypasses the per-cell write path, so everything that path maintained as a side
+/// effect has to be maintained here too: per-column usage counts (which back <c>LastColumnUsed</c>),
+/// the max row and column, and the shared-string reference counts held by text values. None of that
+/// is visible in the cell values themselves, which is why these go looking for it specifically.
+/// </para>
+/// </summary>
+public class BatchRowDeleteCompactionTests
+{
+    [Test]
+    public async Task EveryValueTypeSurvivesTheMove()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A5").Value = "text";
+        ws.Cell("B5").Value = 42.5;
+        ws.Cell("C5").Value = true;
+        ws.Cell("D5").Value = new DateTime(2026, 8, 1);
+        ws.Cell("E5").Value = TimeSpan.FromHours(3);
+        ws.Cell("F5").FormulaA1 = "1+1";
+
+        ws.Rows("1:1,2:2").Delete();
+
+        await Assert.That(ws.Cell("A3").GetString()).IsEqualTo("text");
+        await Assert.That(ws.Cell("B3").GetDouble()).IsEqualTo(42.5);
+        await Assert.That(ws.Cell("C3").GetBoolean()).IsTrue();
+        await Assert.That(ws.Cell("D3").GetDateTime()).IsEqualTo(new DateTime(2026, 8, 1));
+        await Assert.That(ws.Cell("E3").GetTimeSpan()).IsEqualTo(TimeSpan.FromHours(3));
+        await Assert.That(ws.Cell("F3").FormulaA1).IsEqualTo("1+1");
+    }
+
+    [Test]
+    public async Task StylesMoveWithTheirRow()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A5").Value = "styled";
+        ws.Cell("A5").Style.Font.Bold = true;
+        ws.Cell("A5").Style.Fill.BackgroundColor = XLColor.Red;
+
+        ws.Rows("1:1,2:2").Delete();
+
+        await Assert.That(ws.Cell("A3").Style.Font.Bold).IsTrue();
+        await Assert.That(ws.Cell("A3").Style.Fill.BackgroundColor).IsEqualTo(XLColor.Red);
+        await Assert.That(ws.Cell("A5").Style.Font.Bold).IsFalse();
+    }
+
+    [Test]
+    public async Task CommentsMoveWithTheirRow()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A5").GetComment().AddText("note");
+
+        ws.Rows("1:1,2:2").Delete();
+
+        await Assert.That(ws.Cell("A3").HasComment).IsTrue();
+        await Assert.That(ws.Cell("A3").GetComment().Text).IsEqualTo("note");
+        await Assert.That(ws.Cell("A5").HasComment).IsFalse();
+    }
+
+    /// <summary>
+    /// Per-column usage counts back <c>LastColumnUsed</c>, and the compaction has to decrement them for
+    /// the departing rows itself. Deleting the only row that used a far-right column must retire it.
+    /// </summary>
+    [Test]
+    public async Task LastColumnUsedDropsWhenTheOnlyRowUsingItGoes()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").Value = 1;
+        ws.Cell("A2").Value = 2;
+        ws.Cell("H3").Value = "far right";
+        ws.Cell("A4").Value = 4;
+
+        await Assert.That(ws.LastColumnUsed().ColumnNumber()).IsEqualTo(8);
+
+        ws.Rows("3:3").Delete();
+
+        await Assert.That(ws.LastColumnUsed().ColumnNumber()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task LastColumnUsedSurvivesWhenAnotherRowStillUsesIt()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("H3").Value = "far right";
+        ws.Cell("H7").Value = "also far right";
+
+        ws.Rows("3:3").Delete();
+
+        await Assert.That(ws.LastColumnUsed().ColumnNumber()).IsEqualTo(8);
+    }
+
+    [Test]
+    public async Task LastRowUsedReflectsTheCompactedSheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        for (var row = 1; row <= 10; row++)
+            ws.Cell(row, 1).Value = row;
+
+        ws.Rows("2:2,5:5,9:9").Delete();
+
+        await Assert.That(ws.LastRowUsed().RowNumber()).IsEqualTo(7);
+        await Assert.That(ws.Cell(8, 1).IsEmpty()).IsTrue();
+    }
+
+    [Test]
+    public async Task DeletingEveryUsedRowLeavesAnEmptySheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        for (var row = 1; row <= 5; row++)
+            ws.Cell(row, 1).Value = row;
+
+        ws.Rows("1:5").Delete();
+
+        await Assert.That(ws.LastRowUsed()).IsNull();
+        await Assert.That(ws.LastColumnUsed()).IsNull();
+    }
+
+    /// <summary>
+    /// Text values hold shared-string references. The rows that go must release theirs and the rows
+    /// that move must keep theirs; getting either wrong corrupts the table, which only shows up once
+    /// the workbook is written and read back.
+    /// </summary>
+    [Test]
+    public async Task TextValuesRoundTripThroughSaveAfterABatchedDelete()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+        for (var row = 1; row <= 12; row++)
+            ws.Cell(row, 1).Value = $"value-{row}";
+
+        // "value-3" is shared by a row that goes and one that stays.
+        ws.Cell(12, 2).Value = "value-3";
+
+        ws.Rows("3:3,6:6,9:9").Delete();
+
+        using var stream = new MemoryStream();
+        wb.SaveAs(stream);
+        stream.Position = 0;
+
+        using var reloaded = new XLWorkbook(stream);
+        var sheet = reloaded.Worksheet("Data");
+        var expected = new[] { 1, 2, 4, 5, 7, 8, 10, 11, 12 };
+        for (var i = 0; i < expected.Length; i++)
+            await Assert.That(sheet.Cell(i + 1, 1).GetString()).IsEqualTo($"value-{expected[i]}");
+
+        await Assert.That(sheet.Cell(9, 2).GetString()).IsEqualTo("value-3");
+    }
+
+    /// <summary>
+    /// A differential sweep over a sheet carrying values, formulas, styles, merges and a live range.
+    /// Each case deletes a pseudo-random set of rows both ways and compares the whole sheet. The seed
+    /// is fixed so a failure is reproducible.
+    /// </summary>
+    [Test]
+    [Arguments(1)]
+    [Arguments(7)]
+    [Arguments(42)]
+    [Arguments(1234)]
+    public async Task BatchedAndRowAtATimeAgreeOnARichSheet(int seed)
+    {
+        var random = new Random(seed);
+        var targets = new SortedSet<int>();
+        while (targets.Count < 12)
+            targets.Add(random.Next(2, 40));
+
+        using var perRowBook = BuildRichSheet(out var perRow);
+        using var batchedBook = BuildRichSheet(out var batched);
+
+        foreach (var row in targets.Reverse())
+            perRow.Row(row).Delete();
+
+        batched.Rows(string.Join(",", targets.Select(r => $"{r}:{r}"))).Delete();
+
+        for (var row = 1; row <= 45; row++)
+        {
+            for (var column = 1; column <= 4; column++)
+            {
+                var a = perRow.Cell(row, column);
+                var b = batched.Cell(row, column);
+
+                await Assert.That(b.FormulaA1).IsEqualTo(a.FormulaA1);
+                await Assert.That(b.GetString()).IsEqualTo(a.GetString());
+                await Assert.That(b.Style.Font.Bold).IsEqualTo(a.Style.Font.Bold);
+            }
+        }
+
+        await Assert.That(batched.LastRowUsed()?.RowNumber()).IsEqualTo(perRow.LastRowUsed()?.RowNumber());
+        await Assert.That(batched.LastColumnUsed()?.ColumnNumber()).IsEqualTo(perRow.LastColumnUsed()?.ColumnNumber());
+        await Assert.That(batched.MergedRanges.Select(r => r.RangeAddress.ToString()))
+            .IsEquivalentTo(perRow.MergedRanges.Select(r => r.RangeAddress.ToString()));
+    }
+
+    private static XLWorkbook BuildRichSheet(out IXLWorksheet ws)
+    {
+        var wb = new XLWorkbook();
+        ws = wb.AddWorksheet("Sheet1");
+        for (var row = 1; row <= 40; row++)
+        {
+            ws.Cell(row, 1).Value = $"label-{row}";
+            ws.Cell(row, 2).Value = row * 1.5;
+            ws.Cell(row, 3).FormulaA1 = $"B{row}*2";
+
+            if (row % 4 == 0)
+                ws.Cell(row, 1).Style.Font.Bold = true;
+        }
+
+        ws.Cell(1, 4).FormulaA1 = "SUM(B5:B25)";
+        ws.Range("A30:B31").Merge();
+        return wb;
+    }
+}

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -158,12 +158,66 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
         Purge(sheet.Workbook.WorksheetsInternal);
     }
 
+    /// <summary>
+    /// Non-zero while a caller is applying many structural edits that should cost one purge between
+    /// them, not one each.
+    /// </summary>
+    private int _purgeSuspensions;
+
+    /// <summary>Whether a purge was asked for while suspended and still owes its work.</summary>
+    private bool _purgeDeferred;
+
+    /// <summary>
+    /// Coalesces the purges of a run of structural edits into one.
+    /// </summary>
+    /// <remarks>
+    /// A purge throws away the dependency tree and marks every formula in the workbook dirty, so it
+    /// costs a walk of every formula slice. That is the right price once, but a caller deleting a
+    /// scattered set of rows a run at a time pays it per run, and the walk allocates nothing — which
+    /// makes it the kind of quadratic that hides from an allocation profile. Purging is idempotent
+    /// and order-independent, so deferring to a single purge at the end is equivalent.
+    /// </remarks>
+    internal PurgeSuspension SuspendPurge(XLWorkbook workbook) => new(this, workbook);
+
+    internal readonly struct PurgeSuspension : IDisposable
+    {
+        private readonly XLCalcEngine _engine;
+        private readonly XLWorkbook _workbook;
+
+        internal PurgeSuspension(XLCalcEngine engine, XLWorkbook workbook)
+        {
+            _engine = engine;
+            _workbook = workbook;
+            engine._purgeSuspensions++;
+        }
+
+        public void Dispose()
+        {
+            if (--_engine._purgeSuspensions > 0)
+                return;
+
+            if (!_engine._purgeDeferred)
+                return;
+
+            _engine._purgeDeferred = false;
+            _engine.Purge(_workbook.WorksheetsInternal);
+        }
+    }
+
     private void Purge(XLWorksheets sheets)
     {
         _dependencyTree = null;
         _chain = null;
         _needsDependencyTree = false;
         _spillOwners.Clear();
+
+        if (_purgeSuspensions > 0)
+        {
+            // The tree and chain are dropped either way — they are cheap to discard and must not be
+            // trusted mid-edit. Only the formula walk waits.
+            _purgeDeferred = true;
+            return;
+        }
 
         // Mark everything as dirty, because there can be stale values
         foreach (var sheet in sheets)

--- a/XLibur/Excel/Cells/FormulaSlice.cs
+++ b/XLibur/Excel/Cells/FormulaSlice.cs
@@ -43,6 +43,11 @@ internal sealed class FormulaSlice : ISlice
         _formulas.DeleteAreaAndShiftUp(rangeToDelete);
     }
 
+    public void DeleteRowsAndCompact(XLRowDeletionMap map)
+    {
+        _formulas.DeleteRowsAndCompact(map);
+    }
+
     public IEnumerator<Point> GetEnumerator(Area range, bool reverse = false)
     {
         return _formulas.GetEnumerator(range, reverse);

--- a/XLibur/Excel/Cells/ISlice.cs
+++ b/XLibur/Excel/Cells/ISlice.cs
@@ -33,6 +33,16 @@ internal interface ISlice
     int MaxRow { get; }
 
     /// <summary>
+    /// Remove a set of whole rows and close the gaps, in one pass over the slice.
+    /// </summary>
+    /// <remarks>
+    /// The whole-row, whole-deletion counterpart of <see cref="DeleteAreaAndShiftUp"/>. Because a row
+    /// is one stored value rather than a run of cells, and because the entire deletion is applied at
+    /// once, this costs one operation per used row instead of one per cell below each deleted row.
+    /// </remarks>
+    void DeleteRowsAndCompact(XLRowDeletionMap map);
+
+    /// <summary>
     /// A set of columns that have at least one used cell. The order of columns is non-deterministic.
     /// </summary>
     Dictionary<int, int>.KeyCollection UsedColumns { get; }

--- a/XLibur/Excel/Cells/Slice.cs
+++ b/XLibur/Excel/Cells/Slice.cs
@@ -138,6 +138,93 @@ internal sealed partial class Slice<TElement> : ISlice
     }
 
     /// <summary>
+    /// Removes a set of whole rows and closes the gaps, in one pass.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="DeleteAreaAndShiftUp"/> works a cell at a time because the area it is given can be
+    /// narrower than the sheet, so it has to move cells out from under the ones staying put. A whole
+    /// row has no such constraint: the slice stores a row's entire set of columns as one
+    /// <c>RowData</c>, so a surviving row moves by assigning that value at its new index. The cost
+    /// drops from one operation per cell below the deletion to one per used row, and — since this
+    /// takes the whole deletion at once rather than a block at a time — from once per deleted row to
+    /// once altogether.
+    /// <para>
+    /// Rows are walked upward. Every surviving row's destination is at or above where it currently
+    /// sits and destinations rise with sources, so a row is never written over one that has not been
+    /// read yet, and no temporary copy is needed.
+    /// </para>
+    /// </remarks>
+    public void DeleteRowsAndCompact(XLRowDeletionMap map)
+    {
+        var lastUsedRow = MaxRow;
+        if (lastUsedRow == 0)
+            return;
+
+        var rowsEnumerator = new Lut<RowData>.LutEnumerator(_data, XLHelper.MinRowNumber - 1, lastUsedRow - 1);
+
+        // The enumerator walks the same structure being written, and a write can clear the bucket it
+        // is standing on, so collect the used rows before touching anything.
+        var used = new List<(int Row, RowData Data)>();
+        while (rowsEnumerator.MoveNext())
+            used.Add((rowsEnumerator.Index + 1, rowsEnumerator.Current));
+
+        // Destinations claimed by a surviving row, ascending — sources ascend and the mapping is
+        // strictly increasing across survivors, so this list comes out sorted for free.
+        var claimed = new List<int>(used.Count);
+
+        foreach (var (row, data) in used)
+        {
+            if (map.IsDeleted(row))
+            {
+                // The row is going away, so every cell in it stops counting toward its column.
+                ReleaseColumnUsage(in data);
+                continue;
+            }
+
+            var target = map.MapFirst(row);
+            if (target != row)
+                _data.Set(target - 1, data);
+
+            claimed.Add(target);
+        }
+
+        // Clear every slot that held something and did not receive a row. Two cases look the same from
+        // here: a row that moved up and left its old slot behind, and a slot whose new occupant is an
+        // *unused* row, which writes nothing and would otherwise leave the previous contents in place.
+        // The second is the one that bites — a row with no explicit style or value is invisible to the
+        // walk above, so its destination has to be cleared on its behalf.
+        var next = 0;
+        foreach (var (row, _) in used)
+        {
+            while (next < claimed.Count && claimed[next] < row)
+                next++;
+
+            if (next < claimed.Count && claimed[next] == row)
+                continue;
+
+            _data.Set(row - 1, default);
+        }
+
+        if (map.Count > 0)
+            _version++;
+
+        if (_columnUsage.Count == 0)
+            MaxColumn = 0;
+        else if (MaxColumn > 0 && !_columnUsage.ContainsKey(MaxColumn))
+            MaxColumn = CalculateMaxColumn();
+    }
+
+    /// <summary>
+    /// Drops a departing row's cells from the per-column usage counts.
+    /// </summary>
+    private void ReleaseColumnUsage(in RowData data)
+    {
+        var columns = data.GetColumnEnumerator(XLHelper.MinColumnNumber - 1, XLHelper.MaxColumnNumber - 1);
+        while (columns.MoveNext())
+            DecrementColumnUsage(columns.Index + 1);
+    }
+
+    /// <summary>
     /// Get enumerator over used values of the range.
     /// </summary>
     public IEnumerator<Point> GetEnumerator(Area range, bool reverse = false)

--- a/XLibur/Excel/Cells/ValueSlice.cs
+++ b/XLibur/Excel/Cells/ValueSlice.cs
@@ -50,6 +50,16 @@ internal sealed class ValueSlice : ISlice
         _values.DeleteAreaAndShiftUp(rangeToDelete);
     }
 
+    public void DeleteRowsAndCompact(XLRowDeletionMap map)
+    {
+        // Text in the departing rows releases its shared-string references; text in the rows that
+        // survive keeps them, since those cells move rather than disappear.
+        foreach (var (firstRow, lastRow) in map.GetRunsBottomUp())
+            DereferenceTextInRange(new Area(firstRow, 1, lastRow, XLHelper.MaxColumnNumber));
+
+        _values.DeleteRowsAndCompact(map);
+    }
+
     public IEnumerator<Point> GetEnumerator(Area range, bool reverse = false) => _values.GetEnumerator(range, reverse);
 
     public void InsertAreaAndShiftDown(Area range)

--- a/XLibur/Excel/Cells/XLCellsCollection.cs
+++ b/XLibur/Excel/Cells/XLCellsCollection.cs
@@ -145,6 +145,15 @@ internal sealed class XLCellsCollection : IWorkbookListener
     }
 
     /// <summary>
+    /// Remove a set of whole rows from every slice and close the gaps, in one pass each.
+    /// </summary>
+    internal void DeleteRowsAndCompact(XLRowDeletionMap map)
+    {
+        foreach (var slice in _slices)
+            slice.DeleteRowsAndCompact(map);
+    }
+
+    /// <summary>
     /// Direct-mapped cache of recently vended cell wrappers. An <see cref="XLCell"/> is a stateless
     /// handle over (collection, point) — all cell data lives in the slices — so returning the same
     /// instance twice for the same point is equivalent to returning two, and lets the caller reuse

--- a/XLibur/Excel/Ranges/XLRangeBase.cs
+++ b/XLibur/Excel/Ranges/XLRangeBase.cs
@@ -1091,7 +1091,14 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
     /// the whole set of deleted rows before removing them run by run. Running the per-run pass as well
     /// would be both wasted work and wrong, since the formulas already hold their final text.
     /// </param>
-    internal void Delete(XLShiftDeletedCells shiftDeleteCells, bool shiftFormulas)
+    /// <param name="moveCells">
+    /// <c>false</c> only for <see cref="XLRowBatchDelete"/>, which compacts the cells for the whole
+    /// deletion in one pass after the per-run bookkeeping has run. Everything else this method does —
+    /// live ranges, merges, sparklines, conditional formats, data validations, page breaks,
+    /// hyperlinks — is metadata that never reads a cell position, so it composes run by run and does
+    /// not care whether the cells have moved yet.
+    /// </param>
+    internal void Delete(XLShiftDeletedCells shiftDeleteCells, bool shiftFormulas, bool moveCells = true)
     {
         var numberOfRows = RowCount();
         var numberOfColumns = ColumnCount();
@@ -1122,13 +1129,17 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
         switch (shiftDeleteCells)
         {
             case XLShiftDeletedCells.ShiftCellsLeft:
-                Worksheet.Internals.CellsCollection.DeleteAreaAndShiftLeft(range);
+                if (moveCells)
+                    Worksheet.Internals.CellsCollection.DeleteAreaAndShiftLeft(range);
+
                 Worksheet.SparklineGroupsInternal.ShiftColumns(range, -numberOfColumns);
                 columnModifier = ColumnCount();
                 break;
 
             case XLShiftDeletedCells.ShiftCellsUp:
-                Worksheet.Internals.CellsCollection.DeleteAreaAndShiftUp(range);
+                if (moveCells)
+                    Worksheet.Internals.CellsCollection.DeleteAreaAndShiftUp(range);
+
                 Worksheet.SparklineGroupsInternal.ShiftRows(range, -numberOfRows);
                 rowModifier = RowCount();
                 break;

--- a/XLibur/Excel/Ranges/XLRowBatchDelete.cs
+++ b/XLibur/Excel/Ranges/XLRowBatchDelete.cs
@@ -33,14 +33,27 @@ internal static class XLRowBatchDelete
         if (batched)
             ShiftAllFormulas(worksheet.Workbook, worksheet.Name, map);
 
-        foreach (var (firstRow, lastRow) in map.GetRunsBottomUp())
+        // One purge for the whole deletion instead of one per run. Each run's delete asks the calc
+        // engine to drop its dependency tree and mark every formula dirty, and that walk allocates
+        // nothing, so run-by-run it is a quadratic that an allocation profile cannot see.
+        using (worksheet.Workbook.CalcEngine.SuspendPurge(worksheet.Workbook))
         {
-            var range = (XLRange)worksheet.Range(firstRow, 1, lastRow, XLHelper.MaxColumnNumber);
-            range.Delete(XLShiftDeletedCells.ShiftCellsUp, shiftFormulas: !batched);
+            foreach (var (firstRow, lastRow) in map.GetRunsBottomUp())
+            {
+                var range = (XLRange)worksheet.Range(firstRow, 1, lastRow, XLHelper.MaxColumnNumber);
+                range.Delete(XLShiftDeletedCells.ShiftCellsUp, shiftFormulas: !batched, moveCells: !batched);
 
-            for (var row = lastRow; row >= firstRow; row--)
-                worksheet.DeleteRow(row);
+                for (var row = lastRow; row >= firstRow; row--)
+                    worksheet.DeleteRow(row);
+            }
         }
+
+        // The cells move last and all at once. Everything above only touched metadata, none of which
+        // reads a cell position, so deferring the move costs nothing in correctness and turns the
+        // per-run compaction — one operation per cell below each deleted run — into one pass that
+        // moves whole rows.
+        if (batched)
+            worksheet.Internals.CellsCollection.DeleteRowsAndCompact(map);
     }
 
     /// <summary>

--- a/XLibur/Excel/Ranges/XLRowDeletionMap.cs
+++ b/XLibur/Excel/Ranges/XLRowDeletionMap.cs
@@ -70,6 +70,9 @@ internal sealed class XLRowDeletionMap
         return runs;
     }
 
+    /// <summary>Whether this row is one of the deleted ones.</summary>
+    internal bool IsDeleted(int row) => Array.BinarySearch(_deleted, row) >= 0;
+
     /// <summary>
     /// Where the top of a range lands: its own row less the rows deleted strictly above it. A row that
     /// is itself deleted maps to the position its first surviving successor takes.


### PR DESCRIPTION
Follow-on to #347 and #348, both now merged; this rebases onto `main` and stands alone.

This is the one that removes the quadratic. Row scaling goes from 4x per doubling
to 2x, in both time and allocations.

## Two per-run costs remained after #348; both are gone

**The cell move.** `Slice.DeleteAreaAndShiftUp` works a cell at a time because
the area it is given can be narrower than the sheet, so it has to move cells out
from under the ones staying put. A whole row has no such constraint: the slice
stores a row entire set of columns as one `RowData`, so a surviving row moves by
assigning that value at its new index. `DeleteRowsAndCompact` takes the whole
deletion at once, turning one operation per cell below each deleted run into one
per used row.

**The calc purge.** Every structural edit drops the dependency tree and marks
every formula in the workbook dirty — a walk of every formula slice, per run.
That walk allocates nothing, which makes it the kind of quadratic an allocation
profile cannot see: row scaling stayed superlinear in time long after it went
linear in bytes. Purging is idempotent and order-independent, so `SuspendPurge`
coalesces a batch into one.

Deferring the cell move is safe because everything else the per-run delete does
is metadata — live ranges, merges, sparklines, conditional formats, data
validations, page breaks, hyperlinks — and none of it reads a cell position.
That is the claim most worth pushing on in review.

## Numbers

Row scaling, 3 data cols + `SUM` per row, delete every 3rd row:

| rows | ms | MB | ms x prev | MB x prev |
|-----:|---:|---:|----------:|----------:|
| 2000 | 47 | 7 | - | - |
| 4000 | 118 | 13 | 2.52 | 2.00 |
| 8000 | 294 | 26 | 2.50 | 2.00 |
| 16000 | 283 | 49 | 0.96 | 1.86 |
| 32000 | 429 | 98 | 1.52 | 2.01 |

Allocations are exactly linear. Column sensitivity at 8000 rows, which was
~550 ms per column before this change, is now flat:

| data cols | 1 | 3 | 6 | 12 |
|---|---:|---:|---:|---:|
| ms | 23 | 18 | 18 | 18 |

Against `main` before #347, 8000 rows with a `SUM` per row: **19595 ms /
17481 MB -> 294 ms / 26 MB** (67x, 672x).

## The bug the differential test caught

`BatchRowDeleteCompactionTests.BatchedAndRowAtATimeAgreeOnARichSheet` compares
batched against row-at-a-time over a sheet carrying values, formulas, styles and
merges, for four fixed seeds. It failed on the first run.

The compaction visited only rows the slice had an entry for, so a destination
whose new occupant was an *unused* row kept its old contents. In the style slice
a row with no explicit style is invisible to that walk — original row 7 landing
on row 4 slot left row 4 bold behind. Values were fine, which is exactly why a
value-only test would have shipped it. Destinations are now cleared on behalf of
the rows that write nothing.

## Testing

- `XLibur.Tests` 11,776 pass / 4 pre-existing skips; `XLibur.Report.Tests` 481
  pass — re-run after the rebase onto current `main`.
- New `BatchRowDeleteCompactionTests` targets what the compaction bypasses by
  going around the per-cell write path: per-column usage counts (backing
  `LastColumnUsed`), max row/column, shared-string reference counts (asserted via
  a save/reload round-trip, since a refcount error only surfaces there), and that
  styles, comments and every value type move with their row.

## What is still per-run

Conditional formats, data validations, defined names, page breaks, hyperlinks
and merges each still shift a block at a time. Flat on this benchmark; a
heavily-formatted sheet would still show curvature.