### PR TITLE
fix(sbom): use [[ for tests and send every error to stderr

### DIFF
--- a/.github/scripts/generate-sbom.sh
+++ b/.github/scripts/generate-sbom.sh
@@ -31,7 +31,7 @@ version=${1:?usage: generate-sbom.sh <version> <output-dir> <project>...}
 output=${2:?usage: generate-sbom.sh <version> <output-dir> <project>...}
 shift 2
 
-if [ "$#" -eq 0 ]; then
+if [[ "$#" -eq 0 ]]; then
   echo "::error::No projects given — nothing to generate" >&2
   exit 1
 fi
@@ -48,8 +48,8 @@ for project in "$@"; do
   csproj="$repo_root/$project/$project.csproj"
   filename="$project.$version.cdx.json"
 
-  if [ ! -f "$csproj" ]; then
-    echo "::error::$csproj does not exist"
+  if [[ ! -f "$csproj" ]]; then
+    echo "::error::$csproj does not exist" >&2
     status=1
     continue
   fi
@@ -70,20 +70,20 @@ for project in "$@"; do
       --exclude-test-projects \
       --set-name "$project" \
       --set-version "$version"; then
-    echo "::error::CycloneDX failed for $project"
+    echo "::error::CycloneDX failed for $project" >&2
     status=1
   fi
 
   echo "::endgroup::"
 
-  if [ ! -s "$output/$filename" ]; then
-    echo "::error::$filename was not produced"
+  if [[ ! -s "$output/$filename" ]]; then
+    echo "::error::$filename was not produced" >&2
     status=1
   fi
 done
 
-if [ "$status" -ne 0 ]; then
-  echo "::error::SBOM generation failed — refusing to continue"
+if [[ "$status" -ne 0 ]]; then
+  echo "::error::SBOM generation failed — refusing to continue" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Review feedback on #353, both in `.github/scripts/generate-sbom.sh`.

**`[[` instead of `[`** for the four conditionals. The script already declares `bash` in its shebang and is invoked as `bash .github/scripts/generate-sbom.sh` from both release workflows, so the construct is available. `[[` parses as a single shell token rather than as a command with arguments, which removes the word-splitting and glob-expansion footguns that make `[` worth avoiding.

**Every error now goes to stderr.** Four of the five `::error::` messages were writing to stdout — only the no-projects one was redirected. That meant a failing run interleaved its diagnostics with the tool output, and any caller redirecting stdout would swallow the reason it failed.

## Changes

- `[ ... ]` → `[[ ... ]]` at the four conditionals (argument count, missing `.csproj`, empty output file, final status).
- `>&2` added to the four `::error::` messages that lacked it.

No behavioural change on the happy path; exit codes are unchanged.

## Related Issues

Follows up review comments on #353.

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [x] Tested manually

- `bash -n` — syntax clean.
- Happy path: `generate-sbom.sh v0.200.0 ./out XLibur` produces `XLibur.0.200.0.cdx.json` as before, with the `v` prefix still stripped.
- Both failure paths (missing project, empty project list) verified to write **nothing to stdout**, everything to stderr, and exit 1:

  ```
  $ generate-sbom.sh 0.1.0 ./out NoSuchProject 2>/dev/null
  (exit 1)                                    # stdout silent

  $ generate-sbom.sh 0.1.0 ./out NoSuchProject 2>&1 >/dev/null
  ::error::.../NoSuchProject/NoSuchProject.csproj does not exist
  ::error::SBOM generation failed — refusing to continue
  (exit 1)
  ```

No tests added — this is a shell script with no test harness in the repo, and the change is not behavioural.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
