### PR TITLE
feat(core): give XLibur.Report a public surface, dropping the friend grant

### DIFF
--- a/XLibur.Report.props
+++ b/XLibur.Report.props
@@ -21,18 +21,19 @@
     tests are unaffected either way: they compile against the project, and this only changes the
     dependency written into the .nupkg.
 
-    It is an EXACT range while `XLibur.Report` reads core internals through the InternalsVisibleTo
-    grant.
+    It is an open FLOOR, not an exact range: `XLibur.Report` compiles against core's public surface
+    only, so a consumer that pulls a newer core in alongside it gets something core has promised not
+    to break.
 
-    Internals carry no compatibility contract, so an open floor would be a promise core never made:
-    NuGet would happily unify core upward and the report package would fail at runtime against
-    internals that had since moved. Spec 13 replaces the grant with a public surface; once its task 3
-    lands and the report package builds against the released core package, this becomes an open floor
-    (`0.200.0`) and the exactness goes away. Until then, exact is the honest expression of "compiled
-    against these internals".
+    It was exact — `[0.200.0]` — while the report package read core internals through an
+    InternalsVisibleTo grant. Internals carry no compatibility contract, so an open floor would have
+    been a promise core never made: NuGet would happily unify core upward and the report package
+    would fail at runtime against internals that had since moved. Spec 13 replaced that grant with
+    `XLFunctionLibrary` and the `IXLPivotCache` source members, which is what makes a floor honest.
+    0.201.0 is the first core release carrying them, so it is the floor.
   -->
   <PropertyGroup>
-    <XLiburDependencyVersion Condition="'$(XLiburDependencyVersion)' == ''">[0.200.0]</XLiburDependencyVersion>
+    <XLiburDependencyVersion Condition="'$(XLiburDependencyVersion)' == ''">0.201.0</XLiburDependencyVersion>
   </PropertyGroup>
 
   <!--

--- a/XLibur.Report/Functions/ExcelFunctionBridge.cs
+++ b/XLibur.Report/Functions/ExcelFunctionBridge.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
+using System.Runtime.InteropServices;
 using Scriban.Runtime;
 using XLibur.Excel;
 using XLibur.Excel.CalcEngine;
@@ -18,8 +18,8 @@ namespace XLibur.Report.Functions;
 /// they mean in a cell.
 /// </summary>
 /// <remarks>
-/// One adapter over the calc engine's function registry rather than a wrapper per function: a
-/// function added to the engine becomes available to templates without any change here.
+/// One adapter over <see cref="XLFunctionLibrary"/> rather than a wrapper per function: a function
+/// added to the calc engine becomes available to templates without any change here.
 /// <para>
 /// Functions are registered under their upper-case Excel names. That is not cosmetic — Scriban's
 /// keywords are lower case, so <c>if</c> would be parsed as a block conditional while <c>IF</c>
@@ -58,8 +58,8 @@ internal static class ExcelFunctionBridge
     private static readonly ConcurrentDictionary<CultureInfo, ScriptObject> ScribanGlobals = new();
 
     /// <summary>
-    /// Makes every function the calc engine knows about callable from <paramref name="engine"/>.
-    /// Engines that cannot host functions are left alone.
+    /// Makes every function the workbook function library knows about callable from
+    /// <paramref name="engine"/>. Engines that cannot host functions are left alone.
     /// </summary>
     public static void Register(IExpressionEngine engine, CultureInfo? culture = null)
     {
@@ -102,59 +102,46 @@ internal static class ExcelFunctionBridge
         Adapters.GetOrAdd(culture, BuildAdapters);
 
     /// <summary>
-    /// One adapter per registered function, closing over a single calc engine.
+    /// One adapter per available function, closing over a single function library.
     /// </summary>
     /// <remarks>
-    /// Sharing that engine across templates — and so across threads — is safe because these calls
-    /// have no grid: <see cref="CalcContext.CalcEngine"/> is reached only when reading a cell, which
-    /// needs a worksheet, and without one the call has already failed with the
-    /// <see cref="MissingContextException"/> translated below. The engine is here to be handed to a
-    /// <see cref="CalcContext"/>, not to hold state for the call.
+    /// Sharing that library across templates — and so across threads — is what
+    /// <see cref="XLFunctionLibrary"/> is built for: it holds no per-call state, and constructing
+    /// one builds the whole function table, which is the cost this cache exists to pay once.
     /// </remarks>
     private static IReadOnlyList<(string Name, Delegate Function)> BuildAdapters(CultureInfo culture)
     {
-        var calcEngine = new XLCalcEngine(culture);
+        var library = new XLFunctionLibrary(culture);
         var adapters = new List<(string Name, Delegate Function)>();
 
-        foreach (var name in calcEngine.Functions.Names)
+        foreach (var name in library.Names)
         {
-            if (!calcEngine.Functions.TryGetFunc(name, out var definition) || definition is null)
-            {
-                continue;
-            }
-
-            var function = definition;
+            var functionName = name;
             adapters.Add((
                 name.ToUpperInvariant(),
-                new ExcelFunction(arguments => Invoke(calcEngine, function, culture, arguments))));
+                new ExcelFunction(arguments => Invoke(library, functionName, culture, arguments))));
         }
 
         return adapters;
     }
 
     private static object? Invoke(
-        XLCalcEngine calcEngine,
-        FunctionDefinition definition,
+        XLFunctionLibrary library,
+        string name,
         CultureInfo culture,
         object?[] arguments)
     {
         var flattened = Flatten(arguments, culture);
 
-        if (flattened.Count < definition.MinParams || flattened.Count > definition.MaxParams)
-        {
-            return XLError.IncompatibleValue;
-        }
-
-        // No workbook and no cell: a template expression is evaluated before there is a grid to be
-        // relative to. Functions that reach for one throw, and are reported as such below.
-        var context = new CalcContext(calcEngine, culture, workbook: null, worksheet: null, formulaAddress: null);
-        var values = flattened.ToArray();
-
         try
         {
-            return FromAnyValue(definition.CallFunction(context, values.AsSpan()));
+            // Arity is the library's business — a wrong count comes back as an error result, the
+            // same as any other call that was made but could not succeed.
+            return library.TryInvoke(name, CollectionsMarshal.AsSpan(flattened), out var result)
+                ? FromCellValue(result)
+                : XLError.NameNotRecognized;
         }
-        catch (MissingContextException)
+        catch (XLNoWorksheetContextException)
         {
             throw new ExpressionEvaluationException(
                 "This function needs a worksheet to work against, which a template expression does not have. " +
@@ -173,9 +160,9 @@ internal static class ExcelFunctionBridge
     /// <c>MAX</c> — mean by a range argument, and it keeps the bridge clear of the engine's
     /// internal array representation.
     /// </remarks>
-    private static List<AnyValue> Flatten(object?[] arguments, CultureInfo culture)
+    private static List<XLCellValue> Flatten(object?[] arguments, CultureInfo culture)
     {
-        var values = new List<AnyValue>(arguments.Length);
+        var values = new List<XLCellValue>(arguments.Length);
 
         foreach (var argument in arguments)
         {
@@ -183,34 +170,36 @@ internal static class ExcelFunctionBridge
             {
                 foreach (var item in enumerable)
                 {
-                    values.Add(ToAnyValue(item, culture));
+                    values.Add(ToCellValue(item, culture));
                 }
 
                 continue;
             }
 
-            values.Add(ToAnyValue(argument, culture));
+            values.Add(ToCellValue(argument, culture));
         }
 
         return values;
     }
 
-    private static AnyValue ToAnyValue(object? value, CultureInfo culture) => value switch
+    private static XLCellValue ToCellValue(object? value, CultureInfo culture) => value switch
     {
-        null => ScalarValue.Blank.ToAnyValue(),
-        bool logical => AnyValue.From(logical),
-        string text => AnyValue.From(text),
+        null => Blank.Value,
+        bool logical => logical,
+        string text => text,
 
-        // Excel keeps dates as serial numbers, and its date functions expect them that way.
-        DateTime dateTime => AnyValue.From(dateTime.ToOADate()),
-        DateTimeOffset dateTimeOffset => AnyValue.From(dateTimeOffset.DateTime.ToOADate()),
-        TimeSpan timeSpan => AnyValue.From(timeSpan.TotalDays),
+        // Excel keeps dates as serial numbers, and its date functions expect them that way. Passed
+        // as the number rather than as a date-typed cell value, so that what reaches a function is
+        // the serial it would see in a cell formula.
+        DateTime dateTime => dateTime.ToOADate(),
+        DateTimeOffset dateTimeOffset => dateTimeOffset.DateTime.ToOADate(),
+        TimeSpan timeSpan => timeSpan.TotalDays,
 
-        XLError error => AnyValue.From(error),
-        XLCellValue cellValue => ((ScalarValue)cellValue).ToAnyValue(),
+        XLError error => error,
+        XLCellValue cellValue => cellValue,
 
         IConvertible convertible => FromConvertible(convertible, culture),
-        _ => AnyValue.From(value.ToString() ?? string.Empty),
+        _ => value.ToString() ?? string.Empty,
     };
 
     /// <summary>
@@ -223,31 +212,31 @@ internal static class ExcelFunctionBridge
     /// promises — so a value that will not convert is passed as its text, the same as anything else
     /// with no numeric form.
     /// </remarks>
-    private static AnyValue FromConvertible(IConvertible convertible, CultureInfo culture)
+    private static XLCellValue FromConvertible(IConvertible convertible, CultureInfo culture)
     {
         try
         {
-            return AnyValue.From(convertible.ToDouble(culture));
+            return convertible.ToDouble(culture);
         }
         catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException)
         {
-            return AnyValue.From(convertible.ToString(culture) ?? string.Empty);
+            return convertible.ToString(culture) ?? string.Empty;
         }
     }
 
-    private static object? FromAnyValue(AnyValue value)
+    /// <summary>
+    /// The function's result as a template expression sees it. Blank becomes <c>null</c>, which is
+    /// what an expression engine understands as "nothing here".
+    /// </summary>
+    private static object? FromCellValue(XLCellValue value) => value.Type switch
     {
-        if (!value.TryPickScalar(out var scalar, out _))
-        {
-            // An array or reference result has no single value a cell could hold.
-            return XLError.IncompatibleValue;
-        }
-
-        return scalar.Match<object?>(
-            () => null,
-            logical => logical,
-            number => number,
-            text => text,
-            error => error);
-    }
+        XLDataType.Blank => null,
+        XLDataType.Boolean => value.GetBoolean(),
+        XLDataType.Number => value.GetNumber(),
+        XLDataType.Text => value.GetText(),
+        XLDataType.Error => value.GetError(),
+        XLDataType.DateTime => value.GetDateTime(),
+        XLDataType.TimeSpan => value.GetTimeSpan(),
+        _ => null,
+    };
 }

--- a/XLibur.Report/Ranges/RangeExpander.cs
+++ b/XLibur.Report/Ranges/RangeExpander.cs
@@ -531,9 +531,9 @@ internal sealed class RangeExpander
                 .SelectMany(original => Widen(sheet, axis, original, slotsPerItem, itemCount))
                 .ToList();
 
-            // IXLConditionalFormat.Ranges is a fresh projection of the rule's internal area list,
-            // so mutating it does nothing; SetAreas is the supported way to rewrite coverage.
-            ((XLConditionalFormat)format).SetAreas(XLAreaList.FromRanges(widened));
+            // IXLConditionalFormat.Ranges is a fresh projection of the rule's coverage, so mutating
+            // it does nothing; SetRanges is the supported way to rewrite coverage.
+            format.SetRanges(widened);
         }
     }
 

--- a/XLibur.Report/Rewriting/PivotRewriter.cs
+++ b/XLibur.Report/Rewriting/PivotRewriter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel;
-using XLibur.Excel.Coordinates;
 using XLibur.Excel.Exceptions;
 using XLibur.Report.Ranges;
 
