### PR TITLE
chore(sonar): clear the open medium findings, and fix the S2234 suppression that never took

### DIFF
--- a/XLibur.Benchmarks/Program.cs
+++ b/XLibur.Benchmarks/Program.cs
@@ -10,12 +10,14 @@ SixLaborsV1FontBootstrap.Register();
 
 if (args.Length > 0 && args[0].Equals("profile", StringComparison.OrdinalIgnoreCase))
 {
-    // "profile alloc" is a fast, GC-exact allocation report for the save path, split into
-    // create/save phases; "profile create" breaks the create phase down per API call;
-    // "profile streaming [rows]" reports peak heap for the forward-only writer against the
-    // in-memory model; "profile structural" splits the cost of repeated row inserts into its
-    // range-shift and formula-shift halves. The other modes attach dotMemory and target the
-    // load path.
+    // The fast, GC-exact profiling modes are:
+    //   alloc       an allocation report for the save path, split into create and save phases
+    //   create      the create phase broken down per API call
+    //   streaming   peak heap for the forward-only writer measured against the in-memory
+    //               model, optionally taking a row count
+    //   structural  the cost of repeated row inserts split into its range-shift and
+    //               formula-shift halves
+    // Every other mode attaches dotMemory and targets the load path.
     if (args.Length > 1 && args[1].Equals("alloc", StringComparison.OrdinalIgnoreCase))
         SaveAllocationProfile.Run();
     else if (args.Length > 1 && args[1].Equals("create", StringComparison.OrdinalIgnoreCase))

--- a/XLibur.Report.Tests/Rewriting/ChartRewritingTests.cs
+++ b/XLibur.Report.Tests/Rewriting/ChartRewritingTests.cs
@@ -50,7 +50,7 @@ public class ChartRewritingTests
         return template.Generate();
     }
 
-    private static IXLChartSeries Series(IXLWorkbook workbook) =>
+    private static IXLChartSeries Series(XLWorkbook workbook) =>
         workbook.Worksheet("Report").Charts.Single().Series.Single();
 
     [Test]

--- a/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -6,10 +6,14 @@ namespace XLibur.Excel.CalcEngine.Functions;
 /// <summary>
 /// A collection of adapter functions from a more a generic formula function to more specific ones.
 /// </summary>
-// S2234 is suppressed for the whole file. Every adapter forwards its locals arg0..argN-1 to a
+// S2234 is suppressed throughout this file. Every adapter forwards its locals arg0..argN-1 to a
 // Func<> whose own generic parameters the framework names arg1..argN, so the rule matches them by
 // name and reports a transposition that is not there. The calls are positionally correct and the
 // calc-engine tests over these functions cover it.
+//
+// The disable below does not reach the end of the file — a restore further down closes it — so
+// each forwarding call past that point carries its own disable/restore pair. Adding a new adapter
+// means adding the pair around its call as well.
 #pragma warning disable S2234 // Func<> names its generics arg1..argN; our locals are arg0..argN-1
 internal static class SignatureAdapter
 {
@@ -1021,7 +1025,9 @@ internal static class SignatureAdapter
             if (!ToOptionalNumber(args, 4, defaultValue1, ctx).TryPickT0(out var arg4, out var err4))
                 return err4;
 
+#pragma warning disable S2234 // Adapter forwards positionally; the delegate names its own parameters
             return f(ctx, arg0, arg1, arg2, arg3, arg4).ToAnyValue();
+#pragma warning restore S2234
         };
     }
 
@@ -1065,7 +1071,9 @@ internal static class SignatureAdapter
             if (!arg4Converted.TryPickT0(out var arg4, out var err4))
                 return err4;
 
+#pragma warning disable S2234 // Adapter forwards positionally; the delegate names its own parameters
             return f(ctx, arg0, arg1, arg2, arg3, arg4).ToAnyValue();
+#pragma warning restore S2234
         };
     }
 
@@ -1096,7 +1104,9 @@ internal static class SignatureAdapter
             if (!ToOptionalNumber(args, 5, defaultValue1, ctx).TryPickT0(out var arg5, out var err5))
                 return err5;
 
+#pragma warning disable S2234 // Adapter forwards positionally; the delegate names its own parameters
             return f(ctx, arg0, arg1, arg2, arg3, arg4, arg5).ToAnyValue();
+#pragma warning restore S2234
         };
     }
 

