### PR TITLE
ci: ship an SBOM with every package

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,6 +2,13 @@
   "version": 1,
   "isRoot": true,
   "tools": {
+    "cyclonedx": {
+      "version": "6.2.0",
+      "commands": [
+        "dotnet-CycloneDX"
+      ],
+      "rollForward": false
+    },
     "dotnet-stryker": {
       "version": "4.16.0",
       "commands": [

--- a/.github/scripts/generate-sbom.sh
+++ b/.github/scripts/generate-sbom.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Generates a CycloneDX SBOM for each shipped package, one file per package, named to
+# match the .nupkg it describes:
+#
+#   XLibur.0.200.0.nupkg  ->  XLibur.0.200.0.cdx.json
+#
+# The release workflows attach these to the GitHub Release. They complement the SPDX
+# manifest that Microsoft.Sbom.Targets embeds inside each .nupkg (see
+# Directory.Build.targets): the embedded one travels to anyone installing from
+# nuget.org, this one is the higher-fidelity document for tooling, because CycloneDX
+# resolves the ProjectReference graph rather than reading a flat component scan.
+#
+# Usage: generate-sbom.sh <version> <output-dir> <project>...
+#
+#   version     Version being released, with or without a leading "v". Used for the
+#               filenames and stamped into each document.
+#   output-dir  Created if absent.
+#   project     Project directory name, e.g. XLibur.Bundle. Expected to contain
+#               <project>/<project>.csproj.
+#
+# Requires the CycloneDX tool from .config/dotnet-tools.json — run `dotnet tool restore`
+# first.
+#
+# Exits non-zero if any expected document is missing or empty, so a silently failing
+# tool cannot ship a release whose SBOMs are absent.
+
+set -euo pipefail
+
+version=${1:?usage: generate-sbom.sh <version> <output-dir> <project>...}
+output=${2:?usage: generate-sbom.sh <version> <output-dir> <project>...}
+shift 2
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::No projects given — nothing to generate" >&2
+  exit 1
+fi
+
+# The tag prefix is not part of a package version.
+version=${version#v}
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+mkdir -p "$output"
+
+status=0
+
+for project in "$@"; do
+  csproj="$repo_root/$project/$project.csproj"
+  filename="$project.$version.cdx.json"
+
+  if [ ! -f "$csproj" ]; then
+    echo "::error::$csproj does not exist"
+    status=1
+    continue
+  fi
+
+  echo "::group::SBOM for $project"
+
+  # --recursive matters: XLibur.Bundle and XLibur.Report reach most of their closure
+  # through ProjectReference, and without it their documents list almost nothing.
+  # --set-name/--set-version pin the document to the package identity rather than
+  # letting the tool infer it from the project, which at pack time is a MinVer
+  # pre-release on any commit that is not exactly a release tag.
+  if ! dotnet tool run dotnet-CycloneDX "$csproj" \
+      --output "$output" \
+      --filename "$filename" \
+      --output-format Json \
+      --recursive \
+      --exclude-dev \
+      --exclude-test-projects \
+      --set-name "$project" \
+      --set-version "$version"; then
+    echo "::error::CycloneDX failed for $project"
+    status=1
+  fi
+
+  echo "::endgroup::"
+
+  if [ ! -s "$output/$filename" ]; then
+    echo "::error::$filename was not produced"
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo "::error::SBOM generation failed — refusing to continue"
+  exit 1
+fi
+
+echo "Generated SBOMs in $output:"
+ls -la "$output"

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -28,6 +28,11 @@ jobs:
 
     env:
       MinVerDefaultPreReleaseIdentifiers: ${{ inputs.prerelease-label }}
+      # Read as an MSBuild property, so every pack below embeds its SPDX manifest — a
+      # pre-release package carries the same bill of materials a stable one does. There
+      # is no GitHub Release here, so no CycloneDX documents are generated; those are
+      # release assets and this workflow only pushes to NuGet.
+      GenerateSBOM: true
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release-report.yml
+++ b/.github/workflows/release-report.yml
@@ -43,6 +43,9 @@ jobs:
       # is the real thing.
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run != false }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Read as an MSBuild property, so every pack below embeds its SPDX manifest.
+      # Off by default (Directory.Build.targets) so PR builds do not pay for it.
+      GenerateSBOM: true
 
     steps:
       - uses: actions/checkout@v7
@@ -59,6 +62,10 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore XLibur.slnx
+
+      # CycloneDX, pinned in .config/dotnet-tools.json so Dependabot keeps it current.
+      - name: Restore .NET tools
+        run: dotnet tool restore
 
       - name: Build
         run: dotnet build XLibur.slnx --configuration Release --no-restore
@@ -181,6 +188,16 @@ jobs:
           echo "XLibur $version is published — dependency is resolvable"
           echo "CORE_DEPENDENCY=$declared" >> "$GITHUB_ENV"
 
+      # One CycloneDX document per package, attached to the release beside the .nupkg
+      # it describes. This is in addition to the SPDX manifest already embedded in each
+      # package by GenerateSBOM above — that one travels to nuget.org consumers, this one
+      # resolves the ProjectReference graph and is the better document for tooling.
+      #
+      # Runs after the gates above so a release that is going to be refused does not
+      # spend the time, but before the summary, which lists what was produced.
+      - name: Generate SBOMs
+        run: bash .github/scripts/generate-sbom.sh "$REPORT_VERSION" ./sboms XLibur.Report XLibur.Report.DynamicLinq
+
       - name: Summary
         run: |
           {
@@ -196,6 +213,12 @@ jobs:
             echo
             for package in ./artifacts/*.nupkg; do
               echo "- \`$(basename "$package")\`"
+            done
+            echo
+            echo "SBOMs: SPDX embedded in each package under \`_manifest/\`, plus CycloneDX"
+            echo
+            for sbom in ./sboms/*.cdx.json; do
+              echo "- \`$(basename "$sbom")\`"
             done
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -236,10 +259,15 @@ jobs:
           files: |
             ./artifacts/*.nupkg
             ./artifacts/*.snupkg
+            ./sboms/*.cdx.json
 
+      # Includes the SBOMs so a dry run — which publishes nothing — still leaves them
+      # somewhere inspectable.
       - name: Upload packages
         uses: actions/upload-artifact@v7
         if: always()
         with:
           name: report-packages
-          path: ./artifacts/*
+          path: |
+            ./artifacts/*
+            ./sboms/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
     env:
       TAG: ${{ inputs.tag || github.ref_name }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Read as an MSBuild property, so every pack below embeds its SPDX manifest.
+      # Off by default (Directory.Build.targets) so PR builds do not pay for it.
+      GenerateSBOM: true
 
     steps:
       - uses: actions/checkout@v7
@@ -63,6 +66,10 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore XLibur.slnx
+
+      # CycloneDX, pinned in .config/dotnet-tools.json so Dependabot keeps it current.
+      - name: Restore .NET tools
+        run: dotnet tool restore
 
       - name: Build
         run: dotnet build XLibur.slnx --configuration Release --no-restore
@@ -95,6 +102,18 @@ jobs:
             exit 1
           fi
           echo "All packages are version $expected"
+
+      # One CycloneDX document per package, attached to the release beside the .nupkg it
+      # describes. This is in addition to the SPDX manifest already embedded in each
+      # package by GenerateSBOM above — that one travels to nuget.org consumers, this one
+      # resolves the ProjectReference graph and is the better document for tooling.
+      #
+      # The project list matches Pack above; the version is the tag's, already verified
+      # against every package by the step above.
+      - name: Generate SBOMs
+        run: |
+          bash .github/scripts/generate-sbom.sh "${TAG#v}" ./sboms \
+            XLibur XLibur.Fonts.SixLabors.V1 XLibur.Bundle XLibur.Fonts.SixLabors XLibur.Fonts.SkiaSharp
 
       - name: NuGet login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
@@ -153,3 +172,4 @@ jobs:
           files: |
             ./artifacts/*.nupkg
             ./artifacts/*.snupkg
+            ./sboms/*.cdx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ## Unreleased
 
+### 🔒 Supply Chain
+
+- **Every package now ships a Software Bill of Materials.** Each `.nupkg` embeds an SPDX 2.2 manifest under `_manifest/spdx_2.2/`, generated at pack time, so the bill of materials travels with the package to anyone installing it from NuGet. Each release additionally carries a CycloneDX 1.7 document per package (`XLibur.<version>.cdx.json`) as a GitHub Release asset.
+
+  ```bash
+  # Read the embedded manifest without installing
+  unzip -p XLibur.0.200.0.nupkg '_manifest/spdx_2.2/manifest.spdx.json' | jq .
+  ```
+
 ## v0.200.0 - 2026-08-01
 
 ### ⚠️ Breaking Changes

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,66 @@
+<Project>
+
+  <!--
+    Microsoft.Sbom.Targets writes an SPDX manifest into the .nupkg under _manifest/ at pack time,
+    so every package carries its own bill of materials to whoever installs it. That is the layer
+    that reaches nuget.org consumers: nuget.org rewrites the .nupkg on upload, which invalidates
+    any digest-based attestation, but package content is untouched.
+
+    This lives in Directory.Build.targets rather than Directory.Build.props because the .props file
+    is imported before the project body and so could not read IsPackable out of it.
+
+    The gate is IsPackable and NOT GeneratePackageOnBuild, even though the latter names the same
+    seven projects. GeneratePackageOnBuild is set inside a Release-only PropertyGroup, and CI
+    restores at the default configuration and then builds Release without restoring again, so the
+    reference would be absent from project.assets.json but present at build time, failing the build.
+    IsPackable is configuration-independent, so restore and build always agree.
+
+    Within that set the reference is unconditional and only GenerateSBOM is gated. Generation is
+    slow and every packable project sets GeneratePackageOnBuild, so a plain Release build — what
+    build-and-test.yml runs on every PR — would otherwise pay for it. MSBuild surfaces environment
+    variables as properties, so the release workflows set GenerateSBOM=true at job level and the
+    condition below yields to it.
+  -->
+  <ItemGroup Condition="'$(IsPackable)' != 'false'">
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="All" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(GenerateSBOM)' == ''">
+    <GenerateSBOM>false</GenerateSBOM>
+  </PropertyGroup>
+
+  <!--
+    Corrects the metadata Microsoft.Sbom.Targets would otherwise record.
+
+    Its own defaults read $(Version) and $(MSBuildProjectDirectory) during evaluation, which is too
+    early and too broad here:
+
+      * MinVer computes the version inside a target, so at evaluation $(Version) is still unset and
+        the SBOM defaults to 1.0.0 — every release would ship a manifest naming a version that does
+        not exist. Same ordering trap that SetPackageReleaseNotesFromVersion works around in
+        Directory.Build.props. By the time GenerateSbomTarget runs (AfterTargets="Pack")
+        $(PackageVersion) is correct; the tool already relies on that to locate the .nupkg.
+
+      * The default component path is the project directory. The scan reads package metadata out of
+        whatever it finds under there, and because every packable project sets
+        GeneratePackageOnBuild, bin/ already holds this package's own .nupkg by the time pack runs —
+        so the package would list itself as one of its dependencies. Narrowing to obj/ keeps the
+        scan on project.assets.json, the authoritative resolved dependency graph.
+
+        Note this does not eliminate self-reference entirely: obj/Release holds the .nuspec and
+        .symbols.nuspec for the version being packed, which SPDX records as the root package anyway.
+        A dirty local obj/ that has accumulated .nuspec files from earlier builds will add one entry
+        per stale version; a CI checkout is clean, so it sees only the current one.
+
+    Namespaces are based on the repository rather than the tool's spdx.org default so a manifest is
+    traceable to where it was produced.
+  -->
+  <Target Name="SetSbomMetadataFromVersion" BeforeTargets="GenerateSbomTarget">
+    <PropertyGroup>
+      <SbomGenerationPackageVersion>$(PackageVersion)</SbomGenerationPackageVersion>
+      <SbomGenerationBuildComponentPath>$(MSBuildProjectDirectory)/obj</SbomGenerationBuildComponentPath>
+      <SbomGenerationNamespaceBaseUri>$(RepositoryUrl)/spdx</SbomGenerationNamespaceBaseUri>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,30 @@ When reporting, please include:
 
 We will acknowledge receipt within 72 hours and aim to provide a fix or mitigation plan within 30 days, depending on severity.
 
+## Software Bill of Materials
+
+Every published package carries an SBOM, in two forms.
+
+**Embedded, in the package.** Each `.nupkg` contains an SPDX 2.2 manifest generated at pack
+time, so it is available to anyone who installs from NuGet without going back to this
+repository:
+
+```bash
+unzip -p XLibur.0.200.0.nupkg '_manifest/spdx_2.2/manifest.spdx.json' | jq .
+```
+
+`_manifest/spdx_2.2/manifest.spdx.json.sha256` beside it is the manifest's own checksum. Note
+that it attests to the manifest, not to the package — nuget.org rewrites `.nupkg` files when
+they are published, so no signature produced here can cover the file you download from it.
+
+**Attached to each release.** Every GitHub Release also carries a CycloneDX 1.7 document per
+package, named to match the package it describes (`XLibur.0.200.0.cdx.json`). These resolve the
+project graph rather than scanning build output, so they are the more precise record of what a
+given package depends on, and the better input for automated tooling.
+
+Both are produced by the release workflows, from the same commit the packages are built from.
+See `Directory.Build.targets` and `.github/scripts/generate-sbom.sh`.
+
 ## Scope
 
 XLibur processes `.xlsx` and `.xlsm` files, which are ZIP-based XML packages. Security concerns include but are not limited to:

--- a/XLibur.Benchmarks/XLibur.Benchmarks.csproj
+++ b/XLibur.Benchmarks/XLibur.Benchmarks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/XLibur.Examples/XLibur.Examples.csproj
+++ b/XLibur.Examples/XLibur.Examples.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
     <LangVersion>default</LangVersion>
     <RootNamespace>XLibur.Examples</RootNamespace>
     <Company>XLibur</Company>


### PR DESCRIPTION
## Summary

Publishes a Software Bill of Materials with every package, in two layers, because neither alone covers both audiences.

**Embedded SPDX** — `Microsoft.Sbom.Targets` writes a manifest into each `.nupkg` under `_manifest/spdx_2.2/` at pack time. This is the layer that reaches nuget.org consumers: nuget.org rewrites `.nupkg` files on upload, so nothing signed here could cover the file they download, but package *content* survives untouched.

**CycloneDX per package** — one `<Package>.<version>.cdx.json` attached to each GitHub Release beside the `.nupkg` it describes. CycloneDX resolves the `ProjectReference` graph, which the SPDX component scan does not, and that gap is real: `XLibur.Bundle`'s embedded manifest lists 4 packages against CycloneDX's 16.

Generation is gated on `GenerateSBOM`, **off by default**. Every packable project sets `GeneratePackageOnBuild`, so a plain Release build packs — and that is exactly what `build-and-test.yml` runs on every PR. The release workflows set the property at job level; PR build time is unchanged.

## Changes

- **`Directory.Build.targets`** (new) — references `Microsoft.Sbom.Targets` 4.1.5 for packable projects and corrects two of its defaults (below).
- **`.github/scripts/generate-sbom.sh`** (new) — one CycloneDX document per package, following the `roll-changelog.sh` precedent of keeping shared logic in a script rather than duplicated YAML. Exits non-zero if any expected document is missing, so a silently failing tool cannot ship a release with no SBOMs.
- **`.config/dotnet-tools.json`** — pins CycloneDX 6.2.0, so Dependabot's existing `nuget` ecosystem keeps it current.
- **`release.yml`** — `GenerateSBOM`, tool restore, SBOM step for the 5 core packages, `.cdx.json` added to the release assets.
- **`release-report.yml`** — the same for the 2 report packages, plus the step summary and the dry-run artifact so a dispatch run leaves them inspectable.
- **`release-prerelease.yml`** — embedded manifest only; it creates no GitHub Release, so there is nowhere to attach CycloneDX documents.
- **`XLibur.Examples` / `XLibur.Benchmarks`** — declare `IsPackable=false`. Always true of them, and it is what makes the gate below exact.
- **`SECURITY.md`**, **`CHANGELOG.md`** — document both formats and how to read the embedded one.

`build-and-test.yml` is deliberately untouched.

## Three things worth reviewer attention

These were found by testing rather than by design, and each changes what the code had to look like.

1. **The obvious gate would have broken every release.** Gating on `GeneratePackageOnBuild` reads naturally — it names exactly the seven shipping projects — but it is set inside a `Release`-only `PropertyGroup`, and CI restores at the default configuration then builds Release with `--no-restore`. The reference would be absent from `project.assets.json` and required at build time. The gate is `IsPackable` instead, which is configuration-independent, and that is why the two `Exe` projects now declare it.

2. **Every manifest was stamped `1.0.0`.** `Microsoft.Sbom.Targets` reads `$(Version)` during evaluation, but MinVer computes the version inside a target — the same ordering trap `SetPackageReleaseNotesFromVersion` already works around in `Directory.Build.props`. Corrected in a target that runs before `GenerateSbomTarget`.

3. **Each package listed itself as a dependency.** The component scan defaults to the project directory, and because `GeneratePackageOnBuild` is set, `bin/` already holds the package's own `.nupkg` by the time pack runs. Narrowed to `obj/`, which holds `project.assets.json`.

## Related Issues

<!-- none -->

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually

No unit tests — this is build and release plumbing with no library surface. Verified by running the pipeline's own sequence locally:

- Full solution `dotnet build -c Release`: **0 warnings, 0 errors** under `TreatWarningsAsErrors`.
- Replicated the CI order exactly — restore at default configuration, then `build --configuration Release --no-restore`, then `pack --no-build` — with `GenerateSBOM` set as an **environment variable**, which is how the workflows set it. All 5 core packages carry exactly one manifest, each with the correct version and a repository-based namespace.
- Gate holds: packing without the property produces no `_manifest/` and stays at ~2.6s; generation adds ~2s.
- All 7 CycloneDX documents validate as spec 1.7 with correct versions and a stripped `v` prefix; `--recursive` confirmed to pull `XLibur.Bundle`'s full closure including the SkiaSharp native assets.
- Script failure paths exit 1 for a missing project and for an empty project list.
- New `.sh` is LF, per `.gitattributes`.

**Not yet exercised in CI.** The natural first run is **Release Report** via `workflow_dispatch` with dry-run left on — it builds, packs and summarises without publishing, and is the only way to rehearse this short of cutting a tag. `release.yml` mirrors it.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
