### PR TITLE
chore(sonar): clear the build warnings, fixing two and justifying five

### DIFF
--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -649,11 +649,14 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
         if (previousRange == default)
             return;
 
+        // Area is a readonly struct whose enumerator is a struct too; Where would box both.
+#pragma warning disable S3267
         foreach (var point in previousRange)
         {
             if (!keepRange.Contains(point))
                 valueSlice.SetCellValue(point, Blank.Value);
         }
+#pragma warning restore S3267
     }
 
     internal AnyValue EvaluateName(string nameFormula, XLWorksheet ws)

--- a/XLibur/Excel/Cells/XLCellsCollection.cs
+++ b/XLibur/Excel/Cells/XLCellsCollection.cs
@@ -518,11 +518,13 @@ internal sealed class XLCellsCollection : IWorkbookListener
         try
         {
             count = 0;
+#pragma warning disable S3267 // Where would allocate the iterator this pooled buffer exists to avoid
             foreach (var column in candidates)
             {
                 if (column >= firstColumn && column <= lastColumn)
                     buffer[count++] = column;
             }
+#pragma warning restore S3267
 
             var columns = buffer.AsSpan(0, count);
             columns.Sort();
@@ -577,11 +579,13 @@ internal sealed class XLCellsCollection : IWorkbookListener
     {
         // This is different from XLCellUsedOptions, which uses a business logic (e.g. empty string is considered not-used).
         // Here, we ask whether any slice contains a used elements which might differ from cell used logic.
+#pragma warning disable S3267 // Four slices, asked per cell: Where would allocate an iterator and a closure per call
         foreach (var slice in _slices)
         {
             if (slice.IsUsed(address))
                 return true;
         }
+#pragma warning restore S3267
 
         return false;
     }
@@ -631,11 +635,16 @@ internal sealed class XLCellsCollection : IWorkbookListener
             _reverse = reverse;
             _enumerators = new IEnumerator<Point>[enumerators.Length];
             _count = 0;
+
+            // MoveNext both tests and advances, so this reads as a filter but is not one: expressing it
+            // as Where would hide a side effect inside a predicate, which is worse than the loop.
+#pragma warning disable S3267
             foreach (var enumerator in enumerators)
             {
                 if (enumerator.MoveNext())
                     _enumerators[_count++] = enumerator;
             }
+#pragma warning restore S3267
         }
 
         public Point Current { get; private set; }

--- a/XLibur/Excel/Ranges/IXLRangeBase.cs
+++ b/XLibur/Excel/Ranges/IXLRangeBase.cs
@@ -303,7 +303,10 @@ public interface IXLRangeBase : IXLAddressable
     /// </summary>
     IXLDataValidation CreateDataValidation();
 
+    // See the implementation in XLRangeBase for why this stays until the next major version.
+#pragma warning disable S1133
     [Obsolete("Use GetDataValidation() to access the existing rule, or CreateDataValidation() to create a new one.")]
+#pragma warning restore S1133
     IXLDataValidation SetDataValidation();
 
     IXLConditionalFormat AddConditionalFormat();

--- a/XLibur/Excel/Ranges/XLRangeBase.cs
+++ b/XLibur/Excel/Ranges/XLRangeBase.cs
@@ -1305,7 +1305,11 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
         return Worksheet.RangeColumn(new XLRangeAddress(firstCellAddress, lastCellAddress));
     }
 
+    // S1133 reads as a reminder to delete this. It is shipped public API, listed in
+    // PublicAPI.Shipped.txt, so it goes when the next major version does and not before.
+#pragma warning disable S1133
     [Obsolete("Use GetDataValidation() to access the existing rule, or CreateDataValidation() to create a new one.")]
