### PR TITLE
docs: changelog for everything since v0.200.0

### DIFF
--- a/.claude/skills/changelog-generator/SKILL.md
+++ b/.claude/skills/changelog-generator/SKILL.md
@@ -14,12 +14,13 @@ Generate and maintain professional, user-facing `CHANGELOG.md` files by analyzin
 3. **Filter noise** — exclude internal-only changes
 4. **Categorize** — group by change type (emoji sections), then by feature area within each
 5. **Translate** — rewrite commit messages as user-facing entries, each attributed to its PR and author
-6. **Format & write** — create or update `CHANGELOG.md` following the conventions below
+6. **Summarize & format & write** — open each release with a one-paragraph summary, then create or update `CHANGELOG.md` following the conventions below
 7. **Review with the user** — show the draft before finalizing
 ## Step 1: Determine the Commit Range
  
 Resolve what the user means by "since last release" / "for version X" / "past week":
  
+
 ```bash
 # Most recent tag (usually the last release)
 git describe --tags --abbrev=0
@@ -30,6 +31,7 @@ git tag --sort=-creatordate --format='%(refname:short)  %(creatordate:short)'
 # Check whether CHANGELOG.md already exists and read its latest entry
 # (its most recent version heading tells you where to resume from)
 ```
+
  
 Common range patterns:
  
@@ -46,6 +48,7 @@ If no tags exist and no existing changelog gives a starting point, ask the user 
  
 Collect commits with enough context to write meaningful entries:
  
+
 ```bash
 # Subject + body + author + date, machine-parseable
 git log <range> --no-merges --pretty=format:'%H%x09%ad%x09%an%x09%s' --date=short
@@ -53,6 +56,7 @@ git log <range> --no-merges --pretty=format:'%H%x09%ad%x09%an%x09%s' --date=shor
 # For commits whose subject alone is unclear, pull the full message and files touched
 git show <hash> --stat --pretty=format:'%s%n%n%b'
 ```
+
  
 Read commit bodies, not just subjects — the body often explains the user impact that the subject omits. If a commit references a PR or issue number (`#123`), keep the reference; every entry is attributed to it (see Step 5).
 
@@ -186,7 +190,7 @@ This applies to any entry with a migration, wherever it sits — most often ⚠�
 🗑️ Deprecations, but also a ✨ New Feature that supersedes an older call, or a 🐛 Bug Fix whose
 correct behaviour needs a different call site.
 
-````markdown
+```markdown
 - **`IndexColor` is replaced by `RawColor()`.** The property returned a palette index that silently
   went stale when the theme changed; the method resolves against the active theme at call time.
   ([#312](https://github.com/org/repo/pull/312) by [@handle](https://github.com/handle))
@@ -198,7 +202,7 @@ correct behaviour needs a different call site.
   // After
   var c = cell.Style.Font.RawColor();
   ```