@@ -45,39 +44,55 @@ internal static class PivotRewriter
     /// </summary>
     public static void Rewrite(IXLWorkbook workbook, IReadOnlyList<ExpansionRecord> expansions, TemplateErrors errors)
     {
-        if (expansions.Count == 0 || workbook is not XLWorkbook typed)
+        if (expansions.Count == 0)
         {
             return;
         }
 
         var bySheet = ExpansionMap.BySheet(expansions);
 
-        RewriteCaches(typed, bySheet, errors);
-        MovePivotTables(typed, bySheet);
+        RewriteCaches(workbook, bySheet, errors);
+        MovePivotTables(workbook, bySheet);
     }
 
     private static void RewriteCaches(
-        XLWorkbook workbook,
+        IXLWorkbook workbook,
         Dictionary<string, List<ExpansionRecord>> bySheet,
         TemplateErrors errors)
     {
-        foreach (var cache in workbook.PivotCaches.OfType<XLPivotCache>())
+        foreach (var cache in workbook.PivotCaches)
         {
-            // A source XLibur cannot resolve — an external workbook, a consolidation, a connection —
-            // is left exactly as the template had it.
-            if (cache.Source is not XLPivotSourceReference reference)
-            {
-                continue;
-            }
+            var sourceRange = cache.SourceKind == XLPivotSourceKind.Range ? cache.SourceRange : null;
+            string sheetName;
 
-            var sheetName = SourceSheetName(workbook, reference);
-            if (sheetName is null)
+            switch (cache.SourceKind)
             {
-                // A named source that resolves to nothing: most likely a name the report deleted
-                // along with a range that turned out to be empty. The pivot is in the output with
-                // no data behind it, which the report's author needs telling about.
-                errors.Add(SourceUnreadable(reference.Name, null));
-                continue;
+                case XLPivotSourceKind.Range when sourceRange is not null:
+                    sheetName = sourceRange.Worksheet.Name;
+                    break;
+
+                case XLPivotSourceKind.Range:
+                    // The area names a sheet that is not in the workbook, so nothing was generated
+                    // on it either. Left alone, and not worth reporting: the template was already
+                    // like this before the report ran.
+                    continue;
+
+                case XLPivotSourceKind.Name when cache.SourceWorksheet is { } named:
+                    sheetName = named.Name;
+                    break;
+
+                case XLPivotSourceKind.Name:
+                    // A named source that resolves to nothing: most likely a name the report deleted
+                    // along with a range that turned out to be empty. The pivot is in the output with
+                    // no data behind it, which the report's author needs telling about.
+                    errors.Add(SourceUnreadable(cache.SourceName, null));
+                    continue;
+
+                default:
+                    // A source XLibur cannot read — an external workbook, a consolidation, a
+                    // scenario, a connection — is left exactly as the template had it, silently.
+                    // There is nothing wrong with it, and nothing this can do for it.
+                    continue;
             }
 
             if (!bySheet.TryGetValue(sheetName, out var expansions))
@@ -87,9 +102,9 @@ internal static class PivotRewriter
                 continue;
             }
 
-            if (!reference.UsesName)
+            if (sourceRange is not null)
             {
-                cache.Source = new XLPivotSourceReference(RePoint(reference.Area!.Value, expansions));
+                cache.SetSourceRange(RePoint(sourceRange, expansions));
             }
 
             Refresh(cache, sheetName, errors);
@@ -97,26 +112,16 @@ internal static class PivotRewriter
     }
 
     /// <summary>
-    /// Which sheet a cache reads from — the sheet named in an area source, or the sheet the source
-    /// name or table currently resolves to.
-    /// </summary>
-    private static string? SourceSheetName(XLWorkbook workbook, XLPivotSourceReference reference)
-    {
-        if (!reference.UsesName)
-        {
-            return reference.Area!.Value.Name;
-        }
-
-        return reference.TryGetSource(workbook, out var sheet, out _) ? sheet?.Name : null;
-    }
-
-    /// <summary>
     /// Moves and stretches an area source through the expansions on its sheet, in the order they
     /// ran.
     /// </summary>
-    private static SheetArea RePoint(SheetArea source, List<ExpansionRecord> expansions)
+    private static IXLRange RePoint(IXLRange source, List<ExpansionRecord> expansions)
     {
-        var area = source.Area;
+        var worksheet = source.Worksheet;
+        var topRow = source.RangeAddress.FirstAddress.RowNumber;
+        var leftColumn = source.RangeAddress.FirstAddress.ColumnNumber;
+        var bottomRow = source.RangeAddress.LastAddress.RowNumber;
+        var rightColumn = source.RangeAddress.LastAddress.ColumnNumber;
 
         foreach (var expansion in expansions)
         {
@@ -126,46 +131,36 @@ internal static class PivotRewriter
             // but a full-row or full-column insert moves everything past it either way.
             if (expansion.Axis.IsHorizontal)
             {
-                var crosses = area.BottomRow >= template.FirstRow && area.TopRow <= template.LastRow;
+                var crosses = bottomRow >= template.FirstRow && topRow <= template.LastRow;
 
                 if (!crosses)
                 {
-                    area = new Area(
-                        area.TopRow,
-                        Shift(area.LeftColumn, template.LastColumn, expansion.SlotDelta),
-                        area.BottomRow,
-                        Shift(area.RightColumn, template.LastColumn, expansion.SlotDelta));
+                    leftColumn = Shift(leftColumn, template.LastColumn, expansion.SlotDelta);
+                    rightColumn = Shift(rightColumn, template.LastColumn, expansion.SlotDelta);
 
                     continue;
                 }
 
-                var leftColumn = ExpansionMap.MapColumnStart(area.LeftColumn, expansion);
-                var rightColumn = Math.Max(leftColumn, ExpansionMap.MapColumnEnd(area.RightColumn, expansion));
-
-                area = new Area(area.TopRow, leftColumn, area.BottomRow, rightColumn);
+                leftColumn = ExpansionMap.MapColumnStart(leftColumn, expansion);
+                rightColumn = Math.Max(leftColumn, ExpansionMap.MapColumnEnd(rightColumn, expansion));
                 continue;
             }
 
-            var overlaps = area.RightColumn >= template.FirstColumn && area.LeftColumn <= template.LastColumn;
+            var overlaps = rightColumn >= template.FirstColumn && leftColumn <= template.LastColumn;
 
             if (!overlaps)
             {
-                area = new Area(
-                    Shift(area.TopRow, template.LastRow, expansion.SlotDelta),
-                    area.LeftColumn,
-                    Shift(area.BottomRow, template.LastRow, expansion.SlotDelta),
-                    area.RightColumn);
+                topRow = Shift(topRow, template.LastRow, expansion.SlotDelta);
+                bottomRow = Shift(bottomRow, template.LastRow, expansion.SlotDelta);
 
                 continue;
             }
 
-            var topRow = ExpansionMap.MapRowStart(area.TopRow, expansion);
-            var bottomRow = Math.Max(topRow, ExpansionMap.MapRowEnd(area.BottomRow, expansion));
-
-            area = new Area(topRow, area.LeftColumn, bottomRow, area.RightColumn);
+            topRow = ExpansionMap.MapRowStart(topRow, expansion);
+            bottomRow = Math.Max(topRow, ExpansionMap.MapRowEnd(bottomRow, expansion));
         }
 
-        return new SheetArea(source.Name, area);
+        return worksheet.Range(topRow, leftColumn, bottomRow, rightColumn);
     }
 
     /// <summary>
@@ -179,7 +174,7 @@ internal static class PivotRewriter
     /// <summary>
     /// Re-reads the cache's records, and asks Excel to do the same when it opens the file.
     /// </summary>