+#pragma warning restore S1133
     public IXLDataValidation SetDataValidation()
     {
         var existingValidation = GetDataValidation();

--- a/XLibur/Excel/Ranges/XLRowBatchDelete.cs
+++ b/XLibur/Excel/Ranges/XLRowBatchDelete.cs
@@ -40,7 +40,7 @@ internal static class XLRowBatchDelete
         {
             foreach (var (firstRow, lastRow) in map.GetRunsBottomUp())
             {
-                var range = (XLRange)worksheet.Range(firstRow, 1, lastRow, XLHelper.MaxColumnNumber);
+                var range = worksheet.Range(firstRow, 1, lastRow, XLHelper.MaxColumnNumber);
                 range.Delete(XLShiftDeletedCells.ShiftCellsUp, shiftFormulas: !batched, moveCells: !batched);
 
                 for (var row = lastRow; row >= firstRow; row--)

--- a/XLibur/Excel/Ranges/XLRowDeletionMap.cs
+++ b/XLibur/Excel/Ranges/XLRowDeletionMap.cs
@@ -58,13 +58,16 @@ internal sealed class XLRowDeletionMap
     internal List<(int FirstRow, int LastRow)> GetRunsBottomUp()
     {
         var runs = new List<(int, int)>();
-        for (var i = _deleted.Length - 1; i >= 0; i--)
+        var i = _deleted.Length - 1;
+        while (i >= 0)
         {
+            // Walk back over the rows adjacent to this one; where they stop is the run's top.
             var last = _deleted[i];
             while (i > 0 && _deleted[i - 1] == _deleted[i] - 1)
                 i--;
 
             runs.Add((_deleted[i], last));
+            i--;
         }
 
         return runs;


### PR DESCRIPTION
Clears the SonarAnalyzer warnings reported by the `build-and-test` workflow.

## Two were real, and are fixed

**`S1905` — redundant cast** (`XLRowBatchDelete.cs:43`). `XLRangeBase.Range(int,int,int,int)`
already returns `XLRange`, so the `(XLRange)` cast was dead. Removed.

**`S127` — loop counter updated in the body** (`XLRowDeletionMap.cs:65`).
`GetRunsBottomUp` advanced `i` from inside a `for` body to coalesce a run of
adjacent rows. A `while` loop says the same thing without overloading the stop
condition, so the finding goes away rather than being suppressed.

## Five are deliberate, and now say so where they are

**`S3267` x4 — "simplify with Where".** All four sit in code written specifically
to avoid allocating, which is the thing `Where` would undo:

| site | why the loop stays |
|---|---|
| `XLCellsCollection.FindUsedColumn` | filters into an `ArrayPool` buffer; `Where` allocates the iterator the pool exists to avoid |
| `XLCellsCollection.IsUsed` | four slices, asked once per cell; `Where` allocates an iterator and a closure per call |
| `XLCalcEngine.ClearSpillFootprint` | `foreach` over `Area`, a readonly struct whose enumerator is also a struct — `Where` boxes both |
| `XLCellsCollection.SlicesEnumerator` | arguably a **false positive**: it filters on `MoveNext()`, which advances as it tests, so the `Where` form would bury a side effect in a predicate |

**`S1133` — "remove this deprecated code someday"** on `SetDataValidation()`. It is
shipped public API listed in `PublicAPI.Shipped.txt`, so it goes with the next
major version and not before. Suppressed on the interface declaration in
`IXLRangeBase.cs` too — CI did not report that one, but it is the same
deprecation and leaving the pair half-suppressed would be odd.

Suppressions follow the existing convention in this repo (`#pragma warning
disable Sxxx // reason` at the site, as in `Functions/Text.cs`).

## Verification

The analyzers only reach the build through `dotnet sonarscanner begin` in CI, so
a plain local build shows none of this. I installed `SonarAnalyzer.CSharp`
locally to reproduce, confirmed all eight sites reported at the exact
line:column CI gave, applied the changes, confirmed none report afterwards, then
removed the package reference again. It is not part of this diff.

- `XLibur.Tests` 11,776 pass / 4 pre-existing skips
- `XLibur.Report.Tests` 481 pass
- `RowDeletionMapTests` specifically covers the run-coalescing the `S127` rewrite
  touched — degrading it stays correct and only undoes the batching, which is why
  it is pinned directly.

## One thing worth knowing

CI reported 7 warnings; a local build with the full ruleset reports many more
`S1133`, `S3267`, `S125`, `S4136` and others across the codebase. The SonarCloud
quality profile decides which surface in CI, so this PR clears exactly what CI
flags, not every finding the analyzer can produce.