--- a/XLibur/Excel/CalcEngine/XLFunctionLibrary.cs
+++ b/XLibur/Excel/CalcEngine/XLFunctionLibrary.cs
@@ -76,8 +76,7 @@ public sealed class XLFunctionLibrary
     /// </exception>
     public bool TryInvoke(string name, ReadOnlySpan<XLCellValue> arguments, out XLCellValue result)
     {
-        if (name is null)
-            throw new ArgumentNullException(nameof(name));
+        ArgumentNullException.ThrowIfNull(name);
 
         if (!_engine.Functions.TryGetFunc(name, out var definition) || definition is null)
         {

--- a/XLibur/Excel/Cells/XLCellFormula.cs
+++ b/XLibur/Excel/Cells/XLCellFormula.cs
@@ -382,16 +382,30 @@ internal sealed class XLCellFormula
     /// rejects reports <see cref="XLHelper.MaxRowNumber"/>, which never filters, so it still reaches
     /// the shifter's legacy fallback.
     /// </remarks>
-    internal int MaxShiftableRow => _maxShiftableRow != 0
-        ? _maxShiftableRow
-        : _maxShiftableRow = FormulaExtent.Of(A1).MaxRow;
+    internal int MaxShiftableRow
+    {
+        get
+        {
+            if (_maxShiftableRow == 0)
+                _maxShiftableRow = FormulaExtent.Of(A1).MaxRow;
+
+            return _maxShiftableRow;
+        }
+    }
 
     /// <summary>
     /// The column counterpart of <see cref="MaxShiftableRow"/>.
     /// </summary>
-    internal int MaxShiftableColumn => _maxShiftableColumn != 0
-        ? _maxShiftableColumn
-        : _maxShiftableColumn = FormulaExtent.Of(A1).MaxColumn;
+    internal int MaxShiftableColumn
+    {
+        get
+        {
+            if (_maxShiftableColumn == 0)
+                _maxShiftableColumn = FormulaExtent.Of(A1).MaxColumn;
+
+            return _maxShiftableColumn;
+        }
+    }
 
     /// <summary>
     /// Get a lazy initialized AST for the formula.

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -314,11 +314,11 @@ internal static partial class XLCellFormulaShifter
                 var deleted = -_shift;
                 var shiftEnd = shiftStart + deleted - 1;
 
-                // Rows above the deletion keep their number; rows below move up by the deleted count;
-                // rows inside it are gone. A boundary that lands inside the deleted block collapses onto
-                // the edge of the block rather than being moved by the full count — clamping the bottom
-                // is what stops a deletion that swallows a reference's tail from producing an inverted
-                // range such as A2:A8 -> A2:A3 (row 4 survives; the answer is A2:A4).
+                // Rows above the deletion keep their number, rows below move up by the deleted count,
+                // and rows inside it are gone. A boundary that lands inside the deleted block collapses
+                // onto the edge of the block rather than being moved by the full count — clamping the
+                // bottom is what stops a deletion that swallows a reference's tail from producing an
+                // inverted range such as A2:A8 -> A2:A3 (row 4 survives, so the answer is A2:A4).
                 newFirst = refFirst < shiftStart ? refFirst : Math.Max(shiftStart, refFirst - deleted);
                 newLast = refLast <= shiftEnd ? Math.Min(refLast, shiftStart - 1) : refLast - deleted;
 

--- a/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/XLibur/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -244,8 +244,7 @@ internal sealed class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
 
     public IXLConditionalFormat SetRanges(IEnumerable<IXLRange> ranges)
     {
-        if (ranges is null)
-            throw new ArgumentNullException(nameof(ranges));
+        ArgumentNullException.ThrowIfNull(ranges);
 
         var materialized = ranges as IReadOnlyCollection<IXLRange> ?? ranges.ToList();
 

--- a/XLibur/Excel/PivotTables/XLPivotCache.cs
+++ b/XLibur/Excel/PivotTables/XLPivotCache.cs
@@ -142,8 +142,7 @@ internal sealed class XLPivotCache : IXLPivotCache
 
     public IXLPivotCache SetSourceRange(IXLRange range)
     {
-        if (range is null)
-            throw new ArgumentNullException(nameof(range));
+        ArgumentNullException.ThrowIfNull(range);
 
         Source = new XLPivotSourceReference(SheetArea.From(range));
         return this;

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -1554,8 +1554,13 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
 
         // With no split the pane starts at the first row/column; with one, it starts just past the
         // split unless the target already sits below it.
-        static int PaneStart(int split, int index) =>
-            split > 0 ? (index <= split ? split + 1 : index) : 1;
+        static int PaneStart(int split, int index)
+        {
+            if (split <= 0)
+                return 1;
+
+            return index <= split ? split + 1 : index;
+        }
 
         SheetView.PaneTopLeftCellAddress = new XLAddress(this, paneRow, paneColumn,
             fixedRow: false, fixedColumn: false);

--- a/docs/sonar.md
+++ b/docs/sonar.md
@@ -80,6 +80,14 @@ parameter of that method — so the exception names something the caller cannot 
 `arg0..argN-1`; the rule matches them by name and sees a shift. Positionally the call is
 correct, and the calc-engine tests covering these functions pass.
 
+The suppression added for it in `1fcb9b82` did not close the findings, and the reason is
+worth recording: `SignatureAdapter.cs` already carried a run of narrow
+`#pragma warning disable`/`restore S2234` pairs, and the first `restore` cancels the
+file-level `disable` placed above the class. Everything past that point is unsuppressed
+unless it carries its own pair. Three forwarding calls did not, so they kept reporting.
+They now do, matching the pairs already around the neighbouring adapters — a new adapter
+below that line needs the same pair around its call.
+
 `TUnitAssertions0016` says `.IsEqualTo(...)` on a collection compares by reference.
 `Area` is a `readonly struct : IEquatable<Area>, IEnumerable<Point>` with `Equals` and
 `GetHashCode` — it trips the rule only because it also enumerates points. Switching to


### PR DESCRIPTION
## Summary

Clears the eleven open MEDIUM SonarCloud findings. Eight are real and fixed, two are prose
misread as commented-out code and are reworded, and three are genuine false positives whose
existing suppression turned out not to be working — the interesting part of this PR.

Every rule below was verified gone by temporarily referencing `SonarAnalyzer.CSharp` from
`Directory.Build.props` and rebuilding. That probe was reverted; nothing analyzer-related is
committed.

## Changes

**Fixed (8)**

| Rule | Location | Change |
|---|---|---|
| `CA1510` ×3 | `XLFunctionLibrary.cs`, `XLConditionalFormat.cs`, `XLPivotCache.cs` | `ArgumentNullException.ThrowIfNull(...)`, matching the 111 existing uses |
| `CA1859` | `ChartRewritingTests.cs` | `Series(IXLWorkbook)` → `Series(XLWorkbook)`; all 13 call sites already pass the concrete type |
| `S1121` ×2 | `XLCellFormula.cs` | `MaxShiftableRow`/`MaxShiftableColumn` lazy caches lifted out of their ternary assignment into block-bodied getters |
| `S3358` | `XLWorksheet.cs` | `PaneStart` un-nested. Keeps the original `split > 0` predicate as `split <= 0 → 1` rather than `== 0`, so a negative split still behaves as before |

**Reworded, not suppressed (2)**

`XLibur.Benchmarks/Program.cs` and `XLCellFormulaShifter.cs` are prose. Both tripped `S125`
on semicolon-separated clauses that parse as a statement list. The benchmark modes are now a
list and the shifter comment joins its clauses with commas. Same information, rule clean, no
suppression needed.

**`S2234` ×3 — the suppression that never took**

These were triaged as false positives in `docs/sonar.md` and given a file-level
`#pragma warning disable S2234` in `1fcb9b82`, but they stayed open on SonarCloud, which is
why they are back.

`SignatureAdapter.cs` already carried a run of narrow `disable`/`restore S2234` pairs around
individual adapters, and **the first `restore` cancels the file-level `disable`**. Everything
past that line is unsuppressed unless it carries its own pair — which is exactly why the
neighbouring forwarding calls are quiet and these three were not.

They now carry the same pair as their neighbours. The file header no longer claims whole-file
coverage and says what a new adapter below that line needs, and `docs/sonar.md` records the
mechanism so nobody re-adds a file-level pragma that cannot work.

The findings themselves remain false: every adapter forwards locals `arg0..argN-1` to a
`Func<>` whose generic parameters the framework names `arg1..argN`, so the rule matches by
name and sees a shift that is not there. The calls are positionally correct.

## Related Issues

None.

## Testing

- [x] Added or updated unit tests — none needed; every change is behaviour-preserving
- [x] All existing tests pass — `XLibur.Tests` 11,808 passed / 4 skipped, `XLibur.Report.Tests` 481 passed (net10.0, Release)
- [x] Tested manually — full solution builds clean in Release, 0 warnings

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