-    private static void Refresh(XLPivotCache cache, string sheetName, TemplateErrors errors)
+    private static void Refresh(IXLPivotCache cache, string sheetName, TemplateErrors errors)
     {
         try
         {
@@ -214,7 +209,7 @@ internal static class PivotRewriter
     /// Moves a pivot table that sat below rows the report generated, so that it is not written over
     /// by them.
     /// </summary>
-    private static void MovePivotTables(XLWorkbook workbook, Dictionary<string, List<ExpansionRecord>> bySheet)
+    private static void MovePivotTables(IXLWorkbook workbook, Dictionary<string, List<ExpansionRecord>> bySheet)
     {
         foreach (var worksheet in workbook.Worksheets)
         {

--- a/XLibur.Tests/Excel/CalcEngine/XLFunctionLibraryTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/XLFunctionLibraryTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+using XLibur.Excel.CalcEngine;
+using XLibur.Excel.CalcEngine.Exceptions;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+public class XLFunctionLibraryTests
+{
+    private static XLCellValue Invoke(XLFunctionLibrary library, string name, params XLCellValue[] arguments)
+    {
+        return library.TryInvoke(name, arguments.AsSpan(), out var result)
+            ? result
+            : throw new InvalidOperationException($"No function named '{name}'.");
+    }
+
+    [Test]
+    public async Task Names_includes_the_common_functions()
+    {
+        var library = new XLFunctionLibrary();
+
+        await Assert.That(library.Names).IsNotEmpty();
+        await Assert.That(library.Names).Contains("SUM");
+        await Assert.That(library.Names).Contains("ROUND");
+    }
+
+    [Test]
+    public async Task Names_are_all_invocable()
+    {
+        var library = new XLFunctionLibrary();
+        var unresolved = new List<string>();
+
+        // Every advertised name resolves — Names and TryInvoke read the same registry, and a caller
+        // registering one adapter per name relies on that. Throwing counts as resolved: the call
+        // was dispatched, it just needed a grid.
+        foreach (var name in library.Names)
+        {
+            try
+            {
+                if (!library.TryInvoke(name, [], out _))
+                    unresolved.Add(name);
+            }
+            catch (XLNoWorksheetContextException)
+            {
+            }
+        }
+
+        await Assert.That(unresolved).IsEmpty();
+    }
+
+    [Test]
+    public async Task TryInvoke_calls_the_function()
+    {
+        var library = new XLFunctionLibrary();
+
+        await Assert.That(Invoke(library, "SUM", 1, 2, 3)).IsEqualTo((XLCellValue)6.0);
+        await Assert.That(Invoke(library, "ROUND", 3.14159, 2)).IsEqualTo((XLCellValue)3.14);
+        await Assert.That(Invoke(library, "UPPER", "abc")).IsEqualTo((XLCellValue)"ABC");
+    }
+
+    [Test]
+    public async Task TryInvoke_matches_the_name_case_insensitively()
+    {
+        var library = new XLFunctionLibrary();
+
+        await Assert.That(Invoke(library, "sum", 1, 2)).IsEqualTo((XLCellValue)3.0);
+        await Assert.That(Invoke(library, "Sum", 1, 2)).IsEqualTo((XLCellValue)3.0);
+    }
+
+    [Test]
+    public async Task TryInvoke_returns_false_for_an_unknown_function()
+    {
+        var library = new XLFunctionLibrary();
+
+        await Assert.That(library.TryInvoke("NOT_A_FUNCTION", [1.0], out var result)).IsFalse();
+        await Assert.That(result).IsEqualTo(default(XLCellValue));
+    }
+
+    [Test]
+    public async Task TryInvoke_reports_wrong_arity_as_an_error_result()
+    {
+        var library = new XLFunctionLibrary();
+
+        // The call was made and could not succeed, which Excel reports as a value — not as
+        // "there is no such function", which is what false means.
+        await Assert.That(library.TryInvoke("ROUND", [], out var tooFew)).IsTrue();
+        await Assert.That(tooFew).IsEqualTo((XLCellValue)XLError.IncompatibleValue);
+
+        await Assert.That(library.TryInvoke("PI", [1.0, 2.0, 3.0], out var tooMany)).IsTrue();
+        await Assert.That(tooMany).IsEqualTo((XLCellValue)XLError.IncompatibleValue);
+    }
+
+    [Test]
+    public async Task TryInvoke_reports_a_failed_call_as_an_error_result()
+    {
+        var library = new XLFunctionLibrary();
+
+        await Assert.That(Invoke(library, "CHAR", -2)).IsEqualTo((XLCellValue)XLError.IncompatibleValue);
+    }
+
+    [Test]
+    public async Task TryInvoke_throws_for_a_function_that_needs_a_worksheet()
+    {
+        var library = new XLFunctionLibrary();
+
+        await Assert.That(() => library.TryInvoke("ROW", [], out _))
+            .Throws<XLNoWorksheetContextException>();
+    }
+
+    [Test]
+    public async Task TryInvoke_throws_for_a_null_name()
+    {
+        var library = new XLFunctionLibrary();
+
+        await Assert.That(() => library.TryInvoke(null!, [], out _))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task TryInvoke_round_trips_every_scalar_kind()
+    {
+        var library = new XLFunctionLibrary();
+
+        // IF returns its argument untouched, so it reports what survived the conversion in and out.
+        await Assert.That(Invoke(library, "IF", true, 42.5)).IsEqualTo((XLCellValue)42.5);
+        await Assert.That(Invoke(library, "IF", true, "text")).IsEqualTo((XLCellValue)"text");
+        var logical = Invoke(library, "IF", true, true);
+        await Assert.That(logical.IsBoolean).IsTrue();
+        await Assert.That(logical.GetBoolean()).IsTrue();
+
+        await Assert.That(Invoke(library, "IF", true, XLError.DivisionByZero))
+            .IsEqualTo((XLCellValue)XLError.DivisionByZero);
+    }
+
+    [Test]
+    public async Task TryInvoke_keeps_a_blank_result_blank()
+    {
+        var library = new XLFunctionLibrary();
+
+        // Not 0. There is no cell here to apply the "a blank formula result is written as zero"
+        // rule, so the caller is told what the function actually returned.
+        var result = Invoke(library, "IF", true, Blank.Value);
+
+        await Assert.That(result.IsBlank).IsTrue();
+    }
+
+    [Test]
+    public async Task TryInvoke_reports_an_array_result_as_an_error()
+    {
+        var library = new XLFunctionLibrary();
+
+        // SEQUENCE(2, 2) is a 2x2 array: no single value a cell could hold, and no XLCellValue that
+        // could carry it. Reported the way Excel reports a value it cannot place.
+        await Assert.That(Invoke(library, "SEQUENCE", 2, 2)).IsEqualTo((XLCellValue)XLError.IncompatibleValue);
+    }
+
+    [Test]
+    public async Task Culture_defaults_to_invariant_and_is_honoured()
+    {
+        var czech = new XLFunctionLibrary(CultureInfo.GetCultureInfo("cs-CZ"));
+        var invariant = new XLFunctionLibrary();
+
+        // A decimal comma is a number in cs-CZ and not in the invariant culture.
+        await Assert.That(Invoke(czech, "VALUE", "1,5")).IsEqualTo((XLCellValue)1.5);
+        await Assert.That(Invoke(invariant, "VALUE", "1.5")).IsEqualTo((XLCellValue)1.5);
+    }
+
+    [Test]
+    public async Task An_instance_is_safe_to_share_across_threads()
+    {
+        // XLibur.Report shares one library across every template precisely to avoid rebuilding the
+        // function table, so concurrent TryInvoke has to hold up.
+        var library = new XLFunctionLibrary();
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 64).Select(i => Task.Run(() =>
+        {
+            var sum = Invoke(library, "SUM", i, i);
+            var text = Invoke(library, "UPPER", $"v{i}");
+            return (Sum: sum, Text: text);
+        })));
+
+        for (var i = 0; i < results.Length; ++i)
+        {
+            await Assert.That(results[i].Sum).IsEqualTo((XLCellValue)(i * 2.0));
+            await Assert.That(results[i].Text).IsEqualTo((XLCellValue)$"V{i}");
+        }
+    }
+}

--- a/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatSetRangesTests.cs
+++ b/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatSetRangesTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.ConditionalFormats;
+
+/// <summary>
+/// Replacing a rule's coverage wholesale — the public way to widen one rule over blocks generated
+/// from it, instead of leaving a copied rule per block.
+/// </summary>
+public class ConditionalFormatSetRangesTests
+{
+    private static IXLConditionalFormat FormatOver(IXLWorksheet sheet, string address)
+    {
+        var format = sheet.Range(address).AddConditionalFormat();
+        format.WhenEquals("1").Fill.SetBackgroundColor(XLColor.Red);
+        return format;
+    }
+
+    [Test]
+    public async Task SetRanges_replaces_the_coverage()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        var format = FormatOver(sheet, "A1:B2");
+
+        format.SetRanges([sheet.Range("A1:B2"), sheet.Range("A5:B6")]);
+
+        var covered = format.Ranges.Select(r => r.RangeAddress.ToString()).ToList();
+        await Assert.That(covered).IsEquivalentTo(new[] { "A1:B2", "A5:B6" });
+    }
+
+    [Test]
+    public async Task SetRanges_discards_what_the_rule_covered_before()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        var format = FormatOver(sheet, "A1:B2");
+
+        format.SetRanges([sheet.Range("D1:D4")]);
+
+        var covered = format.Ranges.Select(r => r.RangeAddress.ToString()).ToList();
+        await Assert.That(covered).IsEquivalentTo(new[] { "D1:D4" });
+    }
+
+    [Test]
+    public async Task Mutating_what_Ranges_returns_does_nothing()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        var format = FormatOver(sheet, "A1:B2");
+
+        // The reason SetRanges has to exist: Ranges is a fresh projection each call.
+        format.Ranges.Add(sheet.Range("D1:D4"));
+
+        await Assert.That(format.Ranges.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task SetRanges_returns_the_format_for_chaining()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        var format = FormatOver(sheet, "A1:B2");
+
+        await Assert.That(format.SetRanges([sheet.Range("A1:A2")])).IsSameReferenceAs(format);
+    }
+
+    [Test]
+    public async Task SetRanges_rejects_a_range_from_another_worksheet()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        var other = wb.AddWorksheet("Sheet2");
+        var format = FormatOver(sheet, "A1:B2");
+
+        // Coverage is stored as bare rectangles against the rule's own sheet, so accepting this
+        // would silently move the rule rather than extending it.
+        await Assert.That(() => format.SetRanges([other.Range("A1:B2")]))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task SetRanges_rejects_an_empty_set()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        var format = FormatOver(sheet, "A1:B2");
+
+        await Assert.That(() => format.SetRanges([])).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task SetRanges_rejects_null()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        var format = FormatOver(sheet, "A1:B2");
+
+        await Assert.That(() => format.SetRanges(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Coverage_survives_a_save_and_load()
+    {
+        using var stream = new System.IO.MemoryStream();
+
+        using (var wb = new XLWorkbook())
+        {
+            var sheet = wb.AddWorksheet("Sheet1");
+            var format = FormatOver(sheet, "A1:B2");
+            format.SetRanges([sheet.Range("A1:B2"), sheet.Range("A5:B6")]);
+            wb.SaveAs(stream);
+        }
+
+        stream.Position = 0;
+        using var loaded = new XLWorkbook(stream);
+
+        var covered = loaded.Worksheet("Sheet1").ConditionalFormats
+            .Single()
+            .Ranges.Select(r => r.RangeAddress.ToString())
+            .ToList();
+
+        await Assert.That(covered).IsEquivalentTo(new[] { "A1:B2", "A5:B6" });
+    }
+}

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheSourceTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheSourceTests.cs
@@ -1,0 +1,168 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+using XLibur.Excel.Coordinates;
+
+namespace XLibur.Tests.Excel.PivotTables;
+
+/// <summary>
+/// The public source surface of a pivot cache — what it reads from, and re-pointing it.
+/// </summary>
+/// <remarks>
+/// The three-way distinction matters to any caller that rewrites a workbook after generating into
+/// it: a source that cannot be read at all is not the same as one that can be read but no longer
+/// resolves, and treating them alike turns an untouched pivot into a reported error.
+/// </remarks>
+public class XLPivotCacheSourceTests
+{
+    private static readonly object[][] Data =
+    [
+        ["Name", "Count"],
+        ["Cake", 1.0],
+        ["Pie", 2.0],
+        ["Tart", 3.0],
+    ];
+
+    private static XLWorkbook WorkbookWithData(out IXLWorksheet sheet)
+    {
+        var wb = new XLWorkbook();
+        sheet = wb.AddWorksheet("Data");
+        sheet.FirstCell().InsertData(Data);
+        return wb;
+    }
+
+    [Test]
+    public async Task A_range_source_reports_its_range()
+    {
+        using var wb = WorkbookWithData(out var sheet);
+        var range = sheet.Range("A1:B4");
+
+        var cache = wb.PivotCaches.Add(range);
+
+        await Assert.That(cache.SourceKind).IsEqualTo(XLPivotSourceKind.Range);
+        await Assert.That(cache.SourceRange).IsNotNull();
+        await Assert.That(cache.SourceRange!.RangeAddress.ToString()).IsEqualTo("A1:B4");
+        await Assert.That(cache.SourceWorksheet!.Name).IsEqualTo("Data");
+
+        // A range source has no name of its own.
+        await Assert.That(cache.SourceName).IsNull();
+    }
+
+    [Test]
+    public async Task A_table_source_reports_its_name_and_resolved_sheet()
+    {
+        using var wb = WorkbookWithData(out var sheet);
+        var table = sheet.Range("A1:B4").CreateTable("SourceTable");
+
+        // Adding a cache for a range that exactly matches a table records the table by name.
+        var cache = wb.PivotCaches.Add(table.AsRange());
+
+        await Assert.That(cache.SourceKind).IsEqualTo(XLPivotSourceKind.Name);
+        await Assert.That(cache.SourceName).IsEqualTo("SourceTable");
+        await Assert.That(cache.SourceWorksheet).IsNotNull();
+        await Assert.That(cache.SourceWorksheet!.Name).IsEqualTo("Data");
+
+        // A named source has no rectangle of its own — the table owns one, and it can move.
+        await Assert.That(cache.SourceRange).IsNull();
+    }
+
+    [Test]
+    public async Task A_named_source_that_no_longer_resolves_keeps_its_name_and_has_no_sheet()
+    {
+        using var wb = WorkbookWithData(out var sheet);
+        var table = sheet.Range("A1:B4").CreateTable("SourceTable");
+        var cache = wb.PivotCaches.Add(table.AsRange());
+
+        sheet.Tables.Remove("SourceTable");
+
+        // This is the case a nullable-only surface could not tell from an unreadable source kind:
+        // the name is still what the file recorded, there is just nothing behind it any more.
+        await Assert.That(cache.SourceKind).IsEqualTo(XLPivotSourceKind.Name);
+        await Assert.That(cache.SourceName).IsEqualTo("SourceTable");
+        await Assert.That(cache.SourceWorksheet).IsNull();
+        await Assert.That(cache.SourceRange).IsNull();
+    }
+
+    [Test]
+    public async Task SetSourceRange_re_points_the_cache()
+    {
+        using var wb = WorkbookWithData(out var sheet);
+        var cache = wb.PivotCaches.Add(sheet.Range("A1:B2"));
+
+        cache.SetSourceRange(sheet.Range("A1:B4"));
+
+        await Assert.That(cache.SourceKind).IsEqualTo(XLPivotSourceKind.Range);
+        await Assert.That(cache.SourceRange!.RangeAddress.ToString()).IsEqualTo("A1:B4");
+    }
+
+    [Test]
+    public async Task SetSourceRange_then_Refresh_reads_the_new_range()
+    {
+        using var wb = WorkbookWithData(out var sheet);
+        var cache = wb.PivotCaches.Add(sheet.Range("A1:A4"));
+
+        await Assert.That(cache.FieldNames.Count).IsEqualTo(1);
+
+        cache.SetSourceRange(sheet.Range("A1:B4"));
+        cache.Refresh();
+
+        await Assert.That(cache.FieldNames).Contains("Name");
+        await Assert.That(cache.FieldNames).Contains("Count");
+    }
+
+    [Test]
+    public async Task SetSourceRange_returns_the_cache_for_chaining()
+    {
+        using var wb = WorkbookWithData(out var sheet);
+        var cache = wb.PivotCaches.Add(sheet.Range("A1:B2"));
+
+        await Assert.That(cache.SetSourceRange(sheet.Range("A1:B4"))).IsSameReferenceAs(cache);
+    }
+
+    [Test]
+    public async Task A_range_source_whose_sheet_is_gone_has_no_range_and_no_sheet()
+    {
+        using var wb = WorkbookWithData(out var sheet);
+        var cache = wb.PivotCaches.Add(sheet.Range("A1:B4"));
+
+        wb.Worksheets.Delete("Data");
+
+        // Still a range source — the file recorded a rectangle on a sheet — but nothing resolves.
+        await Assert.That(cache.SourceKind).IsEqualTo(XLPivotSourceKind.Range);
+        await Assert.That(cache.SourceRange).IsNull();
+        await Assert.That(cache.SourceWorksheet).IsNull();
+    }
+
+    /// <remarks>
+    /// Built through the internal source types rather than loaded from a file, because a workbook
+    /// carrying a live OLAP connection or a consolidation is not something this suite can author.
+    /// The mapping is what is under test, and it is worth testing directly: no caller in this
+    /// repository exercises these kinds, so a wrong answer here fails nothing else.
+    /// </remarks>
+    [Test]
+    [Arguments(XLPivotSourceKind.Scenario)]
+    [Arguments(XLPivotSourceKind.Connection)]
+    [Arguments(XLPivotSourceKind.Consolidation)]
+    [Arguments(XLPivotSourceKind.ExternalWorkbook)]
+    public async Task A_source_XLibur_cannot_read_reports_its_kind_and_resolves_to_nothing(
+        XLPivotSourceKind expected)
+    {
+        using var wb = WorkbookWithData(out var sheet);
+        IXLPivotSource source = expected switch
+        {
+            XLPivotSourceKind.Scenario => new XLPivotSourceScenario(),
+            XLPivotSourceKind.Connection => new XLPivotSourceConnection(1),
+            XLPivotSourceKind.Consolidation => new XLPivotSourceConsolidation(),
+            _ => new XLPivotSourceExternalWorkbook("rId1", SheetArea.From(sheet.Range("A1:B4"))),
+        };
+
+        var cache = new XLPivotCache(source, wb);
+
+        await Assert.That(cache.SourceKind).IsEqualTo(expected);
+
+        // Null for a different reason than a name that stopped resolving: there is nothing here
+        // XLibur could read even in principle. SourceKind is what tells the two apart.
+        await Assert.That(cache.SourceRange).IsNull();
+        await Assert.That(cache.SourceWorksheet).IsNull();
+        await Assert.That(cache.SourceName).IsNull();
+    }
+}

--- a/XLibur.Tests/PublicSurfaceTests.cs
+++ b/XLibur.Tests/PublicSurfaceTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests;
+
+/// <summary>
+/// Guards the boundary spec 13 drew: XLibur.Report depends on XLibur as a published package, so
+/// what it can reach has to be a surface XLibur promises to keep.
+/// </summary>
+public class PublicSurfaceTests
+{
+    /// <summary>
+    /// The types spec 13 chose <em>not</em> to publish, having replaced Report's use of them with
+    /// <c>XLFunctionLibrary</c> and the <c>IXLPivotCache</c> source members.
+    /// </summary>
+    /// <remarks>
+    /// These are deep calc-engine and coordinate representations. Publishing any of them freezes an
+    /// implementation detail permanently, and would have been done for the sake of two call sites.
+    /// If a change makes one of these public, the design is being bypassed — revise the spec rather
+    /// than the test.
+    /// </remarks>
+    private static readonly string[] MustStayInternal =
+    [
+        "XLibur.Excel.CalcEngine.XLCalcEngine",
+        "XLibur.Excel.CalcEngine.FunctionRegistry",
+        "XLibur.Excel.CalcEngine.FunctionDefinition",
+        "XLibur.Excel.CalcEngine.CalcContext",
+        "XLibur.Excel.CalcEngine.AnyValue",
+        "XLibur.Excel.CalcEngine.ScalarValue",
+        "XLibur.Excel.CalcEngine.Exceptions.MissingContextException",
+        "XLibur.Excel.XLPivotCache",
+        "XLibur.Excel.XLPivotSourceReference",
+        "XLibur.Excel.IXLPivotSource",
+        "XLibur.Excel.Coordinates.SheetArea",
+        "XLibur.Excel.Coordinates.Area",
+    ];
+
+    [Test]
+    public async Task The_types_report_no_longer_reaches_for_are_still_internal()
+    {
+        var assembly = typeof(XLWorkbook).Assembly;
+        var leaked = new List<string>();
+
+        foreach (var name in MustStayInternal)
+        {
+            var type = assembly.GetType(name, throwOnError: false);
+
+            // A rename is not a failure of this test — the point is that nothing here is public.
+            if (type is not null && type.IsVisible)
+                leaked.Add(name);
+        }
+
+        await Assert.That(leaked).IsEmpty();
+    }
+
+    [Test]
+    public async Task The_surface_report_depends_on_is_public()
+    {
+        var assembly = typeof(XLWorkbook).Assembly;
+
+        var functionLibrary = assembly.GetType("XLibur.Excel.CalcEngine.XLFunctionLibrary", throwOnError: false);
+        await Assert.That(functionLibrary).IsNotNull();
+        await Assert.That(functionLibrary!.IsVisible).IsTrue();
+
+        var noContext = assembly.GetType(
+            "XLibur.Excel.CalcEngine.Exceptions.XLNoWorksheetContextException",
+            throwOnError: false);
+        await Assert.That(noContext).IsNotNull();
+        await Assert.That(noContext!.IsVisible).IsTrue();
+
+        var sourceKind = assembly.GetType("XLibur.Excel.XLPivotSourceKind", throwOnError: false);
+        await Assert.That(sourceKind).IsNotNull();
+        await Assert.That(sourceKind!.IsVisible).IsTrue();
+
+        var expected = new[] { "SourceKind", "SourceRange", "SourceName", "SourceWorksheet", "SetSourceRange" };
+        var members = typeof(IXLPivotCache).GetMembers().Select(m => m.Name).ToList();
+
+        foreach (var member in expected)
+            await Assert.That(members).Contains(member);
+    }
+
+    /// <summary>
+    /// The friend grant spec 13 removed. Its test-assembly counterpart is deliberately kept — see
+    /// the comment in <c>XLibur/Properties/AssemblyInfo.cs</c>.
+    /// </summary>
+    [Test]
+    public async Task XLibur_Report_is_not_a_friend_assembly()
+    {
+        var grants = typeof(XLWorkbook).Assembly
+            .GetCustomAttributes(typeof(System.Runtime.CompilerServices.InternalsVisibleToAttribute), false)
+            .Cast<System.Runtime.CompilerServices.InternalsVisibleToAttribute>()
+            .Select(a => a.AssemblyName)
+            .ToList();
+
+        await Assert.That(grants).DoesNotContain("XLibur.Report");
+        await Assert.That(grants).Contains("XLibur.Report.Tests");
+    }
+}

--- a/XLibur/Excel/CalcEngine/Exceptions/XLNoWorksheetContextException.cs
+++ b/XLibur/Excel/CalcEngine/Exceptions/XLNoWorksheetContextException.cs
@@ -1,0 +1,41 @@
+using System;
+using XLibur.Excel.Exceptions;
+
+namespace XLibur.Excel.CalcEngine.Exceptions;
+
+/// <summary>
+/// A function was called without a worksheet to be relative to, and needs one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Thrown by <see cref="XLFunctionLibrary.TryInvoke"/> for the functions whose result depends on
+/// where they are — <c>ROW</c>, <c>COLUMN</c>, <c>OFFSET</c>, <c>INDIRECT</c> and the like. There
+/// is no answer to give outside a grid, and returning one would be misleading, so these belong in
+/// a real cell formula.
+/// </para>
+/// <para>
+/// This is the public face of the calc engine's internal missing-context signal. Catching it is
+/// how a caller tells "this function cannot work here" from a function that ran and failed, which
+/// reports itself as an <see cref="XLError"/> result instead.
+/// </para>
+/// </remarks>
+public sealed class XLNoWorksheetContextException : XLiburException
+{
+    /// <summary>Creates the exception with a default message.</summary>
+    public XLNoWorksheetContextException()
+        : base("The function needs a worksheet to be relative to, and was called without one.")
+    {
+    }
+
+    /// <summary>Creates the exception with <paramref name="message"/>.</summary>
+    public XLNoWorksheetContextException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Creates the exception with <paramref name="message"/> and <paramref name="innerException"/>.</summary>
+    public XLNoWorksheetContextException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/XLibur/Excel/CalcEngine/XLFunctionLibrary.cs
+++ b/XLibur/Excel/CalcEngine/XLFunctionLibrary.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using XLibur.Excel.CalcEngine.Exceptions;
+
+namespace XLibur.Excel.CalcEngine;
+
+/// <summary>
+/// The workbook function library, callable outside a worksheet — the same functions a cell formula
+/// can call, evaluated without a grid to be relative to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is for calling one function with arguments you already have, which is what a reporting or
+/// templating layer needs. It is not a formula evaluator: there is no parsing, no cell references
+/// and no ranges. To evaluate a formula string against real data, use
+/// <see cref="IXLWorksheet.Evaluate(string, string)"/>.
+/// </para>
+/// <para>
+/// An instance holds no per-call state and is safe for concurrent use. Construct one per culture
+/// and share it — constructing one builds the whole function table, so making one per call is
+/// wasteful in a way that is easy not to notice.
+/// </para>
+/// </remarks>
+public sealed class XLFunctionLibrary
+{
+    private readonly XLCalcEngine _engine;
+    private readonly CultureInfo _culture;
+    private readonly IReadOnlyCollection<string> _names;
+
+    /// <summary>
+    /// Creates a library whose functions parse and format according to <paramref name="culture"/>.
+    /// </summary>
+    /// <param name="culture">
+    /// Culture for parsing and formatting. Defaults to <see cref="CultureInfo.InvariantCulture"/>.
+    /// </param>
+    public XLFunctionLibrary(CultureInfo? culture = null)
+    {
+        _culture = culture ?? CultureInfo.InvariantCulture;
+        _engine = new XLCalcEngine(_culture);
+
+        // Snapshotted rather than deferred to the registry's key collection, so that Names is a
+        // stable, safely-enumerable value for a type that promises to be shareable across threads.
+        _names = _engine.Functions.Names.ToList().AsReadOnly();
+    }
+
+    /// <summary>
+    /// Names of every available function, in Excel's own casing (<c>SUM</c>, <c>VLOOKUP</c>).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TryInvoke"/> itself matches names case-insensitively, as Excel does; the casing
+    /// here is for display and for callers registering these functions under a name of their own.
+    /// </remarks>
+    public IReadOnlyCollection<string> Names => _names;
+
+    /// <summary>
+    /// Calls <paramref name="name"/> with <paramref name="arguments"/>.
+    /// </summary>
+    /// <param name="name">Function name, matched case-insensitively.</param>
+    /// <param name="arguments">
+    /// The arguments, already flattened to scalars. A function that takes a range in a cell formula
+    /// — <c>SUM</c>, <c>AVERAGE</c>, <c>COUNT</c> — takes those cells as a run of arguments here.
+    /// </param>
+    /// <param name="result">The function's result, or <c>default</c> if there is no such function.</param>
+    /// <returns>
+    /// <c>false</c> if no function has that name, leaving <paramref name="result"/> default.
+    /// Otherwise <c>true</c>; a call that was made but could not succeed — wrong arity, wrong
+    /// argument type, a division by zero — returns <c>true</c> with an <see cref="XLError"/>
+    /// result, which is how Excel itself reports these.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+    /// <exception cref="XLNoWorksheetContextException">
+    /// The function needs a worksheet to be relative to (<c>ROW</c>, <c>OFFSET</c>, <c>INDIRECT</c>
+    /// and the like). Those belong in a real cell formula.
+    /// </exception>
+    public bool TryInvoke(string name, ReadOnlySpan<XLCellValue> arguments, out XLCellValue result)
+    {
+        if (name is null)
+            throw new ArgumentNullException(nameof(name));
+
+        if (!_engine.Functions.TryGetFunc(name, out var definition) || definition is null)
+        {
+            result = default;
+            return false;
+        }
+
+        if (arguments.Length < definition.MinParams || arguments.Length > definition.MaxParams)
+        {
+            result = XLError.IncompatibleValue;
+            return true;
+        }
+
+        // System.Array, spelled out: the calc engine has its own Array type in this namespace.
+        var args = arguments.Length == 0 ? System.Array.Empty<AnyValue>() : new AnyValue[arguments.Length];
+        for (var i = 0; i < arguments.Length; ++i)
+            args[i] = ((ScalarValue)arguments[i]).ToAnyValue();
+
+        // No workbook and no cell: the whole point is a call made before there is a grid to be
+        // relative to. Functions that reach for one throw, and are translated below.
+        var context = new CalcContext(_engine, _culture, workbook: null, worksheet: null, formulaAddress: null);
+
+        AnyValue value;
+        try
+        {
+            value = definition.CallFunction(context, args.AsSpan());
+        }
+        catch (MissingContextException ex)
+        {
+            throw new XLNoWorksheetContextException(
+                $"'{name}' needs a worksheet to be relative to, and was called without one. "
+                + "Use it in a cell formula instead.",
+                ex);
+        }
+
+        result = ToCellValue(value);
+        return true;
+    }
+
+    /// <summary>
+    /// The result as a cell would hold it.
+    /// </summary>
+    /// <remarks>
+    /// A blank result stays blank rather than becoming <c>0</c> — unlike
+    /// <see cref="ScalarValue.ToCellValue"/>, which applies the rule for a formula *in a cell*,
+    /// where a blank result is written as zero. There is no cell here, so the caller is told what
+    /// the function actually returned and decides what blank means to it.
+    /// </remarks>
+    private static XLCellValue ToCellValue(AnyValue value)
+    {
+        // An array or reference result has no single value a cell could hold. Reported the way
+        // Excel reports a value it cannot place, rather than throwing.
+        if (!value.TryPickScalar(out var scalar, out _))
+            return XLError.IncompatibleValue;
+
+        return scalar.Match<XLCellValue>(
+            () => Blank.Value,
+            logical => logical,
+            number => number,
+            text => text,
+            error => error);
+    }
+}

--- a/XLibur/Excel/ConditionalFormats/IXLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/IXLConditionalFormat.cs
@@ -180,6 +180,23 @@ public interface IXLConditionalFormat
 
     IXLRanges Ranges { get; }
 
+    /// <summary>
+    /// Replaces the ranges this rule covers.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Ranges"/> is a fresh projection of the rule's coverage, so adding to or removing
+    /// from what it returns does nothing. This is how coverage is rewritten wholesale — widening one
+    /// rule over blocks that were generated from it, rather than leaving a copied rule per block.
+    /// </remarks>
+    /// <param name="ranges">
+    /// The ranges to cover. All must belong to the same worksheet as this rule.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="ranges"/> is null.</exception>
+    /// <exception cref="System.ArgumentException">
+    /// <paramref name="ranges"/> is empty, or contains a range from another worksheet.
+    /// </exception>
+    IXLConditionalFormat SetRanges(System.Collections.Generic.IEnumerable<IXLRange> ranges);
+
     XLDictionary<XLFormula> Values { get; }
 
     XLDictionary<XLColor> Colors { get; }

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -242,6 +242,32 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
     /// </summary>
     internal void SetAreas(XLAreaList areas) => Areas = areas;
 
+    public IXLConditionalFormat SetRanges(IEnumerable<IXLRange> ranges)
+    {
+        if (ranges is null)
+            throw new ArgumentNullException(nameof(ranges));
+
+        var materialized = ranges as IReadOnlyCollection<IXLRange> ?? ranges.ToList();
+
+        if (materialized.Count == 0)
+            throw new ArgumentException("A conditional format must cover at least one range.", nameof(ranges));
+
+        foreach (var range in materialized)
+        {
+            // Areas are bare rectangles interpreted against this rule's own sheet, so a range from
+            // elsewhere would silently move the rule rather than being rejected.
+            if (!ReferenceEquals(range.Worksheet, _worksheet))
+            {
+                throw new ArgumentException(
+                    $"Range '{range.RangeAddress}' belongs to a different worksheet than the conditional format.",
+                    nameof(ranges));
+            }
+        }
+
+        Areas = XLAreaList.FromRanges(materialized);
+        return this;
+    }
+
     private XLRange MaterializeRange(Area area)
         => _worksheet.Range(area.TopRow, area.LeftColumn, area.BottomRow, area.RightColumn);
 

--- a/XLibur/Excel/PivotTables/IXLPivotCache.cs
+++ b/XLibur/Excel/PivotTables/IXLPivotCache.cs
@@ -46,10 +46,50 @@ public interface IXLPivotCache
     bool SaveSourceData { get; set; }
 
     /// <summary>
+    /// What kind of source this cache reads from.
+    /// </summary>
+    /// <remarks>
+    /// Check this before <see cref="SourceRange"/> or <see cref="SourceWorksheet"/>: those are
+    /// null both for a source XLibur cannot read at all and for one it can read but that no longer
+    /// resolves, and only this tells the two apart.
+    /// </remarks>
+    XLPivotSourceKind SourceKind { get; }
+
+    /// <summary>
+    /// The range this cache reads from. Non-null only when <see cref="SourceKind"/> is
+    /// <see cref="XLPivotSourceKind.Range"/> and that range's sheet still exists.
+    /// </summary>
+    IXLRange? SourceRange { get; }
+
+    /// <summary>
+    /// The table or defined name this cache reads from. Non-null exactly when
+    /// <see cref="SourceKind"/> is <see cref="XLPivotSourceKind.Name"/> — this is the name the
+    /// file recorded, whether or not it still resolves to anything.
+    /// </summary>
+    string? SourceName { get; }
+
+    /// <summary>
+    /// The worksheet this cache reads from, resolved through the table or defined name when
+    /// <see cref="SourceKind"/> is <see cref="XLPivotSourceKind.Name"/>. Null when the source does
+    /// not resolve — a deleted name, a missing sheet — or when the kind is one XLibur cannot read.
+    /// </summary>
+    IXLWorksheet? SourceWorksheet { get; }
+
+    /// <summary>
     /// Refresh data in the pivot source from the source reference data.
     /// </summary>
     /// <exception cref="InvalidReferenceException">The data source for the pivot table can't be found.</exception>
     IXLPivotCache Refresh();
+
+    /// <summary>
+    /// Re-points the cache at <paramref name="range"/>, making <see cref="SourceKind"/>
+    /// <see cref="XLPivotSourceKind.Range"/> whatever it was before. Does not refresh — call
+    /// <see cref="Refresh"/> to re-read the records.
+    /// </summary>
+    /// <param name="range">The range to read from. Must belong to a worksheet.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="range"/> is null.</exception>
+    /// <exception cref="System.ArgumentException"><paramref name="range"/> has no worksheet.</exception>
+    IXLPivotCache SetSourceRange(IXLRange range);
 
     /// <inheritdoc cref="ItemsToRetainPerField"/>
     IXLPivotCache SetItemsToRetainPerField(XLItemsToRetain value);

--- a/XLibur/Excel/PivotTables/IXLPivotSource.cs
+++ b/XLibur/Excel/PivotTables/IXLPivotSource.cs
@@ -10,6 +10,14 @@ namespace XLibur.Excel;
 internal interface IXLPivotSource : IEquatable<IXLPivotSource>
 {
     /// <summary>
+    /// Which kind of source this is. Surfaced publicly as
+    /// <see cref="IXLPivotCache.SourceKind"/>, so that a caller can tell a source XLibur cannot
+    /// read from one that it can read but that no longer resolves — both of which have no
+    /// worksheet, for entirely different reasons.
+    /// </summary>
+    XLPivotSourceKind Kind { get; }
+
+    /// <summary>
     /// Try to determine actual area of the source reference in the
     /// workbook. Source reference might not be valid in the workbook, some might
     /// not be supported.

--- a/XLibur/Excel/PivotTables/XLPivotCache.cs
+++ b/XLibur/Excel/PivotTables/XLPivotCache.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using XLibur.Excel.Coordinates;
 using XLibur.Excel.Exceptions;
 
 namespace XLibur.Excel;
@@ -46,6 +47,42 @@ internal sealed class XLPivotCache : IXLPivotCache
     public bool RefreshDataOnOpen { get; set; }
 
     public bool SaveSourceData { get; set; }
+
+    public XLPivotSourceKind SourceKind => Source.Kind;
+
+    public IXLRange? SourceRange
+    {
+        get
+        {
+            // A named source has no rectangle of its own — the name or table owns one, and it can
+            // move. Callers that want where it currently points ask SourceWorksheet.
+            if (Source is not XLPivotSourceReference { UsesName: false } reference)
+                return null;
+
+            var sheetArea = reference.Area.Value;
+            if (!_workbook.WorksheetsInternal.TryGetWorksheet(sheetArea.Name, out var sheet))
+                return null;
+
+            var area = sheetArea.Area;
+            return sheet.Range(area.TopRow, area.LeftColumn, area.BottomRow, area.RightColumn);
+        }
+    }
+
+    public string? SourceName => (Source as XLPivotSourceReference)?.Name;
+
+    public IXLWorksheet? SourceWorksheet
+    {
+        get
+        {
+            // Only these two can resolve to a sheet at all. The others throw from TryGetSource
+            // rather than returning false, and a property that reports "no worksheet" by throwing
+            // would be no use to a caller deciding what to do about a pivot it cannot re-point.
+            if (Source.Kind is not (XLPivotSourceKind.Range or XLPivotSourceKind.Name))
+                return null;
+
+            return Source.TryGetSource(_workbook, out var sheet, out _) ? sheet : null;
+        }
+    }
 
     /// <summary>
     /// Number of fields in the cache.
@@ -102,6 +139,15 @@ internal sealed class XLPivotCache : IXLPivotCache
     public IXLPivotCache SetSaveSourceData() => SetSaveSourceData(true);
 
     public IXLPivotCache SetSaveSourceData(bool value) { SaveSourceData = value; return this; }
+
+    public IXLPivotCache SetSourceRange(IXLRange range)
+    {
+        if (range is null)
+            throw new ArgumentNullException(nameof(range));
+
+        Source = new XLPivotSourceReference(SheetArea.From(range));
+        return this;
+    }
 
     #endregion
 

--- a/XLibur/Excel/PivotTables/XLPivotSourceConnection.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceConnection.cs
@@ -16,6 +16,8 @@ internal sealed class XLPivotSourceConnection : IXLPivotSource
 
     public uint ConnectionId { get; }
 
+    public XLPivotSourceKind Kind => XLPivotSourceKind.Connection;
+
     public bool Equals(IXLPivotSource? otherSource)
     {
         var other = otherSource as XLPivotSourceConnection;

--- a/XLibur/Excel/PivotTables/XLPivotSourceConsolidation.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceConsolidation.cs
@@ -10,6 +10,8 @@ namespace XLibur.Excel;
 /// </summary>
 internal sealed class XLPivotSourceConsolidation : IXLPivotSource
 {
+    public XLPivotSourceKind Kind => XLPivotSourceKind.Consolidation;
+
     /// <summary>
     /// Will application automatically create additional page filter in addition to the <see cref="Pages"/>.
     /// </summary>

--- a/XLibur/Excel/PivotTables/XLPivotSourceExternalWorkbook.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceExternalWorkbook.cs
@@ -9,6 +9,8 @@ namespace XLibur.Excel;
 /// </summary>
 internal sealed class XLPivotSourceExternalWorkbook : IXLPivotSource
 {
+    public XLPivotSourceKind Kind => XLPivotSourceKind.ExternalWorkbook;
+
     /// <summary>
     /// External workbook relId. If relationships of cache definition changes, make sure to either keep same or update it.
     /// </summary>

--- a/XLibur/Excel/PivotTables/XLPivotSourceKind.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceKind.cs
@@ -1,0 +1,30 @@
+namespace XLibur.Excel;
+
+/// <summary>
+/// What a <see cref="IXLPivotCache"/> reads its records from.
+/// </summary>
+/// <remarks>
+/// Only <see cref="Range"/> and <see cref="Name"/> can resolve to a worksheet in this workbook.
+/// XLibur cannot read the others, so a cache with one of those sources keeps whatever records the
+/// file was saved with — <see cref="IXLPivotCache.Refresh"/> throws for them.
+/// </remarks>
+public enum XLPivotSourceKind
+{
+    /// <summary>A direct cell area on a sheet in this workbook.</summary>
+    Range,
+
+    /// <summary>A table or a book-scoped defined name in this workbook.</summary>
+    Name,
+
+    /// <summary>Several ranges consolidated into one source.</summary>
+    Consolidation,
+
+    /// <summary>The workbook's scenario data.</summary>
+    Scenario,
+
+    /// <summary>A range in a different workbook.</summary>
+    ExternalWorkbook,
+
+    /// <summary>An external data connection — a database, a query, a cube.</summary>
+    Connection,
+}

--- a/XLibur/Excel/PivotTables/XLPivotSourceReference.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceReference.cs
@@ -23,6 +23,8 @@ internal sealed class XLPivotSourceReference : IXLPivotSource
         Name = namedRangeOrTable;
     }
 
+    public XLPivotSourceKind Kind => UsesName ? XLPivotSourceKind.Name : XLPivotSourceKind.Range;
+
     /// <summary>
     /// Are source data in external workbook defined by a <see cref="Name"/> or by <see cref="Area">cell area</see>.
     /// </summary>

--- a/XLibur/Excel/PivotTables/XLPivotSourceScenario.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceScenario.cs
@@ -9,6 +9,8 @@ namespace XLibur.Excel;
 /// </summary>
 internal sealed class XLPivotSourceScenario : IXLPivotSource
 {
+    public XLPivotSourceKind Kind => XLPivotSourceKind.Scenario;
+
     public bool Equals(IXLPivotSource? other)
     {
         return other is XLPivotSourceScenario;

--- a/XLibur/Properties/AssemblyInfo.cs
+++ b/XLibur/Properties/AssemblyInfo.cs
@@ -3,9 +3,13 @@
 [assembly: InternalsVisibleTo("XLibur.Tests")]
 [assembly: InternalsVisibleTo("XLibur.Benchmarks")]
 
-// XLibur.Report bridges the calc engine's internal FunctionRegistry into template expressions,
-// and re-points internal pivot cache sources after a template range expands. Its tests assert on
-// the same internals — a pivot cache's source and record count are not on the public surface, so
-// there is no other way to state what re-pointing one did.
-[assembly: InternalsVisibleTo("XLibur.Report")]
+// XLibur.Report itself is deliberately NOT here: it ships as its own package on its own version
+// stream, and a package compiled against internals can only ever declare an exact dependency on
+// the core it was built against, because internals carry no compatibility contract. It uses the
+// public XLFunctionLibrary and IXLPivotCache source members instead — see spec 13.
+//
+// The asymmetry with its test assembly is deliberate. XLibur.Report.Tests is IsPackable=false and
+// always builds against the core in this tree, so its use of internals — asserting on a pivot
+// cache's RecordCount, which is not on the public surface and should not be — constrains nothing
+// that ships.
 [assembly: InternalsVisibleTo("XLibur.Report.Tests")]

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -27,6 +27,14 @@ static XLibur.Excel.Streaming.XLStreamingWorkbook.Create(string! path) -> XLibur
 static XLibur.Excel.Streaming.XLStreamingWorkbook.Create(string! path, XLibur.Excel.Streaming.XLStreamingOptions? options) -> XLibur.Excel.Streaming.XLStreamingWorkbook!
 static XLibur.Excel.XLColor.Automatic.get -> XLibur.Excel.XLColor!
 virtual XLibur.Excel.XLWorkbook.Dispose(bool disposing) -> void
+XLibur.Excel.CalcEngine.Exceptions.XLNoWorksheetContextException
+XLibur.Excel.CalcEngine.Exceptions.XLNoWorksheetContextException.XLNoWorksheetContextException() -> void
+XLibur.Excel.CalcEngine.Exceptions.XLNoWorksheetContextException.XLNoWorksheetContextException(string! message) -> void
+XLibur.Excel.CalcEngine.Exceptions.XLNoWorksheetContextException.XLNoWorksheetContextException(string! message, System.Exception! innerException) -> void
+XLibur.Excel.CalcEngine.XLFunctionLibrary
+XLibur.Excel.CalcEngine.XLFunctionLibrary.Names.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+XLibur.Excel.CalcEngine.XLFunctionLibrary.TryInvoke(string! name, System.ReadOnlySpan<XLibur.Excel.XLCellValue> arguments, out XLibur.Excel.XLCellValue result) -> bool
+XLibur.Excel.CalcEngine.XLFunctionLibrary.XLFunctionLibrary(System.Globalization.CultureInfo? culture = null) -> void
 XLibur.Excel.Drawings.IXLPicture.Group.get -> XLibur.Excel.Drawings.IXLPictureGroup?
 XLibur.Excel.Drawings.IXLPicture.IsInGroup.get -> bool
 XLibur.Excel.Drawings.IXLPictureGroup
@@ -167,7 +175,13 @@ XLibur.Excel.IXLPersons.Add(string! displayName) -> XLibur.Excel.IXLPerson!
 XLibur.Excel.IXLPersons.Count.get -> int
 XLibur.Excel.IXLPersons.Get(System.Guid id) -> XLibur.Excel.IXLPerson?
 XLibur.Excel.IXLPersons.GetByDisplayName(string! displayName) -> XLibur.Excel.IXLPerson?
+XLibur.Excel.IXLConditionalFormat.SetRanges(System.Collections.Generic.IEnumerable<XLibur.Excel.IXLRange!>! ranges) -> XLibur.Excel.IXLConditionalFormat!
 XLibur.Excel.IXLPersons.Remove(System.Guid id) -> bool
+XLibur.Excel.IXLPivotCache.SetSourceRange(XLibur.Excel.IXLRange! range) -> XLibur.Excel.IXLPivotCache!
+XLibur.Excel.IXLPivotCache.SourceKind.get -> XLibur.Excel.XLPivotSourceKind
+XLibur.Excel.IXLPivotCache.SourceName.get -> string?
+XLibur.Excel.IXLPivotCache.SourceRange.get -> XLibur.Excel.IXLRange?
+XLibur.Excel.IXLPivotCache.SourceWorksheet.get -> XLibur.Excel.IXLWorksheet?
 XLibur.Excel.IXLSheetView.PaneTopLeftCellAddress.get -> XLibur.Excel.IXLAddress?
 XLibur.Excel.IXLSheetView.PaneTopLeftCellAddress.set -> void
 XLibur.Excel.IXLThreadedComment
@@ -300,6 +314,13 @@ XLibur.Excel.XLMarkerStyle.Square = 7 -> XLibur.Excel.XLMarkerStyle
 XLibur.Excel.XLMarkerStyle.Star = 8 -> XLibur.Excel.XLMarkerStyle
 XLibur.Excel.XLMarkerStyle.Triangle = 9 -> XLibur.Excel.XLMarkerStyle
 XLibur.Excel.XLMarkerStyle.X = 10 -> XLibur.Excel.XLMarkerStyle
+XLibur.Excel.XLPivotSourceKind
+XLibur.Excel.XLPivotSourceKind.Connection = 5 -> XLibur.Excel.XLPivotSourceKind
+XLibur.Excel.XLPivotSourceKind.Consolidation = 2 -> XLibur.Excel.XLPivotSourceKind
+XLibur.Excel.XLPivotSourceKind.ExternalWorkbook = 4 -> XLibur.Excel.XLPivotSourceKind
+XLibur.Excel.XLPivotSourceKind.Name = 1 -> XLibur.Excel.XLPivotSourceKind
+XLibur.Excel.XLPivotSourceKind.Range = 0 -> XLibur.Excel.XLPivotSourceKind
+XLibur.Excel.XLPivotSourceKind.Scenario = 3 -> XLibur.Excel.XLPivotSourceKind
 XLibur.Excel.XLUsedCell
 XLibur.Excel.XLUsedCell.Column.get -> int
 XLibur.Excel.XLUsedCell.Row.get -> int

--- a/docs/specs/13-report-core-public-api.md
+++ b/docs/specs/13-report-core-public-api.md
@@ -1,7 +1,15 @@
 # Spec 13 — A Public Core Surface for `XLibur.Report`
 
-**Area:** Arch · API · Packaging  **Effort:** M  **Status:** Proposed
+**Area:** Arch · API · Packaging  **Effort:** M  **Status:** Accepted
 **Parallelizable?** Tasks 1 and 2 are fully independent; task 3 needs both.
+
+> **Amended 2026-08-01.** Four corrections after a review against the merged tree:
+> §B gained a source-kind discriminator (the original three members could not tell an
+> unresolvable *source kind* from a named source that resolved to nothing, which silently
+> changes `PivotRewriter`'s error behaviour); a third consumer file turned up that this spec
+> did not list, needing the §C addition; the version numbers were renumbered from the stale
+> 0.107.0 to a 0.201.0 floor; and the `XLiburPackAgainstReleasedCore` / `XLiburCoreFloor`
+> build switches this spec cited never existed in the tree.
 
 ## Summary
 
@@ -12,12 +20,12 @@ cadence, is pre-1.0, and should neither inherit core's version nor drag core alo
 breaks.
 
 This spec replaces the friend grant with a small, supported public surface — **two additions,
-expressed in types that are already public** — so Report can depend on a published core
-package with an honest version floor.
+carried almost entirely by types that are already public** — so Report can depend on a
+published core package with an honest version floor. Only two new public types are introduced:
+`XLFunctionLibrary` and the `XLPivotSourceKind` enum.
 
-It is a core-only change. Report's own refactor onto the new surface (task 3) is a separate
-piece of work on the Report branch and is described here only so the surface can be judged
-against its consumer.
+The core additions and Report's refactor onto them are one branch, because both projects live
+in this repository — see the work plan.
 
 ## Current state
 
@@ -28,37 +36,45 @@ against its consumer.
 [assembly: InternalsVisibleTo("XLibur.Report.Tests")]
 ```
 
-Building Report against the released `XLibur 0.106.0` package instead of the project fails with
-**9 errors** (`CS0122` inaccessible, `CS0246` not found) across exactly two files:
+The grant is consumed by three files:
 
 | File | Internals used |
 |---|---|
-| `XLibur.Report/Functions/ExcelFunctionBridge.cs` | `XLCalcEngine`, `FunctionDefinition`, `AnyValue`, `ScalarValue`, `CalcContext`, `MissingContextException` |
-| `XLibur.Report/Rewriting/PivotRewriter.cs` | `XLPivotCache`, `XLPivotSourceReference`, `SheetArea`, `Area` |
+| `XLibur.Report/Functions/ExcelFunctionBridge.cs` | `XLCalcEngine`, `XLCalcEngine.Functions`, `FunctionRegistry`, `FunctionDefinition`, `AnyValue`, `ScalarValue`, `CalcContext`, `MissingContextException` |
+| `XLibur.Report/Rewriting/PivotRewriter.cs` | `XLPivotCache`, `XLPivotCache.Source`, `XLPivotSourceReference` (`UsesName`, `Area`, `Name`, `TryGetSource`), `SheetArea`, `Area` |
+| `XLibur.Report/Ranges/RangeExpander.cs` | `XLConditionalFormat.SetAreas`, `XLAreaList.FromRanges` |
 
-The Report branch also *added* two core members to serve the bridge, which this spec supersedes:
+The third was missed when this spec was first written — grep for the *named types* it listed does
+not find it, because it reaches for a method on a cast rather than for a distinctive type name.
+Only removing the grant and building found it. That is the lesson for the acceptance criteria: the
+compiler is the authority on what the grant is load-bearing for, not a search.
+
+Report also *added* two core members to serve the bridge, which this spec supersedes:
 
 - `FunctionRegistry.Names` (new `public` member on an `internal` class)
 - `XLCalcEngine.Functions` (new `internal` property)
 
-Reproduce the failure from the Report branch:
+`XLibur.Report.Tests` additionally reads `XLPivotCache.RecordCount` and assigns
+`XLPivotCache.Source`. That grant stays — see *The test-assembly grant stays* below.
 
-```
-dotnet build XLibur.Report/XLibur.Report.csproj -c Release -p:XLiburPackAgainstReleasedCore=true
-```
+There is no build switch that compiles Report against a released core package: both projects
+live in this repository and Report holds a plain `ProjectReference`. The cost of the grant is
+therefore not a build failure you can reproduce, but the **exact** version range it forces —
+`XLiburDependencyVersion` is `[0.200.0]` in `XLibur.Report.props`, and that file's own comment
+names this spec as the thing that lets it become an open floor.
 
 ## Why an open version floor over internals is unsafe
 
-Internals carry no compatibility contract, so `XLibur >= 0.107.0` would be a promise core never
+Internals carry no compatibility contract, so `XLibur >= 0.201.0` would be a promise core never
 made. The failure is not hypothetical, because Report is an addon *to* core and consumers will
 routinely reference both:
 
 ```xml
-<PackageReference Include="XLibur" Version="0.120.0" />
-<PackageReference Include="XLibur.Report" Version="0.1.0" />  <!-- built against 0.107.0 internals -->
+<PackageReference Include="XLibur" Version="0.215.0" />
+<PackageReference Include="XLibur.Report" Version="0.201.0" />  <!-- built against 0.201.0 internals -->
 ```
 
-NuGet unifies core upward to 0.120.0. Report was compiled against internals that may since have
+NuGet unifies core upward to 0.215.0. Report was compiled against internals that may since have
 been renamed, resharpened or deleted, and fails at runtime with `MissingMethodException` or
 `TypeLoadException`. Restore is silent; the break surfaces in production.
 
@@ -84,6 +100,10 @@ namespace XLibur.Excel.CalcEngine;
 /// The workbook function library, callable outside a worksheet — the same functions a cell
 /// formula can call, evaluated without a grid to be relative to.
 /// </summary>
+/// <remarks>
+/// An instance holds no per-call state and is safe for concurrent use. Construct one per
+/// culture and share it; constructing one per call rebuilds the whole function table.
+/// </remarks>
 public sealed class XLFunctionLibrary
 {
     /// <param name="culture">Culture for parsing and formatting. Defaults to invariant.</param>
@@ -124,52 +144,137 @@ Why `XLCellValue` is the right currency:
 
 Implementation is a thin adapter over what already exists: construct an `XLCalcEngine`, look the
 name up in its `FunctionRegistry`, arity-check against `MinParams`/`MaxParams`, build the
-no-grid `CalcContext`, convert in and out, and translate `MissingContextException`. The
-`FunctionRegistry.Names` and `XLCalcEngine.Functions` members the Report branch added stay
-`internal` and serve this class instead of serving Report directly.
+no-grid `CalcContext`, convert in and out, and translate `MissingContextException`. Conversion
+needs nothing new — `ScalarValue` already has an implicit `XLCellValue` operator and an internal
+`ToCellValue()`. The `FunctionRegistry.Names` and `XLCalcEngine.Functions` members Report added
+stay `internal` and serve this class instead of serving Report directly.
+
+**Thread-safety is a requirement, not an accident.** `ExcelFunctionBridge` deliberately shares
+one engine and one adapter set across every template and thread, because importing ~400
+functions per `XLTemplate` cost about 12 MB — more than nine tenths of what generating a small
+report allocated. A per-call or non-shareable `XLFunctionLibrary` would silently give that back.
+The sharing is sound for the same reason it is sound today: these calls have no grid, so
+`CalcContext.CalcEngine` is never reached, and the engine is passed only to satisfy the
+`CalcContext` constructor. Task 1 must state this in the XML docs and cover it with a
+concurrent-invocation test.
 
 ### B. Re-pointing a pivot cache's source
 
 `IXLPivotCache` is **already public** and already exposes `Refresh()` and
 `SetRefreshDataOnOpen()`. The only gap is the source reference, currently
-`internal IXLPivotSource XLPivotCache.Source { get; set; }`. Add three members:
+`internal IXLPivotSource XLPivotCache.Source { get; set; }`.
+
+`PivotRewriter` makes a **three-way** decision per cache, and the surface has to preserve all
+three:
+
+1. the source is not a sheet reference at all (a connection, a consolidation, an external
+   workbook, a scenario) → leave the cache exactly as the template had it, **silently**;
+2. the source is a name or table that no longer resolves → leave it alone but **report a
+   template error**, naming the source;
+3. the source resolves → re-point it if it is a direct area, then refresh.
+
+A nullable-only surface collapses 1 and 2 into the same "null" and makes every
+connection-sourced pivot in a template emit a spurious *"source data could not be read"*. So
+the discriminator is explicit:
 
 ```csharp
+namespace XLibur.Excel;
+
+/// <summary>What a pivot cache reads from. Only <see cref="Range"/> and <see cref="Name"/>
+/// resolve to a worksheet; XLibur cannot read the others.</summary>
+public enum XLPivotSourceKind
+{
+    /// <summary>A direct cell area on a sheet in this workbook.</summary>
+    Range,
+
+    /// <summary>A table or a book-scoped defined name.</summary>
+    Name,
+
+    Consolidation,
+    Scenario,
+    ExternalWorkbook,
+    Connection,
+}
+
 public interface IXLPivotCache            // additions only, no changes to existing members
 {
+    /// <summary>What kind of source this cache reads from.</summary>
+    XLPivotSourceKind SourceKind { get; }
+
     /// <summary>
-    /// The range this cache reads from, when the source is a direct range on a sheet.
-    /// Null when the source is a named range or a table — use <see cref="SourceWorksheet"/>.
+    /// The range this cache reads from. Non-null only when <see cref="SourceKind"/> is
+    /// <see cref="XLPivotSourceKind.Range"/> and that range's sheet still exists.
     /// </summary>
     IXLRange? SourceRange { get; }
 
     /// <summary>
-    /// The worksheet this cache reads from, resolved through the named range or table when the
-    /// source is one. Null if the source cannot be resolved, e.g. a deleted name.
+    /// The table or defined name this cache reads from. Non-null exactly when
+    /// <see cref="SourceKind"/> is <see cref="XLPivotSourceKind.Name"/> — the name is what the
+    /// template recorded, whether or not it still resolves.
+    /// </summary>
+    string? SourceName { get; }
+
+    /// <summary>
+    /// The worksheet this cache reads from, resolved through the table or defined name when the
+    /// source is one. Null when the source does not resolve — a deleted name, a missing sheet —
+    /// or when <see cref="SourceKind"/> is a kind XLibur cannot read.
     /// </summary>
     IXLWorksheet? SourceWorksheet { get; }
 
-    /// <summary>Re-points the cache at <paramref name="range"/>. Does not refresh.</summary>
+    /// <summary>
+    /// Re-points the cache at <paramref name="range"/>, making <see cref="SourceKind"/>
+    /// <see cref="XLPivotSourceKind.Range"/> whatever it was before. Does not refresh.
+    /// </summary>
     IXLPivotCache SetSourceRange(IXLRange range);
 }
 ```
 
-These map one-to-one onto what `PivotRewriter` does today: `SourceWorksheet` replaces its
-`SourceSheetName` helper (which calls the internal `TryGetSource`), and
+This maps one-to-one onto what `PivotRewriter` does today: `SourceKind` replaces the
+`cache.Source is not XLPivotSourceReference` type test *and* `XLPivotSourceReference.UsesName`,
+`SourceWorksheet` replaces the `SourceSheetName` helper (which calls the internal
+`TryGetSource`), `SourceName` replaces `reference.Name` in the error message, and
 `SourceRange`/`SetSourceRange` replace reading and assigning `XLPivotSourceReference` over
 `SheetArea`. Report's expansion arithmetic then works in `IXLRange` and never needs `Area`.
+
+Why an enum rather than a `bool HasSheetSource`: the five internal `IXLPivotSource`
+implementations are a closed set that the file format itself defines, a bool would have to be
+replaced the first time a caller wants to tell a connection from an external workbook, and the
+enum costs one trivially-stable public type. `XLPivotSourceKind.Range` and `.Name` collapse
+`XLPivotSourceReference`'s `UsesName` flag into the same enum rather than adding a second
+discriminator, which is why there are six members for five implementations.
 
 Adding members to a public interface is a source-breaking change for external implementers.
 `IXLPivotCache` is not designed to be implemented outside the library — `XLPivotCache` is its
 only implementation and the constructor is internal — so this is acceptable pre-1.0. Note it in
 the changelog under Breaking Changes.
 
+### C. Rewriting a conditional format's coverage
+
+`RangeExpander` widens one template rule over every block generated from it, rather than leaving
+the copy-per-block that expansion would otherwise produce (upstream ClosedXML.Report issue #216 —
+three rules over three rows become nine). `IXLConditionalFormat.Ranges` is a *fresh projection* of
+the rule's internal area list, so adding to what it returns does nothing, and there is no public
+way to replace coverage wholesale. Hence one method, the public counterpart of the internal
+`SetAreas`:
+
+```csharp
+public interface IXLConditionalFormat        // addition only
+{
+    /// <summary>Replaces the ranges this rule covers.</summary>
+    IXLConditionalFormat SetRanges(IEnumerable<IXLRange> ranges);
+}
+```
+
+It validates what the internal path did not have to: a non-empty set, all on the rule's own
+worksheet. Areas are bare rectangles interpreted against that sheet, so a range from elsewhere
+would silently *move* the rule rather than being rejected. `XLAreaList` and `Area` stay internal.
+
 ### What stays internal (non-goals)
 
 `XLCalcEngine`, `FunctionRegistry`, `FunctionDefinition`, `CalcContext`, `AnyValue`,
 `ScalarValue`, `MissingContextException`, `XLPivotCache`, `XLPivotSourceReference`,
-`IXLPivotSource`, `SheetArea`, `Area`. If a task finds itself widening any of these, the design
-above is being bypassed — stop and revise the spec instead.
+`IXLPivotSource`, `SheetArea`, `Area`, `XLAreaList`, `XLConditionalFormat`. If a task finds itself
+widening any of these, the design above is being bypassed — stop and revise the spec instead.
 
 Out of scope: registering *custom* functions with the calc engine, evaluating whole formula
 strings outside a workbook, and any other pivot-source kind (consolidation ranges, external
@@ -191,21 +296,23 @@ merely to avoid an asymmetry would be the tail wagging the dog.
 | # | Task | Files | Depends on |
 |---|---|---|---|
 | 1 | `XLFunctionLibrary` + `XLNoWorksheetContextException`, with tests | `XLibur/Excel/CalcEngine/XLFunctionLibrary.cs`, `.../Exceptions/`, `XLibur.Tests/Excel/CalcEngine/` | — |
-| 2 | `IXLPivotCache.SourceRange` / `SourceWorksheet` / `SetSourceRange`, with tests | `XLibur/Excel/PivotTables/IXLPivotCache.cs`, `XLPivotCache.cs`, `XLibur.Tests/Excel/PivotTables/` | — |
-| 3 | Drop the `XLibur.Report` friend grant; keep the `.Tests` one | `XLibur/Properties/AssemblyInfo.cs` | 1, 2 |
-| 4 | Release core **0.107.0** carrying all of the above | — | 1, 2, 3 |
-| 5 | *(Report branch, separate PR)* refactor `ExcelFunctionBridge` and `PivotRewriter` onto the new surface; revert the `FunctionRegistry.Names` / `XLCalcEngine.Functions` additions to plain internals | `XLibur.Report/**` | 4 |
+| 2 | `XLPivotSourceKind` + `IXLPivotCache.SourceKind` / `SourceRange` / `SourceName` / `SourceWorksheet` / `SetSourceRange`, with tests | `XLibur/Excel/PivotTables/XLPivotSourceKind.cs`, `IXLPivotCache.cs`, `XLPivotCache.cs`, `XLibur.Tests/Excel/PivotTables/` | — |
+| 3 | `IXLConditionalFormat.SetRanges`, with tests | `XLibur/Excel/ConditionalFormats/IXLConditionalFormat.cs`, `XLConditionalFormat.cs`, `XLibur.Tests/Excel/ConditionalFormats/` | — |
+| 4 | Refactor `ExcelFunctionBridge`, `PivotRewriter` and `RangeExpander` onto the new surface; revert `FunctionRegistry.Names` / `XLCalcEngine.Functions` to plain internals | `XLibur.Report/**` | 1, 2, 3 |
+| 5 | Drop the `XLibur.Report` friend grant, keep the `.Tests` one, and open the version floor in `XLibur.Report.props`; add the surface-guard test | `XLibur/Properties/AssemblyInfo.cs`, `XLibur.Report.props`, `XLibur.Tests/` | 4 |
+| 6 | Release core **0.201.0** carrying all of the above | — | 5 |
 
-Tasks 1 and 2 are disjoint and can run in parallel. Task 3 is a two-line deletion that will not
-compile until 1 and 2 are complete *and* task 5 has landed on the Report branch — so on core's
-own branch, task 3 lands together with a temporary `ProjectReference` build check, or simply
-after Report is refactored. Sequence 1‖2 → 5 → 3 → 4 if the Report branch can absorb the
-refactor before core releases.
+Tasks 1, 2 and 3 are disjoint and can run in parallel; 4 then 5 are strictly sequential.
+
+Both projects live in this repository and Report holds a `ProjectReference`, so — unlike what
+this spec first assumed — there is no cross-branch sequencing problem: task 4 simply will not
+compile until task 3 has landed, and the compiler is the check. The whole sequence is one
+branch.
 
 ## Acceptance criteria
 
-1. `dotnet build XLibur.Report/XLibur.Report.csproj -c Release -p:XLiburPackAgainstReleasedCore=true`
-   against core ≥ 0.107.0 succeeds with **0 errors**. It currently produces 9.
+1. `XLibur.Report` compiles with `XLibur`'s friend grant removed — that is, the whole solution
+   builds. This is the check that the public surface is sufficient.
 2. `XLibur/Properties/AssemblyInfo.cs` contains no `InternalsVisibleTo("XLibur.Report")`.
    The `XLibur.Report.Tests` grant is still present and commented.
 3. Every type named under *What stays internal* is still `internal`. Assert this in a test that
@@ -215,12 +322,22 @@ refactor before core releases.
    directly.
 5. `XLFunctionLibrary` covers what the bridge needs: `Names` is non-empty and includes `SUM`;
    `TryInvoke("SUM", [1, 2, 3])` yields `6`; an unknown name returns `false`; wrong arity returns
-   `true` with `XLError.IncompatibleValue`; `ROW` throws `XLNoWorksheetContextException`.
-6. A pivot cache loaded from a file reports a non-null `SourceRange` for a range source and a
-   non-null `SourceWorksheet` for a named-range source; `SetSourceRange` followed by `Refresh()`
-   re-reads from the new range. Verify against a real workbook, per the repo's file-format rule.
-7. The packed `XLibur.Report.nuspec` declares `<dependency id="XLibur" version="0.107.0" />` —
-   the floor, not a MinVer-computed pin. This is the check that proves the lockstep is gone.
+   `true` with `XLError.IncompatibleValue`; `ROW` throws `XLNoWorksheetContextException`; and a
+   round-trip test per scalar kind (blank, logical, number, text, error). One test invokes
+   concurrently from several threads on a shared instance.
+6. A pivot cache loaded from a file reports `SourceKind == Range` with a non-null `SourceRange`
+   for a range source, and `SourceKind == Name` with a non-null `SourceName` and `SourceWorksheet`
+   for a named-range source; a cache whose name has been deleted reports `SourceKind == Name`
+   with a non-null `SourceName` and a **null** `SourceWorksheet`; `SetSourceRange` followed by
+   `Refresh()` re-reads from the new range. Verify against a real workbook, per the repo's
+   file-format rule.
+7. `IXLConditionalFormat.SetRanges` replaces coverage, returns the format, and rejects null, an
+   empty set, and a range from another worksheet. One test asserts that mutating what `Ranges`
+   returns does nothing — the fact that makes this method necessary — and one round-trips the
+   coverage through a save and load.
+8. `XLiburDependencyVersion` in `XLibur.Report.props` is an open floor (`0.201.0`), not the
+   exact `[0.200.0]` range, and the comment above it no longer defers to this spec. This is the
+   check that proves the lockstep is gone.
 
 ## Risks
 
@@ -234,7 +351,11 @@ refactor before core releases.
   found, record it here rather than reaching for `AnyValue`.
 - **Interface additions break external implementers** of `IXLPivotCache` (see §B). Judged
   acceptable pre-1.0; changelog it.
-- **Report cannot release until core 0.107.0 is out.** This spec is a hard prerequisite for
+- **A behaviour regression here is silent.** No Report test covers a connection, consolidation,
+  external-workbook or scenario source, so if the surface cannot express case 1 of §B's three-way
+  decision, nothing fails — the spurious template errors only show up in a user's report. Task 2
+  must test all four unreadable kinds directly, since the Report suite will not catch them.
+- **Report cannot release until core 0.201.0 is out.** This spec is a hard prerequisite for
   Report's independent version stream, not a parallel workstream.
 
 ## References
@@ -242,9 +363,7 @@ refactor before core releases.
 - Spec 12 — [Report templating](12-report-templating.md), *Core APIs this depends on*, which
   documents the internal call patterns being replaced. Its Summary states Report's only touch on
   core is an `InternalsVisibleTo` grant; this spec is what makes that no longer true.
-  *(That file is on the `feat/spec-12-report-templating` branch — the link resolves once it
-  merges.)*
-- `XLibur.Report/XLibur.Report.csproj` — `XLiburCoreFloor` (0.107.0) and the
-  `XLiburPackAgainstReleasedCore` switch that flips the core reference from project to package.
+- `XLibur.Report.props` — `XLiburDependencyVersion`, the exact `[0.200.0]` range this spec
+  turns into an open floor, and the comment that defers to this spec for doing so.
 - NuGet [dependency resolution](https://learn.microsoft.com/nuget/concepts/dependency-resolution)
   — lowest-applicable wins, and why a floor is a floor and not a pin.


### PR DESCRIPTION
## Why

`XLibur.Report` read core internals through an `InternalsVisibleTo` grant. That was fine while the two shipped as one version off one tag — it is what spec 12 assumed — but Report now has its own version stream (`report-v*` tags), and **internals carry no compatibility contract**.

The consequence was concrete rather than theoretical. Because a package compiled against internals can only honestly declare an *exact* dependency, `XLibur.Report.props` pinned `[0.200.0]`. An open floor would have let NuGet unify core upward for anyone referencing both packages, and Report would fail at runtime with `MissingMethodException`/`TypeLoadException` after a silent restore. So the grant made every core release a Report release — exactly what the separate version stream was set up to avoid.

Implements [spec 13](docs/specs/13-report-core-public-api.md), amended in this PR.

## What

Three public additions, all carried by types that were already public (`XLCellValue`, `IXLRange`, `IXLWorksheet`):

| Addition | Replaces |
|---|---|
| `XLFunctionLibrary` + `XLNoWorksheetContextException` | `XLCalcEngine`, `FunctionRegistry`, `FunctionDefinition`, `CalcContext`, `AnyValue`, `ScalarValue`, `MissingContextException` |
| `XLPivotSourceKind` + `IXLPivotCache.SourceKind` / `SourceRange` / `SourceName` / `SourceWorksheet` / `SetSourceRange` | `XLPivotCache.Source`, `XLPivotSourceReference`, `SheetArea`, `Area` |
| `IXLConditionalFormat.SetRanges` | `XLConditionalFormat.SetAreas`, `XLAreaList.FromRanges` |

`XLFunctionLibrary` is documented and tested as safe to share across threads. That is a requirement, not a nicety: `ExcelFunctionBridge` shares one instance per culture on purpose, because importing ~400 functions per `XLTemplate` cost about 12 MB — more than nine tenths of what generating a small report allocated.

Everything under *What stays internal* stays internal. `PublicSurfaceTests` asserts that by reflection, and asserts that the `XLibur.Report` grant is gone while the `XLibur.Report.Tests` one remains. That asymmetry is deliberate and commented: the test assembly is `IsPackable=false` and always builds against the core in this tree, so its use of internals (`RecordCount`) constrains nothing that ships.

`XLiburDependencyVersion` becomes an open floor of `0.201.0`.

## Two corrections to the spec

**It listed two consumer files. There were three.** `RangeExpander` casts to `XLConditionalFormat` to call `SetAreas` — a grep for the type names the spec listed does not find it, because it reaches for a method on a cast. Only removing the grant and building found it. The spec now records that the compiler, not a search, is the authority on what the grant is load-bearing for.

**Its pivot design could not express what `PivotRewriter` does.** The original three nullable members collapse two cases that must stay apart:

- a source kind XLibur cannot read (connection, consolidation, external workbook, scenario) → leave alone **silently**;
- a name or table that no longer resolves → leave alone but **report a template error**.

Both would have been `null`, so Report would have emitted a spurious *"source data could not be read"* for every connection-sourced pivot in a template. No Report test covers those source kinds, so it would have shipped unnoticed. Hence the explicit `XLPivotSourceKind`.

## A real defect this found

Writing the test for those four kinds surfaced a genuine bug: `TryGetSource` **throws `NotImplementedException`** for them rather than returning `false`, so the first `SourceWorksheet` implementation propagated it out of a property. It now returns `null` for kinds that cannot resolve. Report never reaches that path, so nothing else in the repo would have caught it.

## Verification

- Full solution builds with the friend grant removed — this is the check that the surface is sufficient.
- **`XLibur.Report`: 481/481 pass, zero test edits.** This is the evidence the refactor is behaviour-preserving.
- **`XLibur.Tests`: 11808 pass, 4 skipped** (pre-existing, documented). 31 are new.

## Breaking changes

Adding members to `IXLPivotCache` and `IXLConditionalFormat` is source-breaking for external implementers. Neither is designed to be implemented outside the library — each has a single implementation with an internal constructor — and this is pre-1.0. Worth a changelog note under Breaking Changes.

## Follow-up

Release core **0.201.0**; Report cannot move to the open floor until that is published.
