### PR TITLE
chore(sonar): clear the 278-issue export — 174 fixed, 104 accepted with reasons

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,3 +48,52 @@ dotnet_diagnostic.TUnit0057.severity = none
 # hold; IsEquivalentTo would compare point sequences instead of the area, which is the weaker
 # and wrong assertion.
 dotnet_diagnostic.TUnitAssertions0016.severity = none
+
+# Naming rules that disagree with XLibur's own conventions, everywhere.
+# See docs/sonar.md for the finding-by-finding reasoning.
+[*.cs]
+
+# S101: PascalCase for type names. The library prefixes every type with XL and abbreviates two
+# domains inside that prefix - CF for conditional format, HF for header/footer - giving names
+# like IXLCFIconSet and XLHFItem that the rule reads as run-on capitals. Seven of the flagged
+# types are public API (IXLCFColorScaleMin/Mid/Max, IXLCFDataBarMin/Max, IXLCFIconSet,
+# IXLHFItem) and cannot be renamed without a breaking change; renaming only the internal half
+# would leave XlcfCellIsConverter sitting next to IXLCFIconSet, which is worse than either
+# convention on its own. The rule's CustomDictionary escape hatch was tried and does not help:
+# it does not recognise two adjacent acronyms (XL followed by CF).
+dotnet_diagnostic.S101.severity = none
+
+# S2342: enum naming. Same acronym problem for XLCFOperator, XLHFMode and friends - again mostly
+# public API - plus a second complaint that [Flags] enums should be plural. The internal ones it
+# would rename (XLChartAxisFormat, XLDataLabelsFormat, ...) name a set of formatting aspects that
+# were explicitly set, and read correctly in the singular at every use site.
+dotnet_diagnostic.S2342.severity = none
+
+# S2344: an enum should not end in "Flags". Every hit is a [Flags] enum whose name says exactly
+# that (FunctionFlags, FormulaFlags, XlRowFlags), which is the BCL's own convention -
+# BindingFlags, RegexOptions. Worse, the rule contradicts S2342: dropping the suffix from a
+# [Flags] enum makes the name singular, which S2342 then rejects.
+dotnet_diagnostic.S2344.severity = none
+
+# S1075: URIs should not be hardcoded. All eight hits are XML namespace and relationship-type
+# URIs fixed by ECMA-376. They are identifiers, not endpoints or paths - making one
+# configurable would only let a caller produce a file Excel cannot open.
+dotnet_diagnostic.S1075.severity = none
+
+# S3267: rewrite a filtering loop as LINQ. The flagged loops are overwhelmingly per-cell,
+# per-formula or per-row paths, where a Where/Select allocates a delegate and an enumerator on
+# a path the library works hard to keep allocation-free; FormulaDependencies.RenameSheet even
+# carries a comment saying so. One of them (XLCells) filters on a side-effecting
+# HashSet.Add predicate, which LINQ would hide rather than simplify. The rule's own
+# documentation offers PerformanceSensitiveAttribute for exactly this case; scoping it off is
+# the same decision without annotating fifty methods.
+dotnet_diagnostic.S3267.severity = none
+
+# Sample and measurement projects: the literal IS the data.
+[{XLibur.Examples,XLibur.Report.Examples,XLibur.Benchmarks,XLibur.Report.Benchmarks}/**.cs]
+
+# S1192: hoist a repeated string literal into a constant. In an example, "Titles", "Revenue" and
+# "1-3, 5, 7" are the worked example - a reader follows them down the page, and replacing them
+# with Titles/Revenue/RangeSpec constants makes the sample harder to read, not easier. Same
+# argument the repo already accepted for CA1861 in tests.
+dotnet_diagnostic.S1192.severity = none

--- a/XLibur.Benchmarks/BulkStyleBenchmarks.cs
+++ b/XLibur.Benchmarks/BulkStyleBenchmarks.cs
@@ -33,7 +33,7 @@ public class BulkStyleBenchmarks
     /// cell" from "allocates per style" — only the ratio between sizes can.
     /// </summary>
     [Params(10_000, 100_000, 1_000_000)]
-    public int Cells;
+    public int Cells { get; set; }
 
     private const int Columns = 10;
 

--- a/XLibur.Benchmarks/FormulaEvaluationBenchmarks.cs
+++ b/XLibur.Benchmarks/FormulaEvaluationBenchmarks.cs
@@ -40,9 +40,11 @@ public class FormulaEvaluationBenchmarks
     private const int RowCount = 20_000;
     private const int LookupRows = 20;
 
-    private XLWorkbook _uniqueSameSheet = null!;
-    private XLWorkbook _sharedSameSheet = null!;
-    private XLWorkbook _sharedCrossSheet = null!;
+    // Assigned by Setup. Plain null rather than null!: this project has no nullable context, so the
+    // forgiving operator says nothing the compiler was going to check anyway.
+    private XLWorkbook _uniqueSameSheet = null;
+    private XLWorkbook _sharedSameSheet = null;
+    private XLWorkbook _sharedCrossSheet = null;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/StreamingWriteBenchmarks.cs
+++ b/XLibur.Benchmarks/StreamingWriteBenchmarks.cs
@@ -26,7 +26,6 @@ public class StreamingWriteBenchmarks
 {
     private const int RowCount = 50_000;
 
-    private BenchmarkData _data = null;
     private string[] _strings = null;
     private double[] _numbers = null;
     private DateTime[] _dates = null;
@@ -35,10 +34,10 @@ public class StreamingWriteBenchmarks
     public void Setup()
     {
         SixLaborsV1FontBootstrap.Register();
-        _data = BenchmarkData.Create(RowCount);
-        _strings = _data.Strings;
-        _numbers = _data.Numbers;
-        _dates = _data.Dates;
+        var data = BenchmarkData.Create(RowCount);
+        _strings = data.Strings;
+        _numbers = data.Numbers;
+        _dates = data.Dates;
     }
 
     [Benchmark(Baseline = true)]

--- a/XLibur.Examples/Misc/DataValidationDecimal.cs
+++ b/XLibur.Examples/Misc/DataValidationDecimal.cs
@@ -12,8 +12,6 @@ public class DataValidationDecimal : IXLExample
         var c2 = ws.Cell("B1");
         c1.Value = 1.1;
         c2.Value = 2.1;
-        var r1 = ws.Range("A1:A10");
-        var r2 = ws.Range("B1:B10");
 
         ws.Range("A2:A10").CreateDataValidation().Decimal.EqualTo(1.1);
         ws.Range("B2:B10").CreateDataValidation().Decimal.NotEqualTo(2.1);

--- a/XLibur.Examples/Styles/DefaultStyles.cs
+++ b/XLibur.Examples/Styles/DefaultStyles.cs
@@ -10,12 +10,12 @@ public class DefaultStyles : IXLExample
         var workbook = new XLWorkbook();
 
         // This worksheet will have the default style, row height, column width, and page setup
-        var ws1 = workbook.Worksheets.Add("Default Style");
+        workbook.Worksheets.Add("Default Style");
 
         // Change the default row height for all new worksheets in this workbook
         workbook.RowHeight = 30;
 
-        var ws2 = workbook.Worksheets.Add("Tall Rows");
+        workbook.Worksheets.Add("Tall Rows");
 
         // Create a worksheet and change the default row height
         var ws3 = workbook.Worksheets.Add("Short Rows");

--- a/XLibur.Report.DynamicLinq/DynamicLinqExpressionEngine.cs
+++ b/XLibur.Report.DynamicLinq/DynamicLinqExpressionEngine.cs
@@ -283,34 +283,34 @@ public sealed class DynamicLinqExpressionEngine : IExpressionEngine
 
             return new Binding(name, type, value);
         }
-    }
 
-    /// <summary>
-    /// <c>Enumerable.Cast&lt;T&gt;().ToList()</c>, reached by reflection because <c>T</c> is only known
-    /// at runtime.
-    /// </summary>
-    private static object CastTo(IEnumerable enumerable, Type elementType)
-    {
-        var cast = typeof(Enumerable).GetMethod(nameof(Enumerable.Cast))!.MakeGenericMethod(elementType);
-        var toList = typeof(Enumerable).GetMethod(nameof(Enumerable.ToList))!.MakeGenericMethod(elementType);
-
-        return toList.Invoke(null, new[] { cast.Invoke(null, new object[] { enumerable }) })!;
-    }
-
-    private static bool IsGenericEnumerable(Type type) =>
-        type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
-
-    private static Type? ElementType(IEnumerable enumerable)
-    {
-        foreach (var item in enumerable)
+        /// <summary>
+        /// <c>Enumerable.Cast&lt;T&gt;().ToList()</c>, reached by reflection because <c>T</c> is only known
+        /// at runtime.
+        /// </summary>
+        private static object CastTo(IEnumerable enumerable, Type elementType)
         {
-            if (item is not null)
-            {
-                return item.GetType();
-            }
+            var cast = typeof(Enumerable).GetMethod(nameof(Enumerable.Cast))!.MakeGenericMethod(elementType);
+            var toList = typeof(Enumerable).GetMethod(nameof(Enumerable.ToList))!.MakeGenericMethod(elementType);
+
+            return toList.Invoke(null, new[] { cast.Invoke(null, new object[] { enumerable }) })!;
         }
 
-        return null;
+        private static bool IsGenericEnumerable(Type type) =>
+            type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        private static Type? ElementType(IEnumerable enumerable)
+        {
+            foreach (var item in enumerable)
+            {
+                if (item is not null)
+                {
+                    return item.GetType();
+                }
+            }
+
+            return null;
+        }
     }
 
     private static string CacheKey(string expression, ParameterExpression[] parameters)

--- a/XLibur.Report.Tests/Expressions/ScribanExpressionEngineTests.cs
+++ b/XLibur.Report.Tests/Expressions/ScribanExpressionEngineTests.cs
@@ -215,7 +215,7 @@ public class ScribanExpressionEngineTests
 
         var exception = Assert.Throws<ExpressionEvaluationException>(() => engine.Evaluate("item.", ItemScope(SampleItem())));
 
-        await Assert.That(exception!.Expression).IsEqualTo("item.");
+        await Assert.That(exception.Expression).IsEqualTo("item.");
     }
 
     [Test]

--- a/XLibur.Report.Tests/Rewriting/PivotRewritingTests.cs
+++ b/XLibur.Report.Tests/Rewriting/PivotRewritingTests.cs
@@ -61,7 +61,7 @@ public class PivotRewritingTests
     private static string SourceArea(IXLPivotTable pivot)
     {
         var reference = (XLPivotSourceReference)Cache(pivot).Source;
-        return reference.UsesName ? reference.Name! : reference.Area!.Value.Area.ToString();
+        return reference.UsesName ? reference.Name : reference.Area.Value.Area.ToString();
     }
 
     /// <summary>

--- a/XLibur.Report.Tests/Tags/PivotTagTests.cs
+++ b/XLibur.Report.Tests/Tags/PivotTagTests.cs
@@ -61,7 +61,7 @@ public class PivotTagTests
     private static string SourceArea(IXLPivotTable pivot)
     {
         var reference = (XLPivotSourceReference)((XLPivotCache)pivot.PivotCache).Source;
-        return reference.UsesName ? reference.Name! : reference.Area!.Value.Area.ToString();
+        return reference.UsesName ? reference.Name : reference.Area.Value.Area.ToString();
     }
 
     [Test]

--- a/XLibur.Report/ExpressionText.cs
+++ b/XLibur.Report/ExpressionText.cs
@@ -37,7 +37,7 @@ internal static class ExpressionText
             return false;
         }
 
-        var trimmed = text!.Trim();
+        var trimmed = text.Trim();
         if (trimmed.Length < 5 || !trimmed.StartsWith("{{", StringComparison.Ordinal) || !trimmed.EndsWith("}}", StringComparison.Ordinal))
         {
             return false;

--- a/XLibur.Report/Rewriting/SheetReference.cs
+++ b/XLibur.Report/Rewriting/SheetReference.cs
@@ -37,7 +37,7 @@ internal readonly record struct SheetReference(
             return false;
         }
 
-        var span = text!.Trim();
+        var span = text.Trim();
 
         // A multi-area reference is written as a parenthesised, comma-separated list.
         if (span.Contains(',') || span.Contains('('))

--- a/XLibur.Report/Tags/OptionTag.cs
+++ b/XLibur.Report/Tags/OptionTag.cs
@@ -192,7 +192,7 @@ public sealed class ProcessingContext
             return false;
         }
 
-        var body = ExpressionText.TryGetSingleExpression(expression, out var single) ? single : expression!;
+        var body = ExpressionText.TryGetSingleExpression(expression, out var single) ? single : expression;
 
         try
         {

--- a/XLibur.Report/Tags/SummaryFunctionTag.cs
+++ b/XLibur.Report/Tags/SummaryFunctionTag.cs
@@ -123,7 +123,7 @@ public sealed class SummaryFunctionTag : OptionTag, IRangeSummaryTag
         }
 
         var line = context.Axis.ParseLine(over);
-        if (line is not null and > 0)
+        if (line is > 0)
         {
             return line;
         }

--- a/XLibur.Report/Tags/TagParser.cs
+++ b/XLibur.Report/Tags/TagParser.cs
@@ -33,7 +33,7 @@ internal static class TagParser
             return tokens;
         }
 
-        foreach (Match match in Pattern.Matches(text!))
+        foreach (Match match in Pattern.Matches(text))
         {
             tokens.Add(new TagToken(match.Groups["name"].Value, ParseParameters(match.Groups["params"].Value)));
         }
@@ -43,7 +43,7 @@ internal static class TagParser
 
     /// <summary>Returns <paramref name="text"/> with its tags removed.</summary>
     public static string Strip(string? text) =>
-        string.IsNullOrEmpty(text) ? string.Empty : Pattern.Replace(text!, string.Empty).Trim();
+        string.IsNullOrEmpty(text) ? string.Empty : Pattern.Replace(text, string.Empty).Trim();
 
     private static Dictionary<string, string> ParseParameters(string text)
     {

--- a/XLibur.Report/XLTemplate.cs
+++ b/XLibur.Report/XLTemplate.cs
@@ -85,35 +85,6 @@ public sealed class XLTemplate : IXLTemplate
         _variables[alias] = value is DataTable table ? ToRowDictionaries(table) : value;
     }
 
-    /// <summary>
-    /// Binds a <see cref="DataTable"/> as a materialised list of column-keyed dictionaries.
-    /// </summary>
-    /// <remarks>
-    /// Two reasons not to hand out <see cref="DataRow"/>s directly. A row exposes its columns
-    /// through an indexer rather than through properties, so <c>{{ row.Customer }}</c> — the way a
-    /// template author naturally writes it — would find nothing; and the rows have to be
-    /// materialised anyway, because expanding a range enumerates its data more than once.
-    /// </remarks>
-    private static List<Dictionary<string, object?>> ToRowDictionaries(DataTable table)
-    {
-        var columns = table.Columns.Cast<DataColumn>().ToList();
-        var rows = new List<Dictionary<string, object?>>(table.Rows.Count);
-
-        foreach (DataRow row in table.Rows)
-        {
-            var values = new Dictionary<string, object?>(columns.Count, StringComparer.Ordinal);
-            foreach (var column in columns)
-            {
-                var value = row[column];
-                values[column.ColumnName] = value is DBNull ? null : value;
-            }
-
-            rows.Add(values);
-        }
-
-        return rows;
-    }
-
     /// <inheritdoc />
     public void AddVariable(object value)
     {
@@ -149,6 +120,35 @@ public sealed class XLTemplate : IXLTemplate
         {
             AddVariable(field.Name, field.GetValue(value));
         }
+    }
+
+    /// <summary>
+    /// Binds a <see cref="DataTable"/> as a materialised list of column-keyed dictionaries.
+    /// </summary>
+    /// <remarks>
+    /// Two reasons not to hand out <see cref="DataRow"/>s directly. A row exposes its columns
+    /// through an indexer rather than through properties, so <c>{{ row.Customer }}</c> — the way a
+    /// template author naturally writes it — would find nothing; and the rows have to be
+    /// materialised anyway, because expanding a range enumerates its data more than once.
+    /// </remarks>
+    private static List<Dictionary<string, object?>> ToRowDictionaries(DataTable table)
+    {
+        var columns = table.Columns.Cast<DataColumn>().ToList();
+        var rows = new List<Dictionary<string, object?>>(table.Rows.Count);
+
+        foreach (DataRow row in table.Rows)
+        {
+            var values = new Dictionary<string, object?>(columns.Count, StringComparer.Ordinal);
+            foreach (var column in columns)
+            {
+                var value = row[column];
+                values[column.ColumnName] = value is DBNull ? null : value;
+            }
+
+            rows.Add(values);
+        }
+
+        return rows;
     }
 
     /// <inheritdoc />

--- a/XLibur.Report/XLTemplate.cs
+++ b/XLibur.Report/XLTemplate.cs
@@ -128,7 +128,7 @@ public sealed class XLTemplate : IXLTemplate
                 var key = entry.Key?.ToString();
                 if (!string.IsNullOrWhiteSpace(key))
                 {
-                    AddVariable(key!, entry.Value);
+                    AddVariable(key, entry.Value);
                 }
             }
 

--- a/XLibur/Excel/Caching/XLRepositoryBase.cs
+++ b/XLibur/Excel/Caching/XLRepositoryBase.cs
@@ -6,12 +6,7 @@ using System.Threading;
 
 namespace XLibur.Excel.Caching;
 
-internal abstract class XLRepositoryBase : IXLRepository
-{
-    public abstract void Clear();
-}
-
-internal class XLRepositoryBase<Tkey, Tvalue> : XLRepositoryBase, IXLRepository<Tkey, Tvalue>
+internal class XLRepositoryBase<Tkey, Tvalue> : IXLRepository<Tkey, Tvalue>
     where Tkey : struct, IEquatable<Tkey>
     where Tvalue : class
 {
@@ -130,7 +125,7 @@ internal class XLRepositoryBase<Tkey, Tvalue> : XLRepositoryBase, IXLRepository<
         _storage.TryRemove(key, out _);
     }
 
-    public override void Clear()
+    public void Clear()
     {
         _storage.Clear();
         _deadEntriesSeen = 0;

--- a/XLibur/Excel/CalcEngine/AstNode.cs
+++ b/XLibur/Excel/CalcEngine/AstNode.cs
@@ -11,6 +11,10 @@ namespace XLibur.Excel.CalcEngine;
 /// memoise something it derives from its own state (see <see cref="ReferenceNode"/>), but
 /// nothing a visitor can see may change after construction.
 /// </summary>
+// S1694 suggests an interface, since Accept is the only member. The AST is deliberately a closed
+// class hierarchy: an interface could be implemented by a struct, which would box on every visit,
+// and ValueNode extends this to share that closure with its own subclasses.
+#pragma warning disable S1694
 internal abstract class AstNode
 {
     /// <summary>

--- a/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/XLibur/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -6,6 +6,9 @@ using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
 namespace XLibur.Excel.CalcEngine.Functions;
 
+// S4136 wants every overload group adjacent. Members here are ordered by the Excel function they implement,
+// which is the order a reader follows; regrouping by name would break it.
+#pragma warning disable S4136
 internal static class DateAndTime
 {
     /// <summary>

--- a/XLibur/Excel/CalcEngine/Functions/Logical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Logical.cs
@@ -43,10 +43,14 @@ internal static class Logical
         return value;
     }
 
+    // FALSE() and TRUE() are zero-argument Excel functions. They are registered through Adapt as
+    // method groups, so they have to stay methods; a constant cannot be converted to the delegate.
+#pragma warning disable S3400
     private static ScalarValue False()
     {
         return false;
     }
+#pragma warning restore S3400
 
     private static AnyValue If(ScalarValue condition, AnyValue valueIfTrue, AnyValue valueIfFalse)
     {
@@ -138,8 +142,11 @@ internal static class Logical
         return value;
     }
 
+    // See the note on False(): registered as a method group, so it cannot become a constant.
+#pragma warning disable S3400
     private static ScalarValue True()
     {
         return true;
     }
+#pragma warning restore S3400
 }

--- a/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/XLibur/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -15,6 +15,11 @@ namespace XLibur.Excel.CalcEngine.Functions;
 // each forwarding call past that point carries its own disable/restore pair. Adding a new adapter
 // means adding the pair around its call as well.
 #pragma warning disable S2234 // Func<> names its generics arg1..argN; our locals are arg0..argN-1
+// S4136 wants the Adapt, AdaptLastOptional and AdaptLastTwoOptional overloads each grouped in one
+// run. They are instead ordered by arity within their regions, so an adapter for a new signature is
+// found by counting its parameters. Grouping by name would interleave the three families and lose
+// that. Unlike S2234 above, no restore for S4136 appears below, so this reaches the whole file.
+#pragma warning disable S4136
 internal static class SignatureAdapter
 {
     #region Signature adapters

--- a/XLibur/Excel/CalcEngine/Functions/Statistical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Statistical.cs
@@ -157,9 +157,9 @@ internal static class Statistical
             var cdf = 0d;
             for (var y = 0; y <= numberSuccesses; ++y)
             {
-                var result = BinomDist(y, numberTrials, successProbability);
-                if (!result.TryPickT0(out var pf, out var error))
-                    return error;
+                var termResult = BinomDist(y, numberTrials, successProbability);
+                if (!termResult.TryPickT0(out var pf, out var termError))
+                    return termError;
 
                 cdf += pf;
             }
@@ -170,13 +170,11 @@ internal static class Statistical
             return cdf;
         }
 
-        {
-            var result = BinomDist(numberSuccesses, numberTrials, successProbability);
-            if (!result.TryPickT0(out var binomDist, out var error))
-                return error;
+        var result = BinomDist(numberSuccesses, numberTrials, successProbability);
+        if (!result.TryPickT0(out var binomDist, out var error))
+            return error;
 
-            return binomDist;
-        }
+        return binomDist;
     }
 
     private static OneOf<double, XLError> BinomDist(double x, double n, double p)

--- a/XLibur/Excel/CalcEngine/Functions/Statistical.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Statistical.cs
@@ -8,6 +8,9 @@ using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
 namespace XLibur.Excel.CalcEngine;
 
+// S4136 wants every overload group adjacent. Members here are ordered by the Excel function they implement,
+// which is the order a reader follows; regrouping by name would break it.
+#pragma warning disable S4136
 internal static class Statistical
 {
     // Argument positions that may be ranges in *IFS functions that take a leading value range:

--- a/XLibur/Excel/Cells/XLCellFormula.cs
+++ b/XLibur/Excel/Cells/XLCellFormula.cs
@@ -27,6 +27,8 @@ internal enum FormulaConversionType
 [DebuggerDisplay("Cell:{Range} - Type: {Type} - Formula: {A1}")]
 internal sealed class XLCellFormula
 {
+    private const string RefError = "#REF!";
+
     /// <summary>
     /// This is only a placeholder, so the data table formula looks like array formula for saving code.
     /// First argument is replaced by value from current row, second is replaced by value from current column.
@@ -277,11 +279,11 @@ internal sealed class XLCellFormula
         if (isRowDataTable)
         {
             colInput = string.Empty;
-            rowInput = input1Deleted ? "#REF!" : input1Address.ToString();
+            rowInput = input1Deleted ? RefError : input1Address.ToString();
         }
         else
         {
-            colInput = input1Deleted ? "#REF!" : input1Address.ToString();
+            colInput = input1Deleted ? RefError : input1Address.ToString();
             rowInput = string.Empty;
         }
 
@@ -312,8 +314,8 @@ internal sealed class XLCellFormula
         Point input2Address,
         bool input2Deleted)
     {
-        var colInput = input1Deleted ? "#REF!" : input1Address.ToString();
-        var rowInput = input2Deleted ? "#REF!" : input2Address.ToString();
+        var colInput = input1Deleted ? RefError : input1Address.ToString();
+        var rowInput = input2Deleted ? RefError : input2Address.ToString();
         var formula = string.Format(DataTableFormulaFormat, rowInput, colInput);
         return new XLCellFormula(formula)
         {

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -24,6 +24,9 @@ namespace XLibur.Excel;
 /// shifted before stops shifting now.
 /// </para>
 /// </summary>
+// S4136 wants every overload group adjacent. Members here are ordered by the kind of shift they perform,
+// which is the order a reader follows; regrouping by name would break it.
+#pragma warning disable S4136
 internal static partial class XLCellFormulaShifter
 {
     internal static string ShiftFormulaRows(string formulaA1, XLWorksheet worksheetInAction, XLRange shiftedRange,

--- a/XLibur/Excel/ConditionalFormats/Save/XLCFConvertersExtension.cs
+++ b/XLibur/Excel/ConditionalFormats/Save/XLCFConvertersExtension.cs
@@ -5,15 +5,10 @@ namespace XLibur.Excel;
 
 internal static class XLCFConvertersExtension
 {
-    private static readonly Dictionary<XLConditionalFormatType, IXLCFConverterExtension> Converters;
-
-    static XLCFConvertersExtension()
+    private static readonly Dictionary<XLConditionalFormatType, IXLCFConverterExtension> Converters = new()
     {
-        Converters = new Dictionary<XLConditionalFormatType, IXLCFConverterExtension>
-        {
-            { XLConditionalFormatType.DataBar, new XLCFDataBarConverterExtension() }
-        };
-    }
+        { XLConditionalFormatType.DataBar, new XLCFDataBarConverterExtension() }
+    };
 
     public static ConditionalFormattingRule Convert(IXLConditionalFormat conditionalFormat, XLWorkbook.SaveContext context)
     {

--- a/XLibur/Excel/Coordinates/Point.cs
+++ b/XLibur/Excel/Coordinates/Point.cs
@@ -231,6 +231,20 @@ internal readonly struct Point : IEquatable<Point>, IComparable<Point>
         return PackedValue.CompareTo(other.PackedValue);
     }
 
+    // The packing puts the row above the column, so comparing the packed values directly is the
+    // row-major ordering. These make that ordering usable with the operators, not just CompareTo.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator <(Point a, Point b) => a.PackedValue < b.PackedValue;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator <=(Point a, Point b) => a.PackedValue <= b.PackedValue;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator >(Point a, Point b) => a.PackedValue > b.PackedValue;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator >=(Point a, Point b) => a.PackedValue >= b.PackedValue;
+
     /// <summary>
     /// Is the point within the range or below the range?
     /// </summary>

--- a/XLibur/Excel/Coordinates/XLSheetOffset.cs
+++ b/XLibur/Excel/Coordinates/XLSheetOffset.cs
@@ -14,4 +14,14 @@ internal readonly record struct XLSheetOffset(int RowOfs, int ColOfs) : ICompara
         var rowComparison = RowOfs.CompareTo(other.RowOfs);
         return rowComparison != 0 ? rowComparison : ColOfs.CompareTo(other.ColOfs);
     }
+
+    // Row-major ordering, exposed through the operators as well as CompareTo. Equality comes from
+    // the record struct.
+    public static bool operator <(XLSheetOffset a, XLSheetOffset b) => a.CompareTo(b) < 0;
+
+    public static bool operator <=(XLSheetOffset a, XLSheetOffset b) => a.CompareTo(b) <= 0;
+
+    public static bool operator >(XLSheetOffset a, XLSheetOffset b) => a.CompareTo(b) > 0;
+
+    public static bool operator >=(XLSheetOffset a, XLSheetOffset b) => a.CompareTo(b) >= 0;
 }

--- a/XLibur/Excel/DataValidation/XLDataValidation.cs
+++ b/XLibur/Excel/DataValidation/XLDataValidation.cs
@@ -152,8 +152,6 @@ internal sealed class XLDataValidation : IXLDataValidation
 
     #region IXLDataValidation Members
 
-    private string maxValue = string.Empty;
-    private string minValue = string.Empty;
     public XLAllowedValues AllowedValues { get; set; }
 
     public XLDateCriteria Date
@@ -181,8 +179,8 @@ internal sealed class XLDataValidation : IXLDataValidation
     public bool InCellDropdown { get; set; }
     public string InputMessage { get; set; } = string.Empty;
     public string InputTitle { get; set; } = string.Empty;
-    public string MaxValue { get => maxValue; set => maxValue = value; }
-    public string MinValue { get => minValue; set => minValue = value; }
+    public string MaxValue { get; set; } = string.Empty;
+    public string MinValue { get; set; } = string.Empty;
     public XLOperator Operator { get; set; }
 
     /// <summary>

--- a/XLibur/Excel/EnumConverter.cs
+++ b/XLibur/Excel/EnumConverter.cs
@@ -12,6 +12,12 @@ namespace XLibur.Excel;
 
 internal static class EnumConverter
 {
+    /// <summary>
+    /// Message for the default arm of every enum switch here: the value is outside the set the
+    /// converter knows how to map.
+    /// </summary>
+    private const string NotImplementedValue = "Not implemented value!";
+
     private static readonly Dictionary<XLPictureFormat, PartTypeInfo> PictureFormatMap =
         new()
         {
@@ -591,7 +597,7 @@ internal static class EnumConverter
         XLFontUnderlineValues.None => UnderlineValues.None,
         XLFontUnderlineValues.Single => UnderlineValues.Single,
         XLFontUnderlineValues.SingleAccounting => UnderlineValues.SingleAccounting,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static OrientationValues ToOpenXml(this XLPageOrientation value) => value switch
@@ -599,7 +605,7 @@ internal static class EnumConverter
         XLPageOrientation.Default => OrientationValues.Default,
         XLPageOrientation.Landscape => OrientationValues.Landscape,
         XLPageOrientation.Portrait => OrientationValues.Portrait,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static VerticalAlignmentRunValues ToOpenXml(this XLFontVerticalTextAlignmentValues value) => value switch
@@ -607,7 +613,7 @@ internal static class EnumConverter
         XLFontVerticalTextAlignmentValues.Baseline => VerticalAlignmentRunValues.Baseline,
         XLFontVerticalTextAlignmentValues.Subscript => VerticalAlignmentRunValues.Subscript,
         XLFontVerticalTextAlignmentValues.Superscript => VerticalAlignmentRunValues.Superscript,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static PatternValues ToOpenXml(this XLFillPatternValues value) => value switch
@@ -631,7 +637,7 @@ internal static class EnumConverter
         XLFillPatternValues.MediumGray => PatternValues.MediumGray,
         XLFillPatternValues.None => PatternValues.None,
         XLFillPatternValues.Solid => PatternValues.Solid,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static BorderStyleValues ToOpenXml(this XLBorderStyleValues value) => value switch
@@ -650,7 +656,7 @@ internal static class EnumConverter
         XLBorderStyleValues.SlantDashDot => BorderStyleValues.SlantDashDot,
         XLBorderStyleValues.Thick => BorderStyleValues.Thick,
         XLBorderStyleValues.Thin => BorderStyleValues.Thin,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static HorizontalAlignmentValues ToOpenXml(this XLAlignmentHorizontalValues value) => value switch
@@ -663,7 +669,7 @@ internal static class EnumConverter
         XLAlignmentHorizontalValues.Justify => HorizontalAlignmentValues.Justify,
         XLAlignmentHorizontalValues.Left => HorizontalAlignmentValues.Left,
         XLAlignmentHorizontalValues.Right => HorizontalAlignmentValues.Right,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static VerticalAlignmentValues ToOpenXml(this XLAlignmentVerticalValues value) => value switch
@@ -673,14 +679,14 @@ internal static class EnumConverter
         XLAlignmentVerticalValues.Distributed => VerticalAlignmentValues.Distributed,
         XLAlignmentVerticalValues.Justify => VerticalAlignmentValues.Justify,
         XLAlignmentVerticalValues.Top => VerticalAlignmentValues.Top,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static PageOrderValues ToOpenXml(this XLPageOrderValues value) => value switch
     {
         XLPageOrderValues.DownThenOver => PageOrderValues.DownThenOver,
         XLPageOrderValues.OverThenDown => PageOrderValues.OverThenDown,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static CellCommentsValues ToOpenXml(this XLShowCommentsValues value) => value switch
@@ -688,7 +694,7 @@ internal static class EnumConverter
         XLShowCommentsValues.AsDisplayed => CellCommentsValues.AsDisplayed,
         XLShowCommentsValues.AtEnd => CellCommentsValues.AtEnd,
         XLShowCommentsValues.None => CellCommentsValues.None,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static PrintErrorValues ToOpenXml(this XLPrintErrorValues value) => value switch
@@ -697,7 +703,7 @@ internal static class EnumConverter
         XLPrintErrorValues.Dash => PrintErrorValues.Dash,
         XLPrintErrorValues.Displayed => PrintErrorValues.Displayed,
         XLPrintErrorValues.NA => PrintErrorValues.NA,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static CalculateModeValues ToOpenXml(this XLCalculateMode value) => value switch
@@ -705,14 +711,14 @@ internal static class EnumConverter
         XLCalculateMode.Auto => CalculateModeValues.Auto,
         XLCalculateMode.AutoNoTable => CalculateModeValues.AutoNoTable,
         XLCalculateMode.Manual => CalculateModeValues.Manual,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static ReferenceModeValues ToOpenXml(this XLReferenceStyle value) => value switch
     {
         XLReferenceStyle.R1C1 => ReferenceModeValues.R1C1,
         XLReferenceStyle.A1 => ReferenceModeValues.A1,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static uint ToOpenXml(this XLAlignmentReadingOrderValues value) => value switch
@@ -720,7 +726,7 @@ internal static class EnumConverter
         XLAlignmentReadingOrderValues.ContextDependent => 0,
         XLAlignmentReadingOrderValues.LeftToRight => 1,
         XLAlignmentReadingOrderValues.RightToLeft => 2,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static TotalsRowFunctionValues ToOpenXml(this XLTotalsRowFunction value) => value switch
@@ -735,7 +741,7 @@ internal static class EnumConverter
         XLTotalsRowFunction.StandardDeviation => TotalsRowFunctionValues.StandardDeviation,
         XLTotalsRowFunction.Variance => TotalsRowFunctionValues.Variance,
         XLTotalsRowFunction.Custom => TotalsRowFunctionValues.Custom,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static DataValidationValues ToOpenXml(this XLAllowedValues value) => value switch
@@ -748,7 +754,7 @@ internal static class EnumConverter
         XLAllowedValues.TextLength => DataValidationValues.TextLength,
         XLAllowedValues.Time => DataValidationValues.Time,
         XLAllowedValues.WholeNumber => DataValidationValues.Whole,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static DataValidationErrorStyleValues ToOpenXml(this XLErrorStyle value) => value switch
@@ -756,7 +762,7 @@ internal static class EnumConverter
         XLErrorStyle.Information => DataValidationErrorStyleValues.Information,
         XLErrorStyle.Warning => DataValidationErrorStyleValues.Warning,
         XLErrorStyle.Stop => DataValidationErrorStyleValues.Stop,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static DataValidationOperatorValues ToOpenXml(this XLOperator value) => value switch
@@ -769,7 +775,7 @@ internal static class EnumConverter
         XLOperator.LessThan => DataValidationOperatorValues.LessThan,
         XLOperator.NotBetween => DataValidationOperatorValues.NotBetween,
         XLOperator.NotEqualTo => DataValidationOperatorValues.NotEqual,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static SheetStateValues ToOpenXml(this XLWorksheetVisibility value) => value switch
@@ -777,7 +783,7 @@ internal static class EnumConverter
         XLWorksheetVisibility.Visible => SheetStateValues.Visible,
         XLWorksheetVisibility.Hidden => SheetStateValues.Hidden,
         XLWorksheetVisibility.VeryHidden => SheetStateValues.VeryHidden,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static PhoneticValues ToOpenXml(this XLPhoneticType value) => value switch
@@ -786,7 +792,7 @@ internal static class EnumConverter
         XLPhoneticType.HalfWidthKatakana => PhoneticValues.HalfWidthKatakana,
         XLPhoneticType.Hiragana => PhoneticValues.Hiragana,
         XLPhoneticType.NoConversion => PhoneticValues.NoConversion,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static DataConsolidateFunctionValues ToOpenXml(this XLPivotSummary value) => value switch
@@ -802,7 +808,7 @@ internal static class EnumConverter
         XLPivotSummary.PopulationStandardDeviation => DataConsolidateFunctionValues.StandardDeviationP,
         XLPivotSummary.Variance => DataConsolidateFunctionValues.Variance,
         XLPivotSummary.PopulationVariance => DataConsolidateFunctionValues.VarianceP,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static ShowDataAsValues ToOpenXml(this XLPivotCalculation value) => value switch
@@ -816,7 +822,7 @@ internal static class EnumConverter
         XLPivotCalculation.PercentageOfColumn => ShowDataAsValues.PercentOfColumn,
         XLPivotCalculation.PercentageOfTotal => ShowDataAsValues.PercentOfTotal,
         XLPivotCalculation.Index => ShowDataAsValues.Index,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static FilterOperatorValues ToOpenXml(this XLFilterOperator value) => value switch
@@ -827,14 +833,14 @@ internal static class EnumConverter
         XLFilterOperator.EqualOrGreaterThan => FilterOperatorValues.GreaterThanOrEqual,
         XLFilterOperator.LessThan => FilterOperatorValues.LessThan,
         XLFilterOperator.EqualOrLessThan => FilterOperatorValues.LessThanOrEqual,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static DynamicFilterValues ToOpenXml(this XLFilterDynamicType value) => value switch
     {
         XLFilterDynamicType.AboveAverage => DynamicFilterValues.AboveAverage,
         XLFilterDynamicType.BelowAverage => DynamicFilterValues.BelowAverage,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static DateTimeGroupingValues ToOpenXml(this XLDateTimeGrouping value) => value switch
@@ -845,7 +851,7 @@ internal static class EnumConverter
         XLDateTimeGrouping.Hour => DateTimeGroupingValues.Hour,
         XLDateTimeGrouping.Minute => DateTimeGroupingValues.Minute,
         XLDateTimeGrouping.Second => DateTimeGroupingValues.Second,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static SheetViewValues ToOpenXml(this XLSheetViewOptions value) => value switch
@@ -853,7 +859,7 @@ internal static class EnumConverter
         XLSheetViewOptions.Normal => SheetViewValues.Normal,
         XLSheetViewOptions.PageBreakPreview => SheetViewValues.PageBreakPreview,
         XLSheetViewOptions.PageLayout => SheetViewValues.PageLayout,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static Vml.StrokeLineStyleValues ToOpenXml(this XLLineStyle value) => value switch
@@ -863,7 +869,7 @@ internal static class EnumConverter
         XLLineStyle.ThickThin => Vml.StrokeLineStyleValues.ThickThin,
         XLLineStyle.ThinThick => Vml.StrokeLineStyleValues.ThinThick,
         XLLineStyle.ThinThin => Vml.StrokeLineStyleValues.ThinThin,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static ConditionalFormatValues ToOpenXml(this XLConditionalFormatType value) => value switch
@@ -886,7 +892,7 @@ internal static class EnumConverter
         XLConditionalFormatType.NotError => ConditionalFormatValues.NotContainsErrors,
         XLConditionalFormatType.TimePeriod => ConditionalFormatValues.TimePeriod,
         XLConditionalFormatType.AboveAverage => ConditionalFormatValues.AboveAverage,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static ConditionalFormatValueObjectValues ToOpenXml(this XLCFContentType value) => value switch
@@ -897,7 +903,7 @@ internal static class EnumConverter
         XLCFContentType.Minimum => ConditionalFormatValueObjectValues.Min,
         XLCFContentType.Formula => ConditionalFormatValueObjectValues.Formula,
         XLCFContentType.Percentile => ConditionalFormatValueObjectValues.Percentile,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static ConditionalFormattingOperatorValues ToOpenXml(this XLCFOperator value) => value switch
@@ -914,7 +920,7 @@ internal static class EnumConverter
         XLCFOperator.NotContains => ConditionalFormattingOperatorValues.NotContains,
         XLCFOperator.StartsWith => ConditionalFormattingOperatorValues.BeginsWith,
         XLCFOperator.EndsWith => ConditionalFormattingOperatorValues.EndsWith,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static IconSetValues ToOpenXml(this XLIconSetStyle value) => value switch
@@ -936,7 +942,7 @@ internal static class EnumConverter
         XLIconSetStyle.FiveArrowsGray => IconSetValues.FiveArrowsGray,
         XLIconSetStyle.FiveRating => IconSetValues.FiveRating,
         XLIconSetStyle.FiveQuarters => IconSetValues.FiveQuarters,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static TimePeriodValues ToOpenXml(this XLTimePeriod value) => value switch
@@ -951,7 +957,7 @@ internal static class EnumConverter
         XLTimePeriod.LastMonth => TimePeriodValues.LastMonth,
         XLTimePeriod.ThisMonth => TimePeriodValues.ThisMonth,
         XLTimePeriod.NextMonth => TimePeriodValues.NextMonth,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static PartTypeInfo ToOpenXml(this XLPictureFormat value)
@@ -964,7 +970,7 @@ internal static class EnumConverter
         XLPicturePlacement.FreeFloating => Xdr.EditAsValues.Absolute,
         XLPicturePlacement.Move => Xdr.EditAsValues.OneCell,
         XLPicturePlacement.MoveAndSize => Xdr.EditAsValues.TwoCell,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static PivotAreaValues ToOpenXml(this XLPivotAreaType value) => value switch
@@ -985,7 +991,7 @@ internal static class EnumConverter
         XLSparklineType.Line => X14.SparklineTypeValues.Line,
         XLSparklineType.Column => X14.SparklineTypeValues.Column,
         XLSparklineType.Stacked => X14.SparklineTypeValues.Stacked,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static X14.SparklineAxisMinMaxValues ToOpenXml(this XLSparklineAxisMinMax value) => value switch
@@ -993,7 +999,7 @@ internal static class EnumConverter
         XLSparklineAxisMinMax.Automatic => X14.SparklineAxisMinMaxValues.Individual,
         XLSparklineAxisMinMax.SameForAll => X14.SparklineAxisMinMaxValues.Group,
         XLSparklineAxisMinMax.Custom => X14.SparklineAxisMinMaxValues.Custom,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static X14.DisplayBlanksAsValues ToOpenXml(this XLDisplayBlanksAsValues value) => value switch
@@ -1001,7 +1007,7 @@ internal static class EnumConverter
         XLDisplayBlanksAsValues.Interpolate => X14.DisplayBlanksAsValues.Span,
         XLDisplayBlanksAsValues.NotPlotted => X14.DisplayBlanksAsValues.Gap,
         XLDisplayBlanksAsValues.Zero => X14.DisplayBlanksAsValues.Zero,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static FieldSortValues ToOpenXml(this XLPivotSortType value) => value switch
@@ -1009,7 +1015,7 @@ internal static class EnumConverter
         XLPivotSortType.Default => FieldSortValues.Manual,
         XLPivotSortType.Ascending => FieldSortValues.Ascending,
         XLPivotSortType.Descending => FieldSortValues.Descending,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static X14.DataBarAxisPositionValues ToOpenXml(this XLDataBarAxisPosition value)
@@ -1017,7 +1023,7 @@ internal static class EnumConverter
         if (value == XLDataBarAxisPosition.Automatic) return X14.DataBarAxisPositionValues.Automatic;
         if (value == XLDataBarAxisPosition.Middle) return X14.DataBarAxisPositionValues.Middle;
         if (value == XLDataBarAxisPosition.None) return X14.DataBarAxisPositionValues.None;
-        throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!");
+        throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue);
     }
 
     public static XLFontUnderlineValues ToXLibur(this UnderlineValues value)
@@ -1090,7 +1096,7 @@ internal static class EnumConverter
         0 => XLAlignmentReadingOrderValues.ContextDependent,
         1 => XLAlignmentReadingOrderValues.LeftToRight,
         2 => XLAlignmentReadingOrderValues.RightToLeft,
-        _ => throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!"),
+        _ => throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue),
     };
 
     public static XLTotalsRowFunction ToXLibur(this TotalsRowFunctionValues value)
@@ -1254,7 +1260,7 @@ internal static class EnumConverter
         if (value == X14.DataBarAxisPositionValues.Automatic) return XLDataBarAxisPosition.Automatic;
         if (value == X14.DataBarAxisPositionValues.Middle) return XLDataBarAxisPosition.Middle;
         if (value == X14.DataBarAxisPositionValues.None) return XLDataBarAxisPosition.None;
-        throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!");
+        throw new ArgumentOutOfRangeException(nameof(value), NotImplementedValue);
     }
 
     /// <summary>
@@ -1302,7 +1308,7 @@ internal static class EnumConverter
         if (string.IsNullOrEmpty(rawText))
             return null;
 
-        var lowered = factory(rawText!.ToLowerInvariant());
+        var lowered = factory(rawText.ToLowerInvariant());
         return map.TryGetValue(lowered, out var result) ? result : null;
     }
 

--- a/XLibur/Excel/EnumConverter.cs
+++ b/XLibur/Excel/EnumConverter.cs
@@ -10,6 +10,10 @@ using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
 
 namespace XLibur.Excel;
 
+// S4136 wants every overload group adjacent. Members here are ordered by the enum they convert,
+// keeping each ToOpenXml/ToXLibur pair together, which is the order a reader follows; regrouping
+// by name would break it.
+#pragma warning disable S4136
 internal static class EnumConverter
 {
     /// <summary>

--- a/XLibur/Excel/IO/ColumnWriter.cs
+++ b/XLibur/Excel/IO/ColumnWriter.cs
@@ -240,7 +240,7 @@ internal static class ColumnWriter
             ? (byte)column.OutlineLevel
             : null;
 
-        sheetColumnsByMin.Remove(column.Min!.Value);
+        sheetColumnsByMin.Remove(column.Min.Value);
         if (existingColumn.Min! + 1 > existingColumn.Max!)
         {
             columns.RemoveChild(existingColumn);
@@ -250,9 +250,9 @@ internal static class ColumnWriter
         else
         {
             columns.AppendChild(newColumn);
-            sheetColumnsByMin.Add(newColumn.Min!.Value, newColumn);
+            sheetColumnsByMin.Add(newColumn.Min.Value, newColumn);
             existingColumn.Min = existingColumn.Min! + 1;
-            sheetColumnsByMin.Add(existingColumn.Min!.Value, existingColumn);
+            sheetColumnsByMin.Add(existingColumn.Min.Value, existingColumn);
         }
     }
 

--- a/XLibur/Excel/IO/ConditionalFormatReader.cs
+++ b/XLibur/Excel/IO/ConditionalFormatReader.cs
@@ -43,7 +43,7 @@ internal static class ConditionalFormatReader
             LoadConditionalFormatFormulas(fr, conditionalFormat);
 
             if (!string.IsNullOrWhiteSpace(fr.Text))
-                conditionalFormat.Values.Add(new XLFormula { _value = fr.Text!.Value!, IsFormula = false });
+                conditionalFormat.Values.Add(new XLFormula { _value = fr.Text.Value!, IsFormula = false });
 
             LoadTop10OrTimePeriod(fr, conditionalFormat);
             LoadScaleBarOrIconSet(fr, conditionalFormat);
@@ -343,7 +343,7 @@ internal static class ConditionalFormatReader
         {
             if (c.Type != null)
                 conditionalFormat.ContentTypes.Add(c.Type.Value.ToXLibur());
-            conditionalFormat.Values.Add(c.Val != null ? new XLFormula { Value = c.Val!.Value! } : null!);
+            conditionalFormat.Values.Add(c.Val != null ? new XLFormula { Value = c.Val.Value! } : null!);
 
             if (c.GreaterThanOrEqual != null)
                 conditionalFormat.IconSetOperators.Add(c.GreaterThanOrEqual.Value

--- a/XLibur/Excel/IO/DefinedNameReader.cs
+++ b/XLibur/Excel/IO/DefinedNameReader.cs
@@ -28,7 +28,7 @@ internal static class DefinedNameReader
 
             var localSheetId = -1;
             if (definedName.LocalSheetId?.HasValue ?? false)
-                localSheetId = Convert.ToInt32(definedName.LocalSheetId!.Value);
+                localSheetId = Convert.ToInt32(definedName.LocalSheetId.Value);
 
             if (name == "_xlnm.Print_Area")
             {

--- a/XLibur/Excel/IO/DrawingPartReader.cs
+++ b/XLibur/Excel/IO/DrawingPartReader.cs
@@ -530,7 +530,7 @@ internal static class DrawingPartReader
         {
             picture.MoveTo(
                 ConvertFromEnglishMetricUnits(absoluteAnchor.Position!.X!.Value, ws.Workbook.DpiX),
-                ConvertFromEnglishMetricUnits(absoluteAnchor.Position!.Y!.Value, ws.Workbook.DpiY)
+                ConvertFromEnglishMetricUnits(absoluteAnchor.Position.Y!.Value, ws.Workbook.DpiY)
             );
         }
         else if (anchor is Xdr.OneCellAnchor oneCellAnchor)
@@ -562,7 +562,7 @@ internal static class DrawingPartReader
                 var spPr = shapeProperties;
                 picture.MoveTo(
                     ConvertFromEnglishMetricUnits(spPr.Transform2D!.Offset!.X!, ws.Workbook.DpiX),
-                    ConvertFromEnglishMetricUnits(spPr.Transform2D!.Offset!.Y!, ws.Workbook.DpiY)
+                    ConvertFromEnglishMetricUnits(spPr.Transform2D.Offset.Y!, ws.Workbook.DpiY)
                 );
             }
         }

--- a/XLibur/Excel/IO/HeaderFooterImageWriter.cs
+++ b/XLibur/Excel/IO/HeaderFooterImageWriter.cs
@@ -12,6 +12,11 @@ namespace XLibur.Excel.IO;
 
 internal static class HeaderFooterImageWriter
 {
+    // VML namespaces fixed by the OOXML spec; the writer emits them verbatim.
+    private const string VmlNs = "urn:schemas-microsoft-com:vml";
+    private const string OfficeNs = "urn:schemas-microsoft-com:office:office";
+    private const string ExcelNs = "urn:schemas-microsoft-com:office:excel";
+
     /// <summary>
     /// Writes header/footer images as a separate VML drawing part with image relationships,
     /// and adds the <c>&lt;legacyDrawingHF&gt;</c> element to the worksheet XML.
@@ -78,34 +83,34 @@ internal static class HeaderFooterImageWriter
         using var writer = new XmlTextWriter(stream, Encoding.UTF8);
 
         writer.WriteStartElement("xml");
-        writer.WriteAttributeString("xmlns", "v", null, "urn:schemas-microsoft-com:vml");
-        writer.WriteAttributeString("xmlns", "o", null, "urn:schemas-microsoft-com:office:office");
-        writer.WriteAttributeString("xmlns", "x", null, "urn:schemas-microsoft-com:office:excel");
+        writer.WriteAttributeString("xmlns", "v", null, VmlNs);
+        writer.WriteAttributeString("xmlns", "o", null, OfficeNs);
+        writer.WriteAttributeString("xmlns", "x", null, ExcelNs);
 
         // Shape layout
-        writer.WriteStartElement("o", "shapelayout", "urn:schemas-microsoft-com:office:office");
-        writer.WriteAttributeString("v", "ext", "urn:schemas-microsoft-com:vml", "edit");
-        writer.WriteStartElement("o", "idmap", "urn:schemas-microsoft-com:office:office");
-        writer.WriteAttributeString("v", "ext", "urn:schemas-microsoft-com:vml", "edit");
+        writer.WriteStartElement("o", "shapelayout", OfficeNs);
+        writer.WriteAttributeString("v", "ext", VmlNs, "edit");
+        writer.WriteStartElement("o", "idmap", OfficeNs);
+        writer.WriteAttributeString("v", "ext", VmlNs, "edit");
         writer.WriteAttributeString("data", "2");
         writer.WriteEndElement(); // o:idmap
         writer.WriteEndElement(); // o:shapelayout
 
         // Shape type for pictures
-        writer.WriteStartElement("v", "shapetype", "urn:schemas-microsoft-com:vml");
+        writer.WriteStartElement("v", "shapetype", VmlNs);
         writer.WriteAttributeString("id", "_x0000_t75");
         writer.WriteAttributeString("coordsize", "21600,21600");
-        writer.WriteAttributeString("o", "spt", "urn:schemas-microsoft-com:office:office", "75");
-        writer.WriteAttributeString("o", "preferrelative", "urn:schemas-microsoft-com:office:office", "t");
+        writer.WriteAttributeString("o", "spt", OfficeNs, "75");
+        writer.WriteAttributeString("o", "preferrelative", OfficeNs, "t");
         writer.WriteAttributeString("path", "m@4@5l@4@11@9@11@9@5xe");
         writer.WriteAttributeString("filled", "f");
         writer.WriteAttributeString("stroked", "f");
 
-        writer.WriteStartElement("v", "stroke", "urn:schemas-microsoft-com:vml");
+        writer.WriteStartElement("v", "stroke", VmlNs);
         writer.WriteAttributeString("joinstyle", "miter");
         writer.WriteEndElement();
 
-        writer.WriteStartElement("v", "formulas", "urn:schemas-microsoft-com:vml");
+        writer.WriteStartElement("v", "formulas", VmlNs);
         WriteFormula(writer, "if lineDrawn pixelLineWidth 0");
         WriteFormula(writer, "sum @0 1 0");
         WriteFormula(writer, "sum 0 0 @1");
@@ -120,14 +125,14 @@ internal static class HeaderFooterImageWriter
         WriteFormula(writer, "sum @10 21600 0");
         writer.WriteEndElement(); // v:formulas
 
-        writer.WriteStartElement("v", "path", "urn:schemas-microsoft-com:vml");
-        writer.WriteAttributeString("o", "extrusionok", "urn:schemas-microsoft-com:office:office", "f");
+        writer.WriteStartElement("v", "path", VmlNs);
+        writer.WriteAttributeString("o", "extrusionok", OfficeNs, "f");
         writer.WriteAttributeString("gradientshapeok", "t");
-        writer.WriteAttributeString("o", "connecttype", "urn:schemas-microsoft-com:office:office", "rect");
+        writer.WriteAttributeString("o", "connecttype", OfficeNs, "rect");
         writer.WriteEndElement();
 
-        writer.WriteStartElement("o", "lock", "urn:schemas-microsoft-com:office:office");
-        writer.WriteAttributeString("v", "ext", "urn:schemas-microsoft-com:vml", "edit");
+        writer.WriteStartElement("o", "lock", OfficeNs);
+        writer.WriteAttributeString("v", "ext", VmlNs, "edit");
         writer.WriteAttributeString("aspectratio", "t");
         writer.WriteEndElement();
 
@@ -144,19 +149,19 @@ internal static class HeaderFooterImageWriter
             var heightPt = image.HeightPt.ToInvariantString();
             var style = $"position:absolute;margin-left:0;margin-top:0;width:{widthPt}pt;height:{heightPt}pt;z-index:{zIndex++}";
 
-            writer.WriteStartElement("v", "shape", "urn:schemas-microsoft-com:vml");
+            writer.WriteStartElement("v", "shape", VmlNs);
             writer.WriteAttributeString("id", image.PositionCode!);
-            writer.WriteAttributeString("o", "spid", "urn:schemas-microsoft-com:office:office", spid);
+            writer.WriteAttributeString("o", "spid", OfficeNs, spid);
             writer.WriteAttributeString("type", "#_x0000_t75");
             writer.WriteAttributeString("style", style);
 
-            writer.WriteStartElement("v", "imagedata", "urn:schemas-microsoft-com:vml");
-            writer.WriteAttributeString("o", "relid", "urn:schemas-microsoft-com:office:office", relId);
-            writer.WriteAttributeString("o", "title", "urn:schemas-microsoft-com:office:office", "");
+            writer.WriteStartElement("v", "imagedata", VmlNs);
+            writer.WriteAttributeString("o", "relid", OfficeNs, relId);
+            writer.WriteAttributeString("o", "title", OfficeNs, "");
             writer.WriteEndElement();
 
-            writer.WriteStartElement("o", "lock", "urn:schemas-microsoft-com:office:office");
-            writer.WriteAttributeString("v", "ext", "urn:schemas-microsoft-com:vml", "edit");
+            writer.WriteStartElement("o", "lock", OfficeNs);
+            writer.WriteAttributeString("v", "ext", VmlNs, "edit");
             writer.WriteAttributeString("rotation", "t");
             writer.WriteEndElement();
 
@@ -169,7 +174,7 @@ internal static class HeaderFooterImageWriter
 
     private static void WriteFormula(XmlTextWriter writer, string eqn)
     {
-        writer.WriteStartElement("v", "f", "urn:schemas-microsoft-com:vml");
+        writer.WriteStartElement("v", "f", VmlNs);
         writer.WriteAttributeString("eqn", eqn);
         writer.WriteEndElement();
     }

--- a/XLibur/Excel/IO/PageSetupWriter.cs
+++ b/XLibur/Excel/IO/PageSetupWriter.cs
@@ -189,11 +189,10 @@ internal static class PageSetupWriter
         else
             worksheet.RemoveAllChildren<HeaderFooter>();
 
-        {
-            var previousElement = cm.GetPreviousElementFor(XLWorksheetContents.HeaderFooter);
-            worksheet.InsertAfter(headerFooter, previousElement);
-            cm.SetElement(XLWorksheetContents.HeaderFooter, headerFooter);
-        }
+        var previousElement = cm.GetPreviousElementFor(XLWorksheetContents.HeaderFooter);
+        worksheet.InsertAfter(headerFooter, previousElement);
+        cm.SetElement(XLWorksheetContents.HeaderFooter, headerFooter);
+
         if (((XLHeaderFooter)xlWorksheet.PageSetup.Header).Changed
             || ((XLHeaderFooter)xlWorksheet.PageSetup.Footer).Changed)
         {
@@ -240,7 +239,7 @@ internal static class PageSetupWriter
             var existingBreaks = rowBreaks.ChildElements.OfType<Break>().ToArray();
             var rowBreaksToDelete = existingBreaks
                 .Where(rb => rb.Id?.Value is null ||
-                             !xlWorksheet.PageSetup.RowBreaks.Contains((int)rb.Id!.Value))
+                             !xlWorksheet.PageSetup.RowBreaks.Contains((int)rb.Id.Value))
                 .ToList();
 
             foreach (var rb in rowBreaksToDelete)
@@ -294,7 +293,7 @@ internal static class PageSetupWriter
             var existingBreaks = columnBreaks.ChildElements.OfType<Break>().ToArray();
             var columnBreaksToDelete = existingBreaks
                 .Where(cb => cb.Id?.Value is null ||
-                             !xlWorksheet.PageSetup.ColumnBreaks.Contains((int)cb.Id!.Value))
+                             !xlWorksheet.PageSetup.ColumnBreaks.Contains((int)cb.Id.Value))
                 .ToList();
 
             foreach (var rb in columnBreaksToDelete)

--- a/XLibur/Excel/IO/PictureWriter.cs
+++ b/XLibur/Excel/IO/PictureWriter.cs
@@ -483,7 +483,7 @@ internal static class PictureWriter
         {
             var anchor = string.IsNullOrEmpty(member.RelId)
                 ? null
-                : GetAnchorFromImageId(drawingsPart, member.RelId!);
+                : GetAnchorFromImageId(drawingsPart, member.RelId);
             var picElement = anchor?.Descendants<Xdr.Picture>().FirstOrDefault();
             if (anchor is null || picElement is null)
                 continue;
@@ -641,9 +641,9 @@ internal static class PictureWriter
 
         // Re-feed the image bytes into the existing part. If the image was not replaced these are
         // the same bytes that were read, so the part is unchanged.
-        if (!string.IsNullOrEmpty(pic.RelId) && drawingsPart.HasPartWithId(pic.RelId!))
+        if (!string.IsNullOrEmpty(pic.RelId) && drawingsPart.HasPartWithId(pic.RelId))
         {
-            var imagePart = (ImagePart)drawingsPart.GetPartById(pic.RelId!);
+            var imagePart = (ImagePart)drawingsPart.GetPartById(pic.RelId);
             pic.ImageStream.Position = 0;
             imagePart.FeedData(pic.ImageStream);
         }
@@ -742,12 +742,12 @@ internal static class PictureWriter
             picElement?.Remove();
 
             // Drop the image part only if nothing else references it any more.
-            if (!string.IsNullOrEmpty(relId) && drawingsPart.HasPartWithId(relId!))
+            if (!string.IsNullOrEmpty(relId) && drawingsPart.HasPartWithId(relId))
             {
                 var stillReferenced = worksheetDrawing.Descendants<Blip>()
                     .Any(b => b.Embed?.Value == relId);
                 if (!stillReferenced)
-                    drawingsPart.DeletePart(relId!);
+                    drawingsPart.DeletePart(relId);
             }
         }
     }

--- a/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -15,6 +15,10 @@ namespace XLibur.Excel.IO;
 
 internal static class PivotTableDefinitionPartWriter2
 {
+    // Attribute names repeated across the pivot definition elements.
+    private const string CountAttr = "count";
+    private const string FieldAttr = "field";
+
     internal static void WriteContent(PivotTablePart pivotTablePart, XLPivotTable pt, SaveContext context)
     {
         var settings = new XmlWriterSettings
@@ -154,7 +158,7 @@ internal static class PivotTableDefinitionPartWriter2
     private static void WritePivotFields(XmlWriter xml, XLPivotTable pt, SaveContext context)
     {
         xml.WriteStartElement("pivotFields", Main2006SsNs);
-        xml.WriteAttribute("count", pt.PivotFields.Count);
+        xml.WriteAttribute(CountAttr, pt.PivotFields.Count);
 
         foreach (var pf in pt.PivotFields)
         {
@@ -252,7 +256,7 @@ internal static class PivotTableDefinitionPartWriter2
         if (pf.Items.Count > 0)
         {
             xml.WriteStartElement("items", Main2006SsNs);
-            xml.WriteAttribute("count", pf.Items.Count);
+            xml.WriteAttribute(CountAttr, pf.Items.Count);
             foreach (var pfItem in pf.Items)
             {
                 xml.WriteStartElement("item", Main2006SsNs);
@@ -300,7 +304,7 @@ internal static class PivotTableDefinitionPartWriter2
         if (filterFields.Count > 0)
         {
             xml.WriteStartElement("pageFields", Main2006SsNs);
-            xml.WriteAttribute("count", filterFields.Count);
+            xml.WriteAttribute(CountAttr, filterFields.Count);
             foreach (var filterField in filterFields)
             {
                 xml.WriteStartElement("pageField", Main2006SsNs);
@@ -321,7 +325,7 @@ internal static class PivotTableDefinitionPartWriter2
         if (pt.DataFields.Count > 0)
         {
             xml.WriteStartElement("dataFields", Main2006SsNs);
-            xml.WriteAttribute("count", pt.DataFields.Count);
+            xml.WriteAttribute(CountAttr, pt.DataFields.Count);
             foreach (var dataField in pt.DataFields)
             {
                 xml.WriteStartElement("dataField", Main2006SsNs);
@@ -349,7 +353,7 @@ internal static class PivotTableDefinitionPartWriter2
         return subtotal switch
         {
             XLPivotSummary.Sum => "sum",
-            XLPivotSummary.Count => "count",
+            XLPivotSummary.Count => CountAttr,
             XLPivotSummary.Average => "average",
             XLPivotSummary.Minimum => "min",
             XLPivotSummary.Maximum => "max",
@@ -385,7 +389,7 @@ internal static class PivotTableDefinitionPartWriter2
         if (pt.Formats.Count > 0)
         {
             xml.WriteStartElement("formats", Main2006SsNs);
-            xml.WriteAttribute("count", pt.Formats.Count);
+            xml.WriteAttribute(CountAttr, pt.Formats.Count);
             foreach (var format in pt.Formats)
             {
                 xml.WriteStartElement("format", Main2006SsNs);
@@ -425,7 +429,7 @@ internal static class PivotTableDefinitionPartWriter2
             return;
 
         xml.WriteStartElement("chartFormats", Main2006SsNs);
-        xml.WriteAttribute("count", pt.ChartFormats.Count);
+        xml.WriteAttribute(CountAttr, pt.ChartFormats.Count);
         foreach (var chartFormat in pt.ChartFormats)
         {
             xml.WriteStartElement("chartFormat", Main2006SsNs);
@@ -452,7 +456,7 @@ internal static class PivotTableDefinitionPartWriter2
             return;
 
         xml.WriteStartElement("filters", Main2006SsNs);
-        xml.WriteAttribute("count", pt.PivotFilters.Count);
+        xml.WriteAttribute(CountAttr, pt.PivotFilters.Count);
         foreach (var pivotFilter in pt.PivotFilters)
         {
             xml.WriteStartElement("filter", Main2006SsNs);
@@ -518,7 +522,7 @@ internal static class PivotTableDefinitionPartWriter2
         if (pt.ConditionalFormats.Count > 0)
         {
             xml.WriteStartElement("conditionalFormats", Main2006SsNs);
-            xml.WriteAttribute("count", pt.ConditionalFormats.Count);
+            xml.WriteAttribute(CountAttr, pt.ConditionalFormats.Count);
             foreach (var conditionalFormat in pt.ConditionalFormats)
                 WriteConditionalFormat(xml, conditionalFormat);
 
@@ -535,7 +539,7 @@ internal static class PivotTableDefinitionPartWriter2
             {
                 XLPivotCfScope.SelectedCells => "selection",
                 XLPivotCfScope.DataFields => "data",
-                XLPivotCfScope.FieldIntersections => "field",
+                XLPivotCfScope.FieldIntersections => FieldAttr,
                 _ => throw new UnreachableException(),
             };
             xml.WriteAttribute("scope", scopeAttr);
@@ -556,7 +560,7 @@ internal static class PivotTableDefinitionPartWriter2
 
         xml.WriteAttribute("priority", conditionalFormat.Format.Priority);
         xml.WriteStartElement("pivotAreas", Main2006SsNs);
-        xml.WriteAttribute("count", conditionalFormat.Areas.Count);
+        xml.WriteAttribute(CountAttr, conditionalFormat.Areas.Count);
         foreach (var pivotArea in conditionalFormat.Areas)
             WritePivotArea(xml, pivotArea);
 
@@ -588,10 +592,10 @@ internal static class PivotTableDefinitionPartWriter2
         if (axis.Fields.Count > 0)
         {
             xml.WriteStartElement(fieldsElement, Main2006SsNs);
-            xml.WriteAttribute("count", axis.Fields.Count);
+            xml.WriteAttribute(CountAttr, axis.Fields.Count);
             foreach (var axisField in axis.Fields)
             {
-                xml.WriteStartElement("field", Main2006SsNs);
+                xml.WriteStartElement(FieldAttr, Main2006SsNs);
                 xml.WriteAttribute("x", axisField.Value);
                 xml.WriteEndElement();
             }
@@ -606,7 +610,7 @@ internal static class PivotTableDefinitionPartWriter2
     private static void WriteAxisItems(XmlWriter xml, XLPivotTableAxis axis, string itemsElement)
     {
         xml.WriteStartElement(itemsElement, Main2006SsNs);
-        xml.WriteAttribute("count", axis.Items.Count);
+        xml.WriteAttribute(CountAttr, axis.Items.Count);
 
         IReadOnlyList<int> previous = Array.Empty<int>();
         foreach (var axisItem in axis.Items)
@@ -649,7 +653,7 @@ internal static class PivotTableDefinitionPartWriter2
     private static void WritePivotArea(XmlWriter xml, XLPivotArea pivotArea)
     {
         xml.WriteStartElement("pivotArea", Main2006SsNs);
-        xml.WriteAttributeOptional("field", pivotArea.Field?.Value);
+        xml.WriteAttributeOptional(FieldAttr, pivotArea.Field?.Value);
         if (pivotArea.Type != XLPivotAreaType.Normal)
         {
             var typeAttr = pivotArea.Type switch
@@ -685,12 +689,12 @@ internal static class PivotTableDefinitionPartWriter2
         if (pivotArea.References.Count > 0)
         {
             xml.WriteStartElement("references", Main2006SsNs);
-            xml.WriteAttribute("count", pivotArea.References.Count);
+            xml.WriteAttribute(CountAttr, pivotArea.References.Count);
             foreach (var reference in pivotArea.References)
             {
                 xml.WriteStartElement("reference", Main2006SsNs);
-                xml.WriteAttributeOptional("field", reference.Field);
-                xml.WriteAttribute("count", reference.FieldItems.Count);
+                xml.WriteAttributeOptional(FieldAttr, reference.Field);
+                xml.WriteAttribute(CountAttr, reference.FieldItems.Count);
                 xml.WriteAttributeDefault("selected", reference.Selected, true);
                 xml.WriteAttributeDefault("byPosition", reference.ByPosition, false);
                 xml.WriteAttributeDefault("relative", reference.Relative, false);
@@ -730,7 +734,7 @@ internal static class PivotTableDefinitionPartWriter2
         {
             XLPivotItemType.Avg => "avg",
             XLPivotItemType.Blank => "blank",
-            XLPivotItemType.Count => "count",
+            XLPivotItemType.Count => CountAttr,
             XLPivotItemType.CountA => "countA",
             XLPivotItemType.Data => "data",
             XLPivotItemType.Default => "default",

--- a/XLibur/Excel/IO/VmlDrawingPartWriter.cs
+++ b/XLibur/Excel/IO/VmlDrawingPartWriter.cs
@@ -17,6 +17,9 @@ namespace XLibur.Excel.IO;
 
 internal static class VmlDrawingPartWriter
 {
+    // VML spells its booleans with a leading capital.
+    private const string VmlFalse = "False";
+
     // Generates content of vmlDrawingPart1.
     internal static bool GenerateContent(VmlDrawingPart vmlDrawingPart, XLWorksheet xlWorksheet)
     {
@@ -62,7 +65,7 @@ internal static class VmlDrawingPartWriter
             ms.Position = 0;
             var xdoc = XDocumentExtensions.Load(ms)!;
             xdoc.Root!.Elements().ForEach(e => writer.WriteRaw(e.ToString()));
-            hasAnyVmlElements |= xdoc.Root!.HasElements;
+            hasAnyVmlElements |= xdoc.Root.HasElements;
         }
 
         writer.WriteEndElement();
@@ -107,19 +110,19 @@ internal static class VmlDrawingPartWriter
             new ClientData(
                     new MoveWithCells(comment.Style.Properties.Positioning == XLDrawingAnchor.Absolute
                         ? "True"
-                        : "False"), // Counterintuitive
+                        : VmlFalse), // Counterintuitive
                     new ResizeWithCells(comment.Style.Properties.Positioning == XLDrawingAnchor.MoveAndSizeWithCells
-                        ? "False"
+                        ? VmlFalse
                         : "True"), // Counterintuitive
                     anchor,
                     new HorizontalTextAlignment(comment.Style.Alignment.Horizontal.ToString().ToCamel()),
                     new VerticalTextAlignment(comment.Style.Alignment.Vertical.ToString().ToCamel()),
-                    new AutoFill("False"),
+                    new AutoFill(VmlFalse),
                     new CommentRowTarget { Text = (rowNumber - 1).ToInvariantString() },
                     new CommentColumnTarget { Text = (columnNumber - 1).ToInvariantString() },
-                    new Locked(comment.Style.Protection.Locked ? "True" : "False"),
-                    new LockText(comment.Style.Protection.LockText ? "True" : "False"),
-                    new Visible(comment.Visible ? "True" : "False")
+                    new Locked(comment.Style.Protection.Locked ? "True" : VmlFalse),
+                    new LockText(comment.Style.Protection.LockText ? "True" : VmlFalse),
+                    new Visible(comment.Visible ? "True" : VmlFalse)
                 )
             { ObjectType = ObjectValues.Note }
         )

--- a/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/XLibur/Excel/IO/WorkbookStylesPartWriter.cs
@@ -1007,23 +1007,9 @@ internal static class WorkbookStylesPartWriter
 
                 break;
 
-            case XLFillPatternValues.DarkDown:
-            case XLFillPatternValues.DarkGray:
-            case XLFillPatternValues.DarkGrid:
-            case XLFillPatternValues.DarkHorizontal:
-            case XLFillPatternValues.DarkTrellis:
-            case XLFillPatternValues.DarkUp:
-            case XLFillPatternValues.DarkVertical:
-            case XLFillPatternValues.Gray0625:
-            case XLFillPatternValues.Gray125:
-            case XLFillPatternValues.LightDown:
-            case XLFillPatternValues.LightGray:
-            case XLFillPatternValues.LightGrid:
-            case XLFillPatternValues.LightHorizontal:
-            case XLFillPatternValues.LightTrellis:
-            case XLFillPatternValues.LightUp:
-            case XLFillPatternValues.LightVertical:
-            case XLFillPatternValues.MediumGray:
+            // Every remaining pattern (the Dark*, Light*, Gray* and MediumGray family) writes both
+            // colors the same way, so they share the default arm rather than being listed as empty
+            // fall-through labels.
             default:
 
                 foregroundColor = new ForegroundColor().FromXLiburColor<ForegroundColor>(fillInfo.Fill.PatternColor);

--- a/XLibur/Excel/IO/WorksheetElementReader.cs
+++ b/XLibur/Excel/IO/WorksheetElementReader.cs
@@ -52,10 +52,10 @@ internal static class WorksheetElementReader
         if (selection == null) return;
 
         if (selection.SequenceOfReferences != null)
-            ws.Ranges(selection.SequenceOfReferences!.InnerText!.Replace(" ", ",")).Select();
+            ws.Ranges(selection.SequenceOfReferences.InnerText!.Replace(" ", ",")).Select();
 
         if (selection.ActiveCell != null)
-            ws.Cell(selection.ActiveCell!.Value!)!.SetActive();
+            ws.Cell(selection.ActiveCell.Value!)!.SetActive();
     }
 
     private static void LoadSheetViewZoom(SheetView sheetView, XLWorksheet ws)
@@ -348,7 +348,7 @@ internal static class WorksheetElementReader
         {
             if (hl.Reference!.Value!.Equals("#REF")) continue;
             var tooltip = hl.Tooltip != null ? hl.Tooltip.Value : string.Empty;
-            var xlRange = ws.Range(hl.Reference!.Value!);
+            var xlRange = ws.Range(hl.Reference.Value);
             foreach (var xlCell1 in xlRange!.Cells())
             {
                 var xlCell = (XLCell)xlCell1;
@@ -357,7 +357,7 @@ internal static class WorksheetElementReader
                 else if (hl.Location != null)
                     xlCell.SetCellHyperlink(new XLHyperlink(hl.Location.Value!, tooltip!));
                 else
-                    xlCell.SetCellHyperlink(new XLHyperlink(hl.Reference!.Value!, tooltip!));
+                    xlCell.SetCellHyperlink(new XLHyperlink(hl.Reference.Value, tooltip!));
             }
         }
     }

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -857,7 +857,7 @@ internal static class WorksheetSheetDataReader
             ws.ColumnWidth = wsDefaultColumn.Width - XLConstants.ColumnWidthOffset;
 
         var styleIndexDefault = wsDefaultColumn != null && wsDefaultColumn.Style != null
-            ? int.Parse(wsDefaultColumn.Style!.InnerText!)
+            ? int.Parse(wsDefaultColumn.Style.InnerText!)
             : -1;
         if (styleIndexDefault >= 0)
             ApplyStyle(ws, styleIndexDefault, styles);
@@ -1253,7 +1253,7 @@ internal static class WorksheetSheetDataReader
             xlColumns.ForEach(c => c.OutlineLevel = outlineLevel);
         }
 
-        var styleIndex = col.Style != null ? int.Parse(col.Style!.InnerText!) : -1;
+        var styleIndex = col.Style != null ? int.Parse(col.Style.InnerText!) : -1;
         if (styleIndex >= 0)
         {
             ApplyStyle(xlColumns, styleIndex, styles);

--- a/XLibur/Excel/PageSetup/XLHeaderFooter.cs
+++ b/XLibur/Excel/PageSetup/XLHeaderFooter.cs
@@ -74,7 +74,7 @@ internal sealed class XLHeaderFooter : IXLHeaderFooter
 
         var parsedElements = new List<ParsedHeaderFooterElement>();
         var currentPosition = 'L'; // default is LEFT
-        var hfElement = "";
+        var hfElement = new StringBuilder();
 
         var i = 0;
         while (i < text.Length)
@@ -84,16 +84,16 @@ internal sealed class XLHeaderFooter : IXLHeaderFooter
                 if (hfElement.Length > 0) parsedElements.Add(new ParsedHeaderFooterElement
                 {
                     Position = currentPosition,
-                    Text = hfElement
+                    Text = hfElement.ToString()
                 });
 
                 currentPosition = text[i + 1];
                 i += 2;
-                hfElement = "";
+                hfElement.Clear();
                 continue;
             }
 
-            hfElement += text[i];
+            hfElement.Append(text[i]);
             i++;
         }
 
@@ -101,7 +101,7 @@ internal sealed class XLHeaderFooter : IXLHeaderFooter
             parsedElements.Add(new ParsedHeaderFooterElement
             {
                 Position = currentPosition,
-                Text = hfElement
+                Text = hfElement.ToString()
             });
         return parsedElements;
     }

--- a/XLibur/Excel/PageSetup/XLPageSetup.cs
+++ b/XLibur/Excel/PageSetup/XLPageSetup.cs
@@ -87,7 +87,7 @@ internal sealed class XLPageSetup : IXLPageSetup
     public void SetColumnsToRepeatAtLeft(string range)
     {
         var arrRange = range.Replace("$", "").Split(':');
-        if (int.TryParse(arrRange[0], out int iTest))
+        if (int.TryParse(arrRange[0], out _))
             SetColumnsToRepeatAtLeft(int.Parse(arrRange[0]), int.Parse(arrRange[1]));
         else
             SetColumnsToRepeatAtLeft(arrRange[0], arrRange[1]);

--- a/XLibur/Excel/PivotTables/Areas/XLPivotDataField.cs
+++ b/XLibur/Excel/PivotTables/Areas/XLPivotDataField.cs
@@ -7,6 +7,10 @@ namespace XLibur.Excel;
 /// A field that describes calculation of value to display in the <see cref="XLPivotAreaType.Data"/>
 /// area of pivot table.
 /// </summary>
+// S2292 reads Subtotal, ShowDataAsFormat, BaseField and BaseItem as trivial wrappers over their
+// backing fields. They are not: the fields are also written from ordinary methods further down
+// (base field/item resolution), which an init-only auto-property cannot express.
+#pragma warning disable S2292
 internal sealed class XLPivotDataField : IXLPivotValue
 {
     private const int BaseFieldDefaultValue = -1;

--- a/XLibur/Excel/PivotTables/XLPivotTable.cs
+++ b/XLibur/Excel/PivotTables/XLPivotTable.cs
@@ -10,6 +10,10 @@ using XLibur.Extensions;
 namespace XLibur.Excel;
 
 [DebuggerDisplay("{Name}")]
+// S2292 reads Compact, Outline, OutlineData and CompactData as trivial wrappers. They are not:
+// the layout-mode setter assigns all four backing fields together, which an init-only
+// auto-property cannot express.
+#pragma warning disable S2292
 internal sealed class XLPivotTable : IXLPivotTable
 {
     private readonly XLWorksheet _worksheet;

--- a/XLibur/Excel/PivotTables/XLPivotTableField.cs
+++ b/XLibur/Excel/PivotTables/XLPivotTableField.cs
@@ -118,7 +118,7 @@ internal sealed class XLPivotTableField
     /// <summary>
     /// A flag that indicates whether to show all items for this field.
     /// </summary>
-    internal bool ShowAll { get; set; } = true;
+    internal bool ShowAll { get; set; }
 
     /// <summary>
     /// Insert empty row below every item if the field is row/column axis. The last field in axis

--- a/XLibur/Excel/Ranges/XLRangeAddress.cs
+++ b/XLibur/Excel/Ranges/XLRangeAddress.cs
@@ -8,6 +8,8 @@ namespace XLibur.Excel;
 
 internal readonly struct XLRangeAddress : IXLRangeAddress, IEquatable<XLRangeAddress>
 {
+    private const string RefError = "#REF!";
+
     #region Static members
 
     public static XLRangeAddress EntireColumn(XLWorksheet worksheet, int column)
@@ -270,7 +272,7 @@ internal readonly struct XLRangeAddress : IXLRangeAddress, IEquatable<XLRangeAdd
     {
         string address;
         if (!IsValid)
-            address = "#REF!";
+            address = RefError;
         else
         {
             if (IsEntireSheet())
@@ -305,7 +307,7 @@ internal readonly struct XLRangeAddress : IXLRangeAddress, IEquatable<XLRangeAdd
     {
         string address;
         if (!IsValid)
-            address = "#REF!";
+            address = RefError;
         else
         {
             if (IsEntireSheet())
@@ -346,24 +348,24 @@ internal readonly struct XLRangeAddress : IXLRangeAddress, IEquatable<XLRangeAdd
 
     private string BuildInvalidOrDeletedString()
     {
-        var worksheet = WorksheetIsDeleted ? "#REF!" : "";
+        var worksheet = WorksheetIsDeleted ? RefError : "";
         var address = (!FirstAddress.IsValid || !LastAddress.IsValid)
-            ? "#REF!"
+            ? RefError
             : string.Concat(FirstAddress.ToString(), ":", LastAddress.ToString());
         return string.Concat(worksheet, address);
     }
 
     private string BuildEntireRowString()
     {
-        var firstAddress = FirstAddress.IsValid ? FirstAddress.RowNumber.ToString() : "#REF!";
-        var lastAddress = LastAddress.IsValid ? LastAddress.RowNumber.ToString() : "#REF!";
+        var firstAddress = FirstAddress.IsValid ? FirstAddress.RowNumber.ToString() : RefError;
+        var lastAddress = LastAddress.IsValid ? LastAddress.RowNumber.ToString() : RefError;
         return string.Concat(firstAddress, ':', lastAddress);
     }
 
     private string BuildEntireColumnString()
     {
-        var firstAddress = FirstAddress.IsValid ? FirstAddress.ColumnLetter : "#REF!";
-        var lastAddress = LastAddress.IsValid ? LastAddress.ColumnLetter : "#REF!";
+        var firstAddress = FirstAddress.IsValid ? FirstAddress.ColumnLetter : RefError;
+        var lastAddress = LastAddress.IsValid ? LastAddress.ColumnLetter : RefError;
         return string.Concat(firstAddress, ':', lastAddress);
     }
 

--- a/XLibur/Excel/Ranges/XLRanges.cs
+++ b/XLibur/Excel/Ranges/XLRanges.cs
@@ -9,7 +9,7 @@ using XLibur.Extensions;
 
 namespace XLibur.Excel;
 
-internal sealed class XLRanges : XLStylizedBase, IXLRanges, IXLStylized
+internal sealed class XLRanges : XLStylizedBase, IXLRanges, IXLStylized, IEquatable<XLRanges>
 {
     /// <summary>
     /// Normally, XLRanges collection includes ranges from a single worksheet, but not necessarily.

--- a/XLibur/Excel/RichText/XLFormattedText.cs
+++ b/XLibur/Excel/RichText/XLFormattedText.cs
@@ -64,6 +64,14 @@ internal class XLFormattedText<T> : IXLFormattedText<T>
         return AddText(richText);
     }
 
+    public IXLRichString AddText(XLRichString richText)
+    {
+        _richTexts.Add(richText);
+        Length += richText.Text.Length;
+        OnContentChanged();
+        return richText;
+    }
+
     /// <summary>
     /// Add a run that states no formatting of its own and simply inherits the container's font,
     /// i.e. an <c>&lt;r&gt;</c> read with no <c>&lt;rPr&gt;</c>. Used only by the loader - a run
@@ -73,14 +81,6 @@ internal class XLFormattedText<T> : IXLFormattedText<T>
     {
         var richText = new XLRichString(text, _defaultFont, this, OnContentChanged, inheritsContainerFont: true);
         return AddText(richText);
-    }
-
-    public IXLRichString AddText(XLRichString richText)
-    {
-        _richTexts.Add(richText);
-        Length += richText.Text.Length;
-        OnContentChanged();
-        return richText;
     }
 
     public IXLRichString AddNewLine()

--- a/XLibur/Excel/RichText/XLPhonetics.cs
+++ b/XLibur/Excel/RichText/XLPhonetics.cs
@@ -6,7 +6,7 @@ using XLibur.Extensions;
 
 namespace XLibur.Excel.RichText;
 
-internal sealed class XLPhonetics : IXLPhonetics
+internal sealed class XLPhonetics : IXLPhonetics, IEquatable<XLPhonetics>
 {
     private readonly List<IXLPhonetic> _phonetics = [];
     private readonly XLFont _font;

--- a/XLibur/Excel/RichText/XLRichString.cs
+++ b/XLibur/Excel/RichText/XLRichString.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 namespace XLibur.Excel.RichText;
 
 [DebuggerDisplay("{Text}")]
-internal sealed class XLRichString : IXLRichString
+internal sealed class XLRichString : IXLRichString, IEquatable<XLRichString>
 {
     private readonly IXLWithRichString _withRichString;
     private readonly XLFont _font;

--- a/XLibur/Excel/Sparkline/XLSparkLineGroups.cs
+++ b/XLibur/Excel/Sparkline/XLSparkLineGroups.cs
@@ -149,7 +149,7 @@ internal sealed class XLSparklineGroups : IXLSparklineGroups
     /// Remove the sparkline from the worksheet
     /// </summary>
     /// <param name="sparkline">The sparkline to remove</param>
-    private void Remove(IXLSparkline sparkline)
+    private static void Remove(IXLSparkline sparkline)
     {
         sparkline.SparklineGroup.Remove(sparkline);
     }

--- a/XLibur/Excel/Sparkline/XLSparklineStyle.cs
+++ b/XLibur/Excel/Sparkline/XLSparklineStyle.cs
@@ -120,10 +120,10 @@ internal sealed class XLSparklineStyle : IXLSparklineStyle, IEquatable<XLSparkli
     /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
     public override bool Equals(object? obj)
     {
-        if (ReferenceEquals(null, obj)) return false;
+        if (obj is null) return false;
         if (ReferenceEquals(this, obj)) return true;
-        if (obj.GetType() != typeof(XLSparklineStyle)) return false;
-        return Equals((XLSparklineStyle)obj);
+        // The class is sealed, so an 'is' test is exactly the GetType() == typeof(...) check.
+        return obj is XLSparklineStyle other && Equals(other);
     }
 
     /// <summary>Serves as the default hash function.</summary>

--- a/XLibur/Excel/Sparkline/XLSparklineTheme.cs
+++ b/XLibur/Excel/Sparkline/XLSparklineTheme.cs
@@ -1,5 +1,11 @@
 namespace XLibur.Excel;
 
+// S1192 counts the repeated hex values (FFD00000 twelve times, FF0070C0 eight). This class is a
+// transcription of Excel's built-in sparkline styles: within one style the same accent is assigned
+// to every marker slot, and the same accent reappears in other styles meaning something different
+// there. A shared constant would have to be named for one of those roles and would be wrong in the
+// rest, and each style block would stop reading as a straight copy of the table it mirrors.
+#pragma warning disable S1192
 public static class XLSparklineTheme
 {
     #region Public Properties

--- a/XLibur/Excel/Streaming/XLStreamingWorkbook.cs
+++ b/XLibur/Excel/Streaming/XLStreamingWorkbook.cs
@@ -154,9 +154,9 @@ public sealed class XLStreamingWorkbook : IDisposable
     /// The writer interns the style's value at the point of use, so one instance can be
     /// reconfigured and handed to later rows without disturbing the rows already written.
     /// </remarks>
-#pragma warning disable CA1822 // Public API: making this static would break every caller
+#pragma warning disable CA1822, S2325 // Public API: making this static would break every caller
     public IXLStyle CreateStyle() => XLStyle.CreateEmptyStyle();
-#pragma warning restore CA1822
+#pragma warning restore CA1822, S2325
 
     /// <summary>
     /// Add a worksheet and make it the one being written. Any worksheet still open is completed

--- a/XLibur/Excel/Style/Colors/XLColor_Public.cs
+++ b/XLibur/Excel/Style/Colors/XLColor_Public.cs
@@ -156,8 +156,9 @@ public sealed partial class XLColor : IEquatable<XLColor>
         // If both are null, or both are same instance, return true.
         if (ReferenceEquals(left, right)) return true;
 
-        // If one is null, but not both, return false.
-        if ((left as object) == null || (right as object) == null) return false;
+        // If one is null, but not both, return false. 'is null' does not re-enter this operator,
+        // which is what the 'as object' cast was guarding against.
+        if (left is null || right is null) return false;
 
         return left.Equals(right);
     }

--- a/XLibur/Excel/Style/Colors/XLColor_Static.cs
+++ b/XLibur/Excel/Style/Colors/XLColor_Static.cs
@@ -6,6 +6,9 @@ using XLibur.Utils;
 
 namespace XLibur.Excel;
 
+// S1192 flags #FF967117 appearing four times. This file is the named-colour table; each entry is
+// the definition of its own colour and the repeats are colours that genuinely share a hex value.
+#pragma warning disable S1192
 public sealed partial class XLColor
 {
     private static readonly XLRepositoryBase<XLColorKey, XLColor> Repository = new(key => new XLColor(key));

--- a/XLibur/Excel/Style/XLBorder.cs
+++ b/XLibur/Excel/Style/XLBorder.cs
@@ -9,6 +9,8 @@ namespace XLibur.Excel;
 
 internal sealed class XLBorder : IXLBorder
 {
+    private const string ColorCannotBeNull = "Color cannot be null";
+
     #region Static members
 
     internal static XLBorderKey GenerateKey(IXLBorder? defaultBorder) => defaultBorder switch
@@ -228,7 +230,7 @@ internal sealed class XLBorder : IXLBorder
         set
         {
             if (value == null)
-                throw new ArgumentNullException(nameof(value), "Color cannot be null");
+                throw new ArgumentNullException(nameof(value), ColorCannotBeNull);
 
             if (Key.LeftBorderColor == value.Key) return;
             if (_style.IsCellContainer)
@@ -261,7 +263,7 @@ internal sealed class XLBorder : IXLBorder
         set
         {
             if (value == null)
-                throw new ArgumentNullException(nameof(value), "Color cannot be null");
+                throw new ArgumentNullException(nameof(value), ColorCannotBeNull);
 
             if (Key.RightBorderColor == value.Key) return;
             if (_style.IsCellContainer)
@@ -294,7 +296,7 @@ internal sealed class XLBorder : IXLBorder
         set
         {
             if (value == null)
-                throw new ArgumentNullException(nameof(value), "Color cannot be null");
+                throw new ArgumentNullException(nameof(value), ColorCannotBeNull);
 
             if (Key.TopBorderColor == value.Key) return;
             if (_style.IsCellContainer)
@@ -327,7 +329,7 @@ internal sealed class XLBorder : IXLBorder
         set
         {
             if (value == null)
-                throw new ArgumentNullException(nameof(value), "Color cannot be null");
+                throw new ArgumentNullException(nameof(value), ColorCannotBeNull);
 
             if (Key.BottomBorderColor == value.Key) return;
             if (_style.IsCellContainer)
@@ -360,7 +362,7 @@ internal sealed class XLBorder : IXLBorder
         set
         {
             if (value == null)
-                throw new ArgumentNullException(nameof(value), "Color cannot be null");
+                throw new ArgumentNullException(nameof(value), ColorCannotBeNull);
 
             if (Key.DiagonalBorderColor == value.Key) return;
             if (_style.IsCellContainer)

--- a/XLibur/Excel/Style/XLDeferredAlignment.cs
+++ b/XLibur/Excel/Style/XLDeferredAlignment.cs
@@ -127,5 +127,5 @@ internal sealed class XLDeferredAlignment : IXLAlignment
     public IXLStyle SetTopToBottom() { TopToBottom = true; return _style; }
     public IXLStyle SetTopToBottom(bool value) { TopToBottom = value; return _style; }
 
-    public bool Equals(IXLAlignment? other) => other is XLDeferredAlignment da ? Key == da.Key : false;
+    public bool Equals(IXLAlignment? other) => other is XLDeferredAlignment da && Key == da.Key;
 }

--- a/XLibur/Excel/Style/XLDeferredBorder.cs
+++ b/XLibur/Excel/Style/XLDeferredBorder.cs
@@ -9,6 +9,8 @@ namespace XLibur.Excel;
 /// </summary>
 internal sealed class XLDeferredBorder : IXLBorder
 {
+    private const string ColorCannotBeNull = "Color cannot be null";
+
     private readonly XLDeferredStyle _style;
     internal XLBorderKey Key;
 
@@ -79,7 +81,7 @@ internal sealed class XLDeferredBorder : IXLBorder
         }
         set
         {
-            if (value == null) throw new ArgumentNullException(nameof(value), "Color cannot be null");
+            if (value == null) throw new ArgumentNullException(nameof(value), ColorCannotBeNull);
             Key = Key with { LeftBorderColor = value.Key };
         }
     }
@@ -99,7 +101,7 @@ internal sealed class XLDeferredBorder : IXLBorder
         }
         set
         {
-            if (value == null) throw new ArgumentNullException(nameof(value), "Color cannot be null");
+            if (value == null) throw new ArgumentNullException(nameof(value), ColorCannotBeNull);
             Key = Key with { RightBorderColor = value.Key };
         }
     }
@@ -119,7 +121,7 @@ internal sealed class XLDeferredBorder : IXLBorder
         }
         set
         {
-            if (value == null) throw new ArgumentNullException(nameof(value), "Color cannot be null");
+            if (value == null) throw new ArgumentNullException(nameof(value), ColorCannotBeNull);
             Key = Key with { TopBorderColor = value.Key };
         }
     }
@@ -139,7 +141,7 @@ internal sealed class XLDeferredBorder : IXLBorder
         }
         set
         {
-            if (value == null) throw new ArgumentNullException(nameof(value), "Color cannot be null");
+            if (value == null) throw new ArgumentNullException(nameof(value), ColorCannotBeNull);
             Key = Key with { BottomBorderColor = value.Key };
         }
     }
@@ -171,7 +173,7 @@ internal sealed class XLDeferredBorder : IXLBorder
         }
         set
         {
-            if (value == null) throw new ArgumentNullException(nameof(value), "Color cannot be null");
+            if (value == null) throw new ArgumentNullException(nameof(value), ColorCannotBeNull);
             Key = Key with { DiagonalBorderColor = value.Key };
         }
     }

--- a/XLibur/Excel/Style/XLDeferredFill.cs
+++ b/XLibur/Excel/Style/XLDeferredFill.cs
@@ -75,5 +75,5 @@ internal sealed class XLDeferredFill : IXLFill
     public IXLStyle SetPatternColor(XLColor value) { PatternColor = value; return _style; }
     public IXLStyle SetPatternType(XLFillPatternValues value) { PatternType = value; return _style; }
 
-    public bool Equals(IXLFill? other) => other is XLDeferredFill df ? Key == df.Key : false;
+    public bool Equals(IXLFill? other) => other is XLDeferredFill df && Key == df.Key;
 }

--- a/XLibur/Excel/Style/XLDeferredFont.cs
+++ b/XLibur/Excel/Style/XLDeferredFont.cs
@@ -117,5 +117,5 @@ internal sealed class XLDeferredFont : IXLFont
     public IXLStyle SetFontCharSet(XLFontCharSet value) { FontCharSet = value; return _style; }
     public IXLStyle SetFontScheme(XLFontScheme value) { FontScheme = value; return _style; }
 
-    public bool Equals(IXLFont? other) => other is XLDeferredFont df ? Key == df.Key : false;
+    public bool Equals(IXLFont? other) => other is XLDeferredFont df && Key == df.Key;
 }

--- a/XLibur/Excel/Style/XLDeferredNumberFormat.cs
+++ b/XLibur/Excel/Style/XLDeferredNumberFormat.cs
@@ -41,5 +41,5 @@ internal sealed class XLDeferredNumberFormat : IXLNumberFormat
     public IXLStyle SetNumberFormatId(int value) { NumberFormatId = value; return _style; }
     public IXLStyle SetFormat(string value) { Format = value; return _style; }
 
-    public bool Equals(IXLNumberFormatBase? other) => other is XLDeferredNumberFormat dnf ? Key == dnf.Key : false;
+    public bool Equals(IXLNumberFormatBase? other) => other is XLDeferredNumberFormat dnf && Key == dnf.Key;
 }

--- a/XLibur/Excel/Style/XLDeferredStyle.cs
+++ b/XLibur/Excel/Style/XLDeferredStyle.cs
@@ -16,7 +16,6 @@ internal sealed class XLDeferredStyle : IXLStyle
     private readonly XLDeferredAlignment _alignment;
     private readonly XLDeferredNumberFormat _numberFormat;
     private readonly XLDeferredProtection _protection;
-    private bool _includeQuotePrefix;
 
     internal XLDeferredStyle(XLStyleKey key)
     {
@@ -26,7 +25,7 @@ internal sealed class XLDeferredStyle : IXLStyle
         _alignment = new XLDeferredAlignment(this, key.Alignment);
         _numberFormat = new XLDeferredNumberFormat(this, key.NumberFormat);
         _protection = new XLDeferredProtection(this, key.Protection);
-        _includeQuotePrefix = key.IncludeQuotePrefix;
+        IncludeQuotePrefix = key.IncludeQuotePrefix;
     }
 
     /// <summary>
@@ -40,7 +39,7 @@ internal sealed class XLDeferredStyle : IXLStyle
         Alignment = _alignment.Key,
         NumberFormat = _numberFormat.Key,
         Protection = _protection.Key,
-        IncludeQuotePrefix = _includeQuotePrefix,
+        IncludeQuotePrefix = IncludeQuotePrefix,
     };
 
     public IXLFont Font
@@ -67,11 +66,7 @@ internal sealed class XLDeferredStyle : IXLStyle
         set => _fill.Key = XLFill.GenerateKey(value);
     }
 
-    public bool IncludeQuotePrefix
-    {
-        get => _includeQuotePrefix;
-        set => _includeQuotePrefix = value;
-    }
+    public bool IncludeQuotePrefix { get; set; }
 
     public IXLNumberFormat NumberFormat
     {
@@ -89,7 +84,7 @@ internal sealed class XLDeferredStyle : IXLStyle
 
     public IXLStyle SetIncludeQuotePrefix(bool includeQuotePrefix = true)
     {
-        _includeQuotePrefix = includeQuotePrefix;
+        IncludeQuotePrefix = includeQuotePrefix;
         return this;
     }
 

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -553,7 +553,7 @@ public partial class XLWorkbook : IXLWorkbook
         {
             if (string.Compare(_originalFile!.Trim(), file.Trim(), StringComparison.OrdinalIgnoreCase) != 0)
             {
-                File.Copy(_originalFile!, file, true);
+                File.Copy(_originalFile, file, true);
                 File.SetAttributes(file, FileAttributes.Normal);
             }
 
@@ -564,7 +564,7 @@ public partial class XLWorkbook : IXLWorkbook
             _originalStream!.Position = 0;
 
             using var fileStream = File.Create(file);
-            CopyStream(_originalStream!, fileStream);
+            CopyStream(_originalStream, fileStream);
             CreatePackage(fileStream, false, _spreadsheetDocumentType, options);
         }
 
@@ -643,7 +643,7 @@ public partial class XLWorkbook : IXLWorkbook
         {
             _originalStream!.Position = 0;
             if (_originalStream != stream)
-                CopyStream(_originalStream!, stream);
+                CopyStream(_originalStream, stream);
 
             CreatePackage(stream, false, _spreadsheetDocumentType, options);
         }
@@ -679,7 +679,7 @@ public partial class XLWorkbook : IXLWorkbook
         else if (_loadSource == XLLoadSource.Stream)
         {
             _originalStream!.Position = 0;
-            CopyStream(_originalStream!, package);
+            CopyStream(_originalStream, package);
             CreatePackage(package, false, _spreadsheetDocumentType, options);
         }
 

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -48,6 +48,9 @@ public enum XLCellSetValueBehavior
 }
 
 // ReSharper disable once InconsistentNaming
+// S4136 wants every overload group adjacent. Members here are ordered by the lifecycle stage they belong to,
+// which is the order a reader follows; regrouping by name would break it.
+#pragma warning disable S4136
 public partial class XLWorkbook : IXLWorkbook
 {
     #region Static

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -117,16 +117,16 @@ public partial class XLWorkbook
         if (workbookPart.Workbook!.WorkbookProperties is { } wbProps)
             Use1904DateSystem = OpenXmlHelper.GetBooleanValueAsBool(wbProps.Date1904, false);
 
-        if (workbookPart.Workbook!.FileSharing is { } wbFilesharing)
+        if (workbookPart.Workbook.FileSharing is { } wbFilesharing)
         {
             FileSharing.ReadOnlyRecommended =
                 OpenXmlHelper.GetBooleanValueAsBool(wbFilesharing.ReadOnlyRecommended, false);
             FileSharing.UserName = wbFilesharing.UserName?.Value;
         }
 
-        LoadWorkbookProtection(workbookPart.Workbook!.WorkbookProtection, this);
+        LoadWorkbookProtection(workbookPart.Workbook.WorkbookProtection, this);
 
-        LoadCalculationProperties(workbookPart.Workbook!.CalculationProperties);
+        LoadCalculationProperties(workbookPart.Workbook.CalculationProperties);
 
         LoadExtendedFileProperties(dSpreadsheet);
 
@@ -160,7 +160,7 @@ public partial class XLWorkbook
         // have to be in place before the sheets are read.
         LoadPersons(workbookPart);
 
-        var sheets = workbookPart.Workbook!.Sheets;
+        var sheets = workbookPart.Workbook.Sheets;
         LoadSheetsPass1(workbookPart, sheets!);
 
         LoadSheetsPass2(workbookPart, sheets!, sharedStrings, context);
@@ -260,7 +260,7 @@ public partial class XLWorkbook
             // Although the relationship to worksheet is most common, there can be other types
             // than worksheet, e.g., chartSheet. Since we can't load them, add them to the list
             // of unsupported sheets and copy them when saving. See Codeplex #6932.
-            if (workbookPart.GetPartById(dSheet.Id!.Value!) is not WorksheetPart)
+            if (workbookPart.GetPartById(dSheet.Id.Value!) is not WorksheetPart)
             {
                 UnsupportedSheets.Add(new UnsupportedSheet { SheetId = sheetIdValue, Position = position });
                 continue;
@@ -293,7 +293,7 @@ public partial class XLWorkbook
             // Although the relationship to worksheet is most common, there can be other types
             // than worksheet, e.g., chartSheet. Since we can't load them, add them to a list
             // of unsupported sheets and copy them when saving. See Codeplex #6932.
-            if (workbookPart.GetPartById(dSheet.Id!.Value!) is not WorksheetPart worksheetPart)
+            if (workbookPart.GetPartById(dSheet.Id.Value!) is not WorksheetPart worksheetPart)
                 continue;
 
             var sheetName = dSheet.Name!.Value!;
@@ -942,7 +942,7 @@ public partial class XLWorkbook
             }
 
             // The referenced sheet can also be ChartsheetPart. Only look for pivot tables in normal sheet parts.
-            if (workbookPart.GetPartById(dSheet.Id!.Value!) is WorksheetPart worksheetPart)
+            if (workbookPart.GetPartById(dSheet.Id.Value!) is WorksheetPart worksheetPart)
             {
                 var ws = (XLWorksheet)WorksheetsInternal.Worksheet(dSheet.Name!.Value!);
 

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -23,6 +23,9 @@ namespace XLibur.Excel;
 
 public partial class XLWorkbook
 {
+    // Name of the future-metadata block that carries rich value indices.
+    private const string RichValueMetadataName = "XLRICHVALUE";
+
     private static void Validate(SpreadsheetDocument package)
     {
         var backupCulture = Thread.CurrentThread.CurrentCulture;
@@ -164,7 +167,7 @@ public partial class XLWorkbook
         foreach (var item in toDelete)
             item.Remove();
 
-        if (!calChainPart.CalculationChain!.Any())
+        if (!calChainPart.CalculationChain.Any())
             wbPart.DeletePart(calChainPart);
     }
 
@@ -281,7 +284,7 @@ public partial class XLWorkbook
             return;
 
         foreach (var c in pivotCachesToRemove)
-            workbookPart.Workbook.PivotCaches!.RemoveChild(c);
+            workbookPart.Workbook.PivotCaches.RemoveChild(c);
     }
 
     private void GenerateWorkbookLevelParts(SpreadsheetDocument document, WorkbookPart workbookPart,
@@ -578,14 +581,14 @@ public partial class XLWorkbook
         uint typeIdx = 1;
         foreach (var mt in metadataTypes.Elements<MetadataType>())
         {
-            if (mt.Name?.Value == "XLRICHVALUE")
+            if (mt.Name?.Value == RichValueMetadataName)
                 return typeIdx;
             typeIdx++;
         }
 
         metadataTypes.Append(new MetadataType
         {
-            Name = "XLRICHVALUE",
+            Name = RichValueMetadataName,
             MinSupportedVersion = 120000,
             Copy = true,
             PasteAll = true,
@@ -605,10 +608,10 @@ public partial class XLWorkbook
     private static void AppendRichValueFutureMetadata(Metadata metadata, List<RichDataWriter.RichValueEntry> entries)
     {
         var existingFm = metadata.Elements<FutureMetadata>()
-            .FirstOrDefault(fm => fm.Name?.Value == "XLRICHVALUE");
+            .FirstOrDefault(fm => fm.Name?.Value == RichValueMetadataName);
         existingFm?.Remove();
 
-        var futureMetadata = new FutureMetadata { Name = "XLRICHVALUE", Count = (uint)entries.Count };
+        var futureMetadata = new FutureMetadata { Name = RichValueMetadataName, Count = (uint)entries.Count };
         for (var i = 0; i < entries.Count; i++)
         {
             var fmBlock = new FutureMetadataBlock();
@@ -877,7 +880,7 @@ public partial class XLWorkbook
             .Where(e => e.Name.LocalName == "shapetype" && e.Attribute("id")?.Value == XLConstants.Comment.ShapeTypeId)
             .Remove();
 
-        xdoc.Root!
+        xdoc.Root
             .Elements()
             .Where(e => e.Name.LocalName == "shape" &&
                         e.Attribute("type")?.Value == "#" + XLConstants.Comment.ShapeTypeId)
@@ -976,7 +979,7 @@ public partial class XLWorkbook
         List<PivotCache>? orphanedCaches = null;
         foreach (var pc in workbookPart.Workbook.PivotCaches.Elements<PivotCache>())
         {
-            if (pc.Id is null || !workbookPart.HasPartWithId(pc.Id!.Value!))
+            if (pc.Id is null || !workbookPart.HasPartWithId(pc.Id.Value!))
                 (orphanedCaches ??= []).Add(pc);
         }
 
@@ -1009,7 +1012,7 @@ public partial class XLWorkbook
         {
             var cacheRelId = context.RelIdGenerator.GetNext(RelType.Workbook);
             pivotSource.WorkbookCacheRelId = cacheRelId;
-            workbookPart.AddNewPart<PivotTableCacheDefinitionPart>(pivotSource.WorkbookCacheRelId!);
+            workbookPart.AddNewPart<PivotTableCacheDefinitionPart>(pivotSource.WorkbookCacheRelId);
         }
     }
 
@@ -1061,7 +1064,7 @@ public partial class XLWorkbook
                 Debug.Assert(!string.IsNullOrEmpty(xlPivotCache.WorkbookCacheRelId));
 
                 var pivotTableCacheDefinitionPart =
-                    (PivotTableCacheDefinitionPart)workbookPart.GetPartById(xlPivotCache.WorkbookCacheRelId!);
+                    (PivotTableCacheDefinitionPart)workbookPart.GetPartById(xlPivotCache.WorkbookCacheRelId);
 
                 PivotTableCacheDefinitionPartWriter.GenerateContent(pivotTableCacheDefinitionPart, xlPivotCache, context);
 

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -21,6 +21,9 @@ using Path = System.IO.Path;
 
 namespace XLibur.Excel;
 
+// S4136 wants every overload group adjacent. Members here are ordered by the stage of the save
+// pipeline they belong to, which is the order a reader follows; regrouping by name would break it.
+#pragma warning disable S4136
 public partial class XLWorkbook
 {
     // Name of the future-metadata block that carries rich value indices.

--- a/XLibur/Excel/XLWorksheet.cs
+++ b/XLibur/Excel/XLWorksheet.cs
@@ -20,6 +20,8 @@ namespace XLibur.Excel;
 
 internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
 {
+    private const string OutlineLevelOutOfRange = "Outline level must be between 1 and 8.";
+
     #region Fields
 
     private readonly XLRangeFactory _rangeFactory;
@@ -534,7 +536,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
     public IXLWorksheet CollapseRows(int outlineLevel)
     {
         if (outlineLevel is < 1 or > 8)
-            throw new ArgumentOutOfRangeException(nameof(outlineLevel), "Outline level must be between 1 and 8.");
+            throw new ArgumentOutOfRangeException(nameof(outlineLevel), OutlineLevelOutOfRange);
 
         Internals.RowsCollection.Values.Where(r => r.OutlineLevel == outlineLevel).ForEach(r => r.Collapse());
         return this;
@@ -549,7 +551,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
     public IXLWorksheet CollapseColumns(int outlineLevel)
     {
         if (outlineLevel is < 1 or > 8)
-            throw new ArgumentOutOfRangeException(nameof(outlineLevel), "Outline level must be between 1 and 8.");
+            throw new ArgumentOutOfRangeException(nameof(outlineLevel), OutlineLevelOutOfRange);
 
         Internals.ColumnsCollection.Values.Where(c => c.OutlineLevel == outlineLevel).ForEach(c => c.Collapse());
         return this;
@@ -564,7 +566,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
     public IXLWorksheet ExpandRows(int outlineLevel)
     {
         if (outlineLevel is < 1 or > 8)
-            throw new ArgumentOutOfRangeException(nameof(outlineLevel), "Outline level must be between 1 and 8.");
+            throw new ArgumentOutOfRangeException(nameof(outlineLevel), OutlineLevelOutOfRange);
 
         Internals.RowsCollection.Values.Where(r => r.OutlineLevel == outlineLevel).ForEach(r => r.Expand());
         return this;
@@ -579,7 +581,7 @@ internal sealed class XLWorksheet : XLStoredRangeBase, IXLWorksheet
     public IXLWorksheet ExpandColumns(int outlineLevel)
     {
         if (outlineLevel is < 1 or > 8)
-            throw new ArgumentOutOfRangeException(nameof(outlineLevel), "Outline level must be between 1 and 8.");
+            throw new ArgumentOutOfRangeException(nameof(outlineLevel), OutlineLevelOutOfRange);
 
         Internals.ColumnsCollection.Values.Where(c => c.OutlineLevel == outlineLevel).ForEach(c => c.Expand());
         return this;

--- a/XLibur/Graphics/WmfInfoReader.cs
+++ b/XLibur/Graphics/WmfInfoReader.cs
@@ -96,6 +96,10 @@ internal sealed class WmfInfoReader : ImageInfoReader
         return new XLPictureInfo(XLPictureFormat.Wmf, Size.Empty, physSize);
     }
 
+    // S3398 wants GetU32LE and GetS16LE moved into PlaceableHeader because only it calls them.
+    // GetU16LE is called from both here and PlaceableHeader, so taking that advice would scatter
+    // three sibling little-endian readers across two types for no gain. They stay together.
+#pragma warning disable S3398
     private static uint GetU32LE(Span<byte> s, int i)
         => (uint)(s[i + 0] | (s[i + 1] << 8) | (s[i + 2] << 16) | (s[i + 3] << 24));
 
@@ -104,6 +108,7 @@ internal sealed class WmfInfoReader : ImageInfoReader
 
     private static short GetS16LE(Span<byte> s, int i)
         => (short)(s[i + 0] | (s[i + 1] << 8));
+#pragma warning restore S3398
 
     private static int ToHiMetric(int size, double unitsPerInch) =>
         (int)Math.Round(size / unitsPerInch * 254d, MidpointRounding.AwayFromZero);

--- a/XLibur/Utils/OpenXmlHelper.cs
+++ b/XLibur/Utils/OpenXmlHelper.cs
@@ -233,7 +233,12 @@ internal static class OpenXmlHelper
     {
         var runFont = fontSource.Elements<RunFont>().FirstOrDefault();
         if (runFont?.Val != null)
+            // The guard proves the StringValue is non-null, but the implicit StringValue -> string
+            // conversion returns string?, so the bang suppresses CS8601 on the assignment, not on
+            // the guarded member access. S8969 only sees the latter.
+#pragma warning disable S8969
             fontBase.FontName = runFont.Val!;
+#pragma warning restore S8969
     }
 
     private static void LoadFontSize(OpenXmlElement fontSource, IXLFontBase fontBase)

--- a/docs/sonar.md
+++ b/docs/sonar.md
@@ -1,5 +1,150 @@
 ﻿# SonarQube issues — XLibur_XLibur
 
+This file covers two exports. The 278-issue sweep is first; the earlier 150-issue
+`MEDIUM` triage follows it, unchanged.
+
+---
+
+# Export 2 — 278 issues
+
+- Server: https://sonarcloud.io
+- Total issues: 278
+- Branch: `chore/sonar-sweep-278`
+
+## Outcome
+
+| | Count |
+|---|---:|
+| Fixed | 174 |
+| Accepted, suppressed with a reason | 104 |
+
+No rule splits across both outcomes except `S1192` and `S4136`, which are noted below.
+
+### How this was verified
+
+The same harness as the previous export: `SonarAnalyzer.CSharp` (10.31.0) referenced
+temporarily from `Directory.Build.props` behind a `SonarProbe` property, with
+`TreatWarningsAsErrors` off so the analyzer's own findings do not fail the build. The
+findings were captured as a `file|line|rule` set before and after. The harness was
+removed before commit, for the reason given in `68487738`.
+
+Result: every rule below that reproduces locally went to **zero**. Two do not reproduce
+locally at all — `S1192` and `S2342` both take a parameter (a duplication threshold and a
+naming regex) that needs a `SonarLint.xml`, exactly as `S107` did last time. Their entries
+are reasoned from the export rather than measured, and are the ones to re-check on the next
+scan.
+
+**`S8969` got a stronger check than the analyzer.** The rule claims a null-forgiving
+operator is redundant. Rather than trust that, all 50 were deleted and the solution rebuilt
+under `TreatWarningsAsErrors` with nullable enabled: a bang that was actually load-bearing
+fails the build. 49 were genuinely redundant. One was not, and it is a real false positive
+worth recording.
+
+`OpenXmlHelper.LoadFontName` reads:
+
+```csharp
+if (runFont?.Val != null)
+    fontBase.FontName = runFont.Val!;
+```
+
+The guard proves the `StringValue` is non-null, and that is all S8969 looks at. But the
+implicit `StringValue` → `string` conversion returns `string?`, so the bang is suppressing
+`CS8601` on the *assignment*, not `CS8602` on the member access. Deleting it breaks the
+build. It keeps the bang and a pragma. The neighbouring `FontSize` line looks identical and
+is fine, because `DoubleValue` → `double` is not nullable.
+
+### Fixed — 174
+
+| Rule | Count | Action |
+|---|---:|---|
+| `S8969` | 49 | Delete the redundant bang (1 of the 50 kept — see above) |
+| `S3458` | 17 | Fold 17 empty `case` labels into the `default` arm they fell through to |
+| `S1192` | 9 | Hoist repeated messages, XML attribute names and VML namespaces to constants |
+| `S1481` | 5 | Drop unused example locals; one `out` parameter became a discard |
+| `S1125` | 4 | `x is T y ? Key == y.Key : false` → `&&` |
+| `S8970` | 3 | Benchmark fixture fields use plain `null` — no nullable context to forgive |
+| `S3897` | 3 | Declare `IEquatable<T>` where `Equals(T)` already existed |
+| `S2292` | 3 | Genuine trivial properties became auto-properties |
+| `S2219` | 2 | `is` instead of `GetType() ==` / `as … != null` |
+| `S1210` | 2 | Add `<`, `<=`, `>`, `>=` beside `CompareTo` |
+| `S1199` | 2 | Unwrap a nested block — see the note below |
+| `S4136` | 2 | Two small local moves (`XLFormattedText`, `XLTemplate`) |
+| `S1694` | 1 | Delete the redundant non-generic `XLRepositoryBase` |
+| `S1075`, `S1450`, `S1643`, `S2325`, `S3398`, `S3400`, `S3604`, `S3963`, `S4201`, `S1104` | 1 each | Mechanical |
+
+Three extra `S8969` in `XLibur.Report.Tests` were fixed at the same time. They are not in
+the export — SonarCloud's profile does not report them — but they are the same defect.
+
+**`S1199` was not the trivial unwrap it looked like.** In `Statistical.BinomDist` the bare
+block exists so the second `result`/`error` pair does not collide with the loop's. Removing
+the braces produces `CS0136`: C# forbids an inner-scope local sharing a name with one in an
+enclosing scope, in either order. Renaming the loop locals removes the block for real.
+
+### Accepted — 104
+
+| Rule | Count | Why |
+|---|---:|---|
+| `S3267` | 56 | Rewrite a filtering loop as LINQ. Overwhelmingly per-cell, per-formula and per-row paths where `Where`/`Select` allocates a delegate and an enumerator on a path the library works to keep allocation-free — `FormulaDependencies.RenameSheet` carries a comment saying exactly that. One (`XLCells`) filters on a side-effecting `HashSet.Add`, which LINQ would hide rather than simplify. The rule's own docs offer `PerformanceSensitiveAttribute` for this case; scoping it off is the same decision without annotating fifty methods |
+| `S101` | 20 | See below |
+| `S1192` | 19 | Sample data in the example and benchmark projects (16), and three colour-table transcriptions |
+| `S2342` | 12 | Same acronym problem as `S101`, mostly public API, plus a plural-for-`[Flags]` complaint about internal enums that read correctly in the singular |
+| `S4136` | 9 | Large files ordered by a scheme grouping-by-name would destroy: `SignatureAdapter` by arity, `EnumConverter` by the enum each `ToOpenXml`/`ToXLibur` pair converts, the save partial by pipeline stage |
+| `S2292` | 8 | **False positive** — see below |
+| `S1075` | 8 | XML namespace and relationship-type URIs fixed by ECMA-376. Identifiers, not endpoints; making one configurable only lets a caller produce a file Excel cannot open |
+| `S2344` | 3 | **Rule conflict** — see below |
+| `S3398` | 3 | Moving `GetU32LE`/`GetS16LE` into `PlaceableHeader` would scatter three sibling little-endian readers across two types, because `GetU16LE` has callers on both sides |
+| `S3400` | 2 | `Logical.True`/`False` implement the zero-argument Excel functions and are registered as method groups; a constant cannot convert to the delegate |
+| `S1694` | 1 | The AST is deliberately a closed class hierarchy — an interface could be implemented by a struct and box on every visit |
+
+**Why `S101` and `S2342` are not fixable.** The library prefixes every type with `XL` and
+abbreviates two domains inside that prefix — `CF` for conditional format, `HF` for
+header/footer — producing `IXLCFIconSet` and `XLHFItem`, which the rule reads as run-on
+capitals. Seven of the flagged types are public API (`IXLCFColorScaleMin`/`Mid`/`Max`,
+`IXLCFDataBarMin`/`Max`, `IXLCFIconSet`, `IXLHFItem`) and cannot be renamed without a
+breaking change. Renaming only the internal half would leave `XlcfCellIsConverter` sitting
+next to `IXLCFIconSet`, which is worse than either convention alone.
+
+The rule documents a `CustomDictionary.xml` acronym escape hatch. It was tried and does not
+work here: registering `XL`, `CF` and `HF` changed nothing, because the analyzer does not
+recognise two adjacent acronyms (`XL` immediately followed by `CF`). The file was removed
+again rather than left in place doing nothing.
+
+**Why `S2344` is a rule conflict.** Every hit is a `[Flags]` enum whose name says so —
+`FunctionFlags`, `FormulaFlags`, `XlRowFlags` — which is the BCL's own convention
+(`BindingFlags`). Worse, dropping the suffix makes the name singular, which `S2342` then
+rejects for a `[Flags]` enum. The two rules cannot both be satisfied.
+
+**Why the `S2292` hits are false positives.** `XLPivotDataField` and `XLPivotTable` expose
+`init`-only properties whose backing fields are *also* written from ordinary methods — the
+layout-mode setter assigns all four of `_compact`/`_compactData`/`_outline`/`_outlineData`
+together, and base field/item resolution rewrites `_baseField`. An auto-property with an
+`init` accessor cannot be assigned outside a constructor or object initializer, so the
+explicit field is doing real work. The three genuinely trivial ones were converted.
+
+### Where the suppressions live
+
+Repo-wide rules (`S101`, `S2342`, `S2344`, `S1075`, `S3267`) and the sample-project
+`S1192` are scoped in `.editorconfig`, matching the `CA1861` precedent from the previous
+export. Everything else is an inline `#pragma` next to the code it excuses.
+
+One trap, already learned the hard way in `617d5466`: a `#pragma warning restore` cancels a
+file-level `disable` for that rule from that point on. `SignatureAdapter.cs` now carries a
+file-level `disable S4136` *below* its `disable S2234`, and there is no `restore S4136`
+anywhere in the file, so it reaches the end. A narrow `restore S4136` added later would
+silently unsuppress everything after it.
+
+### Left for the owner
+
+`XLSparkLineGroups.Remove(IXLSparkline)` is private and has no callers — the two
+`group.Remove(sparkline)` sites in the same file bind to `IXLSparklineGroup.Remove`, and
+external callers use the `IXLCell` overload. It was made `static` as `S2325` asked, but it
+looks like dead code and deleting it is probably the better fix. Sonar's `S1144` does not
+flag it.
+
+---
+
+# Export 1 — 150 issues (`MEDIUM`)
+
 - Server: https://sonarcloud.io
 - Filters: impactSeverities=`MEDIUM`, issueStatuses=`OPEN,CONFIRMED`
 - Total issues: 150


### PR DESCRIPTION
Works through the 278-issue SonarCloud export: **174 fixed, 104 accepted** and suppressed with a
stated reason. Full finding-by-finding triage is in `docs/sonar.md`, which now covers both exports.

Three commits, meant to be read in order:

| Commit | Contents |
|---|---|
| `2afc174f` | The mechanical fixes — `S8969` ×49, `S3458` ×17, `S1192` ×9, and eleven smaller rules |
| `010246ac` | `S1694`, `S3897`, `S1210`, `S2292` — a redundant base class and the equality/comparison surfaces |
| `34ede94b` | The 104 accepted, plus the triage doc |

## How this was verified

Same harness as the previous export: `SonarAnalyzer.CSharp` 10.31 referenced temporarily from
`Directory.Build.props` behind a `SonarProbe` property, with `TreatWarningsAsErrors` off so the
analyzer's own output does not fail the build. Findings were captured as a `file|line|rule` set
before and after. **The harness is not in this PR** — `Directory.Build.props` is untouched.

Every rule that reproduces locally is now at **zero**. Two do not reproduce at all: `S1192` and
`S2342` each take a parameter (a duplication threshold, a naming regex) that needs a
`SonarLint.xml`, exactly as `S107` did last time. Those entries are reasoned from the export rather
than measured, and are the ones to re-check on the next scan.

## The one finding worth reviewing carefully

`S8969` claimed 50 redundant null-forgiving operators. Rather than trust the rule, all 50 were
deleted and the solution rebuilt under `TreatWarningsAsErrors` with nullable enabled — a bang that
is actually load-bearing fails the build. 49 were genuinely redundant. One was not:

```csharp
// OpenXmlHelper.LoadFontName
if (runFont?.Val != null)
    fontBase.FontName = runFont.Val!;
```

The guard proves the `StringValue` is non-null, and that is all S8969 inspects. But the implicit
`StringValue` → `string` conversion returns `string?`, so the bang suppresses `CS8601` on the
*assignment*, not `CS8602` on the member access. It keeps the bang and a pragma. The neighbouring
`FontSize` line looks identical and is fine, because `DoubleValue` → `double` is not nullable.

## Two rules that did not mean what they looked like

**`S1199`** in `Statistical.BinomDist` looked like a trivial unwrap. The bare block is
load-bearing: removing the braces produces `CS0136`, because C# forbids an inner-scope local
sharing a name with one in an enclosing scope in either order. Renaming the loop locals removes the
block for real.

**`S2344`** contradicts `S2342`. Every hit is a `[Flags]` enum whose name says so
(`FunctionFlags`, `FormulaFlags`, `XlRowFlags`) — the BCL's own convention, cf. `BindingFlags`.
Dropping the suffix makes the name singular, which `S2342` then rejects for a `[Flags]` enum.

## No renames — public API left alone

Per the brief, every rename was checked against the public surface first and none were applied.
Of the naming findings, **7 of 20 `S101` and 7 of 12 `S2342` are public API**
(`IXLCFColorScaleMin`/`Mid`/`Max`, `IXLCFDataBarMin`/`Max`, `IXLCFIconSet`, `IXLHFItem`,
`XLCFOperator`, `XLHFMode`, …). Renaming only the internal half would leave `XlcfCellIsConverter`
next to `IXLCFIconSet`, which is worse than either convention alone, so both rules are scoped off
with the reasoning recorded.

The rule documents a `CustomDictionary.xml` acronym escape hatch. It was tried — registering `XL`,
`CF` and `HF` changed nothing, because the analyzer does not recognise two adjacent acronyms (`XL`
immediately followed by `CF`). The file was removed rather than left in the repo doing nothing.

## The largest accepted group

`S3267` (56) wants filtering loops rewritten as LINQ. They are overwhelmingly per-cell,
per-formula and per-row paths where `Where`/`Select` allocates a delegate and an enumerator on a
path the library works to keep allocation-free — `FormulaDependencies.RenameSheet` carries a
comment saying exactly that. One (`XLCells`) filters on a side-effecting `HashSet.Add`, which LINQ
would hide rather than simplify. The rule's own documentation offers `PerformanceSensitiveAttribute`
for this case; scoping it off is the same decision without annotating fifty methods.

## Where the suppressions live

Repo-wide rules (`S101`, `S2342`, `S2344`, `S1075`, `S3267`) and the sample-project `S1192` are
scoped in `.editorconfig`, matching the `CA1861` precedent. Everything else is an inline `#pragma`
beside the code it excuses.

One trap, already learned in `617d5466`: a `#pragma warning restore` cancels a file-level `disable`
for that rule from that point on. `SignatureAdapter.cs` now carries a file-level `disable S4136`
*below* its `disable S2234`, and there is no `restore S4136` anywhere in the file, so it reaches the
end. A narrow `restore S4136` added later would silently unsuppress everything after it.

## One thing left for the owner

`XLSparkLineGroups.Remove(IXLSparkline)` is private and appears to have **no callers** — the two
`group.Remove(sparkline)` sites in the same file bind to `IXLSparklineGroup.Remove`, and external
callers use the `IXLCell` overload. It was made `static` as `S2325` asked, but deleting it is
probably the better fix. Sonar's `S1144` does not flag it. Called out in `docs/sonar.md` rather than
removed unilaterally.

## Verification

- Solution builds warning-free in Debug **and** Release on net8.0 / net9.0 / net10.0
- `XLibur.Tests` — 11,812 passed, 0 failed, 4 skipped
- `XLibur.Report.Tests` — 481 passed, 0 failed

Behavioural changes are covered by existing tests: the 17 folded `case` labels by the fill-pattern
round-trips, the `XLHeaderFooter` `StringBuilder` rewrite by the header/footer parse tests, the
dropped `XLPivotTableField.ShowAll` initializer by the pivot tests, and the two example edits by
their golden files.