-````
+```
 
 Rules for the example:
 
@@ -242,10 +246,45 @@ Default to a professional, concise, positive tone. Before writing, check for pro
    implementation detail they carry. It does not override the two-level emoji structure or
    attribution — those apply to the section you are writing even when older sections lack them.
 3. A `CONTRIBUTING.md` or docs style guide in the repo
+
+## Step 5b: Write the Per-Release Summary Paragraph
+
+Every version section opens with a **single-paragraph summary**, placed directly under the version
+heading and above the first `###` type section. It gives a reader the shape of the release in a few
+sentences before they drop into the categorized detail below.
+
+Rules for the summary:
+
+- **One paragraph, plain prose.** No bullet list, no `####` subheadings, and no per-entry PR links —
+  those live in the detailed entries beneath it. Two to four sentences is the target.
+- **Lead with new features, named explicitly.** If the release adds capabilities, name each one
+  ("Adds CSV export, faceted search, and a saved-view picker"). These are what people upgrade for,
+  so they go first and they go by name — do not reduce features to a count.
+- **Consolidate bug fixes into a count.** The 🐛 Bug Fixes section already lists them individually;
+  the summary just tallies them ("plus 8 bug fixes", or "plus 8 bug fixes across charts and formula
+  parsing" when they cluster in one or two areas). Do not restate each fix.
+- **Call out anything large by name instead of burying it in the count.** A change that is
+  significant on its own — a data-loss or security fix, a major correctness fix, a breaking change,
+  or a headline performance win — is named in the summary even when it is technically a "fix". The
+  count then covers only the remainder ("fixes a data-loss bug in the export path, plus 5 smaller
+  bug fixes"). Use judgment: "large" means a reader would want to know about it specifically, not
+  see it folded into a number.
+- **Match the release's actual shape.** A features-only release says so ("no bug fixes this
+  release"); a maintenance release says so ("A maintenance release: 8 bug fixes, no new features").
+  Mention Breaking Changes / Security / Deprecations in the summary whenever the release has them —
+  those are the sentences a reader most needs up front.
+- **Stay consistent with the sections below.** Every feature named and every count stated must match
+  what the categorized entries actually contain (see the Step 7 check).
+
+Placement and light styling (a leading `>` blockquote or `**Summary:**` lead-in) may follow the
+project's existing changelog style; if the file already opens releases with a summary line, match
+that. Default to a plain paragraph when there is no existing convention.
+
 ## Step 6: Format and Write CHANGELOG.md
  
 Follow [Keep a Changelog](https://keepachangelog.com) conventions adapted to the sections above:
  
+
 ```markdown
 # Changelog
  
@@ -258,6 +297,8 @@ All notable changes to this project will be documented in this file.
 - [2.4.0](#240---2026-06-02)
 
 ## [2.5.0] - 2026-07-26
+
+This release adds **CSV export for report data** and **faceted search** on the `/v2` endpoint. It also removes the legacy `/v1/search` endpoint (see Breaking Changes) and makes large exports up to 3× faster. On top of that, it fixes a crash when signing in after a long period of inactivity, plus 5 smaller bug fixes across reporting and search.
 
 ### ⚠️ Breaking Changes
 
@@ -297,11 +338,12 @@ All notable changes to this project will be documented in this file.
 ```
 
 Rules for writing the file:
+- **Each version section opens with the one-paragraph summary from Step 5b**, between the version heading and the first `###` type section
 - **A `## Contents` table of contents sits at the top**, between the intro and the newest version — see below
 - **Newest version at the top**, directly under the table of contents
 - Version heading format: `## [X.Y.Z] - YYYY-MM-DD`. If the release isn't tagged/dated yet, use `## [Unreleased]`
 - **Updating an existing changelog:** insert the new section above the previous newest version. Never rewrite or reorder existing entries. Preserve the file's existing heading style, bullet style, and link conventions exactly — consistency beats these guidelines.
-- **A file whose older releases predate this format:** apply the two-level emoji structure and attribution to the section you are writing, and leave already-released sections untouched. Mixed heading styles across releases are expected and fine. Offer to backfill older sections as a separate pass — it means mapping every historical entry to a PR, which is its own job.
+- **A file whose older releases predate this format:** apply the two-level emoji structure, the per-release summary, and attribution to the section you are writing, and leave already-released sections untouched. Mixed heading styles across releases are expected and fine. Offer to backfill older sections as a separate pass — it means mapping every historical entry to a PR, which is its own job.
 
 ### Table of contents
 
@@ -343,6 +385,13 @@ Present the draft to the user before (or immediately after) writing the file, an
 - Which repo you linked PRs against, when the project has more than one remote
 - Any migration example whose replacement API you could not verify against the diff, and any
   migration you judged non-mechanical — those are the two the user most needs to check
+- Any bug fix you promoted out of the summary count into a named call-out — the "is this large
+  enough to name?" judgment is the user's to confirm
+
+**Verify each release summary against its sections:** every feature named in the summary appears
+under ✨ New Features, the bug-fix count matches the number of 🐛 Bug Fixes entries (minus any you
+named separately), and any Breaking Change / Security / Deprecation the summary mentions has a
+matching section. A summary that disagrees with the detail below it is worse than no summary.
 
 Report the section/area layout and the entry count so the user can see the shape at a glance without
 re-reading the file. After restructuring an existing section, verify the entry count is unchanged —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,87 @@
 ## Contents
 
 - [Unreleased](#unreleased)
+- [v0.200.0](#v02000---2026-08-01)
 - [XLibur.Report — Unreleased](#xliburreport--unreleased)
 - [v0.106.0](#v01060---2026-07-25)
 
 ## Unreleased
 
+Promotes to public API the three core capabilities `XLibur.Report` previously reached through
+`InternalsVisibleTo`: `XLFunctionLibrary`, for evaluating a workbook function without a grid;
+source inspection and re-pointing on `IXLPivotCache`; and `IXLConditionalFormat.SetRanges`.
+Deleting a set of rows is up to 67× faster and allocates 670× less. Every package now ships a
+Software Bill of Materials. Adding members to `IXLPivotCache` and `IXLConditionalFormat` is
+source-breaking for anyone implementing those interfaces outside the library (see Breaking
+Changes). No bug fixes this release.
+
+### ⚠️ Breaking Changes
+
+#### Pivot tables and conditional formatting
+
+- **`IXLPivotCache` and `IXLConditionalFormat` gain members**, which is source-breaking for any type outside the library implementing them. Neither interface is designed to be implemented externally — each has a single implementation with an internal constructor — and XLibur is pre-1.0. Consumers that only *use* these interfaces are unaffected. ([#354](https://github.com/XLibur/XLibur/pull/354) by [@jafin](https://github.com/jafin))
+
 ### 🔒 Supply Chain
 
-- **Every package now ships a Software Bill of Materials.** Each `.nupkg` embeds an SPDX 2.2 manifest under `_manifest/spdx_2.2/`, generated at pack time, so the bill of materials travels with the package to anyone installing it from NuGet. Each release additionally carries a CycloneDX 1.7 document per package (`XLibur.<version>.cdx.json`) as a GitHub Release asset.
+- **Every package now ships a Software Bill of Materials.** Each `.nupkg` embeds an SPDX 2.2 manifest under `_manifest/spdx_2.2/`, generated at pack time, so the bill of materials travels with the package to anyone installing it from NuGet. Each release additionally carries a CycloneDX 1.7 document per package (`XLibur.<version>.cdx.json`) as a GitHub Release asset. ([#353](https://github.com/XLibur/XLibur/pull/353), [#356](https://github.com/XLibur/XLibur/pull/356) by [@jafin](https://github.com/jafin))
 
   ```bash
   # Read the embedded manifest without installing
   unzip -p XLibur.0.200.0.nupkg '_manifest/spdx_2.2/manifest.spdx.json' | jq .
   ```
+
+### ✨ New Features
+
+#### Formula functions
+
+- **`XLFunctionLibrary` evaluates one of Excel's ~400 built-in functions without a workbook.** Previously the calculation engine was reachable only through a cell, so computing `SUM` over values you already hold in memory meant building a grid to put them in. An instance is safe to share across threads, which is worth doing: constructing one builds the whole function table, at about 12 MB. ([#354](https://github.com/XLibur/XLibur/pull/354) by [@jafin](https://github.com/jafin))
+
+  ```csharp
+  using XLibur.Excel.CalcEngine;
+
+  var library = new XLFunctionLibrary();               // or pass a CultureInfo
+  ReadOnlySpan<XLCellValue> args = [1.0, 2.0, 3.0];
+
+  if (library.TryInvoke("SUM", args, out var result))
+      Console.WriteLine(result);                       // 6
+  ```
+
+  This calls a function; it does not parse a formula — there are no cell references or ranges, so a function that takes a range in a cell formula takes those cells as a run of arguments here. `TryInvoke` returns `false` only when no function has that name; a call that was made but could not succeed (wrong arity, wrong argument type, division by zero) returns `true` with an `XLError` result, as Excel reports it. Functions that need a worksheet to be relative to — `ROW`, `OFFSET`, `INDIRECT` — throw `XLNoWorksheetContextException`, and a result that is an array or a reference comes back as `#VALUE!`. To evaluate a formula string against real data, use `IXLWorksheet.Evaluate` instead.
+
+#### Pivot tables
+
+- **A pivot cache now reports where its data comes from, and can be re-pointed at a new range.** `SourceKind` distinguishes the six source kinds Excel defines, so a source XLibur cannot resolve (a connection, a consolidation, an external workbook, a scenario) is distinguishable from a named range that no longer exists. `SourceRange`, `SourceName` and `SourceWorksheet` expose the source itself, and `SetSourceRange` moves the cache to a new one — useful after generated rows have grown past the range the template defined. ([#354](https://github.com/XLibur/XLibur/pull/354) by [@jafin](https://github.com/jafin))
+
+  ```csharp
+  var cache = pivotTable.PivotCache;
+
+  if (cache.SourceKind == XLPivotSourceKind.Range)
+      cache.SetSourceRange(worksheet.Range("A1:D500"));
+  ```
+
+  `SourceRange`, `SourceName` and `SourceWorksheet` return `null` for kinds that cannot resolve to a range, rather than throwing — check `SourceKind` first when the distinction matters.
+
+#### Conditional formatting
+
+- **`IXLConditionalFormat.SetRanges` replaces the ranges a rule covers.** `Ranges` returns a fresh projection each time it is read, so there was previously no way to widen an existing rule over a larger block — the only option was deleting the rule and rebuilding it. ([#354](https://github.com/XLibur/XLibur/pull/354) by [@jafin](https://github.com/jafin))
+
+  ```csharp
+  format.SetRanges([worksheet.Range("A1:D500")]);
+  ```
+
+### ⚡ Performance
+
+#### Structural edits
+
+- **Deleting a set of rows is up to 67× faster and allocates 670× less.** `IXLRows.Delete()` looped a single-row delete over its rows, so every consumer of a shift — most expensively the formula pass, which visits every formula in the workbook — ran once per row. The rows are now re-pointed against the whole deletion in one pass, contiguous rows coalesce into one run, the cell compaction moves a row at a time rather than a cell at a time, and the calculation-engine purge that each run repeated is coalesced into one. Deleting every third row of an 8000-row sheet with a `SUM` per row went from 19,595 ms and 17,481 MB to 294 ms and 26 MB, and the growth rate dropped from 4× per doubling to 2×. Row and column *inserts* and single-row deletes get a smaller share of the same win, since formulas the edit cannot reach now skip the parse entirely. ([#347](https://github.com/XLibur/XLibur/pull/347), [#348](https://github.com/XLibur/XLibur/pull/348), [#350](https://github.com/XLibur/XLibur/pull/350) by [@jafin](https://github.com/jafin))
+
+  A workbook holding an array, data-table or dynamic-array formula keeps the row-at-a-time path, because the stored range and spill footprint those carry are relocated by the per-cell shift rather than by rewriting formula text.
+
+### 🔧 Dependencies
+
+- **`XLibur.Fonts.SkiaSharp` moves to SkiaSharp 4.151.0** (from 4.150.1), with the Linux, macOS and Win32 native asset packages following. The font engine decides text metrics, so the thing to watch in a bump like this is column widths and row heights moving; nothing shifted. ([#351](https://github.com/XLibur/XLibur/pull/351) by [@jafin](https://github.com/jafin))
+
+- **`XLibur` moves to OpenMcdf 3.2.0** (from 3.1.4). ([#342](https://github.com/XLibur/XLibur/pull/342) by [@dependabot](https://github.com/apps/dependabot))
 
 ## v0.200.0 - 2026-08-01
 
@@ -323,6 +391,12 @@ above. Nothing in this section has shipped yet.
 - **Hidden sheets are generated.** A hidden sheet is a normal place to keep the lookup tables and working data a report is built from, so generation follows the data rather than what the reader can see. Hiding a sheet controls what the reader sees; deleting it after `Generate()` is what keeps it out of the report. ([#304](https://github.com/XLibur/XLibur/pull/304) by [@jafin](https://github.com/jafin))
 
 - **Defined names bind under Excel's scoping and matching rules.** Two sheet-scoped names sharing a name — a `Q1!Items` section and a `Q2!Items` section — both bind, where previously the second silently generated blank. A workbook-scoped name binds except on a sheet declaring its own name of that name, which is what Excel does. And a name is matched to its variable case-insensitively, as Excel holds names in one case-insensitive namespace, so a template author who types `ITEMS` in the name box has named the variable added as `Items`. An exact match still wins, and two variables differing only by case are reported rather than bound arbitrarily. ([#307](https://github.com/XLibur/XLibur/pull/307), [#314](https://github.com/XLibur/XLibur/pull/314) by [@jafin](https://github.com/jafin))
+
+### 🔧 Dependencies
+
+- **`XLibur.Report` no longer pins an exact core version.** It built against core internals, and a package compiled against internals can only honestly declare an exact dependency — so it pinned `[0.200.0]`, which made every core release a Report release and defeated the point of the separate `report-v*` tag stream. Report now builds against public API only (see the core section above) and declares an open floor of `0.201.0`, so a Report release travels with any core at or above that. ([#354](https://github.com/XLibur/XLibur/pull/354) by [@jafin](https://github.com/jafin))
+
+- **`XLibur.Report.DynamicLinq` moves to System.Linq.Dynamic.Core 1.7.3** (from 1.7.1). ([#345](https://github.com/XLibur/XLibur/pull/345) by [@dependabot](https://github.com/apps/dependabot))
 
 ## v0.106.0 - 2026-07-25
 


### PR DESCRIPTION
Twenty commits landed after `v0.200.0`. Ten of them reach a user, and this records them in the `Unreleased` sections.

Also adds the per-release summary paragraph to the changelog-generator skill (Step 5b), which is the convention the new section follows.

## Core — Unreleased

| Section | Areas | Entries |
|---|---|---|
| ⚠️ Breaking Changes | Pivot tables and conditional formatting | 1 |
| 🔒 Supply Chain | *(existing entry, now attributed)* | 1 |
| ✨ New Features | Formula functions, Pivot tables, Conditional formatting | 3 |
| ⚡ Performance | Structural edits | 1 |
| 🔧 Dependencies | — | 2 |

`XLibur.Report — Unreleased` gains 2 entries under a new 🔧 Dependencies section. No existing entry was reworded or reordered.

## Judgment calls worth a second opinion

- **Three perf PRs collapsed into one entry.** #347, #348 and #350 attack the same path in sequence, and only the combined figure means anything to a reader — #348 measured 6.3× against a baseline that already contained #347. The entry quotes 19,595 ms / 17,481 MB → 294 ms / 26 MB, which is #350 measured against main.
- **A breaking change that no subject line mentions.** #354 adds members to `IXLPivotCache` and `IXLConditionalFormat`, source-breaking for external implementers. Called out per the commit body; consumers that only *use* the interfaces are unaffected.
- **Invented a 🔧 Dependencies section** — the file had no convention for bumps. Includes only *shipped* runtime dependencies: SkiaSharp (#351) and OpenMcdf (#342). The ClosedXML bump (#341, benchmarks only) and the CI-action bumps are excluded. Easy to drop if you would rather not track these at all.
- **`XLibur.Report` floor is `0.201.0`**, which is not released yet — the next Report release needs a core release at or above it. Worth confirming that is the intent.
- **Excluded as internal:** #352, #357 (Sonar), #355 (formatting), #336 (Report CI), and the un-PRd `chore(report)` commit that #354 superseded.

## Verified rather than assumed

- Authors come from `gh pr view --json author`, not `%an` — squash merges rewrite the git author. #342 and #345 are dependabot; the rest are @jafin.
- PRs are linked against `upstream` (XLibur/XLibur), not the `origin` fork.
- All three code examples were read off `PublicAPI.Unshipped.txt` and the `XLFunctionLibrary` source. That corrected two things a plausible guess would have got wrong: an array or reference result returns `#VALUE!` rather than throwing, and `TryInvoke` returns `false` only for an unknown name — a wrong-arity call returns `true` carrying an `XLError`.
- **The table of contents was stale** — `v0.200.0` was missing entirely. Added, with the anchor derived from the literal heading text; the other three still resolve.
- The SBOM entry had no attribution. Now cites #353 and #356, folded together since #356 fixed the #353 script before either shipped.

The ⚠️ Breaking Changes entry deliberately has no before/after example: the fix is "implement the new members", not a call-site edit, so there is nothing to type.