### PR TITLE
chore(build): declare Nullable once, centrally, and fix the 1,438 warnings that surfaced

### DIFF
--- a/.claude/skills/changelog-generator/SKILL.md
+++ b/.claude/skills/changelog-generator/SKILL.md
@@ -14,13 +14,12 @@ Generate and maintain professional, user-facing `CHANGELOG.md` files by analyzin
 3. **Filter noise** — exclude internal-only changes
 4. **Categorize** — group by change type (emoji sections), then by feature area within each
 5. **Translate** — rewrite commit messages as user-facing entries, each attributed to its PR and author
-6. **Summarize & format & write** — open each release with a one-paragraph summary, then create or update `CHANGELOG.md` following the conventions below
+6. **Format & write** — create or update `CHANGELOG.md` following the conventions below
 7. **Review with the user** — show the draft before finalizing
 ## Step 1: Determine the Commit Range
  
 Resolve what the user means by "since last release" / "for version X" / "past week":
  
-
 ```bash
 # Most recent tag (usually the last release)
 git describe --tags --abbrev=0
@@ -31,7 +30,6 @@ git tag --sort=-creatordate --format='%(refname:short)  %(creatordate:short)'
 # Check whether CHANGELOG.md already exists and read its latest entry
 # (its most recent version heading tells you where to resume from)
 ```
-
  
 Common range patterns:
  
@@ -48,7 +46,6 @@ If no tags exist and no existing changelog gives a starting point, ask the user 
  
 Collect commits with enough context to write meaningful entries:
  
-
 ```bash
 # Subject + body + author + date, machine-parseable
 git log <range> --no-merges --pretty=format:'%H%x09%ad%x09%an%x09%s' --date=short
@@ -56,7 +53,6 @@ git log <range> --no-merges --pretty=format:'%H%x09%ad%x09%an%x09%s' --date=shor
 # For commits whose subject alone is unclear, pull the full message and files touched
 git show <hash> --stat --pretty=format:'%s%n%n%b'
 ```
-
  
 Read commit bodies, not just subjects — the body often explains the user impact that the subject omits. If a commit references a PR or issue number (`#123`), keep the reference; every entry is attributed to it (see Step 5).
 
@@ -190,7 +186,7 @@ This applies to any entry with a migration, wherever it sits — most often ⚠�
 🗑️ Deprecations, but also a ✨ New Feature that supersedes an older call, or a 🐛 Bug Fix whose
 correct behaviour needs a different call site.
 
-```markdown
+````markdown
 - **`IndexColor` is replaced by `RawColor()`.** The property returned a palette index that silently
   went stale when the theme changed; the method resolves against the active theme at call time.
   ([#312](https://github.com/org/repo/pull/312) by [@handle](https://github.com/handle))
@@ -202,7 +198,7 @@ correct behaviour needs a different call site.
   // After
   var c = cell.Style.Font.RawColor();
   ```
-```
+````
 
 Rules for the example:
 
@@ -246,45 +242,10 @@ Default to a professional, concise, positive tone. Before writing, check for pro
    implementation detail they carry. It does not override the two-level emoji structure or
    attribution — those apply to the section you are writing even when older sections lack them.
 3. A `CONTRIBUTING.md` or docs style guide in the repo
-
-## Step 5b: Write the Per-Release Summary Paragraph
-
-Every version section opens with a **single-paragraph summary**, placed directly under the version
-heading and above the first `###` type section. It gives a reader the shape of the release in a few
-sentences before they drop into the categorized detail below.
-
-Rules for the summary:
-
-- **One paragraph, plain prose.** No bullet list, no `####` subheadings, and no per-entry PR links —
-  those live in the detailed entries beneath it. Two to four sentences is the target.
-- **Lead with new features, named explicitly.** If the release adds capabilities, name each one
-  ("Adds CSV export, faceted search, and a saved-view picker"). These are what people upgrade for,
-  so they go first and they go by name — do not reduce features to a count.
-- **Consolidate bug fixes into a count.** The 🐛 Bug Fixes section already lists them individually;
-  the summary just tallies them ("plus 8 bug fixes", or "plus 8 bug fixes across charts and formula
-  parsing" when they cluster in one or two areas). Do not restate each fix.
-- **Call out anything large by name instead of burying it in the count.** A change that is
-  significant on its own — a data-loss or security fix, a major correctness fix, a breaking change,
-  or a headline performance win — is named in the summary even when it is technically a "fix". The
-  count then covers only the remainder ("fixes a data-loss bug in the export path, plus 5 smaller
-  bug fixes"). Use judgment: "large" means a reader would want to know about it specifically, not
-  see it folded into a number.
-- **Match the release's actual shape.** A features-only release says so ("no bug fixes this
-  release"); a maintenance release says so ("A maintenance release: 8 bug fixes, no new features").
-  Mention Breaking Changes / Security / Deprecations in the summary whenever the release has them —
-  those are the sentences a reader most needs up front.
-- **Stay consistent with the sections below.** Every feature named and every count stated must match
-  what the categorized entries actually contain (see the Step 7 check).
-
-Placement and light styling (a leading `>` blockquote or `**Summary:**` lead-in) may follow the
-project's existing changelog style; if the file already opens releases with a summary line, match
-that. Default to a plain paragraph when there is no existing convention.
-
 ## Step 6: Format and Write CHANGELOG.md
  
 Follow [Keep a Changelog](https://keepachangelog.com) conventions adapted to the sections above:
  
-
 ```markdown
 # Changelog
  
@@ -297,8 +258,6 @@ All notable changes to this project will be documented in this file.
 - [2.4.0](#240---2026-06-02)
 
 ## [2.5.0] - 2026-07-26
-
-This release adds **CSV export for report data** and **faceted search** on the `/v2` endpoint. It also removes the legacy `/v1/search` endpoint (see Breaking Changes) and makes large exports up to 3× faster. On top of that, it fixes a crash when signing in after a long period of inactivity, plus 5 smaller bug fixes across reporting and search.
 
 ### ⚠️ Breaking Changes
 
@@ -338,12 +297,11 @@ This release adds **CSV export for report data** and **faceted search** on the `
 ```
 
 Rules for writing the file:
-- **Each version section opens with the one-paragraph summary from Step 5b**, between the version heading and the first `###` type section
 - **A `## Contents` table of contents sits at the top**, between the intro and the newest version — see below
 - **Newest version at the top**, directly under the table of contents
 - Version heading format: `## [X.Y.Z] - YYYY-MM-DD`. If the release isn't tagged/dated yet, use `## [Unreleased]`
 - **Updating an existing changelog:** insert the new section above the previous newest version. Never rewrite or reorder existing entries. Preserve the file's existing heading style, bullet style, and link conventions exactly — consistency beats these guidelines.
-- **A file whose older releases predate this format:** apply the two-level emoji structure, the per-release summary, and attribution to the section you are writing, and leave already-released sections untouched. Mixed heading styles across releases are expected and fine. Offer to backfill older sections as a separate pass — it means mapping every historical entry to a PR, which is its own job.
+- **A file whose older releases predate this format:** apply the two-level emoji structure and attribution to the section you are writing, and leave already-released sections untouched. Mixed heading styles across releases are expected and fine. Offer to backfill older sections as a separate pass — it means mapping every historical entry to a PR, which is its own job.
 
 ### Table of contents
 
@@ -385,13 +343,6 @@ Present the draft to the user before (or immediately after) writing the file, an
 - Which repo you linked PRs against, when the project has more than one remote
 - Any migration example whose replacement API you could not verify against the diff, and any
   migration you judged non-mechanical — those are the two the user most needs to check
-- Any bug fix you promoted out of the summary count into a named call-out — the "is this large
-  enough to name?" judgment is the user's to confirm
-
-**Verify each release summary against its sections:** every feature named in the summary appears
-under ✨ New Features, the bug-fix count matches the number of 🐛 Bug Fixes entries (minus any you
-named separately), and any Breaking Change / Security / Deprecation the summary mentions has a
-matching section. A summary that disagrees with the detail below it is worse than no summary.
 
 Report the section/area layout and the entry count so the user can see the shape at a glance without
 re-reading the file. After restructuring an existing section, verify the entry count is unchanged —

--- a/.claude/skills/changelog-generator/SKILL.md
+++ b/.claude/skills/changelog-generator/SKILL.md
@@ -14,12 +14,13 @@ Generate and maintain professional, user-facing `CHANGELOG.md` files by analyzin
 3. **Filter noise** — exclude internal-only changes
 4. **Categorize** — group by change type (emoji sections), then by feature area within each
 5. **Translate** — rewrite commit messages as user-facing entries, each attributed to its PR and author
-6. **Format & write** — create or update `CHANGELOG.md` following the conventions below
+6. **Summarize & format & write** — open each release with a one-paragraph summary, then create or update `CHANGELOG.md` following the conventions below
 7. **Review with the user** — show the draft before finalizing
 ## Step 1: Determine the Commit Range
  
 Resolve what the user means by "since last release" / "for version X" / "past week":
  
+
 ```bash
 # Most recent tag (usually the last release)
 git describe --tags --abbrev=0
@@ -30,6 +31,7 @@ git tag --sort=-creatordate --format='%(refname:short)  %(creatordate:short)'
 # Check whether CHANGELOG.md already exists and read its latest entry
 # (its most recent version heading tells you where to resume from)
 ```
+
  
 Common range patterns:
  
@@ -46,6 +48,7 @@ If no tags exist and no existing changelog gives a starting point, ask the user 
  
 Collect commits with enough context to write meaningful entries:
  
+
 ```bash
 # Subject + body + author + date, machine-parseable
 git log <range> --no-merges --pretty=format:'%H%x09%ad%x09%an%x09%s' --date=short
@@ -53,6 +56,7 @@ git log <range> --no-merges --pretty=format:'%H%x09%ad%x09%an%x09%s' --date=shor
 # For commits whose subject alone is unclear, pull the full message and files touched
 git show <hash> --stat --pretty=format:'%s%n%n%b'
 ```
+
  
 Read commit bodies, not just subjects — the body often explains the user impact that the subject omits. If a commit references a PR or issue number (`#123`), keep the reference; every entry is attributed to it (see Step 5).
 
@@ -186,7 +190,7 @@ This applies to any entry with a migration, wherever it sits — most often ⚠�
 🗑️ Deprecations, but also a ✨ New Feature that supersedes an older call, or a 🐛 Bug Fix whose
 correct behaviour needs a different call site.
 
-````markdown
+```markdown
 - **`IndexColor` is replaced by `RawColor()`.** The property returned a palette index that silently
   went stale when the theme changed; the method resolves against the active theme at call time.
   ([#312](https://github.com/org/repo/pull/312) by [@handle](https://github.com/handle))
@@ -198,7 +202,7 @@ correct behaviour needs a different call site.
   // After
   var c = cell.Style.Font.RawColor();
   ```
-````
+```
 
 Rules for the example:
 
@@ -242,10 +246,45 @@ Default to a professional, concise, positive tone. Before writing, check for pro
    implementation detail they carry. It does not override the two-level emoji structure or
    attribution — those apply to the section you are writing even when older sections lack them.
 3. A `CONTRIBUTING.md` or docs style guide in the repo
+
+## Step 5b: Write the Per-Release Summary Paragraph
+
+Every version section opens with a **single-paragraph summary**, placed directly under the version
+heading and above the first `###` type section. It gives a reader the shape of the release in a few
+sentences before they drop into the categorized detail below.
+
+Rules for the summary:
+
+- **One paragraph, plain prose.** No bullet list, no `####` subheadings, and no per-entry PR links —
+  those live in the detailed entries beneath it. Two to four sentences is the target.
+- **Lead with new features, named explicitly.** If the release adds capabilities, name each one
+  ("Adds CSV export, faceted search, and a saved-view picker"). These are what people upgrade for,
+  so they go first and they go by name — do not reduce features to a count.
+- **Consolidate bug fixes into a count.** The 🐛 Bug Fixes section already lists them individually;
+  the summary just tallies them ("plus 8 bug fixes", or "plus 8 bug fixes across charts and formula
+  parsing" when they cluster in one or two areas). Do not restate each fix.
+- **Call out anything large by name instead of burying it in the count.** A change that is
+  significant on its own — a data-loss or security fix, a major correctness fix, a breaking change,
+  or a headline performance win — is named in the summary even when it is technically a "fix". The
+  count then covers only the remainder ("fixes a data-loss bug in the export path, plus 5 smaller
+  bug fixes"). Use judgment: "large" means a reader would want to know about it specifically, not
+  see it folded into a number.
+- **Match the release's actual shape.** A features-only release says so ("no bug fixes this
+  release"); a maintenance release says so ("A maintenance release: 8 bug fixes, no new features").
+  Mention Breaking Changes / Security / Deprecations in the summary whenever the release has them —
+  those are the sentences a reader most needs up front.
+- **Stay consistent with the sections below.** Every feature named and every count stated must match
+  what the categorized entries actually contain (see the Step 7 check).
+
+Placement and light styling (a leading `>` blockquote or `**Summary:**` lead-in) may follow the
+project's existing changelog style; if the file already opens releases with a summary line, match
+that. Default to a plain paragraph when there is no existing convention.
+
 ## Step 6: Format and Write CHANGELOG.md
  
 Follow [Keep a Changelog](https://keepachangelog.com) conventions adapted to the sections above:
  
+
 ```markdown
 # Changelog
  
@@ -258,6 +297,8 @@ All notable changes to this project will be documented in this file.
 - [2.4.0](#240---2026-06-02)
 
 ## [2.5.0] - 2026-07-26
+
+This release adds **CSV export for report data** and **faceted search** on the `/v2` endpoint. It also removes the legacy `/v1/search` endpoint (see Breaking Changes) and makes large exports up to 3× faster. On top of that, it fixes a crash when signing in after a long period of inactivity, plus 5 smaller bug fixes across reporting and search.
 
 ### ⚠️ Breaking Changes
 
@@ -297,11 +338,12 @@ All notable changes to this project will be documented in this file.
 ```
 
 Rules for writing the file:
+- **Each version section opens with the one-paragraph summary from Step 5b**, between the version heading and the first `###` type section
 - **A `## Contents` table of contents sits at the top**, between the intro and the newest version — see below
 - **Newest version at the top**, directly under the table of contents
 - Version heading format: `## [X.Y.Z] - YYYY-MM-DD`. If the release isn't tagged/dated yet, use `## [Unreleased]`
 - **Updating an existing changelog:** insert the new section above the previous newest version. Never rewrite or reorder existing entries. Preserve the file's existing heading style, bullet style, and link conventions exactly — consistency beats these guidelines.
-- **A file whose older releases predate this format:** apply the two-level emoji structure and attribution to the section you are writing, and leave already-released sections untouched. Mixed heading styles across releases are expected and fine. Offer to backfill older sections as a separate pass — it means mapping every historical entry to a PR, which is its own job.
+- **A file whose older releases predate this format:** apply the two-level emoji structure, the per-release summary, and attribution to the section you are writing, and leave already-released sections untouched. Mixed heading styles across releases are expected and fine. Offer to backfill older sections as a separate pass — it means mapping every historical entry to a PR, which is its own job.
 
 ### Table of contents
 
@@ -343,6 +385,13 @@ Present the draft to the user before (or immediately after) writing the file, an
 - Which repo you linked PRs against, when the project has more than one remote
 - Any migration example whose replacement API you could not verify against the diff, and any
   migration you judged non-mechanical — those are the two the user most needs to check
+- Any bug fix you promoted out of the summary count into a named call-out — the "is this large
+  enough to name?" judgment is the user's to confirm
+
+**Verify each release summary against its sections:** every feature named in the summary appears
+under ✨ New Features, the bug-fix count matches the number of 🐛 Bug Fixes entries (minus any you
+named separately), and any Breaking Change / Security / Deprecation the summary mentions has a
+matching section. A summary that disagrees with the detail below it is worse than no summary.
 
 Report the section/area layout and the entry count so the user can see the shape at a glance without
 re-reading the file. After restructuring an existing section, verify the entry count is unchanged —

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files
+* @jasondsmith72

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default owners for all files
-* @jasondsmith72

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,37 @@ Other notes:
 - Never use `cd <folder> && git <params>` style commands. Use absolute paths or set the working directory separately.
 - Never pass a multi-line commit message as an inline PowerShell here-string (e.g. ``git commit -m @'...'@``). When used in a Bash-shell, each `@` will be interpreted as part of the commit message. Omit the `@` characters, e.g. ``git commit -m '...'``.
 
+### Do not use `sed -i` to edit tracked files — it strips the CR
+
+`.gitattributes` checks every source file out as CRLF (`* text=auto eol=crlf`), matching
+`end_of_line = crlf` in `.editorconfig`. Git Bash's `sed -i` rewrites the file with LF
+endings, so a one-line change turns into a whole-file diff:
+
+```
+sed -i '/<Nullable>/d' XLibur/XLibur.csproj
+git diff --stat   ->  XLibur/XLibur.csproj | 109 +++++-----   # 55-line file
+```
+
+This is the cause of the `.csproj` churn that keeps recurring. Two further traps:
+
+- `git add --renormalize` does **not** fix it. It makes things worse, because it then wants
+  to convert files you never touched.
+- Only some files show it, so a spot check on one file is not proof the batch was clean.
+
+Use instead, in rough order of preference:
+
+1. The **Edit / Write tools** — they preserve the file's existing endings.
+2. A bash line array, which keeps the `\r` as part of each line's content:
+
+   ```bash
+   mapfile -t lines < "$f"
+   lines[$i]="${lines[$i]/old/new}"      # the trailing \r rides along untouched
+   printf '%s\n' "${lines[@]}" > "$f"
+   ```
+
+Whichever you use, verify with `git diff --numstat` afterwards: a file whose changed-line
+count is near its total line count has been rewritten, not edited.
+
 ## Dependencies
 
 - Do NOT upgrade SixLabors.Fonts. Newer versions have a conflicting commercial license.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <TreatWarningsAsErrors Condition="'$(StrykerEnabled)' != 'true'">true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU1605;CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/XLibur.Benchmarks/AllocationBenchmarks.cs
+++ b/XLibur.Benchmarks/AllocationBenchmarks.cs
@@ -67,10 +67,10 @@ public class AllocationBenchmarks
         "E10-F20/G30", "AVERAGE(H1:H50)", "\"literal:A1\"&B2", "C5*D5+E5", "MAX(A1:Z1)", "MIN(B2:B200)",
     ];
 
-    private XLWorkbook _workbook = null;
-    private XLWorksheet _worksheet = null;
-    private XLRange _shiftRange = null;
-    private XLCell[] _emptyCells = null;
+    private XLWorkbook _workbook = null!;
+    private XLWorksheet _worksheet = null!;
+    private XLRange _shiftRange = null!;
+    private XLCell[] _emptyCells = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -78,7 +78,7 @@ public class AllocationBenchmarks
         SixLaborsV1FontBootstrap.Register();
         _workbook = new XLWorkbook();
         _worksheet = (XLWorksheet)_workbook.AddWorksheet("Data");
-        _shiftRange = _worksheet.Range("A1:Z1000");
+        _shiftRange = _worksheet.Range("A1:Z1000")!;
 
         _emptyCells = new XLCell[Colors.Length];
         for (var i = 0; i < _emptyCells.Length; i++)

--- a/XLibur.Benchmarks/BulkStyleBenchmarks.cs
+++ b/XLibur.Benchmarks/BulkStyleBenchmarks.cs
@@ -37,12 +37,10 @@ public class BulkStyleBenchmarks
 
     private const int Columns = 10;
 
-    // Assigned per iteration by Setup. Plain null rather than null!: this project has no nullable
-    // context, so the forgiving operator says nothing the compiler was going to check anyway, and every
-    // other benchmark here declares its fixture fields this way.
-    private XLWorkbook _workbook = null;
-    private IXLWorksheet _worksheet = null;
-    private IXLRange _range = null;
+    // Assigned per iteration by Setup, so the field is never observed null despite the declaration.
+    private XLWorkbook _workbook = null!;
+    private IXLWorksheet _worksheet = null!;
+    private IXLRange _range = null!;
 
     [IterationSetup]
     public void Setup()

--- a/XLibur.Benchmarks/ClosedXmlReadBenchmarks.cs
+++ b/XLibur.Benchmarks/ClosedXmlReadBenchmarks.cs
@@ -12,7 +12,7 @@ public class ClosedXmlReadBenchmarks
     private const int RowCount = 250_000;
     private const int ColCount = 15;
 
-    private byte[] _fileBytes = null;
+    private byte[] _fileBytes = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/ClosedXmlWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/ClosedXmlWorkbookBenchmarks.cs
@@ -11,9 +11,9 @@ public class ClosedXmlWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
 
-    private string[] _strings = null;
-    private double[] _numbers = null;
-    private DateTime[] _dates = null;
+    private string[] _strings = null!;
+    private double[] _numbers = null!;
+    private DateTime[] _dates = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/EpPlusReadBenchmarks.cs
+++ b/XLibur.Benchmarks/EpPlusReadBenchmarks.cs
@@ -12,7 +12,7 @@ public class EpPlusReadBenchmarks
     private const int RowCount = 250_000;
     private const int ColCount = 15;
 
-    private byte[] _fileBytes = null;
+    private byte[] _fileBytes = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/EpPlusWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/EpPlusWorkbookBenchmarks.cs
@@ -13,9 +13,9 @@ public class EpPlusWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
 
-    private string[] _strings = null;
-    private double[] _numbers = null;
-    private DateTime[] _dates = null;
+    private string[] _strings = null!;
+    private double[] _numbers = null!;
+    private DateTime[] _dates = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/FormulaEvaluationBenchmarks.cs
+++ b/XLibur.Benchmarks/FormulaEvaluationBenchmarks.cs
@@ -40,11 +40,10 @@ public class FormulaEvaluationBenchmarks
     private const int RowCount = 20_000;
     private const int LookupRows = 20;
 
-    // Assigned by Setup. Plain null rather than null!: this project has no nullable context, so the
-    // forgiving operator says nothing the compiler was going to check anyway.
-    private XLWorkbook _uniqueSameSheet = null;
-    private XLWorkbook _sharedSameSheet = null;
-    private XLWorkbook _sharedCrossSheet = null;
+    // Assigned by Setup, so the field is never observed null despite the declaration.
+    private XLWorkbook _uniqueSameSheet = null!;
+    private XLWorkbook _sharedSameSheet = null!;
+    private XLWorkbook _sharedCrossSheet = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/OpenXmlWorkbookBenchmarks.cs
@@ -27,9 +27,13 @@ public class OpenXmlWorkbookBenchmarks
     private const int RowCount = 50_000;
     private const string Ns = OpenXmlConst.Main2006SsNs;
 
-    private string[] _strings = null;
-    private double[] _numbers = null;
-    private DateTime[] _dates = null;
+    // OpenXmlAttribute takes a non-nullable namespaceUri, but an unqualified attribute has none and
+    // the SDK expects null there. Named so the intent survives the null-forgiving operator.
+    private const string NoNamespace = null!;
+
+    private string[] _strings = null!;
+    private double[] _numbers = null!;
+    private DateTime[] _dates = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -186,11 +190,11 @@ public class OpenXmlWorkbookBenchmarks
     {
         var attrs = new List<OpenXmlAttribute>
         {
-            new("r", null, cellRef),
-            new("t", null, "s")
+            new("r", NoNamespace,cellRef),
+            new("t", NoNamespace, "s")
         };
         if (styleIndex > 0)
-            attrs.Add(new OpenXmlAttribute("s", null, styleIndex.ToString()));
+            attrs.Add(new OpenXmlAttribute("s", NoNamespace, styleIndex.ToString()));
 
         writer.WriteStartElement(new Cell(), attrs);
         writer.WriteElement(new CellValue(sstId));
@@ -202,11 +206,11 @@ public class OpenXmlWorkbookBenchmarks
         var refStr = cellRef[..cellRefLen].ToString();
         var attrs = new List<OpenXmlAttribute>
         {
-            new("r", null, refStr),
-            new("t", null, "s")
+            new("r", NoNamespace,refStr),
+            new("t", NoNamespace, "s")
         };
         if (styleIndex > 0)
-            attrs.Add(new OpenXmlAttribute("s", null, styleIndex.ToString()));
+            attrs.Add(new OpenXmlAttribute("s", NoNamespace, styleIndex.ToString()));
 
         writer.WriteStartElement(new Cell(), attrs);
         writer.WriteElement(new CellValue(sstId));
@@ -218,10 +222,10 @@ public class OpenXmlWorkbookBenchmarks
         var refStr = cellRef[..cellRefLen].ToString();
         var attrs = new List<OpenXmlAttribute>
         {
-            new("r", null, refStr),
+            new("r", NoNamespace,refStr),
         };
         if (styleIndex > 0)
-            attrs.Add(new OpenXmlAttribute("s", null, styleIndex.ToString()));
+            attrs.Add(new OpenXmlAttribute("s", NoNamespace, styleIndex.ToString()));
 
         writer.WriteStartElement(new Cell(), attrs);
         writer.WriteElement(new CellValue(value.ToString("G15", CultureInfo.InvariantCulture)));
@@ -230,7 +234,7 @@ public class OpenXmlWorkbookBenchmarks
 
     private static void WriteFormulaCell(OpenXmlWriter writer, string cellRef, string formula)
     {
-        var attrs = new List<OpenXmlAttribute> { new("r", null, cellRef) };
+        var attrs = new List<OpenXmlAttribute> { new("r", NoNamespace, cellRef) };
         writer.WriteStartElement(new Cell(), attrs);
         writer.WriteElement(new CellFormula(formula));
         writer.WriteEndElement();

--- a/XLibur.Benchmarks/StreamingWriteBenchmarks.cs
+++ b/XLibur.Benchmarks/StreamingWriteBenchmarks.cs
@@ -26,9 +26,9 @@ public class StreamingWriteBenchmarks
 {
     private const int RowCount = 50_000;
 
-    private string[] _strings = null;
-    private double[] _numbers = null;
-    private DateTime[] _dates = null;
+    private string[] _strings = null!;
+    private double[] _numbers = null!;
+    private DateTime[] _dates = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/StyleKeyHashCodeBenchmarks.cs
+++ b/XLibur.Benchmarks/StyleKeyHashCodeBenchmarks.cs
@@ -15,11 +15,11 @@ public class StyleKeyHashCodeBenchmarks
 {
     private const int Iterations = 100_000;
 
-    private XLFontKey[] _fontKeys = null;
-    private XLBorderKey[] _borderKeys = null;
-    private XLFillKey[] _fillKeys = null;
-    private XLColorKey[] _colorKeys = null;
-    private XLStyleKey[] _styleKeys = null;
+    private XLFontKey[] _fontKeys = null!;
+    private XLBorderKey[] _borderKeys = null!;
+    private XLFillKey[] _fillKeys = null!;
+    private XLColorKey[] _colorKeys = null!;
+    private XLStyleKey[] _styleKeys = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/XLiburReadBenchmarks.cs
+++ b/XLibur.Benchmarks/XLiburReadBenchmarks.cs
@@ -13,7 +13,7 @@ public class XLiburReadBenchmarks
     private const int RowCount = 250_000;
     private const int ColCount = 15;
 
-    private byte[] _fileBytes = null;
+    private byte[] _fileBytes = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs
+++ b/XLibur.Benchmarks/XLiburWorkbookBenchmarks.cs
@@ -15,10 +15,10 @@ public class XLiburWorkbookBenchmarks
 {
     private const int RowCount = 50_000;
 
-    private BenchmarkData _data = null;
-    private string[] _strings = null;
-    private double[] _numbers = null;
-    private DateTime[] _dates = null;
+    private BenchmarkData _data = null!;
+    private string[] _strings = null!;
+    private double[] _numbers = null!;
+    private DateTime[] _dates = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/XLibur.Bundle/XLibur.Bundle.csproj
+++ b/XLibur.Bundle/XLibur.Bundle.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
-        <Nullable>enable</Nullable>
         <Description>Convenience meta-package for XLibur. Installs XLibur together with the default SkiaSharp font engine (MIT). The engine auto-registers on first use — no startup call required. Equivalent to installing XLibur and XLibur.Fonts.SkiaSharp separately.</Description>
         <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
         <PackageTags>Excel OpenXml xlsx Bundle</PackageTags>

--- a/XLibur.Examples/AutoFilters/CustomAutoFilter.cs
+++ b/XLibur.Examples/AutoFilters/CustomAutoFilter.cs
@@ -23,7 +23,7 @@ public class CustomAutoFilter : IXLExample
             .CellBelow().SetValue(4);
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(1).EqualTo(3).Or.GreaterThan(4);
+        ws.RangeUsed()!.SetAutoFilter().Column(1).EqualTo(3).Or.GreaterThan(4);
 
         // Sort the filtered list
         ws.AutoFilter.Sort();
@@ -43,7 +43,7 @@ public class CustomAutoFilter : IXLExample
             .CellBelow().SetValue("D");
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(1).Between("B", "D");
+        ws.RangeUsed()!.SetAutoFilter().Column(1).Between("B", "D");
 
         // Sort the filtered list
         ws.AutoFilter.Sort();
@@ -63,7 +63,7 @@ public class CustomAutoFilter : IXLExample
             .CellBelow().SetValue(4);
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(1).EqualTo(3).Or.EqualTo("C");
+        ws.RangeUsed()!.SetAutoFilter().Column(1).EqualTo(3).Or.EqualTo("C");
 
         // Sort the filtered list
         ws.AutoFilter.Sort();
@@ -98,8 +98,8 @@ public class CustomAutoFilter : IXLExample
             .CellBelow().SetValue("D");
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(2).EqualTo(3).Or.GreaterThan(4);
-        ws.RangeUsed().SetAutoFilter().Column(3).Between("B", "D");
+        ws.RangeUsed()!.SetAutoFilter().Column(2).EqualTo(3).Or.GreaterThan(4);
+        ws.RangeUsed()!.SetAutoFilter().Column(3).Between("B", "D");
 
         // Sort the filtered list
         ws.AutoFilter.Sort(3);

--- a/XLibur.Examples/AutoFilters/DateTimeGroupAutoFilter.cs
+++ b/XLibur.Examples/AutoFilters/DateTimeGroupAutoFilter.cs
@@ -26,7 +26,7 @@ public class DateTimeGroupAutoFilter : IXLExample
         ws.Column(1).Style.NumberFormat.Format = "d MMMM yyyy";
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(1).AddDateGroupFilter(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Unspecified).AddDays(3), XLDateTimeGrouping.Day);
+        ws.RangeUsed()!.SetAutoFilter().Column(1).AddDateGroupFilter(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Unspecified).AddDays(3), XLDateTimeGrouping.Day);
 
         // Sort the filtered list
         ws.AutoFilter.Sort();

--- a/XLibur.Examples/AutoFilters/DynamicAutoFilter.cs
+++ b/XLibur.Examples/AutoFilters/DynamicAutoFilter.cs
@@ -23,7 +23,7 @@ public class DynamicAutoFilter : IXLExample
             .CellBelow().SetValue(4);
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(1).AboveAverage();
+        ws.RangeUsed()!.SetAutoFilter().Column(1).AboveAverage();
 
         // Sort the filtered list
         //ws.AutoFilter.Sort(1);
@@ -58,7 +58,7 @@ public class DynamicAutoFilter : IXLExample
             .CellBelow().SetValue("D");
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(2).BelowAverage();
+        ws.RangeUsed()!.SetAutoFilter().Column(2).BelowAverage();
 
         // Sort the filtered list
         //ws.AutoFilter.Sort(3);

--- a/XLibur.Examples/AutoFilters/RegularAutoFilter.cs
+++ b/XLibur.Examples/AutoFilters/RegularAutoFilter.cs
@@ -34,7 +34,7 @@ public class RegularAutoFilter : IXLExample
             .CellBelow().SetValue("Jacques");
 
         // Add filters
-        var autoFilter = ws.RangeUsed().SetAutoFilter();
+        var autoFilter = ws.RangeUsed()!.SetAutoFilter();
         autoFilter.Column(1).AddFilter(3)
             .AddFilter(1);
 
@@ -60,7 +60,7 @@ public class RegularAutoFilter : IXLExample
             .CellBelow().SetValue("D");
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(1).AddFilter("C")
+        ws.RangeUsed()!.SetAutoFilter().Column(1).AddFilter("C")
             .AddFilter("A");
 
         // Sort the filtered list
@@ -83,7 +83,7 @@ public class RegularAutoFilter : IXLExample
             .CellBelow().SetValue(4);
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(1).AddFilter("C")
+        ws.RangeUsed()!.SetAutoFilter().Column(1).AddFilter("C")
             .AddFilter(1);
 
         // Sort the filtered list
@@ -121,7 +121,7 @@ public class RegularAutoFilter : IXLExample
             .CellBelow().SetValue("D");
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(2).AddFilter(3)
+        ws.RangeUsed()!.SetAutoFilter().Column(2).AddFilter(3)
             .AddFilter(1);
 
         // Sort the filtered list
@@ -144,7 +144,7 @@ public class RegularAutoFilter : IXLExample
             .CellBelow().SetValue(4);
 
         // Add filters
-        var table = ws.RangeUsed().CreateTable();
+        var table = ws.RangeUsed()!.CreateTable();
         table.ShowTotalsRow = true;
         table.Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
         table.AutoFilter.Column(1).AddFilter(3).AddFilter(4);

--- a/XLibur.Examples/AutoFilters/TopBottomAutoFilter.cs
+++ b/XLibur.Examples/AutoFilters/TopBottomAutoFilter.cs
@@ -24,7 +24,7 @@ public class TopBottomAutoFilter : IXLExample
             .CellBelow().SetValue(4);
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(1).Top(2);
+        ws.RangeUsed()!.SetAutoFilter().Column(1).Top(2);
 
         // Sort the filtered list
         //ws.AutoFilter.Sort(1);
@@ -59,7 +59,7 @@ public class TopBottomAutoFilter : IXLExample
             .CellBelow().SetValue("D");
 
         // Add filters
-        ws.RangeUsed().SetAutoFilter().Column(2).Bottom(50, XLTopBottomType.Percent);
+        ws.RangeUsed()!.SetAutoFilter().Column(2).Bottom(50, XLTopBottomType.Percent);
 
         // Sort the filtered list
         //ws.AutoFilter.Sort(3);

--- a/XLibur.Examples/Columns/ColumnCells.cs
+++ b/XLibur.Examples/Columns/ColumnCells.cs
@@ -16,7 +16,7 @@ public class ColumnCells : IXLExample
         columnFromWorksheet.Cells("3,5:6").Style.Fill.BackgroundColor = XLColor.Red;
         columnFromWorksheet.Cells(8, 9).Style.Fill.BackgroundColor = XLColor.Blue;
 
-        var columnFromRange = ws.Range("B1:B9").FirstColumn();
+        var columnFromRange = ws.Range("B1:B9").FirstColumn()!;
 
         columnFromRange.Cell(1).Style.Fill.BackgroundColor = XLColor.Red;
         columnFromRange.Cells("2").Style.Fill.BackgroundColor = XLColor.Blue;

--- a/XLibur.Examples/ConditionalFormatting/ConditionalFormatting.cs
+++ b/XLibur.Examples/ConditionalFormatting/ConditionalFormatting.cs
@@ -14,7 +14,7 @@ public class CFColorScaleLowMidHigh : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().ColorScale()
+        ws.RangeUsed()!.AddConditionalFormat().ColorScale()
             .LowestValue(XLColor.Red)
             .Midpoint(XLCFContentType.Percent, "50", XLColor.Yellow)
             .HighestValue(XLColor.Green);
@@ -35,7 +35,7 @@ public class CFColorScaleLowHigh : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().ColorScale()
+        ws.RangeUsed()!.AddConditionalFormat().ColorScale()
             .Minimum(XLCFContentType.Number, "2", XLColor.Red)
             .Maximum(XLCFContentType.Percentile, "90", XLColor.Green);
 
@@ -55,7 +55,7 @@ public class CFColorScaleMinimumMaximum : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().ColorScale()
+        ws.RangeUsed()!.AddConditionalFormat().ColorScale()
             .LowestValue(XLColor.FromHtml("#FFFF7128"))
             .HighestValue(XLColor.FromHtml("#FFFFEF9C"));
 
@@ -75,7 +75,7 @@ public class CFStartsWith : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed().AddConditionalFormat().WhenStartsWith("Hell")
+        ws.RangeUsed()!.AddConditionalFormat().WhenStartsWith("Hell")
             .Fill.SetBackgroundColor(XLColor.Red)
             .Border.SetOutsideBorder(XLBorderStyleValues.Thick)
             .Border.SetOutsideBorderColor(XLColor.Blue)
@@ -97,7 +97,7 @@ public class CFEndsWith : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed().AddConditionalFormat().WhenEndsWith("ll")
+        ws.RangeUsed()!.AddConditionalFormat().WhenEndsWith("ll")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -116,7 +116,7 @@ public class CFIsBlank : IXLExample
             .CellBelow().SetValue("")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed().AddConditionalFormat().WhenIsBlank()
+        ws.RangeUsed()!.AddConditionalFormat().WhenIsBlank()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -135,7 +135,7 @@ public class CFNotBlank : IXLExample
             .CellBelow().SetValue("")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed().AddConditionalFormat().WhenNotBlank()
+        ws.RangeUsed()!.AddConditionalFormat().WhenNotBlank()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -154,7 +154,7 @@ public class CFIsError : IXLExample
             .CellBelow().SetFormulaA1("1/0")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed().AddConditionalFormat().WhenIsError()
+        ws.RangeUsed()!.AddConditionalFormat().WhenIsError()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -173,7 +173,7 @@ public class CFNotError : IXLExample
             .CellBelow().SetFormulaA1("1/0")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed().AddConditionalFormat().WhenNotError()
+        ws.RangeUsed()!.AddConditionalFormat().WhenNotError()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -192,7 +192,7 @@ public class CFContains : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed().AddConditionalFormat().WhenContains("Hell")
+        ws.RangeUsed()!.AddConditionalFormat().WhenContains("Hell")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -211,7 +211,7 @@ public class CFNotContains : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed().AddConditionalFormat().WhenNotContains("Hell")
+        ws.RangeUsed()!.AddConditionalFormat().WhenNotContains("Hell")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -230,7 +230,7 @@ public class CFEqualsString : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed().AddConditionalFormat().WhenEquals("Hell")
+        ws.RangeUsed()!.AddConditionalFormat().WhenEquals("Hell")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -249,7 +249,7 @@ public class CFEqualsNumber : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenEquals(2)
+        ws.RangeUsed()!.AddConditionalFormat().WhenEquals(2)
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -268,7 +268,7 @@ public class CFNotEqualsString : IXLExample
             .CellBelow().SetValue("Hell")
             .CellBelow().SetValue("Holl");
 
-        ws.RangeUsed().AddConditionalFormat().WhenNotEquals("Hell")
+        ws.RangeUsed()!.AddConditionalFormat().WhenNotEquals("Hell")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -287,7 +287,7 @@ public class CFNotEqualsNumber : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenNotEquals(2)
+        ws.RangeUsed()!.AddConditionalFormat().WhenNotEquals(2)
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -306,7 +306,7 @@ public class CFGreaterThan : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenGreaterThan("2")
+        ws.RangeUsed()!.AddConditionalFormat().WhenGreaterThan("2")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -325,7 +325,7 @@ public class CFEqualOrGreaterThan : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenEqualOrGreaterThan("2")
+        ws.RangeUsed()!.AddConditionalFormat().WhenEqualOrGreaterThan("2")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -344,7 +344,7 @@ public class CFLessThan : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenLessThan("2")
+        ws.RangeUsed()!.AddConditionalFormat().WhenLessThan("2")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -363,7 +363,7 @@ public class CFEqualOrLessThan : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenEqualOrLessThan("2")
+        ws.RangeUsed()!.AddConditionalFormat().WhenEqualOrLessThan("2")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -382,7 +382,7 @@ public class CFBetween : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenBetween("2", "3")
+        ws.RangeUsed()!.AddConditionalFormat().WhenBetween("2", "3")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -401,7 +401,7 @@ public class CFNotBetween : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenNotBetween("2", "3")
+        ws.RangeUsed()!.AddConditionalFormat().WhenNotBetween("2", "3")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -420,7 +420,7 @@ public class CFUnique : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenIsUnique()
+        ws.RangeUsed()!.AddConditionalFormat().WhenIsUnique()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -439,7 +439,7 @@ public class CFDuplicate : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenIsDuplicate()
+        ws.RangeUsed()!.AddConditionalFormat().WhenIsDuplicate()
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -458,7 +458,7 @@ public class CFIsTrue : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenIsTrue("TRUE")
+        ws.RangeUsed()!.AddConditionalFormat().WhenIsTrue("TRUE")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -477,7 +477,7 @@ public class CFTop : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenIsTop(2)
+        ws.RangeUsed()!.AddConditionalFormat().WhenIsTop(2)
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -496,7 +496,7 @@ public class CFBottom : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().WhenIsBottom(10, XLTopBottomType.Percent)
+        ws.RangeUsed()!.AddConditionalFormat().WhenIsBottom(10, XLTopBottomType.Percent)
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -515,7 +515,7 @@ public class CFDataBar : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().DataBar(XLColor.Red, true)
+        ws.RangeUsed()!.AddConditionalFormat().DataBar(XLColor.Red, true)
             .LowestValue()
             .Maximum(XLCFContentType.Percent, "100");
 
@@ -568,7 +568,7 @@ public class CFIconSet : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
+        ws.RangeUsed()!.AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "0", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "2", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "3", XLCFContentType.Number);
@@ -589,12 +589,12 @@ public class CFTwoConditions : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
+        ws.RangeUsed()!.AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "0", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "2", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "3", XLCFContentType.Number);
 
-        ws.RangeUsed().AddConditionalFormat().WhenContains("1")
+        ws.RangeUsed()!.AddConditionalFormat().WhenContains("1")
             .Fill.SetBackgroundColor(XLColor.Red);
 
         workbook.SaveAs(filePath);
@@ -613,7 +613,7 @@ public class CFInsertRows : IXLExample
             .CellRight().SetValue(2)
             .CellRight().SetValue(3);
 
-        var range = ws.RangeUsed();
+        var range = ws.RangeUsed()!;
         range.AddConditionalFormat().WhenEquals("1").Font.SetBold();
         range.InsertRowsAbove(1);
 
@@ -634,7 +634,7 @@ public class CFTest : IXLExample
             .CellBelow().SetValue(3)
             .CellBelow().SetValue(4);
 
-        ws.RangeUsed().AddConditionalFormat().DataBar(XLColor.Red, XLColor.Green)
+        ws.RangeUsed()!.AddConditionalFormat().DataBar(XLColor.Red, XLColor.Green)
             .LowestValue()
             .HighestValue();
 
@@ -673,9 +673,9 @@ public class CFStopIfTrue : IXLExample
             .CellBelow().SetValue(2)
             .CellBelow().SetValue(3);
 
-        ws.RangeUsed().AddConditionalFormat().SetStopIfTrue().WhenGreaterThan(5);
+        ws.RangeUsed()!.AddConditionalFormat().SetStopIfTrue().WhenGreaterThan(5);
 
-        ws.RangeUsed().AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
+        ws.RangeUsed()!.AddConditionalFormat().IconSet(XLIconSetStyle.ThreeTrafficLights2, true, true)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "0", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "2", XLCFContentType.Number)
             .AddValue(XLCFIconSetOperator.EqualOrGreaterThan, "3", XLCFContentType.Number);

--- a/XLibur.Examples/ImageHandling/ImageAnchors.cs
+++ b/XLibur.Examples/ImageHandling/ImageAnchors.cs
@@ -12,7 +12,7 @@ public class ImageAnchors : IXLExample
         using var wb = new XLWorkbook();
         IXLWorksheet ws;
 
-        using (var fs = Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Examples.Resources.ImageHandling.png"))
+        using (var fs = Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Examples.Resources.ImageHandling.png")!)
         {
             ws = wb.Worksheets.Add("Images1");
 
@@ -42,7 +42,7 @@ public class ImageAnchors : IXLExample
             #endregion TwoCellAnchor
         }
 
-        using (var fs = Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg"))
+        using (var fs = Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg")!)
         {
             // Moving images around and scaling them
             ws = wb.Worksheets.Add("Images3");
@@ -61,7 +61,7 @@ public class ImageAnchors : IXLExample
                 .MoveTo(ws.Cell(10, 1));
         }
 
-        using (var fs = Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg"))
+        using (var fs = Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg")!)
         {
             // Changing of placement
             ws = wb.Worksheets.Add("Images4");

--- a/XLibur.Examples/ImageHandling/ImageFormats.cs
+++ b/XLibur.Examples/ImageHandling/ImageFormats.cs
@@ -12,7 +12,7 @@ public class ImageFormats : IXLExample
         IXLWorksheet ws;
 
         using (var fs = Assembly.GetExecutingAssembly()
-                   .GetManifestResourceStream("XLibur.Examples.Resources.ImageHandling.jpg"))
+                   .GetManifestResourceStream("XLibur.Examples.Resources.ImageHandling.jpg")!)
         {
             #region Jpeg
 
@@ -24,7 +24,7 @@ public class ImageFormats : IXLExample
         }
 
         using (var fs = Assembly.GetExecutingAssembly()
-                   .GetManifestResourceStream("XLibur.Examples.Resources.ImageHandling.png"))
+                   .GetManifestResourceStream("XLibur.Examples.Resources.ImageHandling.png")!)
         {
             #region Png
 

--- a/XLibur.Examples/Misc/AdjustToContentsWithAutoFilter.cs
+++ b/XLibur.Examples/Misc/AdjustToContentsWithAutoFilter.cs
@@ -13,7 +13,7 @@ public class AdjustToContentsWithAutoFilter : IXLExample
         ws.Cell("A3").Value = "Hank";
         ws.Cell("A4").Value = "Dagny";
 
-        ws.RangeUsed().SetAutoFilter();
+        ws.RangeUsed()!.SetAutoFilter();
 
         ws.Columns().AdjustToContents();
 

--- a/XLibur.Examples/Misc/AutoFilter.cs
+++ b/XLibur.Examples/Misc/AutoFilter.cs
@@ -14,7 +14,7 @@ public class AutoFilter : IXLExample
         ws.Cell("A3").Value = "Hank";
         ws.Cell("A4").Value = "Dagny";
 
-        ws.RangeUsed().SetAutoFilter();
+        ws.RangeUsed()!.SetAutoFilter();
 
         // You can turn off the autofilter by:
         // 1) worksheet.AutoFilter.Clear()

--- a/XLibur.Examples/Misc/Collections.cs
+++ b/XLibur.Examples/Misc/Collections.cs
@@ -72,9 +72,9 @@ public class Collections : IXLExample
 
     class Person
     {
-        public string House { get; set; }
+        public string House { get; set; } = string.Empty;
 
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         public int Age { get; set; }
     }

--- a/XLibur.Examples/Misc/CopyingRowsAndColumns.cs
+++ b/XLibur.Examples/Misc/CopyingRowsAndColumns.cs
@@ -61,7 +61,7 @@ public class CopyingRowsAndColumns : IXLExample
         destinationRow.Clear();
 
         var originalRow = originalSheet.Row(originalRowNumber);
-        var columnNumber = originalRow.LastCellUsed(XLCellsUsedOptions.All).Address.ColumnNumber;
+        var columnNumber = originalRow.LastCellUsed(XLCellsUsedOptions.All)!.Address.ColumnNumber;
 
         var originalRange = originalSheet.Range(originalRowNumber, 1, originalRowNumber, columnNumber);
         var destRange = destSheet.Range(destRowNumber, 1, destRowNumber, columnNumber);

--- a/XLibur.Examples/Misc/DataValidation.cs
+++ b/XLibur.Examples/Misc/DataValidation.cs
@@ -95,8 +95,8 @@ public class DataValidation : IXLExample
         ws.CopyTo(ws.Name + " - Copy");
         ws2.CopyTo(ws2.Name + " - Copy");
 
-        wb.AddWorksheet("Copy From Range 1").FirstCell().CopyFrom(ws.RangeUsed(XLCellsUsedOptions.All));
-        wb.AddWorksheet("Copy From Range 2").FirstCell().CopyFrom(ws2.RangeUsed(XLCellsUsedOptions.All));
+        wb.AddWorksheet("Copy From Range 1").FirstCell().CopyFrom(ws.RangeUsed(XLCellsUsedOptions.All)!);
+        wb.AddWorksheet("Copy From Range 2").FirstCell().CopyFrom(ws2.RangeUsed(XLCellsUsedOptions.All)!);
 
         wb.SaveAs(filePath);
     }

--- a/XLibur.Examples/Misc/Formulas.cs
+++ b/XLibur.Examples/Misc/Formulas.cs
@@ -47,7 +47,7 @@ public class Formulas : IXLExample
 
         // Setting the formula of a range
         var rngData = ws.Range(2, 1, 4, 7);
-        rngData.LastColumn().FormulaR1C1 = "=IF(RC[-4]=RC[-1],\"Yes\", \"No\")";
+        rngData.LastColumn()!.FormulaR1C1 = "=IF(RC[-4]=RC[-1],\"Yes\", \"No\")";
 
         // Using an array formula:
         // Just put the formula between curly braces

--- a/XLibur.Examples/Misc/InsertingData.cs
+++ b/XLibur.Examples/Misc/InsertingData.cs
@@ -79,9 +79,9 @@ public class InsertingData : IXLExample
 
     private sealed class Person
     {
-        public string House { get; set; }
+        public string House { get; set; } = string.Empty;
 
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         public int Age { get; set; }
 

--- a/XLibur.Examples/Misc/LambdaExpressions.cs
+++ b/XLibur.Examples/Misc/LambdaExpressions.cs
@@ -18,7 +18,7 @@ public class LambdaExpressions : IXLExample
 
             // Define a range with the data
             var firstDataCell = ws.Cell("B4");
-            var lastDataCell = ws.LastCellUsed();
+            var lastDataCell = ws.LastCellUsed()!;
             var rngData = ws.Range(firstDataCell.Address, lastDataCell.Address);
 
             // Delete all rows where Outcast = false (the 3rd column)
@@ -35,7 +35,7 @@ public class LambdaExpressions : IXLExample
             }
 
             // Put a thick border to the bottom of the table (we may have deleted the bottom cells with the border)
-            rngData.LastRow().Style.Border.BottomBorder = XLBorderStyleValues.Thick;
+            rngData.LastRow()!.Style.Border.BottomBorder = XLBorderStyleValues.Thick;
 
             workbook.SaveAs(filePath);
         }

--- a/XLibur.Examples/Misc/ShiftingFormulas.cs
+++ b/XLibur.Examples/Misc/ShiftingFormulas.cs
@@ -39,9 +39,9 @@ public class ShiftingFormulas : IXLExample
 
         var dataGrid = ws.Range("B2:D3");
         ws.Row(1).InsertRowsAbove(1);
-        var newRow = dataGrid.LastRow().InsertRowsAbove(1).First();
+        var newRow = dataGrid.LastRow()!.InsertRowsAbove(1).First();
         newRow.Value = 1;
-        dataGrid.LastColumn().FormulaR1C1 = $"SUM(RC[-{dataGrid.ColumnCount() - 1}]:RC[-1])";
+        dataGrid.LastColumn()!.FormulaR1C1 = $"SUM(RC[-{dataGrid.ColumnCount() - 1}]:RC[-1])";
         ws.Cell(1, 1).InsertCellsBelow(1);
         ws.Column(1).InsertColumnsBefore(1);
         ws.Row(4).Delete();

--- a/XLibur.Examples/Misc/ShowCase.cs
+++ b/XLibur.Examples/Misc/ShowCase.cs
@@ -64,7 +64,7 @@ public class ShowCase : IXLExample
             .Alignment.SetHorizontal(XLAlignmentHorizontalValues.Center);
 
         //Merge title cells
-        rngTable.FirstRow().Merge(); // We could've also used: rngTable.Range("A1:E1").Merge() or rngTable.Row(1).Merge()
+        rngTable.FirstRow()!.Merge(); // We could've also used: rngTable.Range("A1:E1").Merge() or rngTable.Row(1).Merge()
 
         //Formatting headers
         var rngHeaders = rngTable.Range("B3:F3");
@@ -86,7 +86,7 @@ public class ShowCase : IXLExample
         excelTable.Field("DOB").TotalsRowLabel = "Average:";
 
         //Add thick borders to the contents of our spreadsheet
-        ws.RangeUsed().Style.Border.OutsideBorder = XLBorderStyleValues.Thick;
+        ws.RangeUsed()!.Style.Border.OutsideBorder = XLBorderStyleValues.Thick;
 
         // Adjust column widths to their content
         ws.Columns(2, 6).AdjustToContents();

--- a/XLibur.Examples/PivotTables/PivotTables.cs
+++ b/XLibur.Examples/PivotTables/PivotTables.cs
@@ -8,7 +8,9 @@ public class PivotTables : IXLExample
 {
     private sealed class Pastry
     {
-        public Pastry(string name, int? code, int numberOfOrders, double quality, string month, DateTime? bakeDate)
+        // month is nullable: the last row below deliberately leaves it blank, to exercise
+        // ContainsBlank and the integer row/column paths in the pivot table.
+        public Pastry(string name, int? code, int numberOfOrders, double quality, string? month, DateTime? bakeDate)
         {
             Name = name;
             Code = code;
@@ -26,7 +28,7 @@ public class PivotTables : IXLExample
 
         public double Quality { get; set; }
 
-        public string Month { get; set; }
+        public string? Month { get; set; }
 
         public DateTime? BakeDate { get; set; }
     }

--- a/XLibur.Examples/Ranges/AddingRowToTables.cs
+++ b/XLibur.Examples/Ranges/AddingRowToTables.cs
@@ -15,10 +15,10 @@ public class AddingRowToTables : IXLExample
             var wb = new XLWorkbook(tempFile);
             var ws = wb.Worksheets.First();
 
-            var firstCell = ws.FirstCellUsed();
-            var lastCell = ws.LastCellUsed();
+            var firstCell = ws.FirstCellUsed()!;
+            var lastCell = ws.LastCellUsed()!;
             var range = ws.Range(firstCell.Address, lastCell.Address);
-            range.FirstRow().Delete(); // Deleting the "Contacts" header (we don't need it for our purposes)
+            range.FirstRow()!.Delete(); // Deleting the "Contacts" header (we don't need it for our purposes)
 
             // We want to use a theme for table, not the hard coded format of the BasicTable
             range.Clear(XLClearOptions.AllFormats);
@@ -30,7 +30,7 @@ public class AddingRowToTables : IXLExample
 
             ws.Cell("Q6000").Value = "dummy value";
 
-            table.DataRange.InsertRowsBelow(1);
+            table.DataRange!.InsertRowsBelow(1);
 
             wb.SaveAs(filePath);
         }

--- a/XLibur.Examples/Ranges/CopyingRanges.cs
+++ b/XLibur.Examples/Ranges/CopyingRanges.cs
@@ -15,8 +15,8 @@ public class CopyingRanges : IXLExample
             var ws = workbook.Worksheet(1);
 
             // Define a range with the data
-            var firstTableCell = ws.FirstCellUsed();
-            var lastTableCell = ws.LastCellUsed();
+            var firstTableCell = ws.FirstCellUsed()!;
+            var lastTableCell = ws.LastCellUsed()!;
             var rngData = ws.Range(firstTableCell.Address, lastTableCell.Address);
 
             // Copy the table to another worksheet

--- a/XLibur.Examples/Ranges/CurrentRowColumn.cs
+++ b/XLibur.Examples/Ranges/CurrentRowColumn.cs
@@ -18,10 +18,10 @@ public class CurrentRowColumn : IXLExample
             .CellBelow().SetValue(cell.WorksheetColumn().ColumnLetter())
             .CellLeft().SetValue("Red's Column:");
 
-        var row = ws.Range("A6:C6").FirstRow();
+        var row = ws.Range("A6:C6").FirstRow()!;
         row.Style.Fill.SetBackgroundColor(XLColor.Blue);
 
-        var column = ws.Range("B7:B9").FirstColumn();
+        var column = ws.Range("B7:B9").FirstColumn()!;
         column.Style.Fill.SetBackgroundColor(XLColor.Green);
 
         ws.Cell(1, 4)

--- a/XLibur.Examples/Ranges/DefinedNames.cs
+++ b/XLibur.Examples/Ranges/DefinedNames.cs
@@ -42,7 +42,7 @@ public class DefinedNames : IXLExample
 
         // Copy the data in a named range:
         wsPresentation.Cell(4, 1).Value = "People Data:";
-        wsPresentation.Cell(5, 1).CopyFrom(wb.Range("PeopleData"));
+        wsPresentation.Cell(5, 1).CopyFrom(wb.Range("PeopleData")!);
 
         /////////////////////////////////////////////////////////////////////////
         // For the Excel geeks out there who actually know about

--- a/XLibur.Examples/Ranges/SortExample.cs
+++ b/XLibur.Examples/Ranges/SortExample.cs
@@ -14,13 +14,13 @@ public class SortExample : IXLExample
         var wsTable = wb.Worksheets.Add("Table");
         AddTestTable(wsTable);
         var header = wsTable.Row(1).InsertRowsAbove(1).First();
-        for (var co = 1; co <= wsTable.LastColumnUsed().ColumnNumber(); co++)
+        for (var co = 1; co <= wsTable.LastColumnUsed()!.ColumnNumber(); co++)
         {
             header.Cell(co).Value = "Column" + co;
         }
 
-        var rangeTable = wsTable.RangeUsed();
-        var table = rangeTable.CopyTo(wsTable.Column(wsTable.LastColumnUsed().ColumnNumber() + 3)).CreateTable();
+        var rangeTable = wsTable.RangeUsed()!;
+        var table = rangeTable.CopyTo(wsTable.Column(wsTable.LastColumnUsed()!.ColumnNumber() + 3)).CreateTable();
 
         table.Sort("Column2, Column3 Desc, Column1 ASC");
 
@@ -36,9 +36,9 @@ public class SortExample : IXLExample
 
         var wsLeftToRight = wb.Worksheets.Add("Sort Left to Right");
         AddTestTable(wsLeftToRight);
-        wsLeftToRight.RangeUsed().Transpose(XLTransposeOptions.MoveCells);
-        var rangeLeftToRight = wsLeftToRight.RangeUsed();
-        var copyLeftToRight = rangeLeftToRight.CopyTo(wsLeftToRight.Row(wsLeftToRight.LastRowUsed().RowNumber() + 3));
+        wsLeftToRight.RangeUsed()!.Transpose(XLTransposeOptions.MoveCells);
+        var rangeLeftToRight = wsLeftToRight.RangeUsed()!;
+        var copyLeftToRight = rangeLeftToRight.CopyTo(wsLeftToRight.Row(wsLeftToRight.LastRowUsed()!.RowNumber() + 3));
 
         copyLeftToRight.SortLeftToRight();
 
@@ -53,8 +53,8 @@ public class SortExample : IXLExample
 
         var wsComplex2 = wb.Worksheets.Add("Complex 2");
         AddTestTable(wsComplex2);
-        var rangeComplex2 = wsComplex2.RangeUsed();
-        var copyComplex2 = rangeComplex2.CopyTo(wsComplex2.Column(wsComplex2.LastColumnUsed().ColumnNumber() + 3));
+        var rangeComplex2 = wsComplex2.RangeUsed()!;
+        var copyComplex2 = rangeComplex2.CopyTo(wsComplex2.Column(wsComplex2.LastColumnUsed()!.ColumnNumber() + 3));
 
         copyComplex2.SortColumns.Add(1, XLSortOrder.Ascending, false, true);
         copyComplex2.SortColumns.Add(3, XLSortOrder.Descending);
@@ -77,8 +77,8 @@ public class SortExample : IXLExample
 
         var wsComplex1 = wb.Worksheets.Add("Complex 1");
         AddTestTable(wsComplex1);
-        var rangeComplex1 = wsComplex1.RangeUsed();
-        var copyComplex1 = rangeComplex1.CopyTo(wsComplex1.Column(wsComplex1.LastColumnUsed().ColumnNumber() + 3));
+        var rangeComplex1 = wsComplex1.RangeUsed()!;
+        var copyComplex1 = rangeComplex1.CopyTo(wsComplex1.Column(wsComplex1.LastColumnUsed()!.ColumnNumber() + 3));
 
         copyComplex1.Sort("2, 1 DESC", XLSortOrder.Ascending, true);
 
@@ -94,11 +94,11 @@ public class SortExample : IXLExample
 
         var wsSimpleColumn = wb.Worksheets.Add("Simple Column");
         AddTestColumn(wsSimpleColumn);
-        var rangeSimpleColumn = wsSimpleColumn.RangeUsed();
+        var rangeSimpleColumn = wsSimpleColumn.RangeUsed()!;
         var copySimpleColumn =
-            rangeSimpleColumn.CopyTo(wsSimpleColumn.Column(wsSimpleColumn.LastColumnUsed().ColumnNumber() + 3));
+            rangeSimpleColumn.CopyTo(wsSimpleColumn.Column(wsSimpleColumn.LastColumnUsed()!.ColumnNumber() + 3));
 
-        copySimpleColumn.FirstColumn().Sort(XLSortOrder.Descending, true);
+        copySimpleColumn.FirstColumn()!.Sort(XLSortOrder.Descending, true);
 
         wsSimpleColumn.Row(1).InsertRowsAbove(2);
         wsSimpleColumn.Cell(1, 1)
@@ -112,8 +112,8 @@ public class SortExample : IXLExample
 
         var wsSimple = wb.Worksheets.Add("Simple");
         AddTestTable(wsSimple);
-        var rangeSimple = wsSimple.RangeUsed();
-        var copySimple = rangeSimple.CopyTo(wsSimple.Column(wsSimple.LastColumnUsed().ColumnNumber() + 3));
+        var rangeSimple = wsSimple.RangeUsed()!;
+        var copySimple = rangeSimple.CopyTo(wsSimple.Column(wsSimple.LastColumnUsed()!.ColumnNumber() + 3));
 
         copySimple.Sort();
 

--- a/XLibur.Examples/Ranges/Sorting.cs
+++ b/XLibur.Examples/Ranges/Sorting.cs
@@ -15,11 +15,11 @@ public class Sorting : IXLExample
         AddTestTable(wsTable);
 
         wsTable.Row(1).InsertRowsAbove(1);
-        var lastCo = wsTable.LastColumnUsed().ColumnNumber();
+        var lastCo = wsTable.LastColumnUsed()!.ColumnNumber();
         for (var co = 1; co <= lastCo; co++)
             wsTable.Cell(1, co).Value = "Column" + co;
 
-        var table = wsTable.RangeUsed().AsTable();
+        var table = wsTable.RangeUsed()!.AsTable();
         table.Sort("Column2 Desc, 1, 3 Asc");
 
         // Sort table another way
@@ -27,11 +27,11 @@ public class Sorting : IXLExample
         AddTestTable(wsTable);
 
         wsTable.Row(1).InsertRowsAbove(1);
-        lastCo = wsTable.LastColumnUsed().ColumnNumber();
+        lastCo = wsTable.LastColumnUsed()!.ColumnNumber();
         for (var co = 1; co <= lastCo; co++)
             wsTable.Cell(1, co).Value = "Column" + co;
 
-        table = wsTable.RangeUsed().AsTable();
+        table = wsTable.RangeUsed()!.AsTable();
         table.Sort("Column2", XLSortOrder.Descending);
 
         #endregion Sort Table
@@ -41,8 +41,8 @@ public class Sorting : IXLExample
         var wsRows = wb.Worksheets.Add("Rows");
         AddTestTable(wsRows);
         wsRows.Row(1).Sort();
-        wsRows.RangeUsed().Row(2).Sort();
-        wsRows.Rows(3, wsRows.LastRowUsed().RowNumber()).Delete();
+        wsRows.RangeUsed()!.Row(2).Sort();
+        wsRows.Rows(3, wsRows.LastRowUsed()!.RowNumber()).Delete();
 
         #endregion Sort Rows
 
@@ -50,9 +50,9 @@ public class Sorting : IXLExample
 
         var wsColumns = wb.Worksheets.Add("Columns");
         AddTestTable(wsColumns);
-        wsColumns.LastColumnUsed().Delete();
+        wsColumns.LastColumnUsed()!.Delete();
         wsColumns.Column(1).Sort();
-        wsColumns.RangeUsed().Column(2).Sort();
+        wsColumns.RangeUsed()!.Column(2).Sort();
 
         #endregion Sort Columns
 

--- a/XLibur.Examples/Rows/RowCells.cs
+++ b/XLibur.Examples/Rows/RowCells.cs
@@ -15,7 +15,7 @@ public class RowCells : IXLExample
         rowFromWorksheet.Cells("3,5:6").Style.Fill.BackgroundColor = XLColor.Red;
         rowFromWorksheet.Cells(8, 9).Style.Fill.BackgroundColor = XLColor.Blue;
 
-        var rowFromRange = ws.Range("A2:I2").FirstRow();
+        var rowFromRange = ws.Range("A2:I2").FirstRow()!;
 
         rowFromRange.Cell(1).Style.Fill.BackgroundColor = XLColor.Red;
         rowFromRange.Cells("2").Style.Fill.BackgroundColor = XLColor.Blue;

--- a/XLibur.Examples/Tables/InsertingTables.cs
+++ b/XLibur.Examples/Tables/InsertingTables.cs
@@ -76,9 +76,9 @@ public class InsertingTables : IXLExample
 
     private sealed class Person
     {
-        [XLColumn(Header = "House Street")] public string House { get; set; }
+        [XLColumn(Header = "House Street")] public string House { get; set; } = string.Empty;
 
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         public int Age { get; set; }
 

--- a/XLibur.Examples/Tables/UsingTables.cs
+++ b/XLibur.Examples/Tables/UsingTables.cs
@@ -14,10 +14,10 @@ public class UsingTables : IXLExample
             using var wb = new XLWorkbook(tempFile);
             var ws = wb.Worksheet(1);
             ws.Name = "Contacts Table";
-            var firstCell = ws.FirstCellUsed();
-            var lastCell = ws.LastCellUsed();
+            var firstCell = ws.FirstCellUsed()!;
+            var lastCell = ws.LastCellUsed()!;
             var range = ws.Range(firstCell.Address, lastCell.CellRight().Address);
-            range.FirstRow().Delete(); // Deleting the "Contacts" header (we don't need it for our purposes)
+            range.FirstRow()!.Delete(); // Deleting the "Contacts" header (we don't need it for our purposes)
 
             // We want to use a theme for table, not the hard coded format of the BasicTable
             range.Clear(XLClearOptions.AllFormats);
@@ -50,7 +50,7 @@ public class UsingTables : IXLExample
             int columnWithHeaders = lastCell.Address.ColumnNumber + 3;
             int currentRow = table.RangeAddress.FirstAddress.RowNumber;
             ws.Cell(currentRow, columnWithHeaders).Value = "Table Headers";
-            foreach (var cell in table.HeadersRow().Cells())
+            foreach (var cell in table.HeadersRow()!.Cells())
             {
                 currentRow++;
                 ws.Cell(currentRow, columnWithHeaders).Value = cell.Value;
@@ -71,7 +71,7 @@ public class UsingTables : IXLExample
             int columnWithNames = columnWithHeaders + 2;
             currentRow = table.RangeAddress.FirstAddress.RowNumber; // reset the currentRow
             ws.Cell(currentRow, columnWithNames).Value = "Names";
-            foreach (var row in table.DataRange.Rows())
+            foreach (var row in table.DataRange!.Rows())
             {
                 currentRow++;
                 var fName = row.Field("FName").GetString(); // Notice how we're calling the cell by field name

--- a/XLibur.Fonts.SixLabors.Tests/XLibur.Fonts.SixLabors.Tests.csproj
+++ b/XLibur.Fonts.SixLabors.Tests/XLibur.Fonts.SixLabors.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <!-- TUnit runs on Microsoft.Testing.Platform rather than VSTest. -->

--- a/XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj
+++ b/XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
-        <Nullable>enable</Nullable>
         <Description>Default IXLFontEngine implementation for XLibur using SixLabors.Fonts 1.x (Apache 2.0).</Description>
         <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
         <PackageTags>Excel OpenXml xlsx Font SixLabors</PackageTags>

--- a/XLibur.Fonts.SixLabors/XLibur.Fonts.SixLabors.csproj
+++ b/XLibur.Fonts.SixLabors/XLibur.Fonts.SixLabors.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
-        <Nullable>enable</Nullable>
         <RootNamespace>XLibur.Fonts.SixLabors</RootNamespace>
         <Description>SixLabors.Fonts 2.x implementation of IXLFontEngine for XLibur.</Description>
         <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>

--- a/XLibur.Fonts.SkiaSharp.Tests/XLibur.Fonts.SkiaSharp.Tests.csproj
+++ b/XLibur.Fonts.SkiaSharp.Tests/XLibur.Fonts.SkiaSharp.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <!-- TUnit runs on Microsoft.Testing.Platform rather than VSTest. -->

--- a/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
+++ b/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
-        <Nullable>enable</Nullable>
         <RootNamespace>XLibur.Fonts.SkiaSharp</RootNamespace>
         <Description>SkiaSharp implementation of IXLFontEngine for XLibur.</Description>
         <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>

--- a/XLibur.Report.Benchmarks/XLibur.Report.Benchmarks.csproj
+++ b/XLibur.Report.Benchmarks/XLibur.Report.Benchmarks.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <Nullable>enable</Nullable>
     <AssemblyName>XLibur.Report.Benchmarks</AssemblyName>
     <RootNamespace>XLibur.Report.Benchmarks</RootNamespace>
     <Company>XLibur</Company>

--- a/XLibur.Report.DynamicLinq/XLibur.Report.DynamicLinq.csproj
+++ b/XLibur.Report.DynamicLinq/XLibur.Report.DynamicLinq.csproj
@@ -5,7 +5,6 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
-        <Nullable>enable</Nullable>
         <RootNamespace>XLibur.Report.DynamicLinq</RootNamespace>
         <Description>ClosedXML.Report expression-syntax compatibility for XLibur.Report. Runs templates written with C# expressions, lambdas and LINQ inside {{ }} — the syntax ClosedXML.Report used — by plugging a second expression engine into XLibur.Report. Install it only if you have such templates; XLibur.Report's own Scriban engine needs nothing from here.</Description>
         <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>

--- a/XLibur.Report.Examples/XLibur.Report.Examples.csproj
+++ b/XLibur.Report.Examples/XLibur.Report.Examples.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
     <RootNamespace>XLibur.Report.Examples</RootNamespace>
     <Company>XLibur</Company>
     <!-- Worked examples, linked from the docs. Nothing ships from here. -->

--- a/XLibur.Report.Tests/XLibur.Report.Tests.csproj
+++ b/XLibur.Report.Tests/XLibur.Report.Tests.csproj
@@ -6,7 +6,6 @@
          means C# 12 and overload resolution silently breaks (CS0411/CS0121). -->
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <!-- CS4014 (call not awaited) must fail the build. TUnit assertions are awaitable, so an

--- a/XLibur.Report/XLibur.Report.csproj
+++ b/XLibur.Report/XLibur.Report.csproj
@@ -5,7 +5,6 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
-        <Nullable>enable</Nullable>
         <RootNamespace>XLibur.Report</RootNamespace>
         <Description>Report templating for XLibur. Author a report as an ordinary .xlsx template — placeholder expressions, named ranges and tag markers — bind .NET data to it, and generate the finished workbook. Charts, pivot tables and pictures survive range expansion.</Description>
         <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>

--- a/XLibur.Tests/Excel/AutoFilters/AutoFilterRoundTripTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/AutoFilterRoundTripTests.cs
@@ -183,7 +183,7 @@ public class AutoFilterRoundTripTests
         using var doc = SpreadsheetDocument.Open(saved, false);
         var worksheet = doc.WorkbookPart!.WorksheetParts.Single().Worksheet;
 
-        return worksheet.Elements<AutoFilter>().Single().Elements<FilterColumn>().ToList();
+        return worksheet!.Elements<AutoFilter>().Single().Elements<FilterColumn>().ToList();
     }
 
     /// <summary>

--- a/XLibur.Tests/Excel/AutoFilters/AutoFilterTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/AutoFilterTests.cs
@@ -32,8 +32,8 @@ public class AutoFilterTests
             6
         };
 
-        table.DataRange!.InsertRowsBelow(listOfArr.Count - table.DataRange!.RowCount());
-        table.DataRange!.FirstCell().InsertData(listOfArr);
+        table.DataRange!.InsertRowsBelow(listOfArr.Count - table.DataRange.RowCount());
+        table.DataRange.FirstCell().InsertData(listOfArr);
 
         await Assert.That(table.AutoFilter.Range.RangeAddress.ToStringRelative()).IsEqualTo("A1:A5");
         await Assert.That(table.AutoFilter.VisibleRows.Count()).IsEqualTo(5);

--- a/XLibur.Tests/Excel/AutoFilters/AutoFilterTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/AutoFilterTests.cs
@@ -32,8 +32,8 @@ public class AutoFilterTests
             6
         };
 
-        table.DataRange!.InsertRowsBelow(listOfArr.Count - table.DataRange.RowCount());
-        table.DataRange.FirstCell().InsertData(listOfArr);
+        table.DataRange!.InsertRowsBelow(listOfArr.Count - table.DataRange!.RowCount());
+        table.DataRange!.FirstCell().InsertData(listOfArr);
 
         await Assert.That(table.AutoFilter.Range.RangeAddress.ToStringRelative()).IsEqualTo("A1:A5");
         await Assert.That(table.AutoFilter.VisibleRows.Count()).IsEqualTo(5);

--- a/XLibur.Tests/Excel/AutoFilters/DynamicFilterTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/DynamicFilterTests.cs
@@ -14,11 +14,11 @@ public class DynamicFilterTests
         await TestHelper.CreateSaveLoadAssert(
             (_, ws) =>
             {
-                var autoFilter = ws.Cell("A1").InsertData(new object[]
+                var autoFilter = ws.Cell("A1")!.InsertData(new object[]
                 {
                     "Data",
                     1,2,3,4,5,10, // avg. 4.16
-                }).SetAutoFilter();
+                })!.SetAutoFilter();
                 autoFilter.Column(1).AboveAverage();
             },
             async (_, ws) =>

--- a/XLibur.Tests/Excel/AutoFilters/DynamicFilterTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/DynamicFilterTests.cs
@@ -14,7 +14,7 @@ public class DynamicFilterTests
         await TestHelper.CreateSaveLoadAssert(
             (_, ws) =>
             {
-                var autoFilter = ws.Cell("A1")!.InsertData(new object[]
+                var autoFilter = ws.Cell("A1").InsertData(new object[]
                 {
                     "Data",
                     1,2,3,4,5,10, // avg. 4.16

--- a/XLibur.Tests/Excel/AutoFilters/RegularFilterTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/RegularFilterTests.cs
@@ -17,7 +17,7 @@ public class RegularFilterTests
         await TestHelper.CreateSaveLoadAssert(
             (_, ws) =>
             {
-                var autoFilter = ws.Cell("A1")!.InsertData(new object[]
+                var autoFilter = ws.Cell("A1").InsertData(new object[]
                 {
                     "Data",
                     1, 2,

--- a/XLibur.Tests/Excel/AutoFilters/RegularFilterTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/RegularFilterTests.cs
@@ -17,13 +17,13 @@ public class RegularFilterTests
         await TestHelper.CreateSaveLoadAssert(
             (_, ws) =>
             {
-                var autoFilter = ws.Cell("A1").InsertData(new object[]
+                var autoFilter = ws.Cell("A1")!.InsertData(new object[]
                 {
                     "Data",
                     1, 2,
                     new DateTime(2015, 7, 25, 0, 0, 0, DateTimeKind.Unspecified),
                     new DateTime(2015, 8, 25, 0, 0, 0, DateTimeKind.Unspecified),
-                }).SetAutoFilter();
+                })!.SetAutoFilter();
                 autoFilter.Column(1)
                     .AddFilter(1)
                     .AddDateGroupFilter(new DateTime(2015, 8, 1, 0, 0, 0, DateTimeKind.Unspecified), XLDateTimeGrouping.Month);

--- a/XLibur.Tests/Excel/AutoFilters/Top10FilterTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/Top10FilterTests.cs
@@ -14,7 +14,7 @@ public class Top10FilterTests
         await TestHelper.CreateSaveLoadAssert(
             (_, ws) =>
             {
-                var autoFilter = ws.Cell("A1")!.InsertData(new object[]
+                var autoFilter = ws.Cell("A1").InsertData(new object[]
                 {
                     "Data",
                     4, 4, 1, 3, 2, 5,
@@ -140,7 +140,7 @@ public class Top10FilterTests
                 filterColumn.Top(value);
             else
                 filterColumn.Bottom(value);
-        }).Throws<ArgumentOutOfRangeException>()!;
+        }).Throws<ArgumentOutOfRangeException>();
         await Assert.That(ex!.Message).Contains("Value must be between 1 and 500.");
     }
 }

--- a/XLibur.Tests/Excel/AutoFilters/Top10FilterTests.cs
+++ b/XLibur.Tests/Excel/AutoFilters/Top10FilterTests.cs
@@ -14,11 +14,11 @@ public class Top10FilterTests
         await TestHelper.CreateSaveLoadAssert(
             (_, ws) =>
             {
-                var autoFilter = ws.Cell("A1").InsertData(new object[]
+                var autoFilter = ws.Cell("A1")!.InsertData(new object[]
                 {
                     "Data",
                     4, 4, 1, 3, 2, 5,
-                }).SetAutoFilter();
+                })!.SetAutoFilter();
                 autoFilter.Column(1).Top(3);
             },
             async (_, ws) =>
@@ -141,6 +141,6 @@ public class Top10FilterTests
             else
                 filterColumn.Bottom(value);
         }).Throws<ArgumentOutOfRangeException>()!;
-        await Assert.That(ex.Message).Contains("Value must be between 1 and 500.");
+        await Assert.That(ex!.Message).Contains("Value must be between 1 and 500.");
     }
 }

--- a/XLibur.Tests/Excel/CalcEngine/AggregateTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/AggregateTests.cs
@@ -11,14 +11,14 @@ namespace XLibur.Tests.Excel.CalcEngine;
 [SetCulture("en-US")]
 public class AggregateTests
 {
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     /// <summary>Put 1, 2, 3, 4 and 5 into A1:A5.</summary>
-    private static void SeedNumbers(XLWorksheet ws)
+    private static void SeedNumbers(IXLWorksheet ws)
     {
         for (var row = 1; row <= 5; row++)
             ws.Cell(row, 1).Value = row;

--- a/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -233,7 +233,7 @@ public class ArrayFormulaTests
         foreach (var cell in arraySheet.Range("A1:A3").Cells())
         {
             await Assert.That(cell.HasArrayFormula).IsTrue().Because($"{cell.Address} lost its array formula");
-            await Assert.That(cell.FormulaReference.ToStringRelative()).IsEqualTo("A1:A3");
+            await Assert.That(cell.FormulaReference!.ToStringRelative()).IsEqualTo("A1:A3");
         }
     }
 
@@ -251,7 +251,7 @@ public class ArrayFormulaTests
         foreach (var cell in ws.Range("B5:B7").Cells())
         {
             await Assert.That(cell.HasArrayFormula).IsTrue().Because($"{cell.Address} lost its array formula");
-            await Assert.That(cell.FormulaReference.ToStringRelative()).IsEqualTo("B5:B7");
+            await Assert.That(cell.FormulaReference!.ToStringRelative()).IsEqualTo("B5:B7");
         }
     }
 
@@ -267,7 +267,7 @@ public class ArrayFormulaTests
         foreach (var cell in ws.Range("C3:E3").Cells())
         {
             await Assert.That(cell.HasArrayFormula).IsTrue().Because($"{cell.Address} lost its array formula");
-            await Assert.That(cell.FormulaReference.ToStringRelative()).IsEqualTo("C3:E3");
+            await Assert.That(cell.FormulaReference!.ToStringRelative()).IsEqualTo("C3:E3");
         }
     }
 

--- a/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -28,7 +28,7 @@ public class ArrayFormulaTests
             foreach (var arrayFormulaCell in ws.Range("A1:B2").Cells())
             {
                 await Assert.That(arrayFormulaCell.FormulaA1).IsEqualTo("1+2");
-                await Assert.That(arrayFormulaCell.FormulaReference.ToStringRelative()).IsEqualTo("A1:B2");
+                await Assert.That(arrayFormulaCell.FormulaReference.ToStringRelative()!).IsEqualTo("A1:B2");
             }
 
             var outsideCell = ws.Cell("A3");
@@ -48,7 +48,7 @@ public class ArrayFormulaTests
 
         await Assert.That(oneCell.HasArrayFormula).IsTrue();
         await Assert.That(oneCell.FormulaA1).IsEqualTo("2+5");
-        await Assert.That(oneCell.FormulaReference.ToStringRelative()).IsEqualTo("B3:B3");
+        await Assert.That(oneCell.FormulaReference.ToStringRelative()!).IsEqualTo("B3:B3");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -28,7 +28,7 @@ public class ArrayFormulaTests
             foreach (var arrayFormulaCell in ws.Range("A1:B2").Cells())
             {
                 await Assert.That(arrayFormulaCell.FormulaA1).IsEqualTo("1+2");
-                await Assert.That(arrayFormulaCell.FormulaReference.ToStringRelative()!).IsEqualTo("A1:B2");
+                await Assert.That(arrayFormulaCell.FormulaReference.ToStringRelative()).IsEqualTo("A1:B2");
             }
 
             var outsideCell = ws.Cell("A3");
@@ -48,7 +48,7 @@ public class ArrayFormulaTests
 
         await Assert.That(oneCell.HasArrayFormula).IsTrue();
         await Assert.That(oneCell.FormulaA1).IsEqualTo("2+5");
-        await Assert.That(oneCell.FormulaReference.ToStringRelative()!).IsEqualTo("B3:B3");
+        await Assert.That(oneCell.FormulaReference.ToStringRelative()).IsEqualTo("B3:B3");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -28,7 +28,7 @@ public class ArrayFormulaTests
             foreach (var arrayFormulaCell in ws.Range("A1:B2").Cells())
             {
                 await Assert.That(arrayFormulaCell.FormulaA1).IsEqualTo("1+2");
-                await Assert.That(arrayFormulaCell.FormulaReference.ToStringRelative()).IsEqualTo("A1:B2");
+                await Assert.That(arrayFormulaCell.FormulaReference!.ToStringRelative()).IsEqualTo("A1:B2");
             }
 
             var outsideCell = ws.Cell("A3");
@@ -48,7 +48,7 @@ public class ArrayFormulaTests
 
         await Assert.That(oneCell.HasArrayFormula).IsTrue();
         await Assert.That(oneCell.FormulaA1).IsEqualTo("2+5");
-        await Assert.That(oneCell.FormulaReference.ToStringRelative()).IsEqualTo("B3:B3");
+        await Assert.That(oneCell.FormulaReference!.ToStringRelative()).IsEqualTo("B3:B3");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/ArrayShapingTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ArrayShapingTests.cs
@@ -11,14 +11,14 @@ namespace XLibur.Tests.Excel.CalcEngine;
 [SetCulture("en-US")]
 public class ArrayShapingTests
 {
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     /// <summary>Fill A1:C2 with 1..6 read left to right, top to bottom.</summary>
-    private static void SeedGrid(XLWorksheet ws)
+    private static void SeedGrid(IXLWorksheet ws)
     {
         var value = 1;
         for (var row = 1; row <= 2; row++)

--- a/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -541,7 +541,7 @@ internal class DependencyTreeTests
 
     #endregion Structured references
 
-    private static FormulaDependencies GetDependencies(string formula, string formulaAddress = "A1", Action<XLWorkbook> init = null)
+    private static FormulaDependencies GetDependencies(string formula, string formulaAddress = "A1", Action<XLWorkbook> init = null!)
     {
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet");

--- a/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -239,7 +239,7 @@ internal class DependencyTreeTests
         AddFormula(tree, ws, "A4", "=A3");
 
         // Mark the middle one dirty, but A4 is still clear
-        ((XLCell)ws.Cell("A3")).Formula.MarkExplicitlyDirty();
+        ((XLCell)ws.Cell("A3")).Formula!.MarkExplicitlyDirty();
 
         MarkDirty(tree, ws, "A1");
         await AssertDirty(ws, "A2", "A3");
@@ -516,7 +516,7 @@ internal class DependencyTreeTests
         var cell = report.Cell("A1");
         cell.SetFormulaA1("SUM(TableName[Second])");
 
-        var cellFormula = ((XLCell)cell).Formula;
+        var cellFormula = ((XLCell)cell).Formula!;
         var dependencies = tree.AddFormula(new SheetArea(report.Name, cellFormula.Range), cellFormula, wb);
 
         await Assert.That(dependencies.Areas)
@@ -550,7 +550,7 @@ internal class DependencyTreeTests
         var cell = ws.Cell(formulaAddress);
         cell.SetFormulaA1(formula);
 
-        var cellFormula = ((XLCell)cell).Formula;
+        var cellFormula = ((XLCell)cell).Formula!;
         var dependencies = tree.AddFormula(new SheetArea(ws.Name, cellFormula.Range), cellFormula, wb);
         return dependencies;
     }

--- a/XLibur.Tests/Excel/CalcEngine/DistributionTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DistributionTests.cs
@@ -15,10 +15,10 @@ public class DistributionTests
 {
     private const double Tolerance = 1e-9;
 
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     #region Normal

--- a/XLibur.Tests/Excel/CalcEngine/DynamicArrayFunctionTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DynamicArrayFunctionTests.cs
@@ -7,10 +7,10 @@ namespace XLibur.Tests.Excel.CalcEngine;
 // sized range; scalar results (and the top-left collapse) through ws.Evaluate.
 public class DynamicArrayFunctionTests
 {
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/FinancialCashFlowTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FinancialCashFlowTests.cs
@@ -10,10 +10,10 @@ namespace XLibur.Tests.Excel.CalcEngine;
 /// </summary>
 public class FinancialCashFlowTests
 {
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     [Test]
@@ -349,7 +349,7 @@ public class FinancialCashFlowTests
         }
     }
 
-    private static void SeedIrregularSchedule(XLWorksheet ws)
+    private static void SeedIrregularSchedule(IXLWorksheet ws)
     {
         ws.Cell("A1").Value = -10000;
         ws.Cell("A2").Value = 2750;

--- a/XLibur.Tests/Excel/CalcEngine/FinancialTvmTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FinancialTvmTests.cs
@@ -8,10 +8,10 @@ public class FinancialTvmTests
     private const double Tolerance = 1e-4;
     private const double IterativeTolerance = 1e-3;
 
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -431,7 +431,7 @@ public class FormulaParserTests
     public async Task Const_array_must_have_same_number_of_columns()
     {
         var calcEngine = new XLCalcEngine(CultureInfo.InvariantCulture);
-        var ex = await Assert.That(() => calcEngine.Parse("{1;2,3}")).Throws<ExpressionParseException>()!;
+        var ex = await Assert.That(() => calcEngine.Parse("{1;2,3}")).Throws<ExpressionParseException>();
         await Assert.That(ex!.Message).Contains("Rows of an array don't have same size.");
     }
 
@@ -440,7 +440,7 @@ public class FormulaParserTests
     {
         // XLParser allows @ for number through 'PrefixOp + Number'
         var calcEngine = new XLCalcEngine(CultureInfo.InvariantCulture);
-        var ex = await Assert.That(() => calcEngine.Parse("{@1}")).Throws<ExpressionParseException>()!;
+        var ex = await Assert.That(() => calcEngine.Parse("{@1}")).Throws<ExpressionParseException>();
         await Assert.That(ex!.Message).Contains("Unexpected token INTERSECT.");
     }
 

--- a/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -432,7 +432,7 @@ public class FormulaParserTests
     {
         var calcEngine = new XLCalcEngine(CultureInfo.InvariantCulture);
         var ex = await Assert.That(() => calcEngine.Parse("{1;2,3}")).Throws<ExpressionParseException>()!;
-        await Assert.That(ex.Message).Contains("Rows of an array don't have same size.");
+        await Assert.That(ex!.Message).Contains("Rows of an array don't have same size.");
     }
 
     [Test]
@@ -441,7 +441,7 @@ public class FormulaParserTests
         // XLParser allows @ for number through 'PrefixOp + Number'
         var calcEngine = new XLCalcEngine(CultureInfo.InvariantCulture);
         var ex = await Assert.That(() => calcEngine.Parse("{@1}")).Throws<ExpressionParseException>()!;
-        await Assert.That(ex.Message).Contains("Unexpected token INTERSECT.");
+        await Assert.That(ex!.Message).Contains("Unexpected token INTERSECT.");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/HypothesisTestTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/HypothesisTestTests.cs
@@ -12,13 +12,13 @@ namespace XLibur.Tests.Excel.CalcEngine;
 [SetCulture("en-US")]
 public class HypothesisTestTests
 {
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
-    private static void SeedTwoSamples(XLWorksheet ws)
+    private static void SeedTwoSamples(IXLWorksheet ws)
     {
         double[] first = [3, 4, 5, 8, 9, 1, 2, 4, 5];
         double[] second = [6, 19, 3, 2, 14, 4, 5, 17, 1];

--- a/XLibur.Tests/Excel/CalcEngine/IfsSwitchTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/IfsSwitchTests.cs
@@ -5,10 +5,10 @@ namespace XLibur.Tests.Excel.CalcEngine;
 // IFS and SWITCH — scalar logical selectors added alongside IF.
 public class IfsSwitchTests
 {
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -9,7 +9,7 @@ namespace XLibur.Tests.Excel.CalcEngine;
 [SetCulture("en-US")]
 public class LookupTests
 {
-    private static IXLWorksheet ws;
+    private static IXLWorksheet ws = null!;
 
     #region Setup and teardown
 

--- a/XLibur.Tests/Excel/CalcEngine/ModernTextTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/ModernTextTests.cs
@@ -11,10 +11,10 @@ namespace XLibur.Tests.Excel.CalcEngine;
 [SetCulture("en-US")]
 public class ModernTextTests
 {
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/RegressionTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/RegressionTests.cs
@@ -13,14 +13,14 @@ namespace XLibur.Tests.Excel.CalcEngine;
 [SetCulture("en-US")]
 public class RegressionTests
 {
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     /// <summary>x = 9, 7, 5, 3, 1 in column A and y = 10, 6, 1, 5, 3 in column B.</summary>
-    private static void SeedScatter(XLWorksheet ws)
+    private static void SeedScatter(IXLWorksheet ws)
     {
         double[] xs = [9, 7, 5, 3, 1];
         double[] ys = [10, 6, 1, 5, 3];
@@ -32,7 +32,7 @@ public class RegressionTests
     }
 
     /// <summary>x = 1..5 in column A and the exactly linear y = 2x + 1 in column B.</summary>
-    private static void SeedExactLine(XLWorksheet ws)
+    private static void SeedExactLine(IXLWorksheet ws)
     {
         for (var row = 1; row <= 5; row++)
         {

--- a/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/SpillEvaluationTests.cs
@@ -9,10 +9,10 @@ namespace XLibur.Tests.Excel.CalcEngine;
 // footprint clears the cells the previous result no longer covers.
 public class SpillEvaluationTests
 {
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -9,7 +9,7 @@ namespace XLibur.Tests.Excel.CalcEngine;
 public class StatisticalTests
 {
     private const double tolerance = 1e-6;
-    private static XLWorkbook workbook;
+    private static XLWorkbook workbook = null!;
 
     [Test]
     public async Task Average()

--- a/XLibur.Tests/Excel/CalcEngine/StructuredReferenceColonTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/StructuredReferenceColonTests.cs
@@ -117,7 +117,7 @@ internal class StructuredReferenceColonTests
             new object[] { "x", "1", "2" }
         };
         var range = ws2.FirstCell().InsertData(data);
-        range.CreateTable("MyTable");
+        range!.CreateTable("MyTable");
 
         ws.Cell("A1").FormulaA1 =
             "=_xlfn.XLOOKUP(\"x\",MyTable[Key],MyTable[Col: A])+_xlfn.XLOOKUP(\"x\",MyTable[Key],MyTable[Col: B])";
@@ -141,7 +141,7 @@ internal class StructuredReferenceColonTests
             new object[] { "1", "2026-01-01", "2026-12-31" }
         };
         var range = ws2.FirstCell().InsertData(data);
-        range.CreateTable("Dates");
+        range!.CreateTable("Dates");
 
         ws.Cell("A1").FormulaA1 =
             "=_xlfn.XLOOKUP(1,Dates[ID],Dates[Start: Date])";

--- a/XLibur.Tests/Excel/CalcEngine/StructuredReferenceColonTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/StructuredReferenceColonTests.cs
@@ -23,7 +23,7 @@ internal class StructuredReferenceColonTests
             new object[] { "2026-01-01", "1" }
         };
         var range = ws2.FirstCell().InsertData(data);
-        range.CreateTable("Table2");
+        range!.CreateTable("Table2");
 
         ws.FirstCell().Value = "2026-01-01";
         ws.Cell("B1").FormulaA1 =
@@ -49,7 +49,7 @@ internal class StructuredReferenceColonTests
                 new object[] { "2026-01-01", "1" }
             };
             var range = ws2.FirstCell().InsertData(data);
-            range.CreateTable("Table2");
+            range!.CreateTable("Table2");
 
             var ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().Value = "2026-01-01";
@@ -95,7 +95,7 @@ internal class StructuredReferenceColonTests
             new object[] { "2026-01-01", "42" }
         };
         var range = ws2.FirstCell().InsertData(data);
-        range.CreateTable("Table2");
+        range!.CreateTable("Table2");
 
         ws.Cell("A1").FormulaA1 = "=Table2[Value]";
 

--- a/XLibur.Tests/Excel/CalcEngine/WorkdayIntlTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/WorkdayIntlTests.cs
@@ -11,10 +11,10 @@ namespace XLibur.Tests.Excel.CalcEngine;
 [SetCulture("en-US")]
 public class WorkdayIntlTests
 {
-    private static XLWorksheet NewSheet(out XLWorkbook wb)
+    private static IXLWorksheet NewSheet(out XLWorkbook wb)
     {
         wb = new XLWorkbook();
-        return (XLWorksheet)wb.AddWorksheet("Sheet1");
+        return wb.AddWorksheet("Sheet1");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Cells/XLCellFormulaTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellFormulaTests.cs
@@ -108,7 +108,7 @@ public class XLCellFormulaTests
 
         // Only one XLDAPR metadata entry should exist
         var metadata = wbPart.CellMetadataPart!.Metadata;
-        var cellMeta = metadata.GetFirstChild<CellMetadata>()!;
+        var cellMeta = metadata!.GetFirstChild<CellMetadata>()!;
         await Assert.That(cellMeta.Count!.Value).IsEqualTo(ExpectedCellValue.From(1));
 
         // Both cells should reference the same cm index

--- a/XLibur.Tests/Excel/Cells/XLCellFormulaTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellFormulaTests.cs
@@ -45,7 +45,7 @@ public class XLCellFormulaTests
         await Assert.That(metaPart).IsNotNull().Because("CellMetadataPart should exist");
 
         var metadata = metaPart!.Metadata;
-        var metadataType = metadata.MetadataTypes!.Elements<MetadataType>().First();
+        var metadataType = metadata!.MetadataTypes!.Elements<MetadataType>().First();
         await Assert.That(metadataType.Name!.Value).IsEqualTo("XLDAPR");
 
         // Verify futureMetadata block exists

--- a/XLibur.Tests/Excel/Cells/XLCellTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellTests.cs
@@ -100,7 +100,7 @@ public class XLCellTests
     {
         var ws = new XLWorkbook().Worksheets.Add("Sheet1");
         var range = ws.Cell(2, 2).InsertData(InsertDataStrings);
-        await Assert.That(range.ToString()).IsEqualTo("Sheet1!B2:B4");
+        await Assert.That(range.ToString()!).IsEqualTo("Sheet1!B2:B4");
     }
 
     [Test]
@@ -108,7 +108,7 @@ public class XLCellTests
     {
         var ws = new XLWorkbook().Worksheets.Add("Sheet1");
         var range = ws.Cell(2, 2).InsertData(InsertDataStrings, false);
-        await Assert.That(range.ToString()).IsEqualTo("Sheet1!B2:B4");
+        await Assert.That(range.ToString()!).IsEqualTo("Sheet1!B2:B4");
     }
 
     [Test]
@@ -116,7 +116,7 @@ public class XLCellTests
     {
         var ws = new XLWorkbook().Worksheets.Add("Sheet1");
         var range = ws.Cell(2, 2).InsertData(InsertDataStrings, true);
-        await Assert.That(range.ToString()).IsEqualTo("Sheet1!B2:D2");
+        await Assert.That(range.ToString()!).IsEqualTo("Sheet1!B2:D2");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Cells/XLCellTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellTests.cs
@@ -48,7 +48,7 @@ public class XLCellTests
         ws.Row(3).Style.Fill.BackgroundColor = XLColor.Red;
         ws.Column(3).Style.Fill.BackgroundColor = XLColor.Red;
         ws.Cell(2, 2).Value = "ASDF";
-        var range = ws.RangeUsed(XLCellsUsedOptions.All).RangeAddress.ToString();
+        var range = ws.RangeUsed(XLCellsUsedOptions.All)!.RangeAddress.ToString();
         await Assert.That(range).IsEqualTo("B2:C3");
     }
 
@@ -59,7 +59,7 @@ public class XLCellTests
         ws.Row(2).Style.Fill.BackgroundColor = XLColor.Red;
         ws.Column(2).Style.Fill.BackgroundColor = XLColor.Red;
         ws.Cell(3, 3).Value = "ASDF";
-        var range = ws.RangeUsed(XLCellsUsedOptions.All).RangeAddress.ToString();
+        var range = ws.RangeUsed(XLCellsUsedOptions.All)!.RangeAddress.ToString();
         await Assert.That(range).IsEqualTo("B2:C3");
     }
 
@@ -79,7 +79,7 @@ public class XLCellTests
         ws.SparklineGroups.Add("B2", "C3:E3");
         ws.SparklineGroups.Add("F5", "C4:E4");
 
-        var range = ws.RangeUsed(XLCellsUsedOptions.All).RangeAddress.ToString();
+        var range = ws.RangeUsed(XLCellsUsedOptions.All)!.RangeAddress.ToString();
         await Assert.That(range).IsEqualTo("B2:F5");
     }
 

--- a/XLibur.Tests/Excel/Cells/XLCellTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellTests.cs
@@ -100,7 +100,7 @@ public class XLCellTests
     {
         var ws = new XLWorkbook().Worksheets.Add("Sheet1");
         var range = ws.Cell(2, 2).InsertData(InsertDataStrings);
-        await Assert.That(range.ToString()!).IsEqualTo("Sheet1!B2:B4");
+        await Assert.That(range!.ToString()).IsEqualTo("Sheet1!B2:B4");
     }
 
     [Test]
@@ -108,7 +108,7 @@ public class XLCellTests
     {
         var ws = new XLWorkbook().Worksheets.Add("Sheet1");
         var range = ws.Cell(2, 2).InsertData(InsertDataStrings, false);
-        await Assert.That(range.ToString()!).IsEqualTo("Sheet1!B2:B4");
+        await Assert.That(range!.ToString()).IsEqualTo("Sheet1!B2:B4");
     }
 
     [Test]
@@ -116,7 +116,7 @@ public class XLCellTests
     {
         var ws = new XLWorkbook().Worksheets.Add("Sheet1");
         var range = ws.Cell(2, 2).InsertData(InsertDataStrings, true);
-        await Assert.That(range.ToString()!).IsEqualTo("Sheet1!B2:D2");
+        await Assert.That(range!.ToString()).IsEqualTo("Sheet1!B2:D2");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Cells/XLCellValueTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellValueTests.cs
@@ -71,7 +71,7 @@ public class XLCellValueTests
     [Test]
     public async Task NullString_IsConvertedToBlank()
     {
-        XLCellValue value = (string)null;
+        XLCellValue value = (string?)null;
         await Assert.That(value.IsBlank).IsTrue();
         await Assert.That(value.IsText).IsFalse();
     }

--- a/XLibur.Tests/Excel/Cells/XLCellValueTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellValueTests.cs
@@ -603,7 +603,7 @@ public class XLCellValueTests
     public async Task TimeSpan_throws_when_not_representable(double serialDateTime)
     {
         var value = XLCellValue.FromSerialTimeSpan(serialDateTime);
-        var ex = await Assert.That(() => value.GetTimeSpan()).Throws<OverflowException>()!;
+        var ex = await Assert.That(() => value.GetTimeSpan()).Throws<OverflowException>();
         await Assert.That(ex!.Message).IsEqualTo("The serial date time value is too large to be represented in a TimeSpan.");
     }
 }

--- a/XLibur.Tests/Excel/Cells/XLCellValueTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellValueTests.cs
@@ -604,6 +604,6 @@ public class XLCellValueTests
     {
         var value = XLCellValue.FromSerialTimeSpan(serialDateTime);
         var ex = await Assert.That(() => value.GetTimeSpan()).Throws<OverflowException>()!;
-        await Assert.That(ex.Message).IsEqualTo("The serial date time value is too large to be represented in a TimeSpan.");
+        await Assert.That(ex!.Message).IsEqualTo("The serial date time value is too large to be represented in a TimeSpan.");
     }
 }

--- a/XLibur.Tests/Excel/Charts/ChartAnchorTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartAnchorTests.cs
@@ -169,7 +169,7 @@ public class ChartAnchorTests
         {
             var charts = wb.Worksheet("Data").Charts.ToList();
             await Assert.That(charts.Count).IsEqualTo(3).Because("A one-cell or absolute anchored chart used to be skipped on read.");
-            await Assert.That(charts.Select(c => c.Title)).IsEquivalentTo(new[] { "Two cell", "One cell", "Absolute" }, CollectionOrdering.Matching);
+            await Assert.That(charts.Select(c => c.Title)).IsEquivalentTo(new string?[] { "Two cell", "One cell", "Absolute" }, CollectionOrdering.Matching);
             await Assert.That(charts.Select(c => c.Anchor)).IsEquivalentTo(new[]
             {
                 XLDrawingAnchor.MoveAndSizeWithCells,

--- a/XLibur.Tests/Excel/Charts/ChartDataLabelTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartDataLabelTests.cs
@@ -254,7 +254,7 @@ public class ChartDataLabelTests
 
         var ex = await Assert.That(() => labels.Position = XLDataLabelPosition.OutsideEnd).Throws<ArgumentException>();
         await Assert.That(ex!.Message).Contains("ColumnStacked");
-        await Assert.That(ex.Message).Contains("InsideBase").Because("The message lists what Excel does offer.");
+        await Assert.That(ex!.Message).Contains("InsideBase").Because("The message lists what Excel does offer.");
 
         await Assert.That(() => labels.Position = XLDataLabelPosition.InsideEnd).ThrowsNothing();
     }

--- a/XLibur.Tests/Excel/Charts/ChartDataLabelTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartDataLabelTests.cs
@@ -254,7 +254,7 @@ public class ChartDataLabelTests
 
         var ex = await Assert.That(() => labels.Position = XLDataLabelPosition.OutsideEnd).Throws<ArgumentException>();
         await Assert.That(ex!.Message).Contains("ColumnStacked");
-        await Assert.That(ex!.Message).Contains("InsideBase").Because("The message lists what Excel does offer.");
+        await Assert.That(ex.Message).Contains("InsideBase").Because("The message lists what Excel does offer.");
 
         await Assert.That(() => labels.Position = XLDataLabelPosition.InsideEnd).ThrowsNothing();
     }

--- a/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartSeriesFormattingTests.cs
@@ -482,7 +482,7 @@ public class ChartSeriesFormattingTests
     {
         // Left on disk on purpose: this is the file to open in Excel when checking that the
         // formatting renders the way it is meant to.
-        var path = Path.Combine(TestContext.TestDirectory, "FormattedChartExamples.xlsx");
+        var path = Path.Combine(TestContext.TestDirectory!, "FormattedChartExamples.xlsx");
         new XLibur.Examples.Charts.FormattedChartExamples().Create(path);
         Console.Out.WriteLine($"Formatted chart example: {path}");
 

--- a/XLibur.Tests/Excel/Columns/ColumnTests.cs
+++ b/XLibur.Tests/Excel/Columns/ColumnTests.cs
@@ -38,7 +38,7 @@ public class ColumnTests
         var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");
         ws.FirstCell().SetValue("Test").Style.Font.SetBold();
-        ws.FirstColumn()!.CopyTo(ws.Column(2));
+        ws.FirstColumn().CopyTo(ws.Column(2));
 
         await Assert.That(ws.Cell("B1").Style.Font.Bold).IsTrue();
     }
@@ -298,9 +298,9 @@ public class ColumnTests
         var wb = new XLWorkbook();
         wb.DefinedNames.Add("TestName", XLError.NameNotRecognized.ToDisplayString());
         var ws1 = wb.AddWorksheet();
-        await Assert.That(() => ws1.FirstColumn()!.InsertColumnsAfter(1)).ThrowsNothing();
+        await Assert.That(() => ws1.FirstColumn().InsertColumnsAfter(1)).ThrowsNothing();
         var ws2 = wb.AddWorksheet();
-        await Assert.That(() => ws2.FirstColumn()!.InsertColumnsBefore(1)).ThrowsNothing();
+        await Assert.That(() => ws2.FirstColumn().InsertColumnsBefore(1)).ThrowsNothing();
 
         await Assert.That(wb.Worksheets.Count).IsEqualTo(2);
     }

--- a/XLibur.Tests/Excel/Columns/ColumnTests.cs
+++ b/XLibur.Tests/Excel/Columns/ColumnTests.cs
@@ -18,7 +18,7 @@ public class ColumnTests
         var fromColumn = ws.Column(1).ColumnUsed();
         await Assert.That(fromColumn.RangeAddress.ToStringRelative()).IsEqualTo("A2:A3");
 
-        var fromRange = ws.Range("A1:A5").FirstColumn().ColumnUsed();
+        var fromRange = ws.Range("A1:A5").FirstColumn()!.ColumnUsed();
         await Assert.That(fromRange.RangeAddress.ToStringRelative()).IsEqualTo("A2:A3");
     }
 
@@ -38,7 +38,7 @@ public class ColumnTests
         var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");
         ws.FirstCell().SetValue("Test").Style.Font.SetBold();
-        ws.FirstColumn().CopyTo(ws.Column(2));
+        ws.FirstColumn()!.CopyTo(ws.Column(2));
 
         await Assert.That(ws.Cell("B1").Style.Font.Bold).IsTrue();
     }
@@ -236,7 +236,7 @@ public class ColumnTests
         ws.Cell("A1").Value = "A1";
         ws.Cell("B1").Value = "B1";
         ws.Cell("A2").Value = "A2";
-        var lastCoUsed = ws.LastColumnUsed().ColumnNumber();
+        var lastCoUsed = ws.LastColumnUsed()!.ColumnNumber();
         await Assert.That(lastCoUsed).IsEqualTo(2);
     }
 
@@ -298,9 +298,9 @@ public class ColumnTests
         var wb = new XLWorkbook();
         wb.DefinedNames.Add("TestName", XLError.NameNotRecognized.ToDisplayString());
         var ws1 = wb.AddWorksheet();
-        await Assert.That(() => ws1.FirstColumn().InsertColumnsAfter(1)).ThrowsNothing();
+        await Assert.That(() => ws1.FirstColumn()!.InsertColumnsAfter(1)).ThrowsNothing();
         var ws2 = wb.AddWorksheet();
-        await Assert.That(() => ws2.FirstColumn().InsertColumnsBefore(1)).ThrowsNothing();
+        await Assert.That(() => ws2.FirstColumn()!.InsertColumnsBefore(1)).ThrowsNothing();
 
         await Assert.That(wb.Worksheets.Count).IsEqualTo(2);
     }

--- a/XLibur.Tests/Excel/Columns/ColumnTests.cs
+++ b/XLibur.Tests/Excel/Columns/ColumnTests.cs
@@ -245,7 +245,7 @@ public class ColumnTests
     {
         var ws = new XLWorkbook().AddWorksheet("Sheet1") as XLWorksheet;
 
-        var column = new XLColumn(ws, -1);
+        var column = new XLColumn(ws!, -1);
 
         await Assert.That(column.RangeAddress.IsValid).IsFalse();
     }

--- a/XLibur.Tests/Excel/Columns/InsertColumnBeforeDataValidationTests.cs
+++ b/XLibur.Tests/Excel/Columns/InsertColumnBeforeDataValidationTests.cs
@@ -34,7 +34,7 @@ public class InsertColumnBeforeDataValidationTests
         saved.Position = 0;
         using var doc = SpreadsheetDocument.Open(saved, false);
         var sheetPart = doc.WorkbookPart!.WorksheetParts.First();
-        var written = sheetPart.Worksheet.Descendants<DataValidation>()
+        var written = sheetPart.Worksheet!.Descendants<DataValidation>()
             .Select(dv => (title: dv.PromptTitle?.Value ?? string.Empty,
                            sqref: dv.SequenceOfReferences!.InnerText))
             .ToList();
@@ -91,7 +91,7 @@ public class InsertColumnBeforeDataValidationTests
         saved.Position = 0;
         using var doc = SpreadsheetDocument.Open(saved, false);
         var sheetPart = doc.WorkbookPart!.WorksheetParts.First();
-        var dvs = sheetPart.Worksheet.Descendants<DataValidation>()
+        var dvs = sheetPart.Worksheet!.Descendants<DataValidation>()
             .Select(dv => (title: dv.PromptTitle?.Value ?? string.Empty,
                            sqref: dv.SequenceOfReferences!.InnerText,
                            f1: dv.Formula1?.InnerText ?? string.Empty))

--- a/XLibur.Tests/Excel/Columns/InsertColumnBeforeDataValidationTests.cs
+++ b/XLibur.Tests/Excel/Columns/InsertColumnBeforeDataValidationTests.cs
@@ -123,6 +123,6 @@ public class InsertColumnBeforeDataValidationTests
     }
 
     private static string FindSqref(
-        System.Collections.Generic.IEnumerable<(string title, string sqref, string f1)> dvs,
+        System.Collections.Generic.IEnumerable<(string title, string? sqref, string f1)> dvs,
         string title) => dvs.Single(x => x.title == title).sqref;
 }

--- a/XLibur.Tests/Excel/Columns/InsertColumnBeforeDataValidationTests.cs
+++ b/XLibur.Tests/Excel/Columns/InsertColumnBeforeDataValidationTests.cs
@@ -122,7 +122,7 @@ public class InsertColumnBeforeDataValidationTests
         }
     }
 
-    private static string FindSqref(
+    private static string? FindSqref(
         System.Collections.Generic.IEnumerable<(string title, string? sqref, string f1)> dvs,
         string title) => dvs.Single(x => x.title == title).sqref;
 }

--- a/XLibur.Tests/Excel/Comments/CommentsTests.cs
+++ b/XLibur.Tests/Excel/Comments/CommentsTests.cs
@@ -22,7 +22,7 @@ public partial class CommentsTests
         var c = ws.FirstCellUsed();
 
         // None indicates an absence of a color
-        var lineColor = c.GetComment().Style.ColorsAndLines.LineColor;
+        var lineColor = c.GetComment()!.Style.ColorsAndLines.LineColor;
         await Assert.That(lineColor.ColorType).IsEqualTo(XLColorType.Color);
         await Assert.That(lineColor.Color.ToHex()).IsEqualTo("00000000");
 

--- a/XLibur.Tests/Excel/Comments/CommentsTests.cs
+++ b/XLibur.Tests/Excel/Comments/CommentsTests.cs
@@ -22,7 +22,7 @@ public partial class CommentsTests
         var c = ws.FirstCellUsed();
 
         // None indicates an absence of a color
-        var lineColor = c.GetComment()!.Style.ColorsAndLines.LineColor;
+        var lineColor = c.GetComment().Style.ColorsAndLines.LineColor;
         await Assert.That(lineColor.ColorType).IsEqualTo(XLColorType.Color);
         await Assert.That(lineColor.Color.ToHex()).IsEqualTo("00000000");
 

--- a/XLibur.Tests/Excel/Comments/CommentsTests.cs
+++ b/XLibur.Tests/Excel/Comments/CommentsTests.cs
@@ -22,7 +22,7 @@ public partial class CommentsTests
         var c = ws.FirstCellUsed();
 
         // None indicates an absence of a color
-        var lineColor = c.GetComment().Style.ColorsAndLines.LineColor;
+        var lineColor = c!.GetComment().Style.ColorsAndLines.LineColor;
         await Assert.That(lineColor.ColorType).IsEqualTo(XLColorType.Color);
         await Assert.That(lineColor.Color.ToHex()).IsEqualTo("00000000");
 

--- a/XLibur.Tests/Excel/Comments/ThreadedCommentsTests.cs
+++ b/XLibur.Tests/Excel/Comments/ThreadedCommentsTests.cs
@@ -362,9 +362,9 @@ public class ThreadedCommentsTests
         return FindEntry(archive, partPathPrefix) is not null;
     }
 
-    // Not annotated ZipArchiveEntry? even though FirstOrDefault can return null: this project has
-    // no <Nullable>enable</Nullable>, so the annotation only earns a CS8632. Both callers handle null.
-    private static ZipArchiveEntry FindEntry(ZipArchive archive, string partPathPrefix)
+    // FirstOrDefault returns null when nothing matches, and both callers handle that. The project
+    // now has a nullable context, so the annotation says so rather than being suppressed.
+    private static ZipArchiveEntry? FindEntry(ZipArchive archive, string partPathPrefix)
     {
         return archive.Entries.FirstOrDefault(e =>
             e.FullName.StartsWith(partPathPrefix, StringComparison.OrdinalIgnoreCase));

--- a/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
+++ b/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
@@ -89,6 +89,6 @@ public class ConditionalFormatRangeShiftTests
             .ToList();
 
         // A5:A7 spans the insertion at row 6 -> extends to A5:A10; C10:C12 is below -> C13:C15.
-        await Assert.That(areas).IsEquivalentTo(new[] { "A5:A10", "C13:C15" }, CollectionOrdering.Matching);
+        await Assert.That(areas).IsEquivalentTo(new string?[] { "A5:A10", "C13:C15" }, CollectionOrdering.Matching);
     }
 }

--- a/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
+++ b/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatRangeShiftTests.cs
@@ -33,7 +33,7 @@ public class ConditionalFormatRangeShiftTests
             ? $"K12:K{12 + inserted}"      // row above the insertion expands to swallow inserted rows
             : $"K{r + inserted}:K{r + inserted}"); // rows at/below the insertion move down
 
-        var actual = ws.ConditionalFormats.Select(cf => cf.Ranges.Single().RangeAddress.ToString());
+        var actual = ws.ConditionalFormats.Select(cf => cf.Ranges.Single().RangeAddress.ToString()!);
         await Assert.That(actual).IsEquivalentTo(expected.ToList(), CollectionOrdering.Matching);
     }
 

--- a/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatSetRangesTests.cs
+++ b/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatSetRangesTests.cs
@@ -28,7 +28,7 @@ public class ConditionalFormatSetRangesTests
         format.SetRanges([sheet.Range("A1:B2"), sheet.Range("A5:B6")]);
 
         var covered = format.Ranges.Select(r => r.RangeAddress.ToString()).ToList();
-        await Assert.That(covered).IsEquivalentTo(new[] { "A1:B2", "A5:B6" });
+        await Assert.That(covered).IsEquivalentTo(new string?[] { "A1:B2", "A5:B6" });
     }
 
     [Test]
@@ -41,7 +41,7 @@ public class ConditionalFormatSetRangesTests
         format.SetRanges([sheet.Range("D1:D4")]);
 
         var covered = format.Ranges.Select(r => r.RangeAddress.ToString()).ToList();
-        await Assert.That(covered).IsEquivalentTo(new[] { "D1:D4" });
+        await Assert.That(covered).IsEquivalentTo(new string?[] { "D1:D4" });
     }
 
     [Test]
@@ -122,6 +122,6 @@ public class ConditionalFormatSetRangesTests
             .Ranges.Select(r => r.RangeAddress.ToString())
             .ToList();
 
-        await Assert.That(covered).IsEquivalentTo(new[] { "A1:B2", "A5:B6" });
+        await Assert.That(covered).IsEquivalentTo(new string?[] { "A1:B2", "A5:B6" });
     }
 }

--- a/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatsConsolidateTests.cs
+++ b/XLibur.Tests/Excel/ConditionalFormats/ConditionalFormatsConsolidateTests.cs
@@ -123,8 +123,8 @@ public class ConditionalFormatsConsolidateTests
         ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
         await Assert.That(ws.ConditionalFormats.Count()).IsEqualTo(3);
-        await Assert.That((ws.ConditionalFormats.Last().Style as XLStyle).Value).IsEqualTo((ws.ConditionalFormats.First().Style as XLStyle).Value);
-        await Assert.That((ws.ConditionalFormats.ElementAt(1).Style as XLStyle).Value).IsNotEqualTo((ws.ConditionalFormats.First().Style as XLStyle).Value);
+        await Assert.That((ws.ConditionalFormats.Last().Style as XLStyle)!.Value).IsEqualTo((ws.ConditionalFormats.First().Style as XLStyle)!.Value);
+        await Assert.That((ws.ConditionalFormats.ElementAt(1).Style as XLStyle)!.Value).IsNotEqualTo((ws.ConditionalFormats.First().Style as XLStyle)!.Value);
     }
 
     [Test]
@@ -141,8 +141,8 @@ public class ConditionalFormatsConsolidateTests
         ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
         await Assert.That(ws.ConditionalFormats.Count()).IsEqualTo(3);
-        await Assert.That((ws.ConditionalFormats.Last().Style as XLStyle).Value).IsEqualTo((ws.ConditionalFormats.First().Style as XLStyle).Value);
-        await Assert.That((ws.ConditionalFormats.ElementAt(1).Style as XLStyle).Value).IsNotEqualTo((ws.ConditionalFormats.First().Style as XLStyle).Value);
+        await Assert.That((ws.ConditionalFormats.Last().Style as XLStyle)!.Value).IsEqualTo((ws.ConditionalFormats.First().Style as XLStyle)!.Value);
+        await Assert.That((ws.ConditionalFormats.ElementAt(1).Style as XLStyle)!.Value).IsNotEqualTo((ws.ConditionalFormats.First().Style as XLStyle)!.Value);
         await Assert.That(ws.ConditionalFormats.All(cf => cf.Ranges.Count == 1)).IsTrue().Because("Number of ranges in consolidated conditional formats is expected to be 1");
         await Assert.That(ws.ConditionalFormats.ElementAt(0).Ranges.Single().RangeAddress.ToString()).IsEqualTo("A1:A1");
         await Assert.That(ws.ConditionalFormats.ElementAt(1).Ranges.Single().RangeAddress.ToString()).IsEqualTo("A2:A3");
@@ -164,7 +164,7 @@ public class ConditionalFormatsConsolidateTests
         ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
         await Assert.That(ws.ConditionalFormats.Count()).IsEqualTo(1);
-        await Assert.That((cf.Style as XLStyle).Value).IsEqualTo((ws.ConditionalFormats.Single().Style as XLStyle).Value);
+        await Assert.That((cf.Style as XLStyle)!.Value).IsEqualTo((ws.ConditionalFormats.Single().Style as XLStyle)!.Value);
         await Assert.That(ws.ConditionalFormats.Single().Ranges.Single().RangeAddress.ToString()).IsEqualTo("A3:C8");
         await Assert.That(ws.ConditionalFormats.Single().Values.Single().Value.IsFormula).IsTrue();
         await Assert.That(ws.ConditionalFormats.Single().Values.Single().Value.Value).IsEqualTo("A3=$D3");

--- a/XLibur.Tests/Excel/Coordinates/AreaTests.cs
+++ b/XLibur.Tests/Excel/Coordinates/AreaTests.cs
@@ -58,7 +58,7 @@ public class AreaTests
     {
         var left = Area.Parse(leftOperand);
         var right = Area.Parse(rightOperand);
-        var expected = Area.Parse(expectedRange);
+        var expected = Area.Parse(expectedRange!);
 
         await Assert.That(left.Range(right)).IsEqualTo(expected);
     }

--- a/XLibur.Tests/Excel/Coordinates/AreaTests.cs
+++ b/XLibur.Tests/Excel/Coordinates/AreaTests.cs
@@ -54,7 +54,7 @@ public class AreaTests
     [Arguments("I6:J9", "L7", "I6:L9")]
     [Arguments("B2:B4", "A3:C3", "A2:C4")]
     [Arguments("B2:C3", "E5:F6", "B2:F6")]
-    public async Task RangeOperation(string leftOperand, string rightOperand, string expectedRange)
+    public async Task RangeOperation(string leftOperand, string rightOperand, string? expectedRange)
     {
         var left = Area.Parse(leftOperand);
         var right = Area.Parse(rightOperand);
@@ -70,7 +70,7 @@ public class AreaTests
     [Arguments("A1:A3", "B2:C2", null)]
     [Arguments("A1:D6", "B2:C3", "B2:C3")]
     [Arguments("A1:C6", "B4:E10", "B4:C6")]
-    public async Task IntersectOperation(string leftOperand, string rightOperand, string expectedRange)
+    public async Task IntersectOperation(string leftOperand, string rightOperand, string? expectedRange)
     {
         var left = Area.Parse(leftOperand);
         var right = Area.Parse(rightOperand);
@@ -120,7 +120,7 @@ public class AreaTests
     [Arguments("XFD1", "XFB1", null)] // Completely pushed out of the range
     [Arguments("XFA1:XFD1", "XEZ1:XFA1", "XFC1:XFD1")] // Partially pushed out of the range
     [Arguments("XFA1:XFD1", "XFB1:XFC1", "XFA1:XFD1")] // Extend below last row
-    public async Task TryInsertAreaAndShiftRight_without_partial_cover(string original, string inserted, string repositioned)
+    public async Task TryInsertAreaAndShiftRight_without_partial_cover(string original, string inserted, string? repositioned)
     {
         var originalArea = Area.Parse(original);
         var insertedArea = Area.Parse(inserted);
@@ -156,7 +156,7 @@ public class AreaTests
     [Arguments("A1048576", "A1048575", null)] // Completely pushed out of the range
     [Arguments("A1048574:A1048576", "A1048570:A1048571", "A1048576")] // Partially pushed out of the range
     [Arguments("A1048570:A1048572", "A1048571:A1048576", "A1048570:A1048576")] // Extend below last row
-    public async Task TryInsertAreaAndShiftDown_without_partial_cover(string original, string inserted, string repositioned)
+    public async Task TryInsertAreaAndShiftDown_without_partial_cover(string original, string inserted, string? repositioned)
     {
         var originalArea = Area.Parse(original);
         var insertedArea = Area.Parse(inserted);
@@ -191,7 +191,7 @@ public class AreaTests
     [Arguments("D4:E4", "A5:F9", "D4:E4")] // Deleted area is fully downward
     [Arguments("D4:E4", "A1:F3", "D4:E4")] // Deleted area is fully upwards
     [Arguments("D4:E4", "A5:F10", "D4:E4")] // Partial deletion is below -> not affected
-    public async Task TryDeleteAreaAndShiftLeft_without_partial_cover(string original, string deleted, string repositioned)
+    public async Task TryDeleteAreaAndShiftLeft_without_partial_cover(string original, string deleted, string? repositioned)
     {
         var originalArea = Area.Parse(original);
         var deletedArea = Area.Parse(deleted);
@@ -228,7 +228,7 @@ public class AreaTests
     [Arguments("B5:B8", "A1:A10", "B5:B8")] // Deleted area is fully on the left
     [Arguments("B5:B8", "C1:C10", "B5:B8")] // Deleted area is fully on the right
     [Arguments("B5:D8", "B9:C10", "B5:D8")] // Partial deletion is below -> not affected
-    public async Task TryDeleteAreaAndShiftUp_without_partial_cover(string leftOperand, string deleted, string expected)
+    public async Task TryDeleteAreaAndShiftUp_without_partial_cover(string leftOperand, string deleted, string? expected)
     {
         var originalArea = Area.Parse(leftOperand);
         var deletedArea = Area.Parse(deleted);

--- a/XLibur.Tests/Excel/Coordinates/XLAreaListTests.cs
+++ b/XLibur.Tests/Excel/Coordinates/XLAreaListTests.cs
@@ -156,7 +156,7 @@ internal class XLAreaListTests
     [Arguments("B2", "D2", "A1:C3", "E3")] // Intersected area not in corner and shifted doesn't start at target
     [Arguments("D3:G6", "A1", "E4:F5", "A1:B2")]
     [Arguments("B2", "XFD1048576", "A1:C3", null)] // Copied area out of sheet
-    public async Task TryCopyAreaTo_return_list_of_intersecting_areas_shifted_to_target(string areaListText, string targetPointText, string areaToCopyText, string expected)
+    public async Task TryCopyAreaTo_return_list_of_intersecting_areas_shifted_to_target(string areaListText, string targetPointText, string areaToCopyText, string? expected)
     {
         var areaList = Parse(areaListText);
         var targetPoint = Point.Parse(targetPointText);

--- a/XLibur.Tests/Excel/DataValidations/DataValidationDropOnInsertTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationDropOnInsertTests.cs
@@ -28,7 +28,7 @@ public class DataValidationDropOnInsertTests
             .ToList();
 
         // K12 spans the insertion -> K12:K22; K13 -> K23 (not dropped); K23 -> K33.
-        await Assert.That(actual).IsEquivalentTo(new[] { "K12:K22", "K23:K23", "K33:K33" }, CollectionOrdering.Matching);
+        await Assert.That(actual).IsEquivalentTo(new string?[] { "K12:K22", "K23:K23", "K33:K33" }, CollectionOrdering.Matching);
     }
 
     [Test]
@@ -48,6 +48,6 @@ public class DataValidationDropOnInsertTests
             .ToList();
 
         // B spans the insertion boundary column -> B20:L20; C20 -> M20; M20 -> W20.
-        await Assert.That(actual).IsEquivalentTo(new[] { "B20:L20", "M20:M20", "W20:W20" });
+        await Assert.That(actual).IsEquivalentTo(new string?[] { "B20:L20", "M20:M20", "W20:W20" });
     }
 }

--- a/XLibur.Tests/Excel/DataValidations/DataValidationFormulaShiftTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationFormulaShiftTests.cs
@@ -250,7 +250,7 @@ public class DataValidationFormulaShiftTests
         saved.Position = 0;
         using var doc = SpreadsheetDocument.Open(saved, false);
         var sheetPart = doc.WorkbookPart!.WorksheetParts.First();
-        var dv = sheetPart.Worksheet.Descendants<DataValidation>().Single();
+        var dv = sheetPart.Worksheet!.Descendants<DataValidation>().Single();
 
         await Assert.That(dv.SequenceOfReferences!.InnerText).IsEqualTo("F3:F816");
         await Assert.That(dv.Formula1!.InnerText.TrimStart('=')).IsEqualTo("$E3>0");

--- a/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -444,7 +444,7 @@ public class DataValidationTests
         var range2 = ws.Range("C1:C3");
         var dv = new XLDataValidation(range1);
 
-        IXLRange addedRange = null;
+        IXLRange? addedRange = null;
 
         dv.RangeAdded += (s, e) => addedRange = e.Range;
 
@@ -526,7 +526,7 @@ public class DataValidationTests
         var range2 = ws.Range("C1:C3");
         var dv = new XLDataValidation(range1);
         dv.AddRange(range2);
-        IXLRange removedRange = null;
+        IXLRange? removedRange = null;
         dv.RangeRemoved += (s, e) => removedRange = e.Range;
 
         dv.RemoveRange(range2);

--- a/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -104,7 +104,7 @@ public class DataValidationTests
         var ws = wb.Worksheets.Add("Sheet1");
         ws.Cell("A1").SetValue("A");
         ws.Cell("B1").CreateDataValidation().Custom("A1");
-        ws.FirstRow()!.InsertRowsAbove(1);
+        ws.FirstRow().InsertRowsAbove(1);
 
         await Assert.That(ws.Cell("B2").GetDataValidation().Value).IsEqualTo("A2");
     }
@@ -127,7 +127,7 @@ public class DataValidationTests
         var ws = wb.Worksheets.Add("Sheet1");
         ws.Cell("A1").SetValue("A");
         ws.Cell("B1").CreateDataValidation().Custom("A1");
-        ws.FirstColumn()!.InsertColumnsBefore(1);
+        ws.FirstColumn().InsertColumnsBefore(1);
 
         await Assert.That(ws.Cell("C1").GetDataValidation().Value).IsEqualTo("B1");
     }
@@ -158,7 +158,7 @@ public class DataValidationTests
         var dv = table.DataRange!.CreateDataValidation();
         dv.ErrorTitle = "Error";
 
-        await Assert.That(table.DataRange!.FirstCell().GetDataValidation().ErrorTitle).IsEqualTo("Error");
+        await Assert.That(table.DataRange.FirstCell().GetDataValidation().ErrorTitle).IsEqualTo("Error");
     }
 
     [Test]
@@ -491,7 +491,7 @@ public class DataValidationTests
 
         ms.Position = 0;
         using var doc = SpreadsheetDocument.Open(ms, false);
-        var worksheetPart = doc.WorkbookPart.WorksheetParts.First()!;
+        var worksheetPart = doc.WorkbookPart.WorksheetParts.First();
         var dataValidation = worksheetPart.Worksheet
             .Descendants<DataValidation>()
             .First();

--- a/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -491,7 +491,7 @@ public class DataValidationTests
 
         ms.Position = 0;
         using var doc = SpreadsheetDocument.Open(ms, false);
-        var worksheetPart = doc.WorkbookPart.WorksheetParts.First();
+        var worksheetPart = doc.WorkbookPart.WorksheetParts.First()!;
         var dataValidation = worksheetPart.Worksheet
             .Descendants<DataValidation>()
             .First();

--- a/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -491,7 +491,7 @@ public class DataValidationTests
 
         ms.Position = 0;
         using var doc = SpreadsheetDocument.Open(ms, false);
-        var worksheetPart = doc.WorkbookPart.WorksheetParts.First();
+        var worksheetPart = doc.WorkbookPart!.WorksheetParts.First();
         var dataValidation = worksheetPart.Worksheet
             .Descendants<DataValidation>()
             .First();

--- a/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -104,7 +104,7 @@ public class DataValidationTests
         var ws = wb.Worksheets.Add("Sheet1");
         ws.Cell("A1").SetValue("A");
         ws.Cell("B1").CreateDataValidation().Custom("A1");
-        ws.FirstRow().InsertRowsAbove(1);
+        ws.FirstRow()!.InsertRowsAbove(1);
 
         await Assert.That(ws.Cell("B2").GetDataValidation().Value).IsEqualTo("A2");
     }
@@ -127,7 +127,7 @@ public class DataValidationTests
         var ws = wb.Worksheets.Add("Sheet1");
         ws.Cell("A1").SetValue("A");
         ws.Cell("B1").CreateDataValidation().Custom("A1");
-        ws.FirstColumn().InsertColumnsBefore(1);
+        ws.FirstColumn()!.InsertColumnsBefore(1);
 
         await Assert.That(ws.Cell("C1").GetDataValidation().Value).IsEqualTo("B1");
     }
@@ -153,12 +153,12 @@ public class DataValidationTests
             .CellBelow().SetValue("A")
             .CellBelow().SetValue("B");
 
-        var table = ws.RangeUsed().CreateTable();
+        var table = ws.RangeUsed()!.CreateTable();
 
-        var dv = table.DataRange.CreateDataValidation();
+        var dv = table.DataRange!.CreateDataValidation();
         dv.ErrorTitle = "Error";
 
-        await Assert.That(table.DataRange.FirstCell().GetDataValidation().ErrorTitle).IsEqualTo("Error");
+        await Assert.That(table.DataRange!.FirstCell().GetDataValidation().ErrorTitle).IsEqualTo("Error");
     }
 
     [Test]
@@ -170,9 +170,9 @@ public class DataValidationTests
         ws.FirstCell().SetValue("Categories")
             .CellBelow().SetValue("A");
 
-        var table = ws.RangeUsed().CreateTable();
+        var table = ws.RangeUsed()!.CreateTable();
 
-        var dv = table.DataRange.CreateDataValidation();
+        var dv = table.DataRange!.CreateDataValidation();
         dv.ErrorTitle = "Error";
 
         await Assert.That(ws.DataValidations.Single().ErrorTitle).IsEqualTo("Error");
@@ -336,7 +336,7 @@ public class DataValidationTests
     [Test]
     public async Task CannotCreateDataValidationWithoutRange()
     {
-        await Assert.That(() => new XLDataValidation(null)).Throws<ArgumentNullException>();
+        await Assert.That(() => new XLDataValidation(null!)).Throws<ArgumentNullException>();
     }
 
     [Test]
@@ -430,7 +430,7 @@ public class DataValidationTests
         var dv = new XLDataValidation(range1);
 
         dv.RemoveRange(range2);
-        dv.RemoveRange(null);
+        dv.RemoveRange(null!);
 
         await Assert.That(dv.Ranges.Single()).IsSameReferenceAs(range1);
     }
@@ -652,7 +652,7 @@ public class DataValidationTests
         }
 
         // Set up AutoFilter on column 4 with "Is Issue" filter
-        ws.RangeUsed().SetAutoFilter().Column(4).AddFilter("Is Issue");
+        ws.RangeUsed()!.SetAutoFilter().Column(4).AddFilter("Is Issue");
 
         // User passes a pre-quoted string with comma-separated values
         var errorList = new List<string> { "New", "Backdated", "Old", "Other" };

--- a/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -492,7 +492,7 @@ public class DataValidationTests
         ms.Position = 0;
         using var doc = SpreadsheetDocument.Open(ms, false);
         var worksheetPart = doc.WorkbookPart!.WorksheetParts.First();
-        var dataValidation = worksheetPart.Worksheet
+        var dataValidation = worksheetPart.Worksheet!
             .Descendants<DataValidation>()
             .First();
 

--- a/XLibur.Tests/Excel/DataValidations/EmptyDataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/EmptyDataValidationTests.cs
@@ -137,14 +137,15 @@ public class EmptyDataValidationTests
     }
 
     /// <summary>
-    /// Every <c>sqref</c> written to the sheet. Any empty entry here is the corruption this
-    /// class exists to prevent.
+    /// Every <c>sqref</c> written to the sheet. Any empty or null entry here is the corruption
+    /// this class exists to prevent, so the element type stays nullable rather than forgiving
+    /// the null and failing with a NullReferenceException instead of the assertion.
     /// </summary>
-    private static string[] ReadSqrefs(MemoryStream saved)
+    private static string?[] ReadSqrefs(MemoryStream saved)
     {
         saved.Position = 0;
         using var doc = SpreadsheetDocument.Open(saved, false);
-        var worksheet = doc.WorkbookPart!.WorksheetParts.Single().Worksheet;
+        var worksheet = doc.WorkbookPart!.WorksheetParts.Single().Worksheet!;
 
         return worksheet
             .Elements<DocumentFormat.OpenXml.Spreadsheet.DataValidations>()

--- a/XLibur.Tests/Excel/DataValidations/EmptyDataValidationTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/EmptyDataValidationTests.cs
@@ -51,7 +51,7 @@ public class EmptyDataValidationTests
             .Ranges.Select(r => r.RangeAddress.ToString())
             .ToList();
 
-        await Assert.That(remainder).IsEquivalentTo(new[] { "A1:A1", "A4:A5" });
+        await Assert.That(remainder).IsEquivalentTo(new string?[] { "A1:A1", "A4:A5" });
     }
 
     [Test]
@@ -66,7 +66,7 @@ public class EmptyDataValidationTests
         wb.SaveAs(ms);
 
         var written = ReadSqrefs(ms);
-        await Assert.That(written).IsEquivalentTo(new[] { "A1:A5" });
+        await Assert.That(written).IsEquivalentTo(new string?[] { "A1:A5" });
     }
 
     /// <summary>
@@ -88,7 +88,7 @@ public class EmptyDataValidationTests
         wb.SaveAs(ms);
 
         var written = ReadSqrefs(ms);
-        await Assert.That(written).IsEquivalentTo(new[] { "C1:C3" });
+        await Assert.That(written).IsEquivalentTo(new string?[] { "C1:C3" });
     }
 
     /// <summary>
@@ -111,7 +111,7 @@ public class EmptyDataValidationTests
         using var doc = SpreadsheetDocument.Open(ms, false);
         var worksheet = doc.WorkbookPart!.WorksheetParts.Single().Worksheet;
 
-        await Assert.That(worksheet.Elements<DocumentFormat.OpenXml.Spreadsheet.DataValidations>().Any())
+        await Assert.That(worksheet!.Elements<DocumentFormat.OpenXml.Spreadsheet.DataValidations>().Any())
             .IsFalse();
     }
 

--- a/XLibur.Tests/Excel/DataValidations/XLDataValidationsTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/XLDataValidationsTests.cs
@@ -10,7 +10,7 @@ public class XLDataValidationsTests
     [Test]
     public async Task CannotCreateWithoutWorksheet()
     {
-        await Assert.That(() => new XLDataValidations(null)).Throws<ArgumentNullException>();
+        await Assert.That(() => new XLDataValidations(null!)).Throws<ArgumentNullException>();
     }
 
     [Test]

--- a/XLibur.Tests/Excel/DataValidations/XLDataValidationsTests.cs
+++ b/XLibur.Tests/Excel/DataValidations/XLDataValidationsTests.cs
@@ -127,7 +127,7 @@ public class XLDataValidationsTests
         var dv2 = ws.Range("B1:B3").CreateDataValidation();
         dv2.MinValue = "100";
 
-        (ws.DataValidations as XLDataValidations).Consolidate();
+        (ws.DataValidations as XLDataValidations)!.Consolidate();
         dv1.AddRange(ws.Range("C1:C3"));
         dv2.AddRange(ws.Range("D1:D3"));
 

--- a/XLibur.Tests/Excel/Drawings/GroupedPictureTests.cs
+++ b/XLibur.Tests/Excel/Drawings/GroupedPictureTests.cs
@@ -91,7 +91,7 @@ public class GroupedPictureTests
         await Assert.That(extents[1]).IsEqualTo((1_500_000L, 1_500_000L));
 
         // Both image relationships still resolve to image parts.
-        var embeds = drawing!.Descendants<DocumentFormat.OpenXml.Drawing.Blip>()
+        var embeds = drawing.Descendants<DocumentFormat.OpenXml.Drawing.Blip>()
             .Select(b => b.Embed?.Value).Where(v => v is not null).ToList();
         await Assert.That(embeds.Count).IsEqualTo(2);
         foreach (var embed in embeds)
@@ -225,7 +225,7 @@ public class GroupedPictureTests
             await Assert.That(group.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
 
             // The surviving picture's image part is kept; the removed picture's is dropped.
-            var embeds = drawing!.Descendants<DocumentFormat.OpenXml.Drawing.Blip>()
+            var embeds = drawing.Descendants<DocumentFormat.OpenXml.Drawing.Blip>()
                 .Select(b => b.Embed?.Value).Where(v => v is not null).ToList();
             await Assert.That(embeds.Count).IsEqualTo(1);
             await Assert.That(drawingsPart.GetPartById(embeds[0]!)).IsAssignableTo<ImagePart>();
@@ -323,7 +323,7 @@ public class GroupedPictureTests
             var drawing = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing;
             var group = drawing!.Descendants<Xdr.GroupShape>().Single();
             await Assert.That(group.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
-            await Assert.That(drawing!.Descendants<Xdr.Picture>().Count()).IsEqualTo(2).Because("no picture left outside the group");
+            await Assert.That(drawing.Descendants<Xdr.Picture>().Count()).IsEqualTo(2).Because("no picture left outside the group");
             await Assert.That(drawing.Elements<Xdr.AbsoluteAnchor>().Count()).IsEqualTo(1).Because("only the group's anchor remains");
         }
 
@@ -497,11 +497,11 @@ public class GroupedPictureTests
         var drawing = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing;
 
         await Assert.That(drawing!.Descendants<Xdr.GroupShape>().Count()).IsEqualTo(2).Because("outer + inner group preserved");
-        await Assert.That(drawing!.Descendants<Xdr.Picture>().Count()).IsEqualTo(2).Because("both pictures preserved");
-        await Assert.That(drawing!.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1).Because("nested connector preserved");
+        await Assert.That(drawing.Descendants<Xdr.Picture>().Count()).IsEqualTo(2).Because("both pictures preserved");
+        await Assert.That(drawing.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1).Because("nested connector preserved");
 
         // Unedited pictures keep their exact child-space extents at their respective depths.
-        var extents = drawing!.Descendants<Xdr.Picture>()
+        var extents = drawing.Descendants<Xdr.Picture>()
             .Select(p => p.ShapeProperties!.Transform2D!.Extents!.Cx!.Value)
             .OrderByDescending(cx => cx)
             .ToList();
@@ -539,8 +539,8 @@ public class GroupedPictureTests
         {
             var drawing = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing;
             await Assert.That(drawing!.Descendants<Xdr.GroupShape>().Count()).IsEqualTo(2);
-            await Assert.That(drawing!.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
-            await Assert.That(drawing!.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
+            await Assert.That(drawing.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
+            await Assert.That(drawing.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
         }
     }
 
@@ -574,8 +574,8 @@ public class GroupedPictureTests
         {
             var drawing = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing;
             await Assert.That(drawing!.Descendants<Xdr.GroupShape>().Count()).IsEqualTo(2);
-            await Assert.That(drawing!.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
-            await Assert.That(drawing!.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
+            await Assert.That(drawing.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
+            await Assert.That(drawing.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
         }
     }
 }

--- a/XLibur.Tests/Excel/Drawings/GroupedPictureTests.cs
+++ b/XLibur.Tests/Excel/Drawings/GroupedPictureTests.cs
@@ -278,7 +278,7 @@ public class GroupedPictureTests
         using (var package = SpreadsheetDocument.Open(output, false))
         {
             var drawingsPart = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!;
-            var group = drawingsPart.WorksheetDrawing.Descendants<Xdr.GroupShape>().Single();
+            var group = drawingsPart.WorksheetDrawing!.Descendants<Xdr.GroupShape>().Single();
             await Assert.That(group.Descendants<Xdr.Picture>().Count()).IsEqualTo(3);
             await Assert.That(group.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
             await Assert.That(drawingsPart.Parts.Count(p => p.OpenXmlPart is ImagePart)).IsEqualTo(3);

--- a/XLibur.Tests/Excel/Drawings/GroupedPictureTests.cs
+++ b/XLibur.Tests/Excel/Drawings/GroupedPictureTests.cs
@@ -184,7 +184,7 @@ public class GroupedPictureTests
         output.Position = 0;
         using (var package = SpreadsheetDocument.Open(output, false))
         {
-            var group = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing
+            var group = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing!
                 .Descendants<Xdr.GroupShape>().Single();
             await Assert.That(group.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
             await Assert.That(group.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
@@ -421,7 +421,7 @@ public class GroupedPictureTests
         output.Position = 0;
         using (var package = SpreadsheetDocument.Open(output, false))
         {
-            var group = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing
+            var group = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing!
                 .Descendants<Xdr.GroupShape>().Single();
             await Assert.That(group.Descendants<Xdr.Picture>().Count()).IsEqualTo(3).Because("the picture added to the group before its first save must not be dropped");
         }

--- a/XLibur.Tests/Excel/Drawings/GroupedPictureTests.cs
+++ b/XLibur.Tests/Excel/Drawings/GroupedPictureTests.cs
@@ -72,7 +72,7 @@ public class GroupedPictureTests
         await Assert.That(drawingsPart).IsNotNull();
         var drawing = drawingsPart!.WorksheetDrawing;
 
-        var groups = drawing.Descendants<Xdr.GroupShape>().ToList();
+        var groups = drawing!.Descendants<Xdr.GroupShape>().ToList();
         await Assert.That(groups.Count).IsEqualTo(1).Because("group preserved");
 
         // Assert on the group node so the shapes are verified to remain *inside* the group rather
@@ -91,7 +91,7 @@ public class GroupedPictureTests
         await Assert.That(extents[1]).IsEqualTo((1_500_000L, 1_500_000L));
 
         // Both image relationships still resolve to image parts.
-        var embeds = drawing.Descendants<DocumentFormat.OpenXml.Drawing.Blip>()
+        var embeds = drawing!.Descendants<DocumentFormat.OpenXml.Drawing.Blip>()
             .Select(b => b.Embed?.Value).Where(v => v is not null).ToList();
         await Assert.That(embeds.Count).IsEqualTo(2);
         foreach (var embed in embeds)
@@ -131,7 +131,7 @@ public class GroupedPictureTests
         using (var package = SpreadsheetDocument.Open(output, false))
         {
             var drawing = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing;
-            var groups = drawing.Descendants<Xdr.GroupShape>().ToList();
+            var groups = drawing!.Descendants<Xdr.GroupShape>().ToList();
             await Assert.That(groups.Count).IsEqualTo(1);
 
             // The picture stays inside the group after the resize, alongside its sibling and connector.
@@ -219,13 +219,13 @@ public class GroupedPictureTests
         {
             var drawingsPart = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!;
             var drawing = drawingsPart.WorksheetDrawing;
-            var group = drawing.Descendants<Xdr.GroupShape>().Single();
+            var group = drawing!.Descendants<Xdr.GroupShape>().Single();
 
             await Assert.That(group.Descendants<Xdr.Picture>().Count()).IsEqualTo(1);
             await Assert.That(group.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
 
             // The surviving picture's image part is kept; the removed picture's is dropped.
-            var embeds = drawing.Descendants<DocumentFormat.OpenXml.Drawing.Blip>()
+            var embeds = drawing!.Descendants<DocumentFormat.OpenXml.Drawing.Blip>()
                 .Select(b => b.Embed?.Value).Where(v => v is not null).ToList();
             await Assert.That(embeds.Count).IsEqualTo(1);
             await Assert.That(drawingsPart.GetPartById(embeds[0]!)).IsAssignableTo<ImagePart>();
@@ -321,9 +321,9 @@ public class GroupedPictureTests
         using (var package = SpreadsheetDocument.Open(output, false))
         {
             var drawing = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing;
-            var group = drawing.Descendants<Xdr.GroupShape>().Single();
+            var group = drawing!.Descendants<Xdr.GroupShape>().Single();
             await Assert.That(group.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
-            await Assert.That(drawing.Descendants<Xdr.Picture>().Count()).IsEqualTo(2).Because("no picture left outside the group");
+            await Assert.That(drawing!.Descendants<Xdr.Picture>().Count()).IsEqualTo(2).Because("no picture left outside the group");
             await Assert.That(drawing.Elements<Xdr.AbsoluteAnchor>().Count()).IsEqualTo(1).Because("only the group's anchor remains");
         }
 
@@ -496,12 +496,12 @@ public class GroupedPictureTests
         using var package = SpreadsheetDocument.Open(output, false);
         var drawing = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing;
 
-        await Assert.That(drawing.Descendants<Xdr.GroupShape>().Count()).IsEqualTo(2).Because("outer + inner group preserved");
-        await Assert.That(drawing.Descendants<Xdr.Picture>().Count()).IsEqualTo(2).Because("both pictures preserved");
-        await Assert.That(drawing.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1).Because("nested connector preserved");
+        await Assert.That(drawing!.Descendants<Xdr.GroupShape>().Count()).IsEqualTo(2).Because("outer + inner group preserved");
+        await Assert.That(drawing!.Descendants<Xdr.Picture>().Count()).IsEqualTo(2).Because("both pictures preserved");
+        await Assert.That(drawing!.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1).Because("nested connector preserved");
 
         // Unedited pictures keep their exact child-space extents at their respective depths.
-        var extents = drawing.Descendants<Xdr.Picture>()
+        var extents = drawing!.Descendants<Xdr.Picture>()
             .Select(p => p.ShapeProperties!.Transform2D!.Extents!.Cx!.Value)
             .OrderByDescending(cx => cx)
             .ToList();
@@ -538,9 +538,9 @@ public class GroupedPictureTests
         using (var package = SpreadsheetDocument.Open(output, false))
         {
             var drawing = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing;
-            await Assert.That(drawing.Descendants<Xdr.GroupShape>().Count()).IsEqualTo(2);
-            await Assert.That(drawing.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
-            await Assert.That(drawing.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
+            await Assert.That(drawing!.Descendants<Xdr.GroupShape>().Count()).IsEqualTo(2);
+            await Assert.That(drawing!.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
+            await Assert.That(drawing!.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
         }
     }
 
@@ -573,9 +573,9 @@ public class GroupedPictureTests
         using (var package = SpreadsheetDocument.Open(output, false))
         {
             var drawing = package.WorkbookPart!.WorksheetParts.Single().DrawingsPart!.WorksheetDrawing;
-            await Assert.That(drawing.Descendants<Xdr.GroupShape>().Count()).IsEqualTo(2);
-            await Assert.That(drawing.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
-            await Assert.That(drawing.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
+            await Assert.That(drawing!.Descendants<Xdr.GroupShape>().Count()).IsEqualTo(2);
+            await Assert.That(drawing!.Descendants<Xdr.Picture>().Count()).IsEqualTo(2);
+            await Assert.That(drawing!.Descendants<Xdr.ConnectionShape>().Count()).IsEqualTo(1);
         }
     }
 }

--- a/XLibur.Tests/Excel/Drawings/PictureTests.cs
+++ b/XLibur.Tests/Excel/Drawings/PictureTests.cs
@@ -92,7 +92,7 @@ public class PictureTests
             using var imageStream = System.Reflection.Assembly.GetExecutingAssembly()
                 .GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png");
             var imagePart = drawingsPart.AddImagePart(ImagePartType.Png);
-            imagePart.FeedData(imageStream);
+            imagePart.FeedData(imageStream!);
             var imageRelId = drawingsPart.GetIdOfPart(imagePart);
 
             // Create a TwoCellAnchor with a picture that has an empty name

--- a/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
@@ -20,7 +20,7 @@ public class PictureTests
         var ws = wb.AddWorksheet("Sheet1");
 
         using var resourceStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable))!.GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg");
-        var picture = ws.AddPicture(resourceStream, "MyPicture")
+        var picture = ws.AddPicture(resourceStream!, "MyPicture")
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(50, 50)
             .WithSize(200, 200);
@@ -112,7 +112,7 @@ public class PictureTests
         var ws = wb.AddWorksheet("Sheet1");
 
         using var resourceStream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png");
-        var pic = ws.AddPicture(resourceStream, "MyPicture")
+        var pic = ws.AddPicture(resourceStream!, "MyPicture")
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(50, 50);
 
@@ -154,16 +154,16 @@ public class PictureTests
 
         using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png"))
         {
-            ws.AddPicture(stream, XLPictureFormat.Png);
+            ws.AddPicture(stream!, XLPictureFormat.Png);
             stream.Position = 0;
 
-            ws.AddPicture(stream, XLPictureFormat.Png);
+            ws.AddPicture(stream!, XLPictureFormat.Png);
             stream.Position = 0;
 
-            ws.AddPicture(stream, XLPictureFormat.Png).Name = "Picture 4";
+            ws.AddPicture(stream!, XLPictureFormat.Png).Name = "Picture 4";
             stream.Position = 0;
 
-            ws.AddPicture(stream, XLPictureFormat.Png);
+            ws.AddPicture(stream!, XLPictureFormat.Png);
             stream.Position = 0;
         }
 
@@ -181,16 +181,16 @@ public class PictureTests
 
         using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png"))
         {
-            ws.AddPicture(stream, XLPictureFormat.Png);
+            ws.AddPicture(stream!, XLPictureFormat.Png);
             stream.Position = 0;
 
-            ws.AddPicture(stream, XLPictureFormat.Png);
+            ws.AddPicture(stream!, XLPictureFormat.Png);
             stream.Position = 0;
 
-            ws.AddPicture(stream, XLPictureFormat.Png).Name = "Picture 4";
+            ws.AddPicture(stream!, XLPictureFormat.Png).Name = "Picture 4";
             stream.Position = 0;
 
-            ws.AddPicture(stream, XLPictureFormat.Png);
+            ws.AddPicture(stream!, XLPictureFormat.Png);
             stream.Position = 0;
         }
 
@@ -219,7 +219,7 @@ public class PictureTests
         var ws = wb.Worksheets.Add("Sheet1");
 
         using var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png");
-        var pic = ws.AddPicture(stream, XLPictureFormat.Png, "Image1")
+        var pic = ws.AddPicture(stream!, XLPictureFormat.Png, "Image1")
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(220, 155);
 
@@ -323,11 +323,11 @@ public class PictureTests
         var ws2 = wb.AddWorksheet("Sheet2");
 
         using var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png");
-        (ws1 as XLWorksheet)!.AddPicture(stream, "Picture 1", 2);
-        (ws1 as XLWorksheet)!.AddPicture(stream, "Picture 2", 3);
+        (ws1 as XLWorksheet)!.AddPicture(stream!, "Picture 1", 2);
+        (ws1 as XLWorksheet)!.AddPicture(stream!, "Picture 2", 3);
 
         //Internal method - used for loading files
-        var pic = (ws2 as XLWorksheet)!.AddPicture(stream, "Picture 1", 2)
+        var pic = (ws2 as XLWorksheet)!.AddPicture(stream!, "Picture 1", 2)
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(220, 155) as XLPicture;
 
@@ -341,7 +341,7 @@ public class PictureTests
 
         pic.Id = id;
 
-        var pic2 = (ws2 as XLWorksheet)!.AddPicture(stream, "Picture 2", 3)
+        var pic2 = (ws2 as XLWorksheet)!.AddPicture(stream!, "Picture 2", 3)
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(440, 300) as XLPicture;
     }
@@ -355,12 +355,12 @@ public class PictureTests
         IXLPicture original;
         using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png"))
         {
-            original = (ws1 as XLWorksheet)!.AddPicture(stream, "Picture 1", 2)
+            original = (ws1 as XLWorksheet)!.AddPicture(stream!, "Picture 1", 2)
                 .WithPlacement(XLPicturePlacement.FreeFloating)
                 .MoveTo(220, 155) as XLPicture;
         }
 
-        var copy = original.Duplicate()
+        var copy = original.Duplicate()!
             .MoveTo(300, 200) as XLPicture;
 
         await Assert.That(ws1.Pictures.Count).IsEqualTo(2);
@@ -386,13 +386,13 @@ public class PictureTests
         IXLPicture original;
         using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png"))
         {
-            original = (ws1 as XLWorksheet)!.AddPicture(stream, "Picture 1", 2)
+            original = (ws1 as XLWorksheet)!.AddPicture(stream!, "Picture 1", 2)
                 .WithPlacement(XLPicturePlacement.FreeFloating)
                 .MoveTo(220, 155) as XLPicture;
         }
         var ws2 = wb.Worksheets.Add("Sheet2");
 
-        var copy = original.CopyTo(ws2);
+        var copy = original.CopyTo(ws2)!;
 
         await Assert.That(ws1.Pictures.Count).IsEqualTo(1);
         await Assert.That(ws2.Pictures.Count).IsEqualTo(1);
@@ -418,7 +418,7 @@ public class PictureTests
         using var wb = new XLWorkbook();
         using var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png");
         var ws = wb.Worksheets.Add("ImageShift");
-        var picture = ws.AddPicture(stream, XLPictureFormat.Png, "PngImage")
+        var picture = ws.AddPicture(stream!, XLPictureFormat.Png, "PngImage")
             .MoveTo(ws.Cell(5, 2))
             .WithPlacement(XLPicturePlacement.Move);
 
@@ -475,7 +475,7 @@ public class PictureTests
         var ws = wb.AddWorksheet("Sheet1");
 
         using var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png");
-        var pic = ws.AddPicture(stream, XLPictureFormat.Png, "temp");
+        var pic = ws.AddPicture(stream!, XLPictureFormat.Png, "temp");
         pic.Name = name;
 
         await Assert.That(pic.Name).IsEqualTo(name);

--- a/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
@@ -19,7 +19,7 @@ public class PictureTests
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");
 
-        using var resourceStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable)).GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg");
+        using var resourceStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable))!.GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg");
         var picture = ws.AddPicture(resourceStream, "MyPicture")
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(50, 50)
@@ -40,10 +40,10 @@ public class PictureTests
 
         try
         {
-            using (var resourceStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable)).GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg"))
+            using (var resourceStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable))!.GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg"))
             using (var fileStream = File.Create(path))
             {
-                resourceStream.Seek(0, SeekOrigin.Begin);
+                resourceStream!.Seek(0, SeekOrigin.Begin);
                 resourceStream.CopyTo(fileStream);
                 fileStream.Close();
             }
@@ -70,10 +70,10 @@ public class PictureTests
 
         try
         {
-            using (var resourceStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable)).GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg"))
+            using (var resourceStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable))!.GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg"))
             using (var fileStream = File.Create(path))
             {
-                resourceStream.Seek(0, SeekOrigin.Begin);
+                resourceStream!.Seek(0, SeekOrigin.Begin);
                 resourceStream.CopyTo(fileStream);
                 fileStream.Close();
             }
@@ -323,11 +323,11 @@ public class PictureTests
         var ws2 = wb.AddWorksheet("Sheet2");
 
         using var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png");
-        (ws1 as XLWorksheet).AddPicture(stream, "Picture 1", 2);
-        (ws1 as XLWorksheet).AddPicture(stream, "Picture 2", 3);
+        (ws1 as XLWorksheet)!.AddPicture(stream, "Picture 1", 2);
+        (ws1 as XLWorksheet)!.AddPicture(stream, "Picture 2", 3);
 
         //Internal method - used for loading files
-        var pic = (ws2 as XLWorksheet).AddPicture(stream, "Picture 1", 2)
+        var pic = (ws2 as XLWorksheet)!.AddPicture(stream, "Picture 1", 2)
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(220, 155) as XLPicture;
 
@@ -341,7 +341,7 @@ public class PictureTests
 
         pic.Id = id;
 
-        var pic2 = (ws2 as XLWorksheet).AddPicture(stream, "Picture 2", 3)
+        var pic2 = (ws2 as XLWorksheet)!.AddPicture(stream, "Picture 2", 3)
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(440, 300) as XLPicture;
     }
@@ -355,7 +355,7 @@ public class PictureTests
         IXLPicture original;
         using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png"))
         {
-            original = (ws1 as XLWorksheet).AddPicture(stream, "Picture 1", 2)
+            original = (ws1 as XLWorksheet)!.AddPicture(stream, "Picture 1", 2)
                 .WithPlacement(XLPicturePlacement.FreeFloating)
                 .MoveTo(220, 155) as XLPicture;
         }
@@ -386,7 +386,7 @@ public class PictureTests
         IXLPicture original;
         using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png"))
         {
-            original = (ws1 as XLWorksheet).AddPicture(stream, "Picture 1", 2)
+            original = (ws1 as XLWorksheet)!.AddPicture(stream, "Picture 1", 2)
                 .WithPlacement(XLPicturePlacement.FreeFloating)
                 .MoveTo(220, 155) as XLPicture;
         }

--- a/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
@@ -155,7 +155,7 @@ public class PictureTests
         using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png"))
         {
             ws.AddPicture(stream!, XLPictureFormat.Png);
-            stream.Position = 0;
+            stream!.Position = 0;
 
             ws.AddPicture(stream, XLPictureFormat.Png);
             stream.Position = 0;
@@ -182,7 +182,7 @@ public class PictureTests
         using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png"))
         {
             ws.AddPicture(stream!, XLPictureFormat.Png);
-            stream.Position = 0;
+            stream!.Position = 0;
 
             ws.AddPicture(stream, XLPictureFormat.Png);
             stream.Position = 0;
@@ -331,7 +331,7 @@ public class PictureTests
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(220, 155) as XLPicture;
 
-        var id = pic.Id;
+        var id = pic!.Id;
 
         pic.Id = id;
         await Assert.That(pic.Id).IsEqualTo(id);
@@ -360,11 +360,11 @@ public class PictureTests
                 .MoveTo(220, 155) as XLPicture;
         }
 
-        var copy = original.Duplicate()
+        var copy = original!.Duplicate()
             .MoveTo(300, 200) as XLPicture;
 
         await Assert.That(ws1.Pictures.Count).IsEqualTo(2);
-        await Assert.That(copy.Worksheet).IsEqualTo(ws1);
+        await Assert.That(copy!.Worksheet).IsEqualTo(ws1);
         await Assert.That(copy.Format).IsEqualTo(original.Format);
         await Assert.That(copy.Height).IsEqualTo(original.Height);
         await Assert.That(copy.Placement).IsEqualTo(original.Placement);
@@ -392,7 +392,7 @@ public class PictureTests
         }
         var ws2 = wb.Worksheets.Add("Sheet2");
 
-        var copy = original.CopyTo(ws2);
+        var copy = original!.CopyTo(ws2);
 
         await Assert.That(ws1.Pictures.Count).IsEqualTo(1);
         await Assert.That(ws2.Pictures.Count).IsEqualTo(1);

--- a/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
@@ -355,9 +355,9 @@ public class PictureTests
         IXLPicture original;
         using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png"))
         {
-            original = (ws1 as XLWorksheet)!.AddPicture(stream!, "Picture 1", 2)
+            original = ((XLWorksheet)ws1).AddPicture(stream!, "Picture 1", 2)
                 .WithPlacement(XLPicturePlacement.FreeFloating)
-                .MoveTo(220, 155) as XLPicture;
+                .MoveTo(220, 155);
         }
 
         var copy = original!.Duplicate()
@@ -386,9 +386,9 @@ public class PictureTests
         IXLPicture original;
         using (var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("XLibur.Tests.Resource.Images.ImageHandling.png"))
         {
-            original = (ws1 as XLWorksheet)!.AddPicture(stream!, "Picture 1", 2)
+            original = ((XLWorksheet)ws1).AddPicture(stream!, "Picture 1", 2)
                 .WithPlacement(XLPicturePlacement.FreeFloating)
-                .MoveTo(220, 155) as XLPicture;
+                .MoveTo(220, 155);
         }
         var ws2 = wb.Worksheets.Add("Sheet2");
 

--- a/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/XLibur.Tests/Excel/ImageHandling/PictureTests.cs
@@ -157,13 +157,13 @@ public class PictureTests
             ws.AddPicture(stream!, XLPictureFormat.Png);
             stream.Position = 0;
 
-            ws.AddPicture(stream!, XLPictureFormat.Png);
+            ws.AddPicture(stream, XLPictureFormat.Png);
             stream.Position = 0;
 
-            ws.AddPicture(stream!, XLPictureFormat.Png).Name = "Picture 4";
+            ws.AddPicture(stream, XLPictureFormat.Png).Name = "Picture 4";
             stream.Position = 0;
 
-            ws.AddPicture(stream!, XLPictureFormat.Png);
+            ws.AddPicture(stream, XLPictureFormat.Png);
             stream.Position = 0;
         }
 
@@ -184,13 +184,13 @@ public class PictureTests
             ws.AddPicture(stream!, XLPictureFormat.Png);
             stream.Position = 0;
 
-            ws.AddPicture(stream!, XLPictureFormat.Png);
+            ws.AddPicture(stream, XLPictureFormat.Png);
             stream.Position = 0;
 
-            ws.AddPicture(stream!, XLPictureFormat.Png).Name = "Picture 4";
+            ws.AddPicture(stream, XLPictureFormat.Png).Name = "Picture 4";
             stream.Position = 0;
 
-            ws.AddPicture(stream!, XLPictureFormat.Png);
+            ws.AddPicture(stream, XLPictureFormat.Png);
             stream.Position = 0;
         }
 
@@ -360,7 +360,7 @@ public class PictureTests
                 .MoveTo(220, 155) as XLPicture;
         }
 
-        var copy = original.Duplicate()!
+        var copy = original.Duplicate()
             .MoveTo(300, 200) as XLPicture;
 
         await Assert.That(ws1.Pictures.Count).IsEqualTo(2);
@@ -392,7 +392,7 @@ public class PictureTests
         }
         var ws2 = wb.Worksheets.Add("Sheet2");
 
-        var copy = original.CopyTo(ws2)!;
+        var copy = original.CopyTo(ws2);
 
         await Assert.That(ws1.Pictures.Count).IsEqualTo(1);
         await Assert.That(ws2.Pictures.Count).IsEqualTo(1);

--- a/XLibur.Tests/Excel/InsertData/UntypedObjectReaderTests.cs
+++ b/XLibur.Tests/Excel/InsertData/UntypedObjectReaderTests.cs
@@ -12,7 +12,7 @@ public class UntypedObjectReaderTests
 {
     private readonly ArrayList _data = new(new object[]
     {
-        null,
+        null!,
         new TablesTests.TestObjectWithAttributes
         {
             Column1 = "Value 1",
@@ -20,9 +20,9 @@ public class UntypedObjectReaderTests
             UnOrderedColumn = 3,
             MyField = 4,
         },
-        null,
-        null,
-        null,
+        null!,
+        null!,
+        null!,
         new[] { 1, 2, 3 },
         new[] { 4, 5, 6, 7 },
         "Separator",

--- a/XLibur.Tests/Excel/Loading/LoadingTests.cs
+++ b/XLibur.Tests/Excel/Loading/LoadingTests.cs
@@ -132,7 +132,7 @@ public class LoadingTests
         var ws = wb.Worksheets.First();
         var table = ws.Tables.First();
         var rangeBefore = table.RangeAddress.ToString();
-        table.DataRange.InsertRowsBelow(5);
+        table.DataRange!.InsertRowsBelow(5);
 
         await Assert.That(table.RangeAddress.ToString()).IsNotEqualTo(rangeBefore);
     }

--- a/XLibur.Tests/Excel/Misc/CopyContentsTests.cs
+++ b/XLibur.Tests/Excel/Misc/CopyContentsTests.cs
@@ -126,8 +126,8 @@ public class CopyContentsTests
 
         var ws2 = ws1.CopyTo("Sheet2");
 
-        await Assert.That(ws1.FirstCell()!.Address.Worksheet.Name).IsEqualTo("Sheet1");
-        await Assert.That(ws2.FirstCell()!.Address.Worksheet.Name).IsEqualTo("Sheet2");
+        await Assert.That(ws1.FirstCell().Address.Worksheet.Name).IsEqualTo("Sheet1");
+        await Assert.That(ws2.FirstCell().Address.Worksheet.Name).IsEqualTo("Sheet2");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Misc/CopyContentsTests.cs
+++ b/XLibur.Tests/Excel/Misc/CopyContentsTests.cs
@@ -14,7 +14,7 @@ public class CopyContentsTests
         destinationRow.Clear();
 
         var originalRow = originalSheet.Row(originalRowNumber);
-        var columnNumber = originalRow.LastCellUsed(XLCellsUsedOptions.All).Address.ColumnNumber;
+        var columnNumber = originalRow.LastCellUsed(XLCellsUsedOptions.All)!.Address.ColumnNumber;
 
         var originalRange = originalSheet.Range(originalRowNumber, 1, originalRowNumber, columnNumber);
         var destRange = destSheet.Range(destRowNumber, 1, destRowNumber, columnNumber);
@@ -126,8 +126,8 @@ public class CopyContentsTests
 
         var ws2 = ws1.CopyTo("Sheet2");
 
-        await Assert.That(ws1.FirstCell().Address.Worksheet.Name).IsEqualTo("Sheet1");
-        await Assert.That(ws2.FirstCell().Address.Worksheet.Name).IsEqualTo("Sheet2");
+        await Assert.That(ws1.FirstCell()!.Address.Worksheet.Name).IsEqualTo("Sheet1");
+        await Assert.That(ws2.FirstCell()!.Address.Worksheet.Name).IsEqualTo("Sheet2");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Misc/CopyContentsTests.cs
+++ b/XLibur.Tests/Excel/Misc/CopyContentsTests.cs
@@ -126,8 +126,8 @@ public class CopyContentsTests
 
         var ws2 = ws1.CopyTo("Sheet2");
 
-        await Assert.That(ws1.FirstCell().Address.Worksheet.Name).IsEqualTo("Sheet1");
-        await Assert.That(ws2.FirstCell().Address.Worksheet.Name).IsEqualTo("Sheet2");
+        await Assert.That(ws1.FirstCell().Address.Worksheet!.Name).IsEqualTo("Sheet1");
+        await Assert.That(ws2.FirstCell().Address.Worksheet!.Name).IsEqualTo("Sheet2");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Misc/ExtensionsTests.cs
+++ b/XLibur.Tests/Excel/Misc/ExtensionsTests.cs
@@ -72,7 +72,7 @@ public class ExtensionsTests
     [Arguments("Slovenščina", "Slovenščina")]
     [Arguments("", "")]
     [Arguments(null, null)]
-    public async Task CanEscapeSheetName(string sheetName, string expected)
+    public async Task CanEscapeSheetName(string? sheetName, string? expected)
     {
         await Assert.That(sheetName.EscapeSheetName()).IsEqualTo(expected);
     }

--- a/XLibur.Tests/Excel/Misc/ExtensionsTests.cs
+++ b/XLibur.Tests/Excel/Misc/ExtensionsTests.cs
@@ -74,7 +74,7 @@ public class ExtensionsTests
     [Arguments(null, null)]
     public async Task CanEscapeSheetName(string? sheetName, string? expected)
     {
-        await Assert.That(sheetName.EscapeSheetName()).IsEqualTo(expected);
+        await Assert.That(sheetName!.EscapeSheetName()).IsEqualTo(expected);
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Misc/StylesTests.cs
+++ b/XLibur.Tests/Excel/Misc/StylesTests.cs
@@ -10,21 +10,21 @@ public class StylesTests
 {
     private static void SetupBorders(IXLRange range)
     {
-        range.FirstRow().Cell(1).Style.Border.TopBorder = XLBorderStyleValues.None;
-        range.FirstRow().Cell(2).Style.Border.TopBorder = XLBorderStyleValues.Thick;
-        range.FirstRow().Cell(3).Style.Border.TopBorder = XLBorderStyleValues.Double;
+        range.FirstRow()!.Cell(1).Style.Border.TopBorder = XLBorderStyleValues.None;
+        range.FirstRow()!.Cell(2).Style.Border.TopBorder = XLBorderStyleValues.Thick;
+        range.FirstRow()!.Cell(3).Style.Border.TopBorder = XLBorderStyleValues.Double;
 
-        range.LastRow().Cell(1).Style.Border.BottomBorder = XLBorderStyleValues.None;
-        range.LastRow().Cell(2).Style.Border.BottomBorder = XLBorderStyleValues.Thick;
-        range.LastRow().Cell(3).Style.Border.BottomBorder = XLBorderStyleValues.Double;
+        range.LastRow()!.Cell(1).Style.Border.BottomBorder = XLBorderStyleValues.None;
+        range.LastRow()!.Cell(2).Style.Border.BottomBorder = XLBorderStyleValues.Thick;
+        range.LastRow()!.Cell(3).Style.Border.BottomBorder = XLBorderStyleValues.Double;
 
-        range.FirstColumn().Cell(1).Style.Border.LeftBorder = XLBorderStyleValues.None;
-        range.FirstColumn().Cell(2).Style.Border.LeftBorder = XLBorderStyleValues.Thick;
-        range.FirstColumn().Cell(3).Style.Border.LeftBorder = XLBorderStyleValues.Double;
+        range.FirstColumn()!.Cell(1).Style.Border.LeftBorder = XLBorderStyleValues.None;
+        range.FirstColumn()!.Cell(2).Style.Border.LeftBorder = XLBorderStyleValues.Thick;
+        range.FirstColumn()!.Cell(3).Style.Border.LeftBorder = XLBorderStyleValues.Double;
 
-        range.LastColumn().Cell(1).Style.Border.RightBorder = XLBorderStyleValues.None;
-        range.LastColumn().Cell(2).Style.Border.RightBorder = XLBorderStyleValues.Thick;
-        range.LastColumn().Cell(3).Style.Border.RightBorder = XLBorderStyleValues.Double;
+        range.LastColumn()!.Cell(1).Style.Border.RightBorder = XLBorderStyleValues.None;
+        range.LastColumn()!.Cell(2).Style.Border.RightBorder = XLBorderStyleValues.Thick;
+        range.LastColumn()!.Cell(3).Style.Border.RightBorder = XLBorderStyleValues.Double;
     }
 
     [Test]
@@ -46,21 +46,21 @@ public class StylesTests
         await Assert.That(center.Style.Border.LeftBorderColor).IsEqualTo(XLColor.Red);
         await Assert.That(center.Style.Border.RightBorderColor).IsEqualTo(XLColor.Red);
 
-        await Assert.That(range.FirstRow().Cell(1).Style.Border.TopBorder).IsEqualTo(XLBorderStyleValues.None);
-        await Assert.That(range.FirstRow().Cell(2).Style.Border.TopBorder).IsEqualTo(XLBorderStyleValues.Thick);
-        await Assert.That(range.FirstRow().Cell(3).Style.Border.TopBorder).IsEqualTo(XLBorderStyleValues.Double);
+        await Assert.That(range.FirstRow()!.Cell(1).Style.Border.TopBorder).IsEqualTo(XLBorderStyleValues.None);
+        await Assert.That(range.FirstRow()!.Cell(2).Style.Border.TopBorder).IsEqualTo(XLBorderStyleValues.Thick);
+        await Assert.That(range.FirstRow()!.Cell(3).Style.Border.TopBorder).IsEqualTo(XLBorderStyleValues.Double);
 
-        await Assert.That(range.LastRow().Cell(1).Style.Border.BottomBorder).IsEqualTo(XLBorderStyleValues.None);
-        await Assert.That(range.LastRow().Cell(2).Style.Border.BottomBorder).IsEqualTo(XLBorderStyleValues.Thick);
-        await Assert.That(range.LastRow().Cell(3).Style.Border.BottomBorder).IsEqualTo(XLBorderStyleValues.Double);
+        await Assert.That(range.LastRow()!.Cell(1).Style.Border.BottomBorder).IsEqualTo(XLBorderStyleValues.None);
+        await Assert.That(range.LastRow()!.Cell(2).Style.Border.BottomBorder).IsEqualTo(XLBorderStyleValues.Thick);
+        await Assert.That(range.LastRow()!.Cell(3).Style.Border.BottomBorder).IsEqualTo(XLBorderStyleValues.Double);
 
-        await Assert.That(range.FirstColumn().Cell(1).Style.Border.LeftBorder).IsEqualTo(XLBorderStyleValues.None);
-        await Assert.That(range.FirstColumn().Cell(2).Style.Border.LeftBorder).IsEqualTo(XLBorderStyleValues.Thick);
-        await Assert.That(range.FirstColumn().Cell(3).Style.Border.LeftBorder).IsEqualTo(XLBorderStyleValues.Double);
+        await Assert.That(range.FirstColumn()!.Cell(1).Style.Border.LeftBorder).IsEqualTo(XLBorderStyleValues.None);
+        await Assert.That(range.FirstColumn()!.Cell(2).Style.Border.LeftBorder).IsEqualTo(XLBorderStyleValues.Thick);
+        await Assert.That(range.FirstColumn()!.Cell(3).Style.Border.LeftBorder).IsEqualTo(XLBorderStyleValues.Double);
 
-        await Assert.That(range.LastColumn().Cell(1).Style.Border.RightBorder).IsEqualTo(XLBorderStyleValues.None);
-        await Assert.That(range.LastColumn().Cell(2).Style.Border.RightBorder).IsEqualTo(XLBorderStyleValues.Thick);
-        await Assert.That(range.LastColumn().Cell(3).Style.Border.RightBorder).IsEqualTo(XLBorderStyleValues.Double);
+        await Assert.That(range.LastColumn()!.Cell(1).Style.Border.RightBorder).IsEqualTo(XLBorderStyleValues.None);
+        await Assert.That(range.LastColumn()!.Cell(2).Style.Border.RightBorder).IsEqualTo(XLBorderStyleValues.Thick);
+        await Assert.That(range.LastColumn()!.Cell(3).Style.Border.RightBorder).IsEqualTo(XLBorderStyleValues.Double);
     }
 
     [Test]

--- a/XLibur.Tests/Excel/NamedRanges/DefinedNameStructuredReferenceTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/DefinedNameStructuredReferenceTests.cs
@@ -46,7 +46,7 @@ public class DefinedNameStructuredReferenceTests
 
     private static string[] RangesOf(XLWorkbook wb, string formula) =>
         wb.DefinedNames.Add("Probe", formula).Ranges
-            .Select(r => r.RangeAddress.ToString())
+            .Select(r => r.RangeAddress.ToString()!)
             .ToArray();
 
     [Test]

--- a/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -226,7 +226,7 @@ public class NamedRangesTests
 
         var copySheet = wb.AddWorksheet();
         var ex = await Assert.That(() => name.CopyTo(copySheet)).Throws<InvalidOperationException>()!;
-        await Assert.That(ex.Message).IsEqualTo("Cannot copy workbook scoped defined name.");
+        await Assert.That(ex!.Message).IsEqualTo("Cannot copy workbook scoped defined name.");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -225,7 +225,7 @@ public class NamedRangesTests
         var name = wb.DefinedNames.Add("Name", "Sheet!$A$1");
 
         var copySheet = wb.AddWorksheet();
-        var ex = await Assert.That(() => name.CopyTo(copySheet)).Throws<InvalidOperationException>()!;
+        var ex = await Assert.That(() => name.CopyTo(copySheet)).Throws<InvalidOperationException>();
         await Assert.That(ex!.Message).IsEqualTo("Cannot copy workbook scoped defined name.");
     }
 

--- a/XLibur.Tests/Excel/PageSetup/HeaderFooterImageTests.cs
+++ b/XLibur.Tests/Excel/PageSetup/HeaderFooterImageTests.cs
@@ -359,7 +359,7 @@ public class HeaderFooterImageTests
         var ssNs = XNamespace.Get(OpenXmlConst.Main2006SsNs);
 
         await Assert.That(sheetXml.Root!.Element(ssNs + "legacyDrawing")).IsNotNull();
-        await Assert.That(sheetXml.Root!.Element(ssNs + "legacyDrawingHF")).IsNotNull();
+        await Assert.That(sheetXml.Root.Element(ssNs + "legacyDrawingHF")).IsNotNull();
     }
 
     #region Helpers

--- a/XLibur.Tests/Excel/PageSetup/PageBreaksTests.cs
+++ b/XLibur.Tests/Excel/PageSetup/PageBreaksTests.cs
@@ -100,7 +100,7 @@ public class PageBreaksTests
         using var doc = SpreadsheetDocument.Open(ms, false);
         var worksheet = doc.WorkbookPart!.WorksheetParts.Single().Worksheet;
 
-        var rowBreak = worksheet.GetFirstChild<RowBreaks>()!.Elements<Break>().Single();
+        var rowBreak = worksheet!.GetFirstChild<RowBreaks>()!.Elements<Break>().Single();
         await Assert.That(rowBreak.Id!.Value).IsEqualTo(32u);
         await Assert.That(rowBreak.Max!.Value).IsEqualTo(16383u); // last column, 0-based XFD
 

--- a/XLibur.Tests/Excel/PageSetup/PrintAreaTests.cs
+++ b/XLibur.Tests/Excel/PageSetup/PrintAreaTests.cs
@@ -112,7 +112,7 @@ public class PrintAreaTests
         saved.Position = 0;
         using (var doc = SpreadsheetDocument.Open(saved, false))
         {
-            var definedNames = doc.WorkbookPart!.Workbook.DefinedNames;
+            var definedNames = doc.WorkbookPart!.Workbook!.DefinedNames;
             await Assert.That(definedNames).IsNotNull();
 
             var printArea = definedNames!

--- a/XLibur.Tests/Excel/PivotTables/Create/XLPivotTableAddFieldsTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/Create/XLPivotTableAddFieldsTests.cs
@@ -75,7 +75,7 @@ internal class XLPivotTableAddFieldsTests
         });
 
         var ws = wb.AddWorksheet().SetTabActive();
-        var pt = ws.PivotTables.Add("Test", ws.FirstCell(), range);
+        var pt = ws.PivotTables.Add("Test", ws.FirstCell(), range!);
         return pt;
     }
 }

--- a/XLibur.Tests/Excel/PivotTables/PivotChartFormatTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotChartFormatTests.cs
@@ -97,7 +97,7 @@ public class PivotChartFormatTests
         });
 
         var pivots = wb.AddWorksheet("Pivots");
-        var pt = pivots.PivotTables.Add("pvt", pivots.Cell("A1"), range);
+        var pt = pivots.PivotTables.Add("pvt", pivots.Cell("A1"), range!);
         pt.RowLabels.Add("Pastry");
         pt.Values.Add("Sold");
 

--- a/XLibur.Tests/Excel/PivotTables/PivotChartFormatTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotChartFormatTests.cs
@@ -111,7 +111,7 @@ public class PivotChartFormatTests
             .Single()
             .PivotTableDefinition;
 
-        await Assert.That(definition.Elements<ChartFormats>().Any()).IsFalse();
+        await Assert.That(definition!.Elements<ChartFormats>().Any()).IsFalse();
     }
 
     private static System.Collections.Generic.List<ChartFormat> ReadChartFormats(MemoryStream saved)
@@ -123,7 +123,7 @@ public class PivotChartFormatTests
             .Single()
             .PivotTableDefinition;
 
-        return definition.Elements<ChartFormats>()
+        return definition!.Elements<ChartFormats>()
             .SelectMany(cf => cf.Elements<ChartFormat>())
             .ToList();
     }

--- a/XLibur.Tests/Excel/PivotTables/PivotFilterCriteriaTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotFilterCriteriaTests.cs
@@ -38,7 +38,7 @@ public class PivotFilterCriteriaTests
         var written = PivotFilterWorkbook.RoundTripFilterColumn(filterColumn).Elements<Filters>().Single();
 
         await Assert.That(written.Blank!.Value).IsTrue();
-        await Assert.That(written.Elements<Filter>().Select(f => f.Val!.Value).ToList())
+        await Assert.That(written.Elements<Filter>().Select(f => f.Val!.Value!).ToList())
             .IsEquivalentTo(new[] { "Cookies", "Cake" });
     }
 

--- a/XLibur.Tests/Excel/PivotTables/PivotFilterTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotFilterTests.cs
@@ -151,7 +151,7 @@ public class PivotFilterTests
             .Single()
             .PivotTableDefinition;
 
-        await Assert.That(definition.Elements<PivotFilters>().Any()).IsFalse();
+        await Assert.That(definition!.Elements<PivotFilters>().Any()).IsFalse();
     }
 
     private static List<PivotFilter> ReadPivotFilters(MemoryStream saved) =>

--- a/XLibur.Tests/Excel/PivotTables/PivotFilterTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotFilterTests.cs
@@ -137,7 +137,7 @@ public class PivotFilterTests
         });
 
         var pivots = wb.AddWorksheet("Pivots");
-        var pt = pivots.PivotTables.Add("pvt", pivots.Cell("A1"), range);
+        var pt = pivots.PivotTables.Add("pvt", pivots.Cell("A1"), range!);
         pt.RowLabels.Add("Pastry");
         pt.Values.Add("Sold");
 

--- a/XLibur.Tests/Excel/PivotTables/PivotFilterWorkbook.cs
+++ b/XLibur.Tests/Excel/PivotTables/PivotFilterWorkbook.cs
@@ -72,7 +72,7 @@ internal static class PivotFilterWorkbook
             .Single()
             .PivotTableDefinition;
 
-        return definition.Elements<PivotFilters>()
+        return definition!.Elements<PivotFilters>()
             .SelectMany(f => f.Elements<PivotFilter>())
             .ToList();
     }

--- a/XLibur.Tests/Excel/PivotTables/Style/XLPivotFieldStyleFormatsTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/Style/XLPivotFieldStyleFormatsTests.cs
@@ -21,7 +21,7 @@ internal class XLPivotFieldStyleFormatsTests
 
             var ptSheet = wb.AddWorksheet().SetTabActive();
             ptSheet.Column("A").Width = 15;
-            var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+            var pt = dataRange!.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
             pt.RowLabels.Add("Name");
             var monthField = pt.RowLabels.Add("Month");
             pt.Values.Add("Price");
@@ -54,7 +54,7 @@ internal class XLPivotFieldStyleFormatsTests
             });
 
             var ptSheet = wb.AddWorksheet().SetTabActive();
-            var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+            var pt = dataRange!.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
             pt.Layout = layout;
             pt.Values.Add("Price");
             pt.RowLabels.Add("Month");
@@ -85,7 +85,7 @@ internal class XLPivotFieldStyleFormatsTests
             });
 
             var ptSheet = wb.AddWorksheet().SetTabActive();
-            var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+            var pt = dataRange!.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
             pt.Values.Add("Price");
             var nameField = pt.RowLabels.Add("Name")
                 .AddSubtotal(XLSubtotalFunction.Sum)
@@ -127,7 +127,7 @@ internal class XLPivotFieldStyleFormatsTests
             });
 
             var ptSheet = wb.AddWorksheet().SetTabActive();
-            var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+            var pt = dataRange!.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
             var nameRowField = pt.RowLabels.Add("Name");
             var monthRowField = pt.RowLabels.Add("Month");
             var flavorColumnField = pt.ColumnLabels.Add("Flavor");
@@ -164,7 +164,7 @@ internal class XLPivotFieldStyleFormatsTests
             });
 
             var ptSheet = wb.AddWorksheet().SetTabActive();
-            var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+            var pt = dataRange!.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
 
             pt.RowLabels.Add("Name");
             pt.RowLabels.Add(XLConstants.PivotTable.ValuesSentinalLabel);
@@ -195,7 +195,7 @@ internal class XLPivotFieldStyleFormatsTests
             });
 
             var ptSheet = wb.AddWorksheet().SetTabActive();
-            var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+            var pt = dataRange!.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
 
             var nameField = pt.RowLabels.Add("Name");
             var flavorField = pt.ColumnLabels.Add("Flavor");

--- a/XLibur.Tests/Excel/PivotTables/Style/XLPivotTableStyleFormatsTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/Style/XLPivotTableStyleFormatsTests.cs
@@ -22,7 +22,7 @@ internal class XLPivotTableStyleFormatsTests
 
             var ptSheet = wb.AddWorksheet().SetTabActive();
             ptSheet.Column("A").Width = 15;
-            var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+            var pt = dataRange!.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
             pt.RowLabels.Add("Name");
             pt.Values.Add("Price", "Avg $").SetSummaryFormula(XLPivotSummary.Average);
             pt.Values.Add("Price", "Max $").SetSummaryFormula(XLPivotSummary.Maximum);
@@ -56,7 +56,7 @@ internal class XLPivotTableStyleFormatsTests
             });
 
             var ptSheet = wb.AddWorksheet().SetTabActive();
-            var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+            var pt = dataRange!.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
             pt.RowLabels.Add("Name");
             pt.Values.Add("Price");
 
@@ -109,7 +109,7 @@ internal class XLPivotTableStyleFormatsTests
 
             var ptSheet = wb.AddWorksheet().SetTabActive();
             ptSheet.Column("A").Width = 15;
-            var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+            var pt = dataRange!.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
             pt.RowLabels.Add("Name");
             pt.RowLabels.Add("Month");
             pt.Values.Add("Price");

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheSourceTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheSourceTests.cs
@@ -36,7 +36,7 @@ public class XLPivotCacheSourceTests
         using var wb = WorkbookWithData(out var sheet);
         var range = sheet.Range("A1:B4");
 
-        var cache = wb.PivotCaches.Add(range);
+        var cache = wb.PivotCaches.Add(range!);
 
         await Assert.That(cache.SourceKind).IsEqualTo(XLPivotSourceKind.Range);
         await Assert.That(cache.SourceRange).IsNotNull();

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheSourceTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheSourceTests.cs
@@ -36,7 +36,7 @@ public class XLPivotCacheSourceTests
         using var wb = WorkbookWithData(out var sheet);
         var range = sheet.Range("A1:B4");
 
-        var cache = wb.PivotCaches.Add(range!);
+        var cache = wb.PivotCaches.Add(range);
 
         await Assert.That(cache.SourceKind).IsEqualTo(XLPivotSourceKind.Range);
         await Assert.That(cache.SourceRange).IsNotNull();

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
@@ -146,7 +146,7 @@ public class XLPivotCacheTests
         saved.Position = 0;
         using var doc = SpreadsheetDocument.Open(saved, false);
 
-        var declared = doc.WorkbookPart!.Workbook.PivotCaches!
+        var declared = doc.WorkbookPart!.Workbook!.PivotCaches!
             .Elements<PivotCache>()
             .Select(cache => cache.CacheId!.Value)
             .ToList();
@@ -179,7 +179,7 @@ public class XLPivotCacheTests
                 ("Waffles", "Puff")
             });
 
-            var table = range.CreateTable();
+            var table = range!.CreateTable();
 
             var pivotTable = ws.PivotTables.Add("pvt", ws.Cell("D1"), table);
             pivotTable.RowLabels.Add("Pastry");

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
@@ -22,7 +22,7 @@ public class XLPivotCacheTests
         var ws = wb.AddWorksheet();
         var range = ws.FirstCell().InsertData(PivotCacheFieldNamePie);
 
-        var pivotCache = wb.PivotCaches.Add(range);
+        var pivotCache = wb.PivotCaches.Add(range!);
         ws.Cell("A1").Value = "Pastry";
 
         await Assert.That(pivotCache.FieldNames).IsEquivalentTo(PivotCacheFieldNameOnly, CollectionOrdering.Matching);
@@ -35,7 +35,7 @@ public class XLPivotCacheTests
         var ws = wb.AddWorksheet();
         var range = ws.FirstCell().InsertData(PivotCacheFieldNamePie);
 
-        var pivotCache = wb.PivotCaches.Add(range);
+        var pivotCache = wb.PivotCaches.Add(range!);
         ws.Cell("A1").Value = "Pastry";
         pivotCache.Refresh();
 
@@ -49,7 +49,7 @@ public class XLPivotCacheTests
         var ws = wb.AddWorksheet();
         var range = ws.FirstCell().InsertData(PivotCacheFieldNamePie);
 
-        var pivotCache = wb.PivotCaches.Add(range);
+        var pivotCache = wb.PivotCaches.Add(range!);
 
         pivotCache.ItemsToRetainPerField = XLItemsToRetain.None;
         pivotCache.SaveSourceData = false;

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
@@ -179,7 +179,7 @@ public class XLPivotCacheTests
                 ("Waffles", "Puff")
             });
 
-            var table = range.CreateTable()!;
+            var table = range.CreateTable();
 
             var pivotTable = ws.PivotTables.Add("pvt", ws.Cell("D1"), table);
             pivotTable.RowLabels.Add("Pastry");

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
@@ -179,7 +179,7 @@ public class XLPivotCacheTests
                 ("Waffles", "Puff")
             });
 
-            var table = range.CreateTable();
+            var table = range.CreateTable()!;
 
             var pivotTable = ws.PivotTables.Add("pvt", ws.Cell("D1"), table);
             pivotTable.RowLabels.Add("Pastry");

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
@@ -116,11 +116,11 @@ public class XLPivotCacheTests
         });
 
         var pivots = wb.AddWorksheet("Pivots");
-        var byPastry = pivots.PivotTables.Add("byPastry", pivots.Cell("A1"), pastries);
+        var byPastry = pivots.PivotTables.Add("byPastry", pivots.Cell("A1"), pastries!);
         byPastry.RowLabels.Add("Pastry");
         byPastry.Values.Add("Sold");
 
-        var byDough = pivots.PivotTables.Add("byDough", pivots.Cell("F1"), doughs);
+        var byDough = pivots.PivotTables.Add("byDough", pivots.Cell("F1"), doughs!);
         byDough.RowLabels.Add("Dough");
         byDough.Values.Add("Batches");
 

--- a/XLibur.Tests/Excel/PivotTables/XLPivotDataFieldsTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotDataFieldsTests.cs
@@ -31,7 +31,7 @@ internal class XLPivotDataFieldsTests
         var ex = await Assert.That(() => pt.Values.Add("Wrong field name")).Throws<ArgumentOutOfRangeException>();
 
         await Assert.That(ex).IsNotNull();
-        await Assert.That(ex.Message).StartsWith("Field 'Wrong field name' is not in the fields of a pivot cache. Should be one of 'Name','Price'.");
+        await Assert.That(ex!.Message).StartsWith("Field 'Wrong field name' is not in the fields of a pivot cache. Should be one of 'Name','Price'.");
     }
 
     #endregion

--- a/XLibur.Tests/Excel/PivotTables/XLPivotDataFieldsTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotDataFieldsTests.cs
@@ -26,7 +26,7 @@ internal class XLPivotDataFieldsTests
             ("Cake", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
 
         var ex = await Assert.That(() => pt.Values.Add("Wrong field name")).Throws<ArgumentOutOfRangeException>();
 
@@ -49,7 +49,7 @@ internal class XLPivotDataFieldsTests
             ("Cake", 10, 5),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         pt.Values.Add("Price");
         pt.Values.Add("Qty");
 
@@ -73,7 +73,7 @@ internal class XLPivotDataFieldsTests
             ("Cake", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
 
         await Assert.That(() => pt.Values.Clear()).ThrowsNothing();
     }
@@ -89,7 +89,7 @@ internal class XLPivotDataFieldsTests
             ("Cake", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         pt.Values.Add("Price");
 
         pt.Values.Clear();
@@ -114,7 +114,7 @@ internal class XLPivotDataFieldsTests
             ("Cake", 10, 5),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         pt.Values.Add("Price");
         pt.Values.Add("Qty");
 
@@ -136,7 +136,7 @@ internal class XLPivotDataFieldsTests
             ("Cake", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
 
         await Assert.That(() => pt.Values.Remove("NonExistent")).ThrowsNothing();
     }

--- a/XLibur.Tests/Excel/PivotTables/XLPivotSourceTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotSourceTests.cs
@@ -75,7 +75,7 @@ internal class XLPivotSourceTests
         await Assert.That(sheet!.Name).IsEqualTo("Data");
         // Should resolve to table area (A1:A2), not defined name area (B1:B5)
         await Assert.That(sheetArea!.Value.LeftColumn).IsEqualTo(1);
-        await Assert.That(sheetArea!.Value.RightColumn).IsEqualTo(1);
+        await Assert.That(sheetArea.Value.RightColumn).IsEqualTo(1);
     }
 
     [Test]

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableAxisFieldTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableAxisFieldTests.cs
@@ -41,8 +41,8 @@ internal class XLPivotTableAxisFieldTests
         var colorField = pt.RowLabels.Add("Color");
 
         var ex1 = await Assert.That(() => idField.SetCustomName("Color")).Throws<ArgumentException>();
-        await Assert.That(ex1.Message).IsEqualTo("Custom name 'Color' is already used by another field.");
+        await Assert.That(ex1!.Message).IsEqualTo("Custom name 'Color' is already used by another field.");
         var ex2 = await Assert.That(() => colorField.SetCustomName("Custom ID")).Throws<ArgumentException>();
-        await Assert.That(ex2.Message).IsEqualTo("Custom name 'Custom ID' is already used by another field.");
+        await Assert.That(ex2!.Message).IsEqualTo("Custom name 'Custom ID' is already used by another field.");
     }
 }

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableAxisFieldTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableAxisFieldTests.cs
@@ -40,7 +40,7 @@ internal class XLPivotTableAxisFieldTests
         var idField = pt.RowLabels.Add("ID", "Custom ID");
         var colorField = pt.RowLabels.Add("Color");
 
-        var ex1 = await Assert.That(() => idField.SetCustomName("Color")).Throws<ArgumentException>()!;
+        var ex1 = await Assert.That(() => idField.SetCustomName("Color")).Throws<ArgumentException>();
         await Assert.That(ex1.Message).IsEqualTo("Custom name 'Color' is already used by another field.");
         var ex2 = await Assert.That(() => colorField.SetCustomName("Custom ID")).Throws<ArgumentException>();
         await Assert.That(ex2.Message).IsEqualTo("Custom name 'Custom ID' is already used by another field.");

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableAxisFieldTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableAxisFieldTests.cs
@@ -18,7 +18,7 @@ internal class XLPivotTableAxisFieldTests
             ("ID", "Color", "Count"),
             (1, "Blue", 10),
         });
-        var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), range);
+        var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), range!);
         var colorField = pt.RowLabels.Add("Color");
 
         colorField.SetCustomName("Changed color");
@@ -36,7 +36,7 @@ internal class XLPivotTableAxisFieldTests
             ("ID", "Color", "Count"),
             (1, "Blue", 10),
         });
-        var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), range);
+        var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), range!);
         var idField = pt.RowLabels.Add("ID", "Custom ID");
         var colorField = pt.RowLabels.Add("Color");
 

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
@@ -25,7 +25,7 @@ internal class XLPivotTableAxisTests
             (1, 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         var internalPt = (XLPivotTable)pt;
         await Assert.That(internalPt.PivotFields[0].Items).IsEmpty();
 
@@ -54,7 +54,7 @@ internal class XLPivotTableAxisTests
             (1, 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         pt.RowLabels.Add("ID", "Item ID");
 
         var ex = await Assert.That(() => pt.RowLabels.Add("ID", "Item ID")).Throws<InvalidOperationException>()!;
@@ -72,7 +72,7 @@ internal class XLPivotTableAxisTests
             (1, 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         await Assert.That(() => pt.RowLabels.Add("ID", "Item ID")).ThrowsNothing();
 
         var ex = await Assert.That(() => pt.RowLabels.Add("nonexistent")).Throws<InvalidOperationException>()!;
@@ -94,7 +94,7 @@ internal class XLPivotTableAxisTests
             (1, "Blue", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         pt.RowLabels.Add("ID", "Item ID");
         pt.RowLabels.Add("Color", "Custom color");
 
@@ -126,7 +126,7 @@ internal class XLPivotTableAxisTests
             (1, "Blue", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         var idField = pt.RowLabels.Add("ID", "Item ID");
         pt.ColumnLabels.Add("Color");
 
@@ -151,7 +151,7 @@ internal class XLPivotTableAxisTests
             (1, "Blue", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         pt.RowLabels.Add("ID", "Item ID");
         pt.ColumnLabels.Add("Color");
 
@@ -175,7 +175,7 @@ internal class XLPivotTableAxisTests
             (1, "Blue", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         pt.RowLabels.Add("ID", "Item ID");
         pt.ColumnLabels.Add("Color");
 
@@ -199,7 +199,7 @@ internal class XLPivotTableAxisTests
             (1, "Blue", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         var idField = pt.RowLabels.Add("ID", "Item ID");
         pt.ColumnLabels.Add("Color");
 
@@ -224,7 +224,7 @@ internal class XLPivotTableAxisTests
             (1, "Blue", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         pt.RowLabels.Add("ID");
 
         pt.RowLabels.Remove("id");
@@ -250,7 +250,7 @@ internal class XLPivotTableAxisTests
             (1, 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         var field = pt.RowLabels.Add("ID");
 
         field.SetSubtotal(XLSubtotalFunction.Sum, true);
@@ -269,7 +269,7 @@ internal class XLPivotTableAxisTests
             (1, 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         var field = pt.RowLabels.Add("ID")
             .AddSubtotal(XLSubtotalFunction.Sum)
             .AddSubtotal(XLSubtotalFunction.Average);
@@ -291,7 +291,7 @@ internal class XLPivotTableAxisTests
             (1, 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         var field = pt.RowLabels.Add("ID");
 
         // By default, new field has Automatic subtotal
@@ -313,7 +313,7 @@ internal class XLPivotTableAxisTests
             (1, 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         var field = pt.RowLabels.Add("ID")
             .SetSubtotal(XLSubtotalFunction.Sum, true)
             .SetSubtotal(XLSubtotalFunction.Sum, true);
@@ -332,7 +332,7 @@ internal class XLPivotTableAxisTests
             (1, 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         var field = pt.RowLabels.Add("ID");
 
         // Default field has Automatic
@@ -355,7 +355,7 @@ internal class XLPivotTableAxisTests
             (1, "Blue", 10),
         });
         var ptSheet = wb.AddWorksheet();
-        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+        var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         pt.Values.Add("Count");
         var filterField = pt.ReportFilters.Add("Color");
 

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
@@ -58,7 +58,7 @@ internal class XLPivotTableAxisTests
         pt.RowLabels.Add("ID", "Item ID");
 
         var ex = await Assert.That(() => pt.RowLabels.Add("ID", "Item ID")).Throws<InvalidOperationException>()!;
-        await Assert.That(ex.Message).IsEqualTo("Custom name 'Item ID' is already used.");
+        await Assert.That(ex!.Message).IsEqualTo("Custom name 'Item ID' is already used.");
     }
 
     [Test]
@@ -76,7 +76,7 @@ internal class XLPivotTableAxisTests
         await Assert.That(() => pt.RowLabels.Add("ID", "Item ID")).ThrowsNothing();
 
         var ex = await Assert.That(() => pt.RowLabels.Add("nonexistent")).Throws<InvalidOperationException>()!;
-        await Assert.That(ex.Message).IsEqualTo("Field 'nonexistent' not found in pivot cache.");
+        await Assert.That(ex!.Message).IsEqualTo("Field 'nonexistent' not found in pivot cache.");
     }
 
     #endregion
@@ -157,7 +157,7 @@ internal class XLPivotTableAxisTests
 
         await Assert.That(pt.RowLabels.Get("id").SourceName).IsEqualTo("ID");
         var ex = await Assert.That(() => pt.RowLabels.Get("color")).Throws<KeyNotFoundException>()!;
-        await Assert.That(ex.Message).IsEqualTo("Field with source name 'color' not found in AxisRow.");
+        await Assert.That(ex!.Message).IsEqualTo("Field with source name 'color' not found in AxisRow.");
     }
 
     #endregion

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
@@ -57,7 +57,7 @@ internal class XLPivotTableAxisTests
         var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         pt.RowLabels.Add("ID", "Item ID");
 
-        var ex = await Assert.That(() => pt.RowLabels.Add("ID", "Item ID")).Throws<InvalidOperationException>()!;
+        var ex = await Assert.That(() => pt.RowLabels.Add("ID", "Item ID")).Throws<InvalidOperationException>();
         await Assert.That(ex!.Message).IsEqualTo("Custom name 'Item ID' is already used.");
     }
 
@@ -75,7 +75,7 @@ internal class XLPivotTableAxisTests
         var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range!);
         await Assert.That(() => pt.RowLabels.Add("ID", "Item ID")).ThrowsNothing();
 
-        var ex = await Assert.That(() => pt.RowLabels.Add("nonexistent")).Throws<InvalidOperationException>()!;
+        var ex = await Assert.That(() => pt.RowLabels.Add("nonexistent")).Throws<InvalidOperationException>();
         await Assert.That(ex!.Message).IsEqualTo("Field 'nonexistent' not found in pivot cache.");
     }
 
@@ -156,7 +156,7 @@ internal class XLPivotTableAxisTests
         pt.ColumnLabels.Add("Color");
 
         await Assert.That(pt.RowLabels.Get("id").SourceName).IsEqualTo("ID");
-        var ex = await Assert.That(() => pt.RowLabels.Get("color")).Throws<KeyNotFoundException>()!;
+        var ex = await Assert.That(() => pt.RowLabels.Get("color")).Throws<KeyNotFoundException>();
         await Assert.That(ex!.Message).IsEqualTo("Field with source name 'color' not found in AxisRow.");
     }
 

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableFiltersTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableFiltersTests.cs
@@ -18,7 +18,7 @@ public class XLPivotTableFiltersTests
             ("B", false),
         });
 
-        var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), data);
+        var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), data!);
         pt.RowLabels.Add("Col1");
         var filter = pt.ReportFilters.Add("Col2");
 
@@ -37,7 +37,7 @@ public class XLPivotTableFiltersTests
             ("Cake", "Tokyo", "Vanilla", 7),
         });
 
-        var pt = ws.PivotTables.Add("pt", ws.Cell("E2"), data);
+        var pt = ws.PivotTables.Add("pt", ws.Cell("E2"), data!);
 
         // No filter, the table is at the original cell
         await Assert.That(((XLPivotTable)pt).Area.ToString()).IsEqualTo("E2");

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -200,21 +200,21 @@ public class XLPivotTableTests
         using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx"));
         using var wb = new XLWorkbook(stream);
         var ws1 = wb.Worksheet("pvt1");
-        var pt1 = ws1.PivotTables.First() as XLPivotTable;
+        var pt1 = (XLPivotTable)ws1.PivotTables.First();
 
-        await Assert.That(() => pt1!.CopyTo(pt1.TargetCell)).Throws<InvalidOperationException>();
+        await Assert.That(() => pt1.CopyTo(pt1.TargetCell)).Throws<InvalidOperationException>();
 
-        var pt2 = pt1!.CopyTo(ws1.Cell("AB100")) as XLPivotTable;
+        var pt2 = (XLPivotTable)pt1.CopyTo(ws1.Cell("AB100"));
 
         await AssertPivotTablesAreEqual(pt1, pt2, compareName: false);
 
         var ws2 = wb.AddWorksheet("Copy Of pvt1");
-        await AssertPivotTablesAreEqual(pt1, pt1.CopyTo(ws2.FirstCell()) as XLPivotTable, compareName: true);
+        await AssertPivotTablesAreEqual(pt1, (XLPivotTable)pt1.CopyTo(ws2.FirstCell()), compareName: true);
 
         using var wb2 = new XLWorkbook();
         wb.Worksheet("PastrySalesData").CopyTo(wb2);
 
-        await AssertPivotTablesAreEqual(pt1, pt1.CopyTo(wb2.AddWorksheet("pvt").FirstCell()) as XLPivotTable, compareName: true);
+        await AssertPivotTablesAreEqual(pt1, (XLPivotTable)pt1.CopyTo(wb2.AddWorksheet("pvt").FirstCell()), compareName: true);
     }
 
     private static async Task AssertPivotTablesAreEqual(XLPivotTable original, XLPivotTable copy, bool compareName)
@@ -590,7 +590,7 @@ public class XLPivotTableTests
         await TestHelper.CreateAndCompare(() =>
         {
             var wb = new XLWorkbook(stream);
-            var srcRange = wb.Range("Sheet1!$B$2:$H$207");
+            var srcRange = wb.Range("Sheet1!$B$2:$H$207")!;
 
             var pivotSource = wb.PivotCaches.Add(srcRange);
 

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -202,19 +202,19 @@ public class XLPivotTableTests
         var ws1 = wb.Worksheet("pvt1");
         var pt1 = ws1.PivotTables.First() as XLPivotTable;
 
-        await Assert.That(() => pt1.CopyTo(pt1.TargetCell)!).Throws<InvalidOperationException>();
+        await Assert.That(() => pt1.CopyTo(pt1.TargetCell)).Throws<InvalidOperationException>();
 
-        var pt2 = pt1.CopyTo(ws1.Cell("AB100"))! as XLPivotTable;
+        var pt2 = pt1.CopyTo(ws1.Cell("AB100")) as XLPivotTable;
 
         await AssertPivotTablesAreEqual(pt1, pt2, compareName: false);
 
         var ws2 = wb.AddWorksheet("Copy Of pvt1");
-        await AssertPivotTablesAreEqual(pt1, pt1.CopyTo(ws2.FirstCell())! as XLPivotTable, compareName: true);
+        await AssertPivotTablesAreEqual(pt1, pt1.CopyTo(ws2.FirstCell()) as XLPivotTable, compareName: true);
 
         using var wb2 = new XLWorkbook();
         wb.Worksheet("PastrySalesData").CopyTo(wb2);
 
-        await AssertPivotTablesAreEqual(pt1, pt1.CopyTo(wb2.AddWorksheet("pvt").FirstCell())! as XLPivotTable, compareName: true);
+        await AssertPivotTablesAreEqual(pt1, pt1.CopyTo(wb2.AddWorksheet("pvt").FirstCell()) as XLPivotTable, compareName: true);
     }
 
     private static async Task AssertPivotTablesAreEqual(XLPivotTable original, XLPivotTable copy, bool compareName)

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -202,19 +202,19 @@ public class XLPivotTableTests
         var ws1 = wb.Worksheet("pvt1");
         var pt1 = ws1.PivotTables.First() as XLPivotTable;
 
-        await Assert.That(() => pt1.CopyTo(pt1.TargetCell)).Throws<InvalidOperationException>();
+        await Assert.That(() => pt1.CopyTo(pt1.TargetCell)!).Throws<InvalidOperationException>();
 
-        var pt2 = pt1.CopyTo(ws1.Cell("AB100")) as XLPivotTable;
+        var pt2 = pt1.CopyTo(ws1.Cell("AB100"))! as XLPivotTable;
 
         await AssertPivotTablesAreEqual(pt1, pt2, compareName: false);
 
         var ws2 = wb.AddWorksheet("Copy Of pvt1");
-        await AssertPivotTablesAreEqual(pt1, pt1.CopyTo(ws2.FirstCell()) as XLPivotTable, compareName: true);
+        await AssertPivotTablesAreEqual(pt1, pt1.CopyTo(ws2.FirstCell())! as XLPivotTable, compareName: true);
 
         using var wb2 = new XLWorkbook();
         wb.Worksheet("PastrySalesData").CopyTo(wb2);
 
-        await AssertPivotTablesAreEqual(pt1, pt1.CopyTo(wb2.AddWorksheet("pvt").FirstCell()) as XLPivotTable, compareName: true);
+        await AssertPivotTablesAreEqual(pt1, pt1.CopyTo(wb2.AddWorksheet("pvt").FirstCell())! as XLPivotTable, compareName: true);
     }
 
     private static async Task AssertPivotTablesAreEqual(XLPivotTable original, XLPivotTable copy, bool compareName)
@@ -941,7 +941,7 @@ public class XLPivotTableTests
 
         using var doc = SpreadsheetDocument.Open(ms, false);
         var cachePart = doc.WorkbookPart!.GetPartsOfType<PivotTableCacheDefinitionPart>().First();
-        var cacheFields = cachePart.PivotCacheDefinition.CacheFields!.Elements<CacheField>().ToList();
+        var cacheFields = cachePart.PivotCacheDefinition!.CacheFields!.Elements<CacheField>().ToList();
         await Assert.That(cacheFields.Count).IsEqualTo(4);
 
         var calcField = cacheFields[3];
@@ -968,7 +968,7 @@ public class XLPivotTableTests
         outputStream.Position = 0;
         using var doc = SpreadsheetDocument.Open(outputStream, false);
         var cachePart = doc.WorkbookPart!.GetPartsOfType<PivotTableCacheDefinitionPart>().First();
-        var cacheFields = cachePart.PivotCacheDefinition.CacheFields!.Elements<CacheField>().ToList();
+        var cacheFields = cachePart.PivotCacheDefinition!.CacheFields!.Elements<CacheField>().ToList();
 
         // Should have 3 data fields + 1 calculated field = 4 total
         await Assert.That(cacheFields.Count).IsEqualTo(4).Because("Expected 3 source fields + 1 calculated field");

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -202,9 +202,9 @@ public class XLPivotTableTests
         var ws1 = wb.Worksheet("pvt1");
         var pt1 = ws1.PivotTables.First() as XLPivotTable;
 
-        await Assert.That(() => pt1.CopyTo(pt1.TargetCell)).Throws<InvalidOperationException>();
+        await Assert.That(() => pt1!.CopyTo(pt1.TargetCell)).Throws<InvalidOperationException>();
 
-        var pt2 = pt1.CopyTo(ws1.Cell("AB100")) as XLPivotTable;
+        var pt2 = pt1!.CopyTo(ws1.Cell("AB100")) as XLPivotTable;
 
         await AssertPivotTablesAreEqual(pt1, pt2, compareName: false);
 

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -116,7 +116,7 @@ public class XLPivotTableTests
         using var wbassert = new XLWorkbook(ms);
         var wsassert = wbassert.Worksheet("BlankPivotTable");
         var ptassert = wsassert.PivotTable("pvtOptionsTest");
-        await Assert.That(ptassert).IsNotEqualTo(null).Because("name save failure");
+        await Assert.That(ptassert).IsNotNull().Because("name save failure");
         await Assert.That(ptassert.ColumnHeaderCaption).IsEqualTo("clmn header").Because("ColumnHeaderCaption save failure");
         await Assert.That(ptassert.RowHeaderCaption).IsEqualTo("row header").Because("RowHeaderCaption save failure");
         await Assert.That(ptassert.MergeAndCenterWithLabels).IsTrue().Because("MergeAndCenterWithLabels save failure");
@@ -187,7 +187,7 @@ public class XLPivotTableTests
         var wsassert = wbassert.Worksheet("pvtFieldOptionsTest");
         var ptassert = wsassert.PivotTable("pvtFieldOptionsTest");
         var pfassert = ptassert.RowLabels.Get("Name");
-        await Assert.That(pfassert).IsNotEqualTo(null).Because("name save failure");
+        await Assert.That(pfassert).IsNotNull().Because("name save failure");
         await Assert.That(pfassert.SubtotalCaption).IsEqualTo("Test caption").Because("SubtotalCaption save failure");
         await Assert.That(pfassert.CustomName).IsEqualTo("Test name").Because("CustomName save failure");
         await AssertFieldOptions(pfassert, withDefaults);
@@ -1201,7 +1201,7 @@ public class XLPivotTableTests
         var pivotTablePart = doc.WorkbookPart!.WorksheetParts
             .SelectMany(wsp => wsp.GetPartsOfType<PivotTablePart>())
             .First();
-        var pivotFields = pivotTablePart.PivotTableDefinition.PivotFields!.Elements<PivotField>().ToList();
+        var pivotFields = pivotTablePart.PivotTableDefinition!.PivotFields!.Elements<PivotField>().ToList();
 
         // Field 0 (Name) has sortType="descending" and autoSortScope
         var nameField = pivotFields[0];

--- a/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -42,7 +42,7 @@ public class XLPivotTableTests
 
             var data = wb.Worksheet("Data");
 
-            var pt = data.RangeUsed().CreatePivotTable(wb.AddWorksheet("pvt2").FirstCell(), "pvt2");
+            var pt = data.RangeUsed()!.CreatePivotTable(wb.AddWorksheet("pvt2").FirstCell(), "pvt2");
 
             pt.ColumnLabels.Add("Sex");
             pt.RowLabels.Add("FullName");
@@ -350,7 +350,7 @@ public class XLPivotTableTests
 
             // Add a new sheet for our pivot table
             var ptSheet = wb.Worksheets.Add("pvt");
-            var pt = ptSheet.PivotTables.Add("pvt", ptSheet.Cell(1, 1), range);
+            var pt = ptSheet.PivotTables.Add("pvt", ptSheet.Cell(1, 1), range!);
             pt.RowLabels.Add("Name");
             pt.Values.Add("Sold count");
 
@@ -652,8 +652,8 @@ public class XLPivotTableTests
             ("Pie", 14),
         });
 
-        var rangePivot1 = ws.PivotTables.Add("rangePivot1", ws.Cell("D1"), range);
-        var rangePivot2 = ws.PivotTables.Add("rangePivot2", ws.Cell("D20"), range);
+        var rangePivot1 = ws.PivotTables.Add("rangePivot1", ws.Cell("D1"), range!);
+        var rangePivot2 = ws.PivotTables.Add("rangePivot2", ws.Cell("D20"), range!);
 
         await Assert.That(rangePivot2).IsNotSameReferenceAs(rangePivot1);
         await Assert.That(rangePivot2.PivotCache).IsSameReferenceAs(rangePivot1.PivotCache);
@@ -784,7 +784,7 @@ public class XLPivotTableTests
             ("Name", "City", "Flavor", "Sales"),
             ("Cake", "Tokyo", "Vanilla", 7),
         });
-        var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), data);
+        var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), data!);
         pt.ReportFilters.Add("City");
 
         // Even when we added filter and a gap row, the target cell is still E1
@@ -813,7 +813,7 @@ public class XLPivotTableTests
             ("Cake", "Tokyo", "Vanilla", 7),
         });
 
-        var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), data);
+        var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), data!);
         pt.FilterAreaOrder = order;
 
         pt.ReportFilters.Add("Name");
@@ -851,7 +851,7 @@ public class XLPivotTableTests
 
                 var ptSheet = wb.AddWorksheet().SetTabActive();
                 ptSheet.Column("A").Width = 15;
-                var pt = dataRange.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
+                var pt = dataRange!.CreatePivotTable(ptSheet.Cell("A1"), "pivot table");
 
                 // Add at least two fields to each axis to make each layout distinctive.
                 pt.RowLabels.Add("Name");

--- a/XLibur.Tests/Excel/Protection/XLSheetProtectionTests.cs
+++ b/XLibur.Tests/Excel/Protection/XLSheetProtectionTests.cs
@@ -150,7 +150,7 @@ public class XLSheetProtectionTests
         await Assert.That(ReferenceEquals(ws1.Protection, ws2.Protection)).IsFalse();
         await Assert.That(ws2.Protection.IsProtected).IsTrue();
         await Assert.That(ws2.Protection.AllowedElements).IsEqualTo(XLSheetProtectionElements.FormatColumns | XLSheetProtectionElements.FormatRows | XLSheetProtectionElements.SelectEverything);
-        await Assert.That((ws2.Protection as XLSheetProtection).PasswordHash).IsEqualTo((ws1.Protection as XLSheetProtection).PasswordHash);
+        await Assert.That(((XLSheetProtection)ws2.Protection).PasswordHash).IsEqualTo(((XLSheetProtection)ws1.Protection).PasswordHash);
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Ranges/BatchRowDeleteCompactionTests.cs
+++ b/XLibur.Tests/Excel/Ranges/BatchRowDeleteCompactionTests.cs
@@ -85,11 +85,11 @@ public class BatchRowDeleteCompactionTests
         ws.Cell("H3").Value = "far right";
         ws.Cell("A4").Value = 4;
 
-        await Assert.That(ws.LastColumnUsed().ColumnNumber()).IsEqualTo(8);
+        await Assert.That(ws.LastColumnUsed()!.ColumnNumber()).IsEqualTo(8);
 
         ws.Rows("3:3").Delete();
 
-        await Assert.That(ws.LastColumnUsed().ColumnNumber()).IsEqualTo(1);
+        await Assert.That(ws.LastColumnUsed()!.ColumnNumber()).IsEqualTo(1);
     }
 
     [Test]
@@ -102,7 +102,7 @@ public class BatchRowDeleteCompactionTests
 
         ws.Rows("3:3").Delete();
 
-        await Assert.That(ws.LastColumnUsed().ColumnNumber()).IsEqualTo(8);
+        await Assert.That(ws.LastColumnUsed()!.ColumnNumber()).IsEqualTo(8);
     }
 
     [Test]
@@ -115,7 +115,7 @@ public class BatchRowDeleteCompactionTests
 
         ws.Rows("2:2,5:5,9:9").Delete();
 
-        await Assert.That(ws.LastRowUsed().RowNumber()).IsEqualTo(7);
+        await Assert.That(ws.LastRowUsed()!.RowNumber()).IsEqualTo(7);
         await Assert.That(ws.Cell(8, 1).IsEmpty()).IsTrue();
     }
 

--- a/XLibur.Tests/Excel/Ranges/BatchRowDeleteTests.cs
+++ b/XLibur.Tests/Excel/Ranges/BatchRowDeleteTests.cs
@@ -222,7 +222,7 @@ public class BatchRowDeleteTests
 
         ws.Rows("2:2,12:12,15:15").Delete();
 
-        await Assert.That(wb.DefinedName("Block").RefersTo).IsEqualTo("Data!$A$9:$A$17");
+        await Assert.That(wb.DefinedName("Block")!.RefersTo).IsEqualTo("Data!$A$9:$A$17");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Ranges/MergedRangesTests.cs
+++ b/XLibur.Tests/Excel/Ranges/MergedRangesTests.cs
@@ -14,8 +14,8 @@ public class MergedRangesTests
         var ws = wb.Worksheets.Add("Sheet");
         ws.Range("B2:D4").Merge();
 
-        var first = ws.FirstCellUsed(XLCellsUsedOptions.All).Address.ToStringRelative();
-        var last = ws.LastCellUsed(XLCellsUsedOptions.All).Address.ToStringRelative();
+        var first = ws.FirstCellUsed(XLCellsUsedOptions.All)!.Address.ToStringRelative();
+        var last = ws.LastCellUsed(XLCellsUsedOptions.All)!.Address.ToStringRelative();
 
         await Assert.That(first).IsEqualTo("B2");
         await Assert.That(last).IsEqualTo("D4");

--- a/XLibur.Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeIndexTest.cs
@@ -16,7 +16,7 @@ public class RangeIndexTest
     public async Task FindExistingMatches()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
 
         for (var i = 1; i <= TestCount; i++)
@@ -33,7 +33,7 @@ public class RangeIndexTest
     public async Task FindNonExistingMatches()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
 
         for (var i = 1; i <= TestCount; i++)
@@ -47,7 +47,7 @@ public class RangeIndexTest
     public async Task FindExistingIntersections()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
 
         for (var i = 1; i <= TestCount; i++)
@@ -70,7 +70,7 @@ public class RangeIndexTest
     public async Task FindNonExistingIntersections()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
 
         for (var i = 1; i <= TestCount; i++)
@@ -92,7 +92,7 @@ public class RangeIndexTest
     public async Task FindMatchAfterColumnShifting()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
 
         ws.Column(1).InsertColumnsBefore(1000);
@@ -106,7 +106,7 @@ public class RangeIndexTest
     public async Task FindIntersectionsAfterColumnShifting()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
 
         ws.Column(3).InsertColumnsBefore(2);
@@ -120,7 +120,7 @@ public class RangeIndexTest
     public async Task FindMatchAfterRowShifting()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
 
         ws.Row(10).InsertRowsBelow(3);
@@ -134,7 +134,7 @@ public class RangeIndexTest
     public async Task FindIntersectionsAfterRowShifting()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
 
         ws.Row(10).InsertRowsBelow(3);
@@ -148,7 +148,7 @@ public class RangeIndexTest
     public async Task CreateQuadTree()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var quadTree = new Quadrant();
         var range = ws.Range("BT76:CA87");
 
@@ -206,7 +206,7 @@ public class RangeIndexTest
     public async Task XLRangesCountChangesCorrectly()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var range1 = ws.Range("A1:B2");
         var range2 = ws.Range("A2:B3");
         var range3 = ws.Range("A1:B2"); // same as range1
@@ -245,7 +245,7 @@ public class RangeIndexTest
     public async Task AddingAndRemovingOneRangeAtATimeNeverBuildsQuadTree()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = CreateRangeIndex(ws);
 
         // A collection that never holds more than one range has nothing to gain from a QuadTree.
@@ -267,7 +267,7 @@ public class RangeIndexTest
     public async Task QuadTreeRemainsConsistentAcrossRemoveAndReAdd()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
 
         await Assert.That(index.IsIndexed).IsTrue();
@@ -297,7 +297,7 @@ public class RangeIndexTest
     public async Task QuadTreeRemoveAllKeepsNonMatchingRangesFindable()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
 
         var removed = index.RemoveAll(r => r.RangeAddress.FirstAddress.RowNumber % 4 == 0);
@@ -316,7 +316,7 @@ public class RangeIndexTest
     public async Task QuadTreeRemoveByAddressAllowsReAddingSameAddress()
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+        var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
         var index = FillIndexWithTestData(ws);
         var address = new XLAddress(ws, 200, 3, false, false);
 

--- a/XLibur.Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeIndexTest.cs
@@ -152,7 +152,7 @@ public class RangeIndexTest
         var quadTree = new Quadrant();
         var range = ws.Range("BT76:CA87");
 
-        quadTree.Add(range);
+        quadTree.Add(range!);
 
         var level0 = quadTree;
         await Assert.That(level0.MinimumColumn).IsEqualTo(1);
@@ -160,7 +160,7 @@ public class RangeIndexTest
         await Assert.That(level0.MinimumRow).IsEqualTo(1);
         await Assert.That(level0.MaximumRow).IsEqualTo(XLHelper.MaxRowNumber);
         await Assert.That(level0.Ranges).IsNull();
-        await Assert.That(level0.Children.Count).IsEqualTo(128);
+        await Assert.That(level0.Children!.Count).IsEqualTo(128);
         await Assert.That(level0.Children.All(child => child.Level == 1)).IsTrue();
         await Assert.That(level0.Children.Count(child =>
             child.MinimumColumn == 1 &&
@@ -197,7 +197,7 @@ public class RangeIndexTest
         await Assert.That(level8.MaximumColumn).IsEqualTo(128);
         await Assert.That(level8.MaximumRow).IsEqualTo(128);
 
-        var level9 = level8.Children[0];
+        var level9 = level8.Children![0];
         await Assert.That(level9.Ranges).IsNotNull();
         await Assert.That(level9.Ranges.Single()).IsEqualTo(range);
     }
@@ -213,9 +213,9 @@ public class RangeIndexTest
 
         var ranges = new XLRanges { range1 };
         await Assert.That(ranges.Count).IsEqualTo(1);
-        ranges.Add(range2);
+        ranges.Add(range2!);
         await Assert.That(ranges.Count).IsEqualTo(2);
-        ranges.Add(range3);
+        ranges.Add(range3!);
         await Assert.That(ranges.Count).IsEqualTo(2);
 
         // Add many entries to activate QuadTree

--- a/XLibur.Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeIndexTest.cs
@@ -179,18 +179,18 @@ public class RangeIndexTest
             child.MaximumRow == 24576 &&
             child.Y == 2)).IsEqualTo(2);
 
-        await Assert.That(level0.Children[0].Children.Any()).IsTrue();
+        await Assert.That(level0.Children[0].Children!.Any()).IsTrue();
         await Assert.That(level0.Children.Skip(1).All(child => child.Children == null)).IsTrue();
 
         var level8 = level0
             .Children[0] // 1
-            .Children[0] // 2
-            .Children[0] // 3
-            .Children[0] // 4
-            .Children[0] // 5
-            .Children[0] // 6
-            .Children[0] // 7
-            .Children[^1]; // 8
+            .Children![0] // 2
+            .Children![0] // 3
+            .Children![0] // 4
+            .Children![0] // 5
+            .Children![0] // 6
+            .Children![0] // 7
+            .Children![^1]; // 8
 
         await Assert.That(level8.MinimumColumn).IsEqualTo(65);
         await Assert.That(level8.MinimumRow).IsEqualTo(65);
@@ -207,15 +207,15 @@ public class RangeIndexTest
     {
         using var wb = new XLWorkbook();
         var ws = (XLWorksheet)wb.Worksheets.Add("Sheet1");
-        var range1 = ws.Range("A1:B2");
-        var range2 = ws.Range("A2:B3");
-        var range3 = ws.Range("A1:B2"); // same as range1
+        var range1 = ws.Range("A1:B2")!;
+        var range2 = ws.Range("A2:B3")!;
+        var range3 = ws.Range("A1:B2")!; // same as range1
 
         var ranges = new XLRanges { range1 };
         await Assert.That(ranges.Count).IsEqualTo(1);
-        ranges.Add(range2!);
+        ranges.Add(range2);
         await Assert.That(ranges.Count).IsEqualTo(2);
-        ranges.Add(range3!);
+        ranges.Add(range3);
         await Assert.That(ranges.Count).IsEqualTo(2);
 
         // Add many entries to activate QuadTree

--- a/XLibur.Tests/Excel/Ranges/RangeShiftNotificationTests.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeShiftNotificationTests.cs
@@ -25,7 +25,7 @@ public class RangeShiftNotificationTests
     {
         using var wb = new XLWorkbook();
         var ws = (XLWorksheet)wb.AddWorksheet();
-        ws.Cell("A1").Value = "anchor";
+        ws.Cell("A1")!.Value = "anchor";
         var before = ws.RangeShiftPasses;
 
         ws.Row(3).InsertRowsAbove(1000);
@@ -38,7 +38,7 @@ public class RangeShiftNotificationTests
     {
         using var wb = new XLWorkbook();
         var ws = (XLWorksheet)wb.AddWorksheet();
-        ws.Cell("A1").Value = "anchor";
+        ws.Cell("A1")!.Value = "anchor";
         var before = ws.RangeShiftPasses;
 
         ws.Row(3).InsertRowsBelow(1000);
@@ -51,7 +51,7 @@ public class RangeShiftNotificationTests
     {
         using var wb = new XLWorkbook();
         var ws = (XLWorksheet)wb.AddWorksheet();
-        ws.Cell("A1").Value = "anchor";
+        ws.Cell("A1")!.Value = "anchor";
         var before = ws.RangeShiftPasses;
 
         ws.Column(3).InsertColumnsBefore(500);
@@ -64,7 +64,7 @@ public class RangeShiftNotificationTests
     {
         using var wb = new XLWorkbook();
         var ws = (XLWorksheet)wb.AddWorksheet();
-        ws.Cell("A1").Value = "anchor";
+        ws.Cell("A1")!.Value = "anchor";
         var before = ws.RangeShiftPasses;
 
         ws.Column(3).InsertColumnsAfter(500);
@@ -77,10 +77,10 @@ public class RangeShiftNotificationTests
     {
         using var wb = new XLWorkbook();
         var ws = (XLWorksheet)wb.AddWorksheet();
-        ws.Cell("A1").Value = "anchor";
+        ws.Cell("A1")!.Value = "anchor";
         var before = ws.RangeShiftPasses;
 
-        ws.Range("B2:C500").Delete(XLShiftDeletedCells.ShiftCellsUp);
+        ws.Range("B2:C500")!.Delete(XLShiftDeletedCells.ShiftCellsUp);
 
         await Assert.That(ws.RangeShiftPasses - before).IsEqualTo(1);
     }

--- a/XLibur.Tests/Excel/Ranges/RangeShiftingTests.cs
+++ b/XLibur.Tests/Excel/Ranges/RangeShiftingTests.cs
@@ -77,12 +77,12 @@ public class RangeShiftingTests
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet();
         var deletedRange = ws.Range(deletedRangeAddress);
-        var rangeHeight = deletedRange.LastRow().RowNumber() - deletedRange.FirstRow().RowNumber() + 1;
+        var rangeHeight = deletedRange.LastRow()!.RowNumber() - deletedRange.FirstRow()!.RowNumber() + 1;
         var mergedRange = ws.Range(
-            deletedRange.LastRow().RowNumber() + 1,
-            deletedRange.FirstColumn().ColumnNumber(),
-            deletedRange.LastRow().RowNumber() + rangeHeight,
-            deletedRange.LastColumn().ColumnNumber()
+            deletedRange.LastRow()!.RowNumber() + 1,
+            deletedRange.FirstColumn()!.ColumnNumber(),
+            deletedRange.LastRow()!.RowNumber() + rangeHeight,
+            deletedRange.LastColumn()!.ColumnNumber()
         );
         mergedRange.Merge();
 
@@ -101,12 +101,12 @@ public class RangeShiftingTests
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet();
         var deletedRange = ws.Range(deletedRangeAddress);
-        var rangeWidth = deletedRange.LastColumn().ColumnNumber() - deletedRange.FirstColumn().ColumnNumber() + 1;
+        var rangeWidth = deletedRange.LastColumn()!.ColumnNumber() - deletedRange.FirstColumn()!.ColumnNumber() + 1;
         var mergedRange = ws.Range(
-            deletedRange.FirstRow().RowNumber(),
-            deletedRange.LastColumn().ColumnNumber() + 1,
-            deletedRange.LastRow().RowNumber(),
-            deletedRange.LastColumn().ColumnNumber() + rangeWidth
+            deletedRange.FirstRow()!.RowNumber(),
+            deletedRange.LastColumn()!.ColumnNumber() + 1,
+            deletedRange.LastRow()!.RowNumber(),
+            deletedRange.LastColumn()!.ColumnNumber() + rangeWidth
         );
         mergedRange.Merge();
 

--- a/XLibur.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/XLibur.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -45,7 +45,7 @@ public class UsedAndUnusedCellsTests
 
         i = 0;
         row = workbook.Worksheets.First().LastRowUsed(XLCellsUsedOptions.All);
-        await Assert.That(row.RowNumber()).IsEqualTo(6);
+        await Assert.That(row!.RowNumber()).IsEqualTo(6);
         foreach (var cell in row.Cells())
         {
             i++;
@@ -54,7 +54,7 @@ public class UsedAndUnusedCellsTests
 
         i = 0;
         row = workbook.Worksheets.First().LastRowUsed(XLCellsUsedOptions.All);
-        await Assert.That(row.RowNumber()).IsEqualTo(6);
+        await Assert.That(row!.RowNumber()).IsEqualTo(6);
         foreach (var cell in row.CellsUsed())
         {
             i++;
@@ -248,7 +248,7 @@ public class UsedAndUnusedCellsTests
         var actual = ws.LastCellUsed(XLCellsUsedOptions.All,
             c => c.Style.Fill.BackgroundColor == XLColor.Yellow);
 
-        await Assert.That(actual.Address.ToString()!).IsEqualTo("C2");
+        await Assert.That(actual!.Address.ToString()).IsEqualTo("C2");
     }
 
     [Test]
@@ -266,7 +266,7 @@ public class UsedAndUnusedCellsTests
         var actual = ws.FirstCellUsed(XLCellsUsedOptions.All,
             c => c.Style.Fill.BackgroundColor == XLColor.Yellow);
 
-        await Assert.That(actual.Address.ToString()!).IsEqualTo("A2");
+        await Assert.That(actual!.Address.ToString()).IsEqualTo("A2");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/XLibur.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -36,7 +36,7 @@ public class UsedAndUnusedCellsTests
         await Assert.That(i).IsEqualTo(2);
 
         i = 0;
-        row = workbook.Worksheets.First().FirstRow()!.RowBelow();
+        row = workbook.Worksheets.First().FirstRow().RowBelow();
         foreach (var cell in row.Cells())
         {
             i++;
@@ -45,7 +45,7 @@ public class UsedAndUnusedCellsTests
 
         i = 0;
         row = workbook.Worksheets.First().LastRowUsed(XLCellsUsedOptions.All);
-        await Assert.That(row.RowNumber()!).IsEqualTo(6);
+        await Assert.That(row.RowNumber()).IsEqualTo(6);
         foreach (var cell in row.Cells())
         {
             i++;
@@ -54,7 +54,7 @@ public class UsedAndUnusedCellsTests
 
         i = 0;
         row = workbook.Worksheets.First().LastRowUsed(XLCellsUsedOptions.All);
-        await Assert.That(row.RowNumber()!).IsEqualTo(6);
+        await Assert.That(row.RowNumber()).IsEqualTo(6);
         foreach (var cell in row.CellsUsed())
         {
             i++;
@@ -86,7 +86,7 @@ public class UsedAndUnusedCellsTests
         await Assert.That(i).IsEqualTo(3);
 
         i = 0;
-        row = workbook.Worksheets.First().FirstRow()!.RowBelow(); //This row has no empty cells BETWEEN used cells
+        row = workbook.Worksheets.First().FirstRow().RowBelow(); //This row has no empty cells BETWEEN used cells
         foreach (var cell in row.Cells(false))
         {
             i++;
@@ -106,7 +106,7 @@ public class UsedAndUnusedCellsTests
         await Assert.That(i).IsEqualTo(2);
 
         i = 0;
-        column = workbook.Worksheets.First().FirstColumn()!.ColumnRight().ColumnRight();
+        column = workbook.Worksheets.First().FirstColumn().ColumnRight().ColumnRight();
         foreach (var cell in column.Cells())
         {
             i++;
@@ -142,7 +142,7 @@ public class UsedAndUnusedCellsTests
         await Assert.That(i).IsEqualTo(4);
 
         i = 0;
-        column = workbook.Worksheets.First().FirstColumn()!.ColumnRight().ColumnRight(); //This column has no empty cells BETWEEN used cells
+        column = workbook.Worksheets.First().FirstColumn().ColumnRight().ColumnRight(); //This column has no empty cells BETWEEN used cells
         foreach (var cell in column.Cells(false))
         {
             i++;

--- a/XLibur.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/XLibur.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -6,7 +6,7 @@ namespace XLibur.Tests.Excel.Ranges;
 
 public class UsedAndUnusedCellsTests
 {
-    private XLWorkbook workbook;
+    private XLWorkbook workbook = null!;
 
     [Before(HookType.Test)]
     public void SetupWorkbook()
@@ -36,7 +36,7 @@ public class UsedAndUnusedCellsTests
         await Assert.That(i).IsEqualTo(2);
 
         i = 0;
-        row = workbook.Worksheets.First().FirstRow().RowBelow();
+        row = workbook.Worksheets.First().FirstRow()!.RowBelow();
         foreach (var cell in row.Cells())
         {
             i++;
@@ -86,7 +86,7 @@ public class UsedAndUnusedCellsTests
         await Assert.That(i).IsEqualTo(3);
 
         i = 0;
-        row = workbook.Worksheets.First().FirstRow().RowBelow(); //This row has no empty cells BETWEEN used cells
+        row = workbook.Worksheets.First().FirstRow()!.RowBelow(); //This row has no empty cells BETWEEN used cells
         foreach (var cell in row.Cells(false))
         {
             i++;
@@ -106,7 +106,7 @@ public class UsedAndUnusedCellsTests
         await Assert.That(i).IsEqualTo(2);
 
         i = 0;
-        column = workbook.Worksheets.First().FirstColumn().ColumnRight().ColumnRight();
+        column = workbook.Worksheets.First().FirstColumn()!.ColumnRight().ColumnRight();
         foreach (var cell in column.Cells())
         {
             i++;
@@ -142,7 +142,7 @@ public class UsedAndUnusedCellsTests
         await Assert.That(i).IsEqualTo(4);
 
         i = 0;
-        column = workbook.Worksheets.First().FirstColumn().ColumnRight().ColumnRight(); //This column has no empty cells BETWEEN used cells
+        column = workbook.Worksheets.First().FirstColumn()!.ColumnRight().ColumnRight(); //This column has no empty cells BETWEEN used cells
         foreach (var cell in column.Cells(false))
         {
             i++;
@@ -198,7 +198,7 @@ public class UsedAndUnusedCellsTests
         sheet.Range("C1:E1").Value = "row1";
         sheet.Range("A2:E2").Value = "row2";
 
-        var used = sheet.RangeUsed().RangeAddress.ToString(XLReferenceStyle.A1);
+        var used = sheet.RangeUsed()!.RangeAddress.ToString(XLReferenceStyle.A1);
 
         await Assert.That(used).IsEqualTo("A1:E2");
     }
@@ -308,7 +308,7 @@ public class UsedAndUnusedCellsTests
         var firstCell = ws.FirstCellUsed(XLCellsUsedOptions.All);
 
         await Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count()).IsEqualTo(0);
-        await Assert.That(firstCell.Address.ToString()).IsEqualTo("A1");
+        await Assert.That(firstCell!.Address.ToString()).IsEqualTo("A1");
     }
 
     [Test]
@@ -321,7 +321,7 @@ public class UsedAndUnusedCellsTests
         var lastCell = ws.LastCellUsed(XLCellsUsedOptions.All);
 
         await Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count()).IsEqualTo(0);
-        await Assert.That(lastCell.Address.ToString()).IsEqualTo(XLHelper.LastCell);
+        await Assert.That(lastCell!.Address.ToString()).IsEqualTo(XLHelper.LastCell);
     }
 
     [Test]
@@ -334,7 +334,7 @@ public class UsedAndUnusedCellsTests
         var firstCell = ws.FirstCellUsed(XLCellsUsedOptions.All);
 
         await Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count()).IsEqualTo(0);
-        await Assert.That(firstCell.Address.ToString()).IsEqualTo("A1");
+        await Assert.That(firstCell!.Address.ToString()).IsEqualTo("A1");
     }
 
     [Test]
@@ -347,7 +347,7 @@ public class UsedAndUnusedCellsTests
         var lastCell = ws.LastCellUsed(XLCellsUsedOptions.All);
 
         await Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count()).IsEqualTo(0);
-        await Assert.That(lastCell.Address.ToString()).IsEqualTo(XLHelper.LastCell);
+        await Assert.That(lastCell!.Address.ToString()).IsEqualTo(XLHelper.LastCell);
     }
 
     [Test]
@@ -360,7 +360,7 @@ public class UsedAndUnusedCellsTests
         var firstCell = ws.FirstCellUsed(XLCellsUsedOptions.All);
 
         await Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count()).IsEqualTo(0);
-        await Assert.That(firstCell.Address.ToString()).IsEqualTo("A1");
+        await Assert.That(firstCell!.Address.ToString()).IsEqualTo("A1");
     }
 
     [Test]
@@ -373,6 +373,6 @@ public class UsedAndUnusedCellsTests
         var lastCell = ws.LastCellUsed(XLCellsUsedOptions.All);
 
         await Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count()).IsEqualTo(0);
-        await Assert.That(lastCell.Address.ToString()).IsEqualTo(XLHelper.LastCell);
+        await Assert.That(lastCell!.Address.ToString()).IsEqualTo(XLHelper.LastCell);
     }
 }

--- a/XLibur.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/XLibur.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -45,7 +45,7 @@ public class UsedAndUnusedCellsTests
 
         i = 0;
         row = workbook.Worksheets.First().LastRowUsed(XLCellsUsedOptions.All);
-        await Assert.That(row.RowNumber()).IsEqualTo(6);
+        await Assert.That(row.RowNumber()!).IsEqualTo(6);
         foreach (var cell in row.Cells())
         {
             i++;
@@ -54,7 +54,7 @@ public class UsedAndUnusedCellsTests
 
         i = 0;
         row = workbook.Worksheets.First().LastRowUsed(XLCellsUsedOptions.All);
-        await Assert.That(row.RowNumber()).IsEqualTo(6);
+        await Assert.That(row.RowNumber()!).IsEqualTo(6);
         foreach (var cell in row.CellsUsed())
         {
             i++;
@@ -71,7 +71,7 @@ public class UsedAndUnusedCellsTests
 
         ws.Range("B3:F6").SetValue(100);
 
-        await Assert.That(ws.FirstRowUsed(XLCellsUsedOptions.AllContents).RowNumber()).IsEqualTo(3);
+        await Assert.That(ws.FirstRowUsed(XLCellsUsedOptions.AllContents)!.RowNumber()).IsEqualTo(3);
     }
 
     [Test]
@@ -228,7 +228,7 @@ public class UsedAndUnusedCellsTests
         var options = includeFormatting
             ? XLCellsUsedOptions.All
             : XLCellsUsedOptions.AllContents | XLCellsUsedOptions.MergedRanges;
-        var actual = ws.RangeUsed(options).RangeAddress;
+        var actual = ws.RangeUsed(options)!.RangeAddress;
 
         await Assert.That(actual.ToString()).IsEqualTo(expectedRange);
     }
@@ -248,7 +248,7 @@ public class UsedAndUnusedCellsTests
         var actual = ws.LastCellUsed(XLCellsUsedOptions.All,
             c => c.Style.Fill.BackgroundColor == XLColor.Yellow);
 
-        await Assert.That(actual.Address.ToString()).IsEqualTo("C2");
+        await Assert.That(actual.Address.ToString()!).IsEqualTo("C2");
     }
 
     [Test]
@@ -266,7 +266,7 @@ public class UsedAndUnusedCellsTests
         var actual = ws.FirstCellUsed(XLCellsUsedOptions.All,
             c => c.Style.Fill.BackgroundColor == XLColor.Yellow);
 
-        await Assert.That(actual.Address.ToString()).IsEqualTo("A2");
+        await Assert.That(actual.Address.ToString()!).IsEqualTo("A2");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -190,8 +190,8 @@ public class XLRangeAddressTests
         var ws = wb.AddWorksheet("Sheet1");
 
         var wsRange = ws.AsRange();
-        var row = ws.FirstRow().RowBelow(4).AsRange();
-        var column = ws.FirstColumn().ColumnRight(4).AsRange();
+        var row = ws.FirstRow()!.RowBelow(4).AsRange();
+        var column = ws.FirstColumn()!.ColumnRight(4).AsRange();
 
         await Assert.That(wsRange.RangeAddress.ToString()).IsEqualTo($"1:{XLHelper.MaxRowNumber}");
         await Assert.That(row.RangeAddress.ToString()).IsEqualTo("5:5");

--- a/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -293,7 +293,7 @@ public class XLRangeAddressTests
     {
         var ws = new XLWorkbook().AddWorksheet() as XLWorksheet;
 
-        var range = ws.Range("B3:E5");
+        var range = ws.Range("B3:E5")!;
         var rangeAddress = range.RangeAddress as IXLRangeAddress;
         await Assert.That(rangeAddress.ColumnSpan).IsEqualTo(4);
         await Assert.That(rangeAddress.RowSpan).IsEqualTo(3);
@@ -339,7 +339,7 @@ public class XLRangeAddressTests
     private static IXLRangeAddress ProduceInvalidAddressOnDeletedWorksheet()
     {
         var address = ProduceInvalidAddress();
-        address.Worksheet.Delete();
+        address.Worksheet!.Delete();
         return address;
     }
 

--- a/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -190,8 +190,8 @@ public class XLRangeAddressTests
         var ws = wb.AddWorksheet("Sheet1");
 
         var wsRange = ws.AsRange();
-        var row = ws.FirstRow()!.RowBelow(4).AsRange();
-        var column = ws.FirstColumn()!.ColumnRight(4).AsRange();
+        var row = ws.FirstRow().RowBelow(4).AsRange();
+        var column = ws.FirstColumn().ColumnRight(4).AsRange();
 
         await Assert.That(wsRange.RangeAddress.ToString()).IsEqualTo($"1:{XLHelper.MaxRowNumber}");
         await Assert.That(row.RangeAddress.ToString()).IsEqualTo("5:5");

--- a/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -291,7 +291,7 @@ public class XLRangeAddressTests
     [Test]
     public async Task TestSpanProperties()
     {
-        var ws = new XLWorkbook().AddWorksheet() as XLWorksheet;
+        var ws = (XLWorksheet)new XLWorkbook().AddWorksheet();
 
         var range = ws.Range("B3:E5")!;
         var rangeAddress = range.RangeAddress as IXLRangeAddress;
@@ -299,7 +299,7 @@ public class XLRangeAddressTests
         await Assert.That(rangeAddress.RowSpan).IsEqualTo(3);
         await Assert.That(rangeAddress.NumberOfCells).IsEqualTo(12);
 
-        range = ws.Range("E5:B3");
+        range = ws.Range("E5:B3")!;
         rangeAddress = range.RangeAddress;
         await Assert.That(rangeAddress.ColumnSpan).IsEqualTo(4);
         await Assert.That(rangeAddress.RowSpan).IsEqualTo(3);

--- a/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -85,7 +85,7 @@ public class XLRangeBaseTests
         ws.Cell(1, 1).Value = "Hello World!";
         wb.DefinedNames.Add("SingleCell", "Sheet1!$A$1");
         var range = wb.Range("SingleCell");
-        await Assert.That(range.CellsUsed().Count()).IsEqualTo(1);
+        await Assert.That(range.CellsUsed()!.Count()).IsEqualTo(1);
         await Assert.That(range.CellsUsed().Single().GetText()).IsEqualTo("Hello World!");
     }
 
@@ -103,7 +103,7 @@ public class XLRangeBaseTests
         wb.DefinedNames.Add("FNameColumn", $"{table.Name}[FName]");
 
         var namedRange = wb.Range("FNameColumn");
-        await Assert.That(namedRange.Cells().Count()).IsEqualTo(3);
+        await Assert.That(namedRange.Cells()!.Count()).IsEqualTo(3);
         await Assert.That(namedRange.CellsUsed().Select(cell => cell.GetText()).SequenceEqual(["John", "Hank", "Dagny"])).IsTrue();
     }
 
@@ -205,11 +205,11 @@ public class XLRangeBaseTests
         var ws = wb.AddWorksheet("Sheet1");
         await Assert.That(ws.Cell("A1").AsRange().Shrink()).IsNull();
         await Assert.That(ws.Range("B2:C3").Shrink()).IsNull();
-        await Assert.That(ws.Range("B2:D4").Shrink().RangeAddress.ToString()).IsEqualTo("C3:C3");
-        await Assert.That(ws.Range("A1:Z26").Shrink(10).RangeAddress.ToString()).IsEqualTo("K11:P16");
+        await Assert.That(ws.Range("B2:D4")!.Shrink().RangeAddress.ToString()).IsEqualTo("C3:C3");
+        await Assert.That(ws.Range("A1:Z26")!.Shrink(10).RangeAddress.ToString()).IsEqualTo("K11:P16");
 
         // Grow and shrink back
-        await Assert.That(ws.Cell("Z26").AsRange().Grow(10).Shrink(10).RangeAddress.ToString()).IsEqualTo("Z26:Z26");
+        await Assert.That(ws.Cell("Z26")!.AsRange().Grow(10).Shrink(10).RangeAddress.ToString()).IsEqualTo("Z26:Z26");
     }
 
     [Test]
@@ -218,10 +218,10 @@ public class XLRangeBaseTests
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");
 
-        await Assert.That(ws.Range("B9:I11").Intersection(ws.Range("D4:G16")).ToString()).IsEqualTo("D9:G11");
-        await Assert.That(ws.Range("E9:I11").Intersection(ws.Range("D4:G16")).ToString()).IsEqualTo("E9:G11");
-        await Assert.That(ws.Cell("E9").AsRange().Intersection(ws.Range("D4:G16")).ToString()).IsEqualTo("E9:E9");
-        await Assert.That(ws.Range("D4:G16").Intersection(ws.Cell("E9").AsRange()).ToString()).IsEqualTo("E9:E9");
+        await Assert.That(ws.Range("B9:I11")!.Intersection(ws.Range("D4:G16")).ToString()).IsEqualTo("D9:G11");
+        await Assert.That(ws.Range("E9:I11")!.Intersection(ws.Range("D4:G16")).ToString()).IsEqualTo("E9:G11");
+        await Assert.That(ws.Cell("E9")!.AsRange().Intersection(ws.Range("D4:G16")).ToString()).IsEqualTo("E9:E9");
+        await Assert.That(ws.Range("D4:G16")!.Intersection(ws.Cell("E9").AsRange()).ToString()).IsEqualTo("E9:E9");
 
         var rangeAddress = (XLRangeAddress)ws.Cell("C3").AsRange().Intersection(ws.Cell("A1").AsRange());
         await Assert.That(rangeAddress.IsValid).IsFalse();
@@ -497,7 +497,7 @@ public class XLRangeBaseTests
         var range = ws.Range(rangeAddress) as XLRange;
         var splitter = ws.Range(splitBy);
 
-        var result = range.Split(splitter.RangeAddress, includeIntersection);
+        var result = range.Split(splitter.RangeAddress, includeIntersection)!;
 
         var actualAddresses = string.Join(",", result.Select(r => r.RangeAddress.ToString()));
 
@@ -526,7 +526,7 @@ public class XLRangeBaseTests
         // Sort uses cached values - update them
         ws.RecalculateAllFormulas();
 
-        range.Sort("3 DESC");
+        range!.Sort("3 DESC");
 
         await Assert.That(ws.Cell("A2").Value).IsEqualTo(32);
         await Assert.That(ws.Cell("A3").Value).IsEqualTo(6);

--- a/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using XLibur.Excel;
@@ -557,4 +558,19 @@ public class XLRangeBaseTests
         var masterCellFormula = ws.Cell("A1").FormulaA1;
         await Assert.That(masterCellFormula).IsEqualTo(expected);
     }
+
+    // IXLRange.Cell and IXLRange.Range are annotated non-null. They used to reach that annotation
+    // with a null-forgiving operator over a lookup that really can return null, which handed the
+    // caller a null through a non-nullable reference and failed later, somewhere else. They now
+    // throw at the call site, matching what IXLWorksheet has always done.
+
+    [Test]
+    public async Task Cell_by_address_throws_when_the_address_resolves_to_nothing()
+    {
+        using var wb = new XLWorkbook();
+        IXLRange range = wb.AddWorksheet().Range("A1:C3");
+
+        await Assert.That(() => range.Cell("not an address")).Throws<ArgumentException>();
+    }
+
 }

--- a/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -190,11 +190,11 @@ public class XLRangeBaseTests
     {
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");
-        await Assert.That(ws.Cell("A1").AsRange().Grow()!.RangeAddress.ToString()).IsEqualTo("A1:B2");
-        await Assert.That(ws.Cell("A2").AsRange().Grow()!.RangeAddress.ToString()).IsEqualTo("A1:B3");
-        await Assert.That(ws.Cell("B1").AsRange().Grow()!.RangeAddress.ToString()).IsEqualTo("A1:C2");
+        await Assert.That(ws.Cell("A1").AsRange().Grow().RangeAddress.ToString()).IsEqualTo("A1:B2");
+        await Assert.That(ws.Cell("A2").AsRange().Grow().RangeAddress.ToString()).IsEqualTo("A1:B3");
+        await Assert.That(ws.Cell("B1").AsRange().Grow().RangeAddress.ToString()).IsEqualTo("A1:C2");
 
-        await Assert.That(ws.Cell("F5").AsRange().Grow()!.RangeAddress.ToString()).IsEqualTo("E4:G6");
+        await Assert.That(ws.Cell("F5").AsRange().Grow().RangeAddress.ToString()).IsEqualTo("E4:G6");
         await Assert.That(ws.Cell("F5").AsRange().Grow(2).RangeAddress.ToString()).IsEqualTo("D3:H7");
         await Assert.That(ws.Cell("F5").AsRange().Grow(100).RangeAddress.ToString()).IsEqualTo("A1:DB105");
     }
@@ -210,7 +210,7 @@ public class XLRangeBaseTests
         await Assert.That(ws.Range("A1:Z26").Shrink(10)!.RangeAddress.ToString()).IsEqualTo("K11:P16");
 
         // Grow and shrink back
-        await Assert.That(ws.Cell("Z26").AsRange().Grow(10)!.Shrink(10)!.RangeAddress.ToString()).IsEqualTo("Z26:Z26");
+        await Assert.That(ws.Cell("Z26").AsRange().Grow(10).Shrink(10)!.RangeAddress.ToString()).IsEqualTo("Z26:Z26");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -229,7 +229,7 @@ public class XLRangeBaseTests
         rangeAddress = (XLRangeAddress)ws.Cell("A1").AsRange().Intersection(ws.Cell("C3").AsRange());
         await Assert.That(rangeAddress.IsValid).IsFalse();
 
-        await Assert.That(ws.Range("A1:C3").Intersection(null)).IsNull();
+        await Assert.That(ws.Range("A1:C3").Intersection(null!)).IsNull();
 
         var otherWs = wb.AddWorksheet("Sheet2");
         await Assert.That(ws.Intersection(otherWs)).IsNull();
@@ -249,7 +249,7 @@ public class XLRangeBaseTests
 
         await Assert.That(ws.Cell("A1").AsRange().Union(ws.Cell("C3").AsRange()).Count()).IsEqualTo(2);
 
-        await Assert.That(ws.Range("A1:C3").Union(null).Count()).IsEqualTo(9);
+        await Assert.That(ws.Range("A1:C3").Union(null!).Count()).IsEqualTo(9);
 
         var otherWs = wb.AddWorksheet("Sheet2");
         await Assert.That(ws.Union(otherWs).Any()).IsFalse();
@@ -269,7 +269,7 @@ public class XLRangeBaseTests
 
         await Assert.That(ws.Cell("A1").AsRange().Difference(ws.Cell("C3").AsRange()).Count()).IsEqualTo(1);
 
-        await Assert.That(ws.Range("A1:C3").Difference(null).Count()).IsEqualTo(9);
+        await Assert.That(ws.Range("A1:C3").Difference(null!).Count()).IsEqualTo(9);
 
         var otherWs = wb.AddWorksheet("Sheet2");
         await Assert.That(ws.Difference(otherWs).Any()).IsFalse();
@@ -391,7 +391,7 @@ public class XLRangeBaseTests
         var rangesCopy = ranges.ToList();
 
         ranges.RemoveAll(null, false);
-        ws.FirstColumn().InsertColumnsBefore(1);
+        ws.FirstColumn()!.InsertColumnsBefore(1);
 
         await Assert.That(ranges.Count).IsEqualTo(0);
         // if ranges were not disposed they addresses should change

--- a/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -224,10 +224,10 @@ public class XLRangeBaseTests
         await Assert.That(ws.Cell("E9").AsRange().Intersection(ws.Range("D4:G16"))!.ToString()).IsEqualTo("E9:E9");
         await Assert.That(ws.Range("D4:G16").Intersection(ws.Cell("E9").AsRange())!.ToString()).IsEqualTo("E9:E9");
 
-        var rangeAddress = (XLRangeAddress)ws.Cell("C3").AsRange().Intersection(ws.Cell("A1").AsRange());
+        var rangeAddress = (XLRangeAddress)ws.Cell("C3").AsRange().Intersection(ws.Cell("A1").AsRange())!;
         await Assert.That(rangeAddress.IsValid).IsFalse();
 
-        rangeAddress = (XLRangeAddress)ws.Cell("A1").AsRange().Intersection(ws.Cell("C3").AsRange());
+        rangeAddress = (XLRangeAddress)ws.Cell("A1").AsRange().Intersection(ws.Cell("C3").AsRange())!;
         await Assert.That(rangeAddress.IsValid).IsFalse();
 
         await Assert.That(ws.Range("A1:C3").Intersection(null!)).IsNull();
@@ -495,7 +495,7 @@ public class XLRangeBaseTests
     {
         var wb = new XLWorkbook();
         var ws = wb.AddWorksheet();
-        var range = ws.Range(rangeAddress) as XLRange;
+        var range = (XLRange)ws.Range(rangeAddress);
         var splitter = ws.Range(splitBy);
 
         var result = range.Split(splitter.RangeAddress, includeIntersection);

--- a/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -86,7 +86,7 @@ public class XLRangeBaseTests
         ws.Cell(1, 1).Value = "Hello World!";
         wb.DefinedNames.Add("SingleCell", "Sheet1!$A$1");
         var range = wb.Range("SingleCell");
-        await Assert.That(range.CellsUsed().Count()).IsEqualTo(1);
+        await Assert.That(range!.CellsUsed().Count()).IsEqualTo(1);
         await Assert.That(range.CellsUsed().Single().GetText()).IsEqualTo("Hello World!");
     }
 
@@ -104,7 +104,7 @@ public class XLRangeBaseTests
         wb.DefinedNames.Add("FNameColumn", $"{table.Name}[FName]");
 
         var namedRange = wb.Range("FNameColumn");
-        await Assert.That(namedRange.Cells().Count()).IsEqualTo(3);
+        await Assert.That(namedRange!.Cells().Count()).IsEqualTo(3);
         await Assert.That(namedRange.CellsUsed().Select(cell => cell.GetText()).SequenceEqual(["John", "Hank", "Dagny"])).IsTrue();
     }
 

--- a/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -85,7 +85,7 @@ public class XLRangeBaseTests
         ws.Cell(1, 1).Value = "Hello World!";
         wb.DefinedNames.Add("SingleCell", "Sheet1!$A$1");
         var range = wb.Range("SingleCell");
-        await Assert.That(range.CellsUsed()!.Count()).IsEqualTo(1);
+        await Assert.That(range.CellsUsed().Count()).IsEqualTo(1);
         await Assert.That(range.CellsUsed().Single().GetText()).IsEqualTo("Hello World!");
     }
 
@@ -103,7 +103,7 @@ public class XLRangeBaseTests
         wb.DefinedNames.Add("FNameColumn", $"{table.Name}[FName]");
 
         var namedRange = wb.Range("FNameColumn");
-        await Assert.That(namedRange.Cells()!.Count()).IsEqualTo(3);
+        await Assert.That(namedRange.Cells().Count()).IsEqualTo(3);
         await Assert.That(namedRange.CellsUsed().Select(cell => cell.GetText()).SequenceEqual(["John", "Hank", "Dagny"])).IsTrue();
     }
 
@@ -189,11 +189,11 @@ public class XLRangeBaseTests
     {
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");
-        await Assert.That(ws.Cell("A1").AsRange().Grow().RangeAddress.ToString()).IsEqualTo("A1:B2");
-        await Assert.That(ws.Cell("A2").AsRange().Grow().RangeAddress.ToString()).IsEqualTo("A1:B3");
-        await Assert.That(ws.Cell("B1").AsRange().Grow().RangeAddress.ToString()).IsEqualTo("A1:C2");
+        await Assert.That(ws.Cell("A1").AsRange().Grow()!.RangeAddress.ToString()).IsEqualTo("A1:B2");
+        await Assert.That(ws.Cell("A2").AsRange().Grow()!.RangeAddress.ToString()).IsEqualTo("A1:B3");
+        await Assert.That(ws.Cell("B1").AsRange().Grow()!.RangeAddress.ToString()).IsEqualTo("A1:C2");
 
-        await Assert.That(ws.Cell("F5").AsRange().Grow().RangeAddress.ToString()).IsEqualTo("E4:G6");
+        await Assert.That(ws.Cell("F5").AsRange().Grow()!.RangeAddress.ToString()).IsEqualTo("E4:G6");
         await Assert.That(ws.Cell("F5").AsRange().Grow(2).RangeAddress.ToString()).IsEqualTo("D3:H7");
         await Assert.That(ws.Cell("F5").AsRange().Grow(100).RangeAddress.ToString()).IsEqualTo("A1:DB105");
     }
@@ -205,11 +205,11 @@ public class XLRangeBaseTests
         var ws = wb.AddWorksheet("Sheet1");
         await Assert.That(ws.Cell("A1").AsRange().Shrink()).IsNull();
         await Assert.That(ws.Range("B2:C3").Shrink()).IsNull();
-        await Assert.That(ws.Range("B2:D4")!.Shrink().RangeAddress.ToString()).IsEqualTo("C3:C3");
-        await Assert.That(ws.Range("A1:Z26")!.Shrink(10).RangeAddress.ToString()).IsEqualTo("K11:P16");
+        await Assert.That(ws.Range("B2:D4").Shrink()!.RangeAddress.ToString()).IsEqualTo("C3:C3");
+        await Assert.That(ws.Range("A1:Z26").Shrink(10)!.RangeAddress.ToString()).IsEqualTo("K11:P16");
 
         // Grow and shrink back
-        await Assert.That(ws.Cell("Z26")!.AsRange().Grow(10).Shrink(10).RangeAddress.ToString()).IsEqualTo("Z26:Z26");
+        await Assert.That(ws.Cell("Z26").AsRange().Grow(10)!.Shrink(10)!.RangeAddress.ToString()).IsEqualTo("Z26:Z26");
     }
 
     [Test]
@@ -218,10 +218,10 @@ public class XLRangeBaseTests
         using var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");
 
-        await Assert.That(ws.Range("B9:I11")!.Intersection(ws.Range("D4:G16")).ToString()).IsEqualTo("D9:G11");
-        await Assert.That(ws.Range("E9:I11")!.Intersection(ws.Range("D4:G16")).ToString()).IsEqualTo("E9:G11");
-        await Assert.That(ws.Cell("E9")!.AsRange().Intersection(ws.Range("D4:G16")).ToString()).IsEqualTo("E9:E9");
-        await Assert.That(ws.Range("D4:G16")!.Intersection(ws.Cell("E9").AsRange()).ToString()).IsEqualTo("E9:E9");
+        await Assert.That(ws.Range("B9:I11").Intersection(ws.Range("D4:G16"))!.ToString()).IsEqualTo("D9:G11");
+        await Assert.That(ws.Range("E9:I11").Intersection(ws.Range("D4:G16"))!.ToString()).IsEqualTo("E9:G11");
+        await Assert.That(ws.Cell("E9").AsRange().Intersection(ws.Range("D4:G16"))!.ToString()).IsEqualTo("E9:E9");
+        await Assert.That(ws.Range("D4:G16").Intersection(ws.Cell("E9").AsRange())!.ToString()).IsEqualTo("E9:E9");
 
         var rangeAddress = (XLRangeAddress)ws.Cell("C3").AsRange().Intersection(ws.Cell("A1").AsRange());
         await Assert.That(rangeAddress.IsValid).IsFalse();
@@ -391,7 +391,7 @@ public class XLRangeBaseTests
         var rangesCopy = ranges.ToList();
 
         ranges.RemoveAll(null, false);
-        ws.FirstColumn()!.InsertColumnsBefore(1);
+        ws.FirstColumn().InsertColumnsBefore(1);
 
         await Assert.That(ranges.Count).IsEqualTo(0);
         // if ranges were not disposed they addresses should change
@@ -497,7 +497,7 @@ public class XLRangeBaseTests
         var range = ws.Range(rangeAddress) as XLRange;
         var splitter = ws.Range(splitBy);
 
-        var result = range.Split(splitter.RangeAddress, includeIntersection)!;
+        var result = range.Split(splitter.RangeAddress, includeIntersection);
 
         var actualAddresses = string.Join(",", result.Select(r => r.RangeAddress.ToString()));
 

--- a/XLibur.Tests/Excel/Ranges/XLRangesEqualityTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangesEqualityTests.cs
@@ -75,10 +75,10 @@ public class XLRangesEqualityTests
         var ws = wb.AddWorksheet();
         var ranges = new XLRanges { ws.Range("A1:B2") };
 
-        object nullObject = null;
+        object? nullObject = null;
 
         await Assert.That(ranges.Equals(null)).IsFalse();
-        await Assert.That(ranges.Equals(nullObject)).IsFalse();
+        await Assert.That(ranges!.Equals(nullObject)).IsFalse();
         await Assert.That(ranges.Equals("not a range collection")).IsFalse();
     }
 

--- a/XLibur.Tests/Excel/Ranges/XLRangesEqualityTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangesEqualityTests.cs
@@ -78,7 +78,7 @@ public class XLRangesEqualityTests
         object nullObject = null;
 
         await Assert.That(ranges.Equals(null)).IsFalse();
-        await Assert.That(ranges.Equals(nullObject)!).IsFalse();
+        await Assert.That(ranges.Equals(nullObject)).IsFalse();
         await Assert.That(ranges.Equals("not a range collection")).IsFalse();
     }
 

--- a/XLibur.Tests/Excel/Ranges/XLRangesEqualityTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangesEqualityTests.cs
@@ -78,7 +78,7 @@ public class XLRangesEqualityTests
         object nullObject = null;
 
         await Assert.That(ranges.Equals(null)).IsFalse();
-        await Assert.That(ranges.Equals(nullObject)).IsFalse();
+        await Assert.That(ranges.Equals(nullObject)!).IsFalse();
         await Assert.That(ranges.Equals("not a range collection")).IsFalse();
     }
 

--- a/XLibur.Tests/Excel/Rows/RowTests.cs
+++ b/XLibur.Tests/Excel/Rows/RowTests.cs
@@ -25,7 +25,7 @@ public class RowTests
         var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");
         ws.FirstCell().SetValue("Test").Style.Font.SetBold();
-        ws.FirstRow().CopyTo(ws.Row(2));
+        ws.FirstRow()!.CopyTo(ws.Row(2));
 
         await Assert.That(ws.Cell("A2").Style.Font.Bold).IsTrue();
     }
@@ -239,7 +239,7 @@ public class RowTests
         var fromRow = ws.Row(1).RowUsed();
         await Assert.That(fromRow.RangeAddress.ToStringRelative()).IsEqualTo("B1:C1");
 
-        var fromRange = ws.Range("A1:E1").FirstRow().RowUsed();
+        var fromRange = ws.Range("A1:E1").FirstRow()!.RowUsed();
         await Assert.That(fromRange.RangeAddress.ToStringRelative()).IsEqualTo("B1:C1");
     }
 

--- a/XLibur.Tests/Excel/Rows/RowTests.cs
+++ b/XLibur.Tests/Excel/Rows/RowTests.cs
@@ -25,7 +25,7 @@ public class RowTests
         var wb = new XLWorkbook();
         var ws = wb.AddWorksheet("Sheet1");
         ws.FirstCell().SetValue("Test").Style.Font.SetBold();
-        ws.FirstRow()!.CopyTo(ws.Row(2));
+        ws.FirstRow().CopyTo(ws.Row(2));
 
         await Assert.That(ws.Cell("A2").Style.Font.Bold).IsTrue();
     }

--- a/XLibur.Tests/Excel/Rows/RowTests.cs
+++ b/XLibur.Tests/Excel/Rows/RowTests.cs
@@ -287,7 +287,7 @@ public class RowTests
     {
         var ws = new XLWorkbook().AddWorksheet("Sheet1") as XLWorksheet;
 
-        var row = new XLRow(ws, -1);
+        var row = new XLRow(ws!, -1);
 
         await Assert.That(row.RangeAddress.IsValid).IsFalse();
     }

--- a/XLibur.Tests/Excel/Rows/RowTests.cs
+++ b/XLibur.Tests/Excel/Rows/RowTests.cs
@@ -363,9 +363,9 @@ public class RowTests
         await Assert.That(loadedWs.Internals.RowsCollection).IsEmpty();
 
         // But cell data should still be accessible
-        await Assert.That(loadedWs.Cell("A1").GetString()).IsEqualTo("Hello");
-        await Assert.That(loadedWs.Cell("A2").GetString()).IsEqualTo("World");
-        await Assert.That(loadedWs.Cell("A3").GetValue<int>()).IsEqualTo(42);
+        await Assert.That(loadedWs.Cell("A1")!.GetString()).IsEqualTo("Hello");
+        await Assert.That(loadedWs.Cell("A2")!.GetString()).IsEqualTo("World");
+        await Assert.That(loadedWs.Cell("A3")!.GetValue<int>()).IsEqualTo(42);
     }
 
     [Test]
@@ -391,9 +391,9 @@ public class RowTests
         await Assert.That(loadedWs.Internals.RowsCollection[2].Height).IsEqualTo(30).Within(XLHelper.Epsilon);
 
         // All cell data should still be accessible
-        await Assert.That(loadedWs.Cell("A1").GetString()).IsEqualTo("Normal row");
-        await Assert.That(loadedWs.Cell("A2").GetString()).IsEqualTo("Custom height row");
-        await Assert.That(loadedWs.Cell("A3").GetString()).IsEqualTo("Normal row");
+        await Assert.That(loadedWs.Cell("A1")!.GetString()).IsEqualTo("Normal row");
+        await Assert.That(loadedWs.Cell("A2")!.GetString()).IsEqualTo("Custom height row");
+        await Assert.That(loadedWs.Cell("A3")!.GetString()).IsEqualTo("Normal row");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Saving/SavingTests.cs
+++ b/XLibur.Tests/Excel/Saving/SavingTests.cs
@@ -299,7 +299,7 @@ public class SavingTests
         var ws = wb.AddWorksheet("Sheet1");
         ws.Cell("D4").Value = "Hello world.";
 
-        ws.AddPicture(imageStream, "MyPicture")
+        ws.AddPicture(imageStream!, "MyPicture")
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(50, 50)
             .WithSize(200, 200);
@@ -663,7 +663,7 @@ public class SavingTests
 
         using (var wb = SpreadsheetDocument.Open(ms, false))
         {
-            await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties.FilterPrivacy!.Value).IsTrue();
+            await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties!.FilterPrivacy!.Value).IsTrue();
         }
     }
 
@@ -682,7 +682,7 @@ public class SavingTests
 
         using (var wb = SpreadsheetDocument.Open(ms, false))
         {
-            await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties.FilterPrivacy).IsNull();
+            await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties!.FilterPrivacy).IsNull();
         }
     }
 
@@ -691,7 +691,7 @@ public class SavingTests
     {
         using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FilterPrivacyEnabledWorkbook.xlsx"));
         using var wb = SpreadsheetDocument.Open(stream, false);
-        await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties.FilterPrivacy!.Value).IsTrue();
+        await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties!.FilterPrivacy!.Value).IsTrue();
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Saving/SavingTests.cs
+++ b/XLibur.Tests/Excel/Saving/SavingTests.cs
@@ -295,7 +295,7 @@ public class SavingTests
     {
         using var ms = new MemoryStream();
         using var wb = new XLWorkbook();
-        using var imageStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable)).GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg");
+        using var imageStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable))!.GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg");
         var ws = wb.AddWorksheet("Sheet1");
         ws.Cell("D4").Value = "Hello world.";
 
@@ -663,7 +663,7 @@ public class SavingTests
 
         using (var wb = SpreadsheetDocument.Open(ms, false))
         {
-            await Assert.That(wb.WorkbookPart.Workbook.WorkbookProperties.FilterPrivacy!.Value).IsTrue();
+            await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties.FilterPrivacy!.Value).IsTrue();
         }
     }
 
@@ -682,7 +682,7 @@ public class SavingTests
 
         using (var wb = SpreadsheetDocument.Open(ms, false))
         {
-            await Assert.That(wb.WorkbookPart.Workbook.WorkbookProperties.FilterPrivacy).IsNull();
+            await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties.FilterPrivacy).IsNull();
         }
     }
 
@@ -691,7 +691,7 @@ public class SavingTests
     {
         using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FilterPrivacyEnabledWorkbook.xlsx"));
         using var wb = SpreadsheetDocument.Open(stream, false);
-        await Assert.That(wb.WorkbookPart.Workbook.WorkbookProperties.FilterPrivacy!.Value).IsTrue();
+        await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties.FilterPrivacy!.Value).IsTrue();
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Saving/SavingTests.cs
+++ b/XLibur.Tests/Excel/Saving/SavingTests.cs
@@ -663,7 +663,7 @@ public class SavingTests
 
         using (var wb = SpreadsheetDocument.Open(ms, false))
         {
-            await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties!.FilterPrivacy!.Value).IsTrue();
+            await Assert.That(wb.WorkbookPart!.Workbook!.WorkbookProperties!.FilterPrivacy!.Value).IsTrue();
         }
     }
 
@@ -682,7 +682,7 @@ public class SavingTests
 
         using (var wb = SpreadsheetDocument.Open(ms, false))
         {
-            await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties!.FilterPrivacy).IsNull();
+            await Assert.That(wb.WorkbookPart!.Workbook!.WorkbookProperties!.FilterPrivacy).IsNull();
         }
     }
 
@@ -691,7 +691,7 @@ public class SavingTests
     {
         using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FilterPrivacyEnabledWorkbook.xlsx"));
         using var wb = SpreadsheetDocument.Open(stream, false);
-        await Assert.That(wb.WorkbookPart!.Workbook.WorkbookProperties!.FilterPrivacy!.Value).IsTrue();
+        await Assert.That(wb.WorkbookPart!.Workbook!.WorkbookProperties!.FilterPrivacy!.Value).IsTrue();
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Sparklines/SparklineShiftTests.cs
+++ b/XLibur.Tests/Excel/Sparklines/SparklineShiftTests.cs
@@ -22,7 +22,7 @@ public class SparklineShiftTests
     [Test]
     public async Task SparklineColumnShiftedOutOfSheetAreRemoved()
     {
-        await AssertSparklinePosition("XFD1", ws => ws.Column("C").InsertColumnsAfter(1), null);
+        await AssertSparklinePosition("XFD1", ws => ws.Column("C").InsertColumnsAfter(1), null!);
     }
 
     [Test]
@@ -40,7 +40,7 @@ public class SparklineShiftTests
     [Test]
     public async Task SparklineRowShiftedOutOfSheetAreRemoved()
     {
-        await AssertSparklinePosition($"A{XLHelper.MaxRowNumber}", ws => ws.Row(2).InsertRowsBelow(1), null);
+        await AssertSparklinePosition($"A{XLHelper.MaxRowNumber}", ws => ws.Row(2).InsertRowsBelow(1), null!);
     }
 
     private static async Task AssertSparklinePosition(string sparklineAddress, Action<IXLWorksheet> insertAction, string expectedAddress)

--- a/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
+++ b/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
@@ -701,7 +701,7 @@ public class SparklinesTests
             await Assert.That(group.ElementAt(1).SourceData.RangeAddress.ToString()).IsEqualTo("B2:Z2");
             await Assert.That(group.ElementAt(2).SourceData.RangeAddress.ToString()).IsEqualTo("B3:Z3");
 
-            await Assert.That(group.DateRange.RangeAddress.ToString()).IsEqualTo("B4:Z4");
+            await Assert.That(group.DateRange.RangeAddress.ToString()!).IsEqualTo("B4:Z4");
 
             await Assert.That(group.Style.FirstMarkerColor).IsEqualTo(XLColor.AliceBlue);
             await Assert.That(group.Style.HighMarkerColor).IsEqualTo(XLColor.Alizarin);
@@ -784,7 +784,7 @@ public class SparklinesTests
         using var ms = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Sparklines\SparklineThemes\inputfile.xlsx"));
         using var wb = new XLWorkbook(ms);
         var expectedStyle = GetThemeByName(expectedThemeName);
-        var actualStyle = wb.Cell(cellAddress).Sparkline.SparklineGroup.Style;
+        var actualStyle = wb.Cell(cellAddress)!.Sparkline.SparklineGroup.Style;
 
         await Assert.That(actualStyle).IsEqualTo(expectedStyle);
         return;
@@ -793,7 +793,7 @@ public class SparklinesTests
         {
             var themes = typeof(XLSparklineTheme);
             var prop = themes.GetProperty(themeName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-            return prop.GetValue(null, null) as IXLSparklineStyle;
+            return prop.GetValue(null, null)! as IXLSparklineStyle;
         }
     }
 
@@ -865,9 +865,9 @@ public class SparklinesTests
             var ws = wb.Worksheets.Single();
 
             await Assert.That(ws.SparklineGroups.Count()).IsEqualTo(2);
-            await Assert.That(ws.Cell("A2").Sparkline.IsValid).IsFalse();
-            await Assert.That(ws.Cell("A5").Sparkline.SourceData.RangeAddress.ToString()).IsEqualTo("B5:F5");
-            await Assert.That(ws.Cell("A5").Sparkline.SparklineGroup.DateRange).IsNull();
+            await Assert.That(ws.Cell("A2")!.Sparkline.IsValid).IsFalse();
+            await Assert.That(ws.Cell("A5")!.Sparkline.SourceData.RangeAddress.ToString()).IsEqualTo("B5:F5");
+            await Assert.That(ws.Cell("A5")!.Sparkline.SparklineGroup.DateRange).IsNull();
         }
     }
 
@@ -990,7 +990,7 @@ public class SparklinesTests
 
         await Assert.That(ws.SparklineGroups.Count()).IsEqualTo(1);
         await Assert.That(target.HasSparkline).IsTrue();
-        await Assert.That(target.Sparkline.SparklineGroup).IsSameReferenceAs(ws.Cell("A2").Sparkline.SparklineGroup);
+        await Assert.That(target.Sparkline.SparklineGroup).IsSameReferenceAs(ws.Cell("A2")!.Sparkline.SparklineGroup);
         await Assert.That(target.Sparkline.SourceData.RangeAddress.ToString()).IsEqualTo("E4:I4");
     }
 
@@ -1013,8 +1013,8 @@ public class SparklinesTests
         await Assert.That(ws2.SparklineGroups.Count()).IsEqualTo(2);
         await Assert.That(target1.HasSparkline).IsTrue();
         await Assert.That(target2.HasSparkline).IsTrue();
-        await Assert.That(target1.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 2'!E4:I4");
-        await Assert.That(target2.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 3'!E5:I5");
+        await Assert.That(target1.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)!).IsEqualTo("'Sheet 2'!E4:I4");
+        await Assert.That(target2.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)!).IsEqualTo("'Sheet 3'!E5:I5");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
+++ b/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
@@ -865,9 +865,9 @@ public class SparklinesTests
             var ws = wb.Worksheets.Single();
 
             await Assert.That(ws.SparklineGroups.Count()).IsEqualTo(2);
-            await Assert.That(ws.Cell("A2")!.Sparkline.IsValid).IsFalse();
-            await Assert.That(ws.Cell("A5")!.Sparkline.SourceData.RangeAddress.ToString()).IsEqualTo("B5:F5");
-            await Assert.That(ws.Cell("A5")!.Sparkline.SparklineGroup.DateRange).IsNull();
+            await Assert.That(ws.Cell("A2").Sparkline.IsValid).IsFalse();
+            await Assert.That(ws.Cell("A5").Sparkline.SourceData.RangeAddress.ToString()).IsEqualTo("B5:F5");
+            await Assert.That(ws.Cell("A5").Sparkline.SparklineGroup.DateRange).IsNull();
         }
     }
 
@@ -885,7 +885,7 @@ public class SparklinesTests
 
         axis.ManualMin = 100;
 
-        await Assert.That(axis.ManualMin!.Value).IsEqualTo(100).Within(XLHelper.Epsilon);
+        await Assert.That(axis.ManualMin.Value).IsEqualTo(100).Within(XLHelper.Epsilon);
         await Assert.That(axis.MinAxisType).IsEqualTo(XLSparklineAxisMinMax.Custom);
     }
 
@@ -899,7 +899,7 @@ public class SparklinesTests
 
         axis.ManualMax = 100;
 
-        await Assert.That(axis.ManualMax!.Value).IsEqualTo(100).Within(XLHelper.Epsilon);
+        await Assert.That(axis.ManualMax.Value).IsEqualTo(100).Within(XLHelper.Epsilon);
         await Assert.That(axis.MaxAxisType).IsEqualTo(XLSparklineAxisMinMax.Custom);
     }
 
@@ -990,7 +990,7 @@ public class SparklinesTests
 
         await Assert.That(ws.SparklineGroups.Count()).IsEqualTo(1);
         await Assert.That(target.HasSparkline).IsTrue();
-        await Assert.That(target.Sparkline.SparklineGroup).IsSameReferenceAs(ws.Cell("A2")!.Sparkline.SparklineGroup);
+        await Assert.That(target.Sparkline.SparklineGroup).IsSameReferenceAs(ws.Cell("A2").Sparkline.SparklineGroup);
         await Assert.That(target.Sparkline.SourceData.RangeAddress.ToString()).IsEqualTo("E4:I4");
     }
 
@@ -1013,8 +1013,8 @@ public class SparklinesTests
         await Assert.That(ws2.SparklineGroups.Count()).IsEqualTo(2);
         await Assert.That(target1.HasSparkline).IsTrue();
         await Assert.That(target2.HasSparkline).IsTrue();
-        await Assert.That(target1.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)!).IsEqualTo("'Sheet 2'!E4:I4");
-        await Assert.That(target2.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)!).IsEqualTo("'Sheet 3'!E5:I5");
+        await Assert.That(target1.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 2'!E4:I4");
+        await Assert.That(target2.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 3'!E5:I5");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
+++ b/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
@@ -784,7 +784,7 @@ public class SparklinesTests
         using var ms = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Sparklines\SparklineThemes\inputfile.xlsx"));
         using var wb = new XLWorkbook(ms);
         var expectedStyle = GetThemeByName(expectedThemeName);
-        var actualStyle = wb.Cell(cellAddress)!.Sparkline.SparklineGroup.Style;
+        var actualStyle = wb.Cell(cellAddress)!.Sparkline!.SparklineGroup.Style;
 
         await Assert.That(actualStyle).IsEqualTo(expectedStyle);
         return;
@@ -865,9 +865,9 @@ public class SparklinesTests
             var ws = wb.Worksheets.Single();
 
             await Assert.That(ws.SparklineGroups.Count()).IsEqualTo(2);
-            await Assert.That(ws.Cell("A2").Sparkline.IsValid).IsFalse();
-            await Assert.That(ws.Cell("A5").Sparkline.SourceData.RangeAddress.ToString()).IsEqualTo("B5:F5");
-            await Assert.That(ws.Cell("A5").Sparkline.SparklineGroup.DateRange).IsNull();
+            await Assert.That(ws.Cell("A2").Sparkline!.IsValid).IsFalse();
+            await Assert.That(ws.Cell("A5").Sparkline!.SourceData.RangeAddress.ToString()).IsEqualTo("B5:F5");
+            await Assert.That(ws.Cell("A5").Sparkline!.SparklineGroup.DateRange).IsNull();
         }
     }
 
@@ -990,7 +990,7 @@ public class SparklinesTests
 
         await Assert.That(ws.SparklineGroups.Count()).IsEqualTo(1);
         await Assert.That(target.HasSparkline).IsTrue();
-        await Assert.That(target.Sparkline.SparklineGroup).IsSameReferenceAs(ws.Cell("A2").Sparkline.SparklineGroup);
+        await Assert.That(target.Sparkline!.SparklineGroup).IsSameReferenceAs(ws.Cell("A2").Sparkline!.SparklineGroup);
         await Assert.That(target.Sparkline.SourceData.RangeAddress.ToString()).IsEqualTo("E4:I4");
     }
 
@@ -1013,8 +1013,8 @@ public class SparklinesTests
         await Assert.That(ws2.SparklineGroups.Count()).IsEqualTo(2);
         await Assert.That(target1.HasSparkline).IsTrue();
         await Assert.That(target2.HasSparkline).IsTrue();
-        await Assert.That(target1.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 2'!E4:I4");
-        await Assert.That(target2.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 3'!E5:I5");
+        await Assert.That(target1.Sparkline!.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 2'!E4:I4");
+        await Assert.That(target2.Sparkline!.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 3'!E5:I5");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
+++ b/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
@@ -14,14 +14,14 @@ public class SparklinesTests
     [Test]
     public async Task CannotCreateSparklineGroupsWithoutWorksheet()
     {
-        Action action = () => _ = new XLSparklineGroups(null);
+        Action action = () => _ = new XLSparklineGroups(null!);
         await Assert.That(action).Throws<ArgumentNullException>();
     }
 
     [Test]
     public async Task CannotCreateSparklineGroupWithoutWorksheet()
     {
-        Action action = () => _ = new XLSparklineGroup(null);
+        Action action = () => _ = new XLSparklineGroup(null!);
         await Assert.That(action).Throws<ArgumentNullException>();
     }
 
@@ -29,7 +29,7 @@ public class SparklinesTests
     public async Task CannotCreateSparklineWithoutGroup()
     {
         var ws = new XLWorkbook().AddWorksheet("Sheet1");
-        Action action = () => _ = new XLSparkline(null, ws.Cell("A1"), ws.Range("A2:A5"));
+        Action action = () => _ = new XLSparkline(null!, ws.Cell("A1"), ws.Range("A2:A5"));
         await Assert.That(action).Throws<ArgumentNullException>();
     }
 
@@ -38,7 +38,7 @@ public class SparklinesTests
     {
         var ws = new XLWorkbook().AddWorksheet("Sheet1");
         var group = new XLSparklineGroup(ws);
-        Action action = () => _ = new XLSparkline(group, null, ws.Range("A2:A5"));
+        Action action = () => _ = new XLSparkline(group, null!, ws.Range("A2:A5"));
         await Assert.That(action).Throws<ArgumentNullException>();
     }
 
@@ -496,7 +496,7 @@ public class SparklinesTests
         var ws = new XLWorkbook().AddWorksheet("Sheet 1");
         var group = ws.SparklineGroups.Add("A1", "B1:Z1");
 
-        Action action = () => group.Style = null;
+        Action action = () => group.Style = null!;
 
         await Assert.That(action).Throws<ArgumentNullException>();
     }
@@ -1032,7 +1032,7 @@ public class SparklinesTests
         await Assert.That(ws1.SparklineGroups.Count()).IsEqualTo(1);
         await Assert.That(ws2.SparklineGroups.Count()).IsEqualTo(1);
         await Assert.That(target.HasSparkline).IsTrue();
-        await Assert.That(target.Sparkline.SparklineGroup.DateRange.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 2'!D6:H6");
+        await Assert.That(target.Sparkline!.SparklineGroup.DateRange!.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 2'!D6:H6");
     }
 
     [Test]
@@ -1051,7 +1051,7 @@ public class SparklinesTests
         await Assert.That(ws1.SparklineGroups.Count()).IsEqualTo(1);
         await Assert.That(ws2.SparklineGroups.Count()).IsEqualTo(1);
         await Assert.That(target.HasSparkline).IsTrue();
-        await Assert.That(target.Sparkline.SparklineGroup.DateRange.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 3'!D6:H6");
+        await Assert.That(target.Sparkline!.SparklineGroup.DateRange!.RangeAddress.ToString(XLReferenceStyle.A1, true)).IsEqualTo("'Sheet 3'!D6:H6");
     }
 
     #endregion Copy sparkline groups

--- a/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
+++ b/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
@@ -793,7 +793,7 @@ public class SparklinesTests
         {
             var themes = typeof(XLSparklineTheme);
             var prop = themes.GetProperty(themeName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-            return prop.GetValue(null, null)! as IXLSparklineStyle;
+            return (IXLSparklineStyle)prop!.GetValue(null, null)!;
         }
     }
 

--- a/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
+++ b/XLibur.Tests/Excel/Sparklines/SparklinesTests.cs
@@ -701,7 +701,7 @@ public class SparklinesTests
             await Assert.That(group.ElementAt(1).SourceData.RangeAddress.ToString()).IsEqualTo("B2:Z2");
             await Assert.That(group.ElementAt(2).SourceData.RangeAddress.ToString()).IsEqualTo("B3:Z3");
 
-            await Assert.That(group.DateRange.RangeAddress.ToString()!).IsEqualTo("B4:Z4");
+            await Assert.That(group.DateRange!.RangeAddress.ToString()!).IsEqualTo("B4:Z4");
 
             await Assert.That(group.Style.FirstMarkerColor).IsEqualTo(XLColor.AliceBlue);
             await Assert.That(group.Style.HighMarkerColor).IsEqualTo(XLColor.Alizarin);
@@ -917,7 +917,7 @@ public class SparklinesTests
         axis.MinAxisType = axisType;
 
         if (expectedManualMin.HasValue)
-            await Assert.That(axis.ManualMin.Value).IsEqualTo(expectedManualMin.Value).Within(XLHelper.Epsilon);
+            await Assert.That(axis.ManualMin!.Value).IsEqualTo(expectedManualMin.Value).Within(XLHelper.Epsilon);
         else
             await Assert.That(axis.ManualMin).IsNull();
     }
@@ -936,7 +936,7 @@ public class SparklinesTests
         axis.MaxAxisType = axisType;
 
         if (expectedManualMax.HasValue)
-            await Assert.That(axis.ManualMax.Value).IsEqualTo(expectedManualMax.Value).Within(XLHelper.Epsilon);
+            await Assert.That(axis.ManualMax!.Value).IsEqualTo(expectedManualMax.Value).Within(XLHelper.Epsilon);
         else
             await Assert.That(axis.ManualMax).IsNull();
     }

--- a/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
+++ b/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
@@ -143,7 +143,7 @@ public class StreamingWriteTests
         var sst = doc.WorkbookPart!.SharedStringTablePart!.SharedStringTable;
 
         // 10 text cells referencing 2 distinct strings.
-        await Assert.That(sst.Count!.Value).IsEqualTo(10U);
+        await Assert.That(sst!.Count!.Value).IsEqualTo(10U);
         await Assert.That(sst.UniqueCount!.Value).IsEqualTo(2U);
     }
 
@@ -673,7 +673,7 @@ public class StreamingWriteTests
         sheet.AddRow().Cell("second");
 
         // A ref struct cannot be captured in a lambda, so the assertion is written out.
-        Exception caught = null;
+        Exception? caught = null;
         try
         {
             first.Cell("too late");
@@ -732,7 +732,7 @@ public class StreamingWriteTests
         var row = sheet.AddRow();
         row.Cell("a").Cell("b").Cell("c");
 
-        Exception caught = null;
+        Exception? caught = null;
         try
         {
             row.At(2);

--- a/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
+++ b/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
@@ -225,7 +225,7 @@ public class StreamingWriteTests
         using (var doc = SpreadsheetDocument.Open(ms, false))
         {
             var sst = doc.WorkbookPart!.SharedStringTablePart!.SharedStringTable;
-            await Assert.That(sst.Count()).IsEqualTo(2);
+            await Assert.That(sst.Count()!).IsEqualTo(2);
         }
 
         ms.Position = 0;

--- a/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
+++ b/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
@@ -225,7 +225,7 @@ public class StreamingWriteTests
         using (var doc = SpreadsheetDocument.Open(ms, false))
         {
             var sst = doc.WorkbookPart!.SharedStringTablePart!.SharedStringTable;
-            await Assert.That(sst.Count()!).IsEqualTo(2);
+            await Assert.That(sst.Count()).IsEqualTo(2);
         }
 
         ms.Position = 0;

--- a/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
+++ b/XLibur.Tests/Excel/Streaming/StreamingWriteTests.cs
@@ -224,7 +224,7 @@ public class StreamingWriteTests
         ms.Position = 0;
         using (var doc = SpreadsheetDocument.Open(ms, false))
         {
-            var sst = doc.WorkbookPart!.SharedStringTablePart!.SharedStringTable;
+            var sst = doc.WorkbookPart!.SharedStringTablePart!.SharedStringTable!;
             await Assert.That(sst.Count()).IsEqualTo(2);
         }
 

--- a/XLibur.Tests/Excel/Styles/ColorTests.cs
+++ b/XLibur.Tests/Excel/Styles/ColorTests.cs
@@ -53,25 +53,25 @@ public class ColorTests
         var color3 = new BackgroundColor().FromXLiburColor<BackgroundColor>(xlColor3);
         var color4 = new BackgroundColor().FromXLiburColor<BackgroundColor>(xlColor4);
 
-        await Assert.That(color1.Rgb.Value).IsEqualTo("FFFF0000");
+        await Assert.That(color1.Rgb!.Value).IsEqualTo("FFFF0000");
         await Assert.That(color1.Indexed).IsNull();
         await Assert.That(color1.Theme).IsNull();
         await Assert.That(color1.Tint).IsNull();
 
         await Assert.That(color2.Rgb).IsNull();
-        await Assert.That(color2.Indexed.Value).IsEqualTo(20u);
+        await Assert.That(color2.Indexed!.Value).IsEqualTo(20u);
         await Assert.That(color2.Theme).IsNull();
         await Assert.That(color2.Tint).IsNull();
 
         await Assert.That(color3.Rgb).IsNull();
         await Assert.That(color3.Indexed).IsNull();
-        await Assert.That(color3.Theme.Value).IsEqualTo(4u);
+        await Assert.That(color3.Theme!.Value).IsEqualTo(4u);
         await Assert.That(color3.Tint).IsNull();
 
         await Assert.That(color4.Rgb).IsNull();
         await Assert.That(color4.Indexed).IsNull();
-        await Assert.That(color4.Theme.Value).IsEqualTo(5u);
-        await Assert.That(color4.Tint.Value).IsEqualTo(0.4);
+        await Assert.That(color4.Theme!.Value).IsEqualTo(5u);
+        await Assert.That(color4.Tint!.Value).IsEqualTo(0.4);
     }
 
     [Test]
@@ -87,25 +87,25 @@ public class ColorTests
         var color3 = new X14.FillColor().FromXLiburColor<X14.FillColor>(xlColor3);
         var color4 = new X14.HighMarkerColor().FromXLiburColor<X14.HighMarkerColor>(xlColor4);
 
-        await Assert.That(color1.Rgb.Value).IsEqualTo("FFFF0000");
+        await Assert.That(color1.Rgb!.Value).IsEqualTo("FFFF0000");
         await Assert.That(color1.Indexed).IsNull();
         await Assert.That(color1.Theme).IsNull();
         await Assert.That(color1.Tint).IsNull();
 
         await Assert.That(color2.Rgb).IsNull();
-        await Assert.That(color2.Indexed.Value).IsEqualTo(20u);
+        await Assert.That(color2.Indexed!.Value).IsEqualTo(20u);
         await Assert.That(color2.Theme).IsNull();
         await Assert.That(color2.Tint).IsNull();
 
         await Assert.That(color3.Rgb).IsNull();
         await Assert.That(color3.Indexed).IsNull();
-        await Assert.That(color3.Theme.Value).IsEqualTo(4u);
+        await Assert.That(color3.Theme!.Value).IsEqualTo(4u);
         await Assert.That(color3.Tint).IsNull();
 
         await Assert.That(color4.Rgb).IsNull();
         await Assert.That(color4.Indexed).IsNull();
-        await Assert.That(color4.Theme.Value).IsEqualTo(5u);
-        await Assert.That(color4.Tint.Value).IsEqualTo(0.4);
+        await Assert.That(color4.Theme!.Value).IsEqualTo(5u);
+        await Assert.That(color4.Tint!.Value).IsEqualTo(0.4);
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Styles/StyleTests.cs
+++ b/XLibur.Tests/Excel/Styles/StyleTests.cs
@@ -19,7 +19,7 @@ public class StyleTests
             ws.FirstCell().SetValue("Empty cell with quote prefix:");
             var cell = ws.FirstCell().CellRight() as XLCell;
 
-            await Assert.That(cell.IsEmpty()).IsTrue();
+            await Assert.That(cell.IsEmpty()!).IsTrue();
             cell.Value = String.Empty;
             cell.Style.IncludeQuotePrefix = true;
 

--- a/XLibur.Tests/Excel/Styles/StyleTests.cs
+++ b/XLibur.Tests/Excel/Styles/StyleTests.cs
@@ -19,7 +19,7 @@ public class StyleTests
             ws.FirstCell().SetValue("Empty cell with quote prefix:");
             var cell = ws.FirstCell().CellRight() as XLCell;
 
-            await Assert.That(cell.IsEmpty()!).IsTrue();
+            await Assert.That(cell.IsEmpty()).IsTrue();
             cell.Value = String.Empty;
             cell.Style.IncludeQuotePrefix = true;
 

--- a/XLibur.Tests/Excel/Styles/StyleTests.cs
+++ b/XLibur.Tests/Excel/Styles/StyleTests.cs
@@ -19,7 +19,7 @@ public class StyleTests
             ws.FirstCell().SetValue("Empty cell with quote prefix:");
             var cell = ws.FirstCell().CellRight() as XLCell;
 
-            await Assert.That(cell.IsEmpty()).IsTrue();
+            await Assert.That(cell!.IsEmpty()).IsTrue();
             cell.Value = String.Empty;
             cell.Style.IncludeQuotePrefix = true;
 

--- a/XLibur.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
+++ b/XLibur.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
@@ -588,7 +588,7 @@ public class AppendingAndReplacingTableDataTests
 
             var appendedRange = table.AppendData(list, propagateExtraColumns: true);
 
-            await Assert.That(appendedRange.RangeAddress.ToString()).IsEqualTo("B6:G9");
+            await Assert.That(appendedRange.RangeAddress.ToString()!).IsEqualTo("B6:G9");
 
             ws.Columns().AdjustToContents();
 

--- a/XLibur.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
+++ b/XLibur.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
@@ -588,7 +588,7 @@ public class AppendingAndReplacingTableDataTests
 
             var appendedRange = table.AppendData(list, propagateExtraColumns: true);
 
-            await Assert.That(appendedRange.RangeAddress.ToString()!).IsEqualTo("B6:G9");
+            await Assert.That(appendedRange!.RangeAddress.ToString()!).IsEqualTo("B6:G9");
 
             ws.Columns().AdjustToContents();
 

--- a/XLibur.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
+++ b/XLibur.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
@@ -17,10 +17,10 @@ public class AppendingAndReplacingTableDataTests
         public int Age { get; set; }
 
         [XLColumn(Header = "Last name", Order = 2)]
-        public string LastName { get; set; }
+        public string LastName { get; set; } = string.Empty;
 
         [XLColumn(Header = "First name", Order = 1)]
-        public string FirstName { get; set; }
+        public string FirstName { get; set; } = string.Empty;
 
         [XLColumn(Header = "Full name", Order = 0)]
         public string FullName => string.Concat(FirstName, " ", LastName);
@@ -142,7 +142,7 @@ public class AppendingAndReplacingTableDataTests
             IEnumerable<Person> personEnumerable = NewData;
             var addedRange = table.AppendData(personEnumerable);
 
-            await Assert.That(addedRange.RangeAddress.ToString()).IsEqualTo("B6:G7");
+            await Assert.That(addedRange!.RangeAddress.ToString()).IsEqualTo("B6:G7");
             ws.Columns().AdjustToContents();
 
             wb.SaveAs(ms);
@@ -152,8 +152,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(5);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(5);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -172,7 +172,7 @@ public class AppendingAndReplacingTableDataTests
             IEnumerable<Person> personEnumerable = NewData;
             var addedRange = table.AppendData(personEnumerable);
 
-            await Assert.That(addedRange.RangeAddress.ToString()).IsEqualTo("B6:G7");
+            await Assert.That(addedRange!.RangeAddress.ToString()).IsEqualTo("B6:G7");
             ws.Columns().AdjustToContents();
 
             wb.SaveAs(ms);
@@ -182,8 +182,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(5);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(5);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -199,14 +199,14 @@ public class AppendingAndReplacingTableDataTests
 
             var table = ws.Tables.First();
 
-            var cell = table.LastRow().FirstCell().CellRight(2).CellBelow(1);
+            var cell = table.LastRow()!.FirstCell().CellRight(2).CellBelow(1);
             address = cell.Address;
             cell.Value = value;
 
             IEnumerable<Person> personEnumerable = NewData;
             var addedRange = table.AppendData(personEnumerable);
 
-            await Assert.That(addedRange.RangeAddress.ToString()).IsEqualTo("B6:G7");
+            await Assert.That(addedRange!.RangeAddress.ToString()).IsEqualTo("B6:G7");
             ws.Columns().AdjustToContents();
 
             wb.SaveAs(ms);
@@ -220,8 +220,8 @@ public class AppendingAndReplacingTableDataTests
 
             var cell = ws.Cell(address);
             await Assert.That(cell.Value).IsEqualTo("de Beer");
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(5);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(5);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
 
             await Assert.That(cell.CellBelow(NewData.Length).Value).IsEqualTo(value);
         }
@@ -242,7 +242,7 @@ public class AppendingAndReplacingTableDataTests
 
             var addedRange = table.AppendData(list);
 
-            await Assert.That(addedRange.RangeAddress.ToString()).IsEqualTo("B6:G7");
+            await Assert.That(addedRange!.RangeAddress.ToString()).IsEqualTo("B6:G7");
 
             ws.Columns().AdjustToContents();
 
@@ -253,8 +253,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(5);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(5);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -275,7 +275,7 @@ public class AppendingAndReplacingTableDataTests
 
             var addedRange = table.AppendData(dataTable);
 
-            await Assert.That(addedRange.RangeAddress.ToString()).IsEqualTo("B6:G7");
+            await Assert.That(addedRange!.RangeAddress.ToString()).IsEqualTo("B6:G7");
             ws.Columns().AdjustToContents();
 
             wb.SaveAs(ms);
@@ -285,8 +285,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(5);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(5);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -313,8 +313,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(2);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(2);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -344,8 +344,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(2);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(2);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -376,8 +376,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(2);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(2);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -407,8 +407,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(6);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -438,8 +438,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(1);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(1);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -469,8 +469,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(4);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(10);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(4);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(10);
 
             await Assert.That(table.Worksheet.Cell("H5").FormulaA1).IsEqualTo("SUM($G$3:G5)");
             await Assert.That(table.Worksheet.Cell("H6").FormulaA1).IsEqualTo("SUM($G$3:G6)");
@@ -515,8 +515,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(4);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(10);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(4);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(10);
 
             await Assert.That(table.Worksheet.Cell("H5").FormulaA1).IsEqualTo("SUM($G$3:G5)");
             await Assert.That(table.Worksheet.Cell("H6").FormulaA1).IsEqualTo("SUM($G$3:G6)");
@@ -568,8 +568,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(2);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(2);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -599,8 +599,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(7);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(10);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(7);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(10);
 
             await Assert.That(table.Worksheet.Cell("H8").FormulaA1).IsEqualTo("SUM($G$3:G8)");
             await Assert.That(table.Worksheet.Cell("H9").FormulaA1).IsEqualTo("SUM($G$3:G9)");
@@ -640,7 +640,7 @@ public class AppendingAndReplacingTableDataTests
 
             var addedRange = table.AppendData(personEnumerable);
 
-            await Assert.That(addedRange.RangeAddress.ToString()).IsEqualTo("B6:G11");
+            await Assert.That(addedRange!.RangeAddress.ToString()).IsEqualTo("B6:G11");
             ws.Columns().AdjustToContents();
 
             wb.SaveAs(ms);
@@ -650,8 +650,8 @@ public class AppendingAndReplacingTableDataTests
         {
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
-            await Assert.That(table.DataRange.RowCount()).IsEqualTo(9);
-            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(10);
+            await Assert.That(table.DataRange!.RowCount()).IsEqualTo(9);
+            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(10);
 
             await Assert.That(table.Worksheet.Cell("H10").FormulaA1).IsEqualTo("SUM($G$3:G10)");
             await Assert.That(table.Worksheet.Cell("H11").FormulaA1).IsEqualTo("SUM($G$3:G11)");

--- a/XLibur.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
+++ b/XLibur.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
@@ -153,7 +153,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(5);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -183,7 +183,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(5);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -221,7 +221,7 @@ public class AppendingAndReplacingTableDataTests
             var cell = ws.Cell(address);
             await Assert.That(cell.Value).IsEqualTo("de Beer");
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(5);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
 
             await Assert.That(cell.CellBelow(NewData.Length).Value).IsEqualTo(value);
         }
@@ -254,7 +254,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(5);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -286,7 +286,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(5);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -314,7 +314,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(2);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -345,7 +345,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(2);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -377,7 +377,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(2);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -408,7 +408,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(6);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -439,7 +439,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(1);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -470,7 +470,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(4);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(10);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(10);
 
             await Assert.That(table.Worksheet.Cell("H5").FormulaA1).IsEqualTo("SUM($G$3:G5)");
             await Assert.That(table.Worksheet.Cell("H6").FormulaA1).IsEqualTo("SUM($G$3:G6)");
@@ -516,7 +516,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(4);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(10);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(10);
 
             await Assert.That(table.Worksheet.Cell("H5").FormulaA1).IsEqualTo("SUM($G$3:G5)");
             await Assert.That(table.Worksheet.Cell("H6").FormulaA1).IsEqualTo("SUM($G$3:G6)");
@@ -569,7 +569,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(2);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(6);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(6);
         }
     }
 
@@ -600,7 +600,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(7);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(10);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(10);
 
             await Assert.That(table.Worksheet.Cell("H8").FormulaA1).IsEqualTo("SUM($G$3:G8)");
             await Assert.That(table.Worksheet.Cell("H9").FormulaA1).IsEqualTo("SUM($G$3:G9)");
@@ -651,7 +651,7 @@ public class AppendingAndReplacingTableDataTests
             var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
 
             await Assert.That(table.DataRange!.RowCount()).IsEqualTo(9);
-            await Assert.That(table.DataRange!.ColumnCount()).IsEqualTo(10);
+            await Assert.That(table.DataRange.ColumnCount()).IsEqualTo(10);
 
             await Assert.That(table.Worksheet.Cell("H10").FormulaA1).IsEqualTo("SUM($G$3:G10)");
             await Assert.That(table.Worksheet.Cell("H11").FormulaA1).IsEqualTo("SUM($G$3:G11)");

--- a/XLibur.Tests/Excel/Tables/TablesTests.cs
+++ b/XLibur.Tests/Excel/Tables/TablesTests.cs
@@ -20,9 +20,9 @@ public class TablesTests
 {
     public class TestObjectWithoutAttributes
     {
-        public string Column1 { get; set; }
+        public string Column1 { get; set; } = string.Empty;
 
-        public string Column2 { get; set; }
+        public string Column2 { get; set; } = string.Empty;
     }
 
     public class TestObjectWithAttributes
@@ -30,10 +30,10 @@ public class TablesTests
         public int UnOrderedColumn { get; set; }
 
         [XLColumn(Header = "SecondColumn", Order = 1)]
-        public string Column1 { get; set; }
+        public string Column1 { get; set; } = string.Empty;
 
         [XLColumn(Header = "FirstColumn", Order = 0)]
-        public string Column2 { get; set; }
+        public string Column2 { get; set; } = string.Empty;
 
         [XLColumn(Header = "SomeFieldNotProperty", Order = 2)]
         public int MyField;
@@ -250,9 +250,9 @@ public class TablesTests
 
         var row = table.DataRange!.FirstRow();
         row!.Field("Value").Value = 3;
-        row = table.DataRange.InsertRowsAbove(1).First();
+        row = table.DataRange!.InsertRowsAbove(1).First();
         row.Field("Value").Value = 2;
-        row = table.DataRange.InsertRowsAbove(1).First();
+        row = table.DataRange!.InsertRowsAbove(1).First();
         row.Field("Value").Value = 1;
 
         await Assert.That(ws.Cell(2, 1).GetDouble()).IsEqualTo(1);
@@ -296,9 +296,9 @@ public class TablesTests
 
         var row = table.DataRange!.FirstRow();
         row!.Field("Value").Value = 1;
-        row = table.DataRange.InsertRowsBelow(1).First();
+        row = table.DataRange!.InsertRowsBelow(1).First();
         row.Field("Value").Value = 2;
-        row = table.DataRange.InsertRowsBelow(1).First();
+        row = table.DataRange!.InsertRowsBelow(1).First();
         row.Field("Value").Value = 3;
 
         await Assert.That(ws.Cell(2, 1).GetDouble()).IsEqualTo(1);
@@ -350,9 +350,9 @@ public class TablesTests
         await Assert.That(ws.Cell(1, 1).IsEmpty(XLCellsUsedOptions.All)).IsTrue();
         await Assert.That(table.HeadersRow()).IsNull();
         await Assert.That(table.DataRange!.FirstRow()!.Field("Categories").GetText()).IsEqualTo("A");
-        await Assert.That(table.DataRange.LastRow()!.Field("Categories").GetText()).IsEqualTo("C");
-        await Assert.That(table.DataRange.FirstCell().GetText()).IsEqualTo("A");
-        await Assert.That(table.DataRange.LastCell().GetText()).IsEqualTo("C");
+        await Assert.That(table.DataRange!.LastRow()!.Field("Categories").GetText()).IsEqualTo("C");
+        await Assert.That(table.DataRange!.FirstCell().GetText()).IsEqualTo("A");
+        await Assert.That(table.DataRange!.LastCell().GetText()).IsEqualTo("C");
 
         table.SetShowHeaderRow();
         var headerRow = table.HeadersRow();
@@ -368,10 +368,10 @@ public class TablesTests
         await Assert.That(ws.FirstCell().GetText()).IsEqualTo("x");
         await Assert.That(ws.Cell("A2").GetText()).IsEqualTo("Categories");
         await Assert.That(headerRow).IsNotEqualTo(null);
-        await Assert.That(table.DataRange.FirstRow()!.Field("Categories").GetText()).IsEqualTo("A");
-        await Assert.That(table.DataRange.LastRow()!.Field("Categories").GetText()).IsEqualTo("C");
-        await Assert.That(table.DataRange.FirstCell().GetText()).IsEqualTo("A");
-        await Assert.That(table.DataRange.LastCell().GetText()).IsEqualTo("C");
+        await Assert.That(table.DataRange!.FirstRow()!.Field("Categories").GetText()).IsEqualTo("A");
+        await Assert.That(table.DataRange!.LastRow()!.Field("Categories").GetText()).IsEqualTo("C");
+        await Assert.That(table.DataRange!.FirstCell().GetText()).IsEqualTo("A");
+        await Assert.That(table.DataRange!.LastCell().GetText()).IsEqualTo("C");
     }
 
     [Test]
@@ -606,10 +606,10 @@ public class TablesTests
 
         table.DataRange!.Rows(3, 4).Delete();
 
-        await Assert.That(table.DataRange.Rows().Count()).IsEqualTo(2);
+        await Assert.That(table.DataRange!.Rows().Count()).IsEqualTo(2);
 
-        await Assert.That(table.DataRange.FirstCell().Value).IsEqualTo("b");
-        await Assert.That(table.DataRange.LastCell().Value).IsEqualTo(777);
+        await Assert.That(table.DataRange!.FirstCell().Value).IsEqualTo("b");
+        await Assert.That(table.DataRange!.LastCell().Value).IsEqualTo(777);
 
         await Assert.That(table.RangeAddress.ToString()).IsEqualTo("B2:E4");
     }

--- a/XLibur.Tests/Excel/Tables/TablesTests.cs
+++ b/XLibur.Tests/Excel/Tables/TablesTests.cs
@@ -250,9 +250,9 @@ public class TablesTests
 
         var row = table.DataRange!.FirstRow();
         row!.Field("Value").Value = 3;
-        row = table.DataRange!.InsertRowsAbove(1).First();
+        row = table.DataRange.InsertRowsAbove(1).First();
         row.Field("Value").Value = 2;
-        row = table.DataRange!.InsertRowsAbove(1).First();
+        row = table.DataRange.InsertRowsAbove(1).First();
         row.Field("Value").Value = 1;
 
         await Assert.That(ws.Cell(2, 1).GetDouble()).IsEqualTo(1);
@@ -296,9 +296,9 @@ public class TablesTests
 
         var row = table.DataRange!.FirstRow();
         row!.Field("Value").Value = 1;
-        row = table.DataRange!.InsertRowsBelow(1).First();
+        row = table.DataRange.InsertRowsBelow(1).First();
         row.Field("Value").Value = 2;
-        row = table.DataRange!.InsertRowsBelow(1).First();
+        row = table.DataRange.InsertRowsBelow(1).First();
         row.Field("Value").Value = 3;
 
         await Assert.That(ws.Cell(2, 1).GetDouble()).IsEqualTo(1);
@@ -350,9 +350,9 @@ public class TablesTests
         await Assert.That(ws.Cell(1, 1).IsEmpty(XLCellsUsedOptions.All)).IsTrue();
         await Assert.That(table.HeadersRow()).IsNull();
         await Assert.That(table.DataRange!.FirstRow()!.Field("Categories").GetText()).IsEqualTo("A");
-        await Assert.That(table.DataRange!.LastRow()!.Field("Categories").GetText()).IsEqualTo("C");
-        await Assert.That(table.DataRange!.FirstCell().GetText()).IsEqualTo("A");
-        await Assert.That(table.DataRange!.LastCell().GetText()).IsEqualTo("C");
+        await Assert.That(table.DataRange.LastRow()!.Field("Categories").GetText()).IsEqualTo("C");
+        await Assert.That(table.DataRange.FirstCell().GetText()).IsEqualTo("A");
+        await Assert.That(table.DataRange.LastCell().GetText()).IsEqualTo("C");
 
         table.SetShowHeaderRow();
         var headerRow = table.HeadersRow();
@@ -368,10 +368,10 @@ public class TablesTests
         await Assert.That(ws.FirstCell().GetText()).IsEqualTo("x");
         await Assert.That(ws.Cell("A2").GetText()).IsEqualTo("Categories");
         await Assert.That(headerRow).IsNotEqualTo(null);
-        await Assert.That(table.DataRange!.FirstRow()!.Field("Categories").GetText()).IsEqualTo("A");
-        await Assert.That(table.DataRange!.LastRow()!.Field("Categories").GetText()).IsEqualTo("C");
-        await Assert.That(table.DataRange!.FirstCell().GetText()).IsEqualTo("A");
-        await Assert.That(table.DataRange!.LastCell().GetText()).IsEqualTo("C");
+        await Assert.That(table.DataRange.FirstRow()!.Field("Categories").GetText()).IsEqualTo("A");
+        await Assert.That(table.DataRange.LastRow()!.Field("Categories").GetText()).IsEqualTo("C");
+        await Assert.That(table.DataRange.FirstCell().GetText()).IsEqualTo("A");
+        await Assert.That(table.DataRange.LastCell().GetText()).IsEqualTo("C");
     }
 
     [Test]
@@ -606,10 +606,10 @@ public class TablesTests
 
         table.DataRange!.Rows(3, 4).Delete();
 
-        await Assert.That(table.DataRange!.Rows().Count()).IsEqualTo(2);
+        await Assert.That(table.DataRange.Rows().Count()).IsEqualTo(2);
 
-        await Assert.That(table.DataRange!.FirstCell().Value).IsEqualTo("b");
-        await Assert.That(table.DataRange!.LastCell().Value).IsEqualTo(777);
+        await Assert.That(table.DataRange.FirstCell().Value).IsEqualTo("b");
+        await Assert.That(table.DataRange.LastCell().Value).IsEqualTo(777);
 
         await Assert.That(table.RangeAddress.ToString()).IsEqualTo("B2:E4");
     }

--- a/XLibur.Tests/Excel/Tables/TablesTests.cs
+++ b/XLibur.Tests/Excel/Tables/TablesTests.cs
@@ -356,7 +356,7 @@ public class TablesTests
 
         table.SetShowHeaderRow();
         var headerRow = table.HeadersRow();
-        await Assert.That(headerRow).IsNotEqualTo(null);
+        await Assert.That(headerRow).IsNotNull();
         await Assert.That(headerRow!.Cell(1).GetText()).IsEqualTo("Categories");
 
         table.SetShowHeaderRow(false);
@@ -367,7 +367,7 @@ public class TablesTests
 
         await Assert.That(ws.FirstCell().GetText()).IsEqualTo("x");
         await Assert.That(ws.Cell("A2").GetText()).IsEqualTo("Categories");
-        await Assert.That(headerRow).IsNotEqualTo(null);
+        await Assert.That(headerRow).IsNotNull();
         await Assert.That(table.DataRange.FirstRow()!.Field("Categories").GetText()).IsEqualTo("A");
         await Assert.That(table.DataRange.LastRow()!.Field("Categories").GetText()).IsEqualTo("C");
         await Assert.That(table.DataRange.FirstCell().GetText()).IsEqualTo("A");

--- a/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -173,8 +173,8 @@ public class XLWorksheetTests
         await Assert.That(ws.MergedRanges.First().RangeAddress.ToStringRelative()).IsEqualTo("A1:B2");
         await Assert.That(ws.MergedRanges.Last().RangeAddress.ToStringRelative()).IsEqualTo("D2:E2");
 
-        await Assert.That(ws.Cell("A2")!.MergedRange().RangeAddress.ToStringRelative()).IsEqualTo("A1:B2");
-        await Assert.That(ws.Cell("D2")!.MergedRange().RangeAddress.ToStringRelative()).IsEqualTo("D2:E2");
+        await Assert.That(ws.Cell("A2").MergedRange().RangeAddress.ToStringRelative()).IsEqualTo("A1:B2");
+        await Assert.That(ws.Cell("D2").MergedRange().RangeAddress.ToStringRelative()).IsEqualTo("D2:E2");
 
         await Assert.That(ws.Cell("Z10").MergedRange()).IsNull();
     }

--- a/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -235,10 +235,10 @@ public class XLWorksheetTests
         await Assert.That(wb.Worksheets.TryGetWorksheet("sHEeT1", out _)).IsTrue();
         await Assert.That(wb.Worksheets.TryGetWorksheet("Sheeeet2", out _)).IsFalse();
 
-        await Assert.That(wb.TryGetWorksheet("Sheet1", out IXLWorksheet _)).IsTrue();
-        await Assert.That(wb.TryGetWorksheet("sheet1", out IXLWorksheet _)).IsTrue();
-        await Assert.That(wb.TryGetWorksheet("sHEeT1", out IXLWorksheet _)).IsTrue();
-        await Assert.That(wb.TryGetWorksheet("Sheeeet2", out IXLWorksheet _)).IsFalse();
+        await Assert.That(wb.TryGetWorksheet("Sheet1", out IXLWorksheet? _)).IsTrue();
+        await Assert.That(wb.TryGetWorksheet("sheet1", out IXLWorksheet? _)).IsTrue();
+        await Assert.That(wb.TryGetWorksheet("sHEeT1", out IXLWorksheet? _)).IsTrue();
+        await Assert.That(wb.TryGetWorksheet("Sheeeet2", out IXLWorksheet? _)).IsFalse();
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -173,8 +173,8 @@ public class XLWorksheetTests
         await Assert.That(ws.MergedRanges.First().RangeAddress.ToStringRelative()).IsEqualTo("A1:B2");
         await Assert.That(ws.MergedRanges.Last().RangeAddress.ToStringRelative()).IsEqualTo("D2:E2");
 
-        await Assert.That(ws.Cell("A2").MergedRange().RangeAddress.ToStringRelative()).IsEqualTo("A1:B2");
-        await Assert.That(ws.Cell("D2").MergedRange().RangeAddress.ToStringRelative()).IsEqualTo("D2:E2");
+        await Assert.That(ws.Cell("A2").MergedRange()!.RangeAddress.ToStringRelative()).IsEqualTo("A1:B2");
+        await Assert.That(ws.Cell("D2").MergedRange()!.RangeAddress.ToStringRelative()).IsEqualTo("D2:E2");
 
         await Assert.That(ws.Cell("Z10").MergedRange()).IsNull();
     }
@@ -905,7 +905,7 @@ public class XLWorksheetTests
             await Assert.That(copy.ElementAt(i).SourceData.RangeAddress.ToString()).IsEqualTo(original.ElementAt(i).SourceData.RangeAddress.ToString());
         }
 
-        await Assert.That(copy.DateRange.RangeAddress.ToString()!).IsEqualTo(original.DateRange.RangeAddress.ToString()!);
+        await Assert.That(copy.DateRange!.RangeAddress.ToString()!).IsEqualTo(original.DateRange!.RangeAddress.ToString()!);
         await Assert.That(copy.DateRange.Worksheet).IsSameReferenceAs(ws2);
 
         await Assert.That(copy.DisplayEmptyCellsAs).IsEqualTo(original.DisplayEmptyCellsAs);

--- a/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -173,8 +173,8 @@ public class XLWorksheetTests
         await Assert.That(ws.MergedRanges.First().RangeAddress.ToStringRelative()).IsEqualTo("A1:B2");
         await Assert.That(ws.MergedRanges.Last().RangeAddress.ToStringRelative()).IsEqualTo("D2:E2");
 
-        await Assert.That(ws.Cell("A2").MergedRange().RangeAddress.ToStringRelative()).IsEqualTo("A1:B2");
-        await Assert.That(ws.Cell("D2").MergedRange().RangeAddress.ToStringRelative()).IsEqualTo("D2:E2");
+        await Assert.That(ws.Cell("A2")!.MergedRange().RangeAddress.ToStringRelative()).IsEqualTo("A1:B2");
+        await Assert.That(ws.Cell("D2")!.MergedRange().RangeAddress.ToStringRelative()).IsEqualTo("D2:E2");
 
         await Assert.That(ws.Cell("Z10").MergedRange()).IsNull();
     }
@@ -544,11 +544,11 @@ public class XLWorksheetTests
         async Task AssertStylesAreEqual(IXLWorksheet ws1Assert, IXLWorksheet ws2)
         {
             await Assert.That((ws2.Style as XLStyle)!.Value).IsEqualTo((ws1Assert.Style as XLStyle)!.Value).Because("Worksheet styles differ");
-            var cellsUsed = ws1Assert.Range(ws1Assert.FirstCell(), ws1Assert.LastCellUsed()).Cells();
+            var cellsUsed = ws1Assert.Range(ws1Assert.FirstCell(), ws1Assert.LastCellUsed()!).Cells();
             foreach (var cell in cellsUsed)
             {
                 var style1 = (cell.Style as XLStyle)!.Value;
-                var style2 = (ws2.Cell(cell.Address.ToString()).Style as XLStyle)!.Value;
+                var style2 = (ws2.Cell(cell.Address.ToString()!).Style as XLStyle)!.Value;
                 await Assert.That(style2).IsEqualTo(style1).Because($"Cell {cell.Address} styles differ");
             }
         }
@@ -686,13 +686,13 @@ public class XLWorksheetTests
     public async Task CopyWorksheetPreservesPictures()
     {
         using var ms = new MemoryStream();
-        using var imageStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable))
+        using var imageStream = System.Reflection.Assembly.GetAssembly(typeof(XLibur.Examples.BasicTable))!
             .GetManifestResourceStream("XLibur.Examples.Resources.SampleImage.jpg");
         using var wb1 = new XLWorkbook();
 
         var ws1 = wb1.Worksheets.Add("Original");
 
-        ws1.AddPicture(imageStream, "MyPicture")
+        ws1.AddPicture(imageStream!, "MyPicture")
             .WithPlacement(XLPicturePlacement.FreeFloating)
             .MoveTo(50, 50)
             .WithSize(200, 200);
@@ -905,7 +905,7 @@ public class XLWorksheetTests
             await Assert.That(copy.ElementAt(i).SourceData.RangeAddress.ToString()).IsEqualTo(original.ElementAt(i).SourceData.RangeAddress.ToString());
         }
 
-        await Assert.That(copy.DateRange.RangeAddress.ToString()).IsEqualTo(original.DateRange.RangeAddress.ToString());
+        await Assert.That(copy.DateRange.RangeAddress.ToString()!).IsEqualTo(original.DateRange.RangeAddress.ToString()!);
         await Assert.That(copy.DateRange.Worksheet).IsSameReferenceAs(ws2);
 
         await Assert.That(copy.DisplayEmptyCellsAs).IsEqualTo(original.DisplayEmptyCellsAs);

--- a/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -547,8 +547,8 @@ public class XLWorksheetTests
             var cellsUsed = ws1Assert.Range(ws1Assert.FirstCell(), ws1Assert.LastCellUsed()).Cells();
             foreach (var cell in cellsUsed)
             {
-                var style1 = (cell.Style as XLStyle).Value;
-                var style2 = (ws2.Cell(cell.Address.ToString()).Style as XLStyle).Value;
+                var style1 = (cell.Style as XLStyle)!.Value;
+                var style2 = (ws2.Cell(cell.Address.ToString()).Style as XLStyle)!.Value;
                 await Assert.That(style2).IsEqualTo(style1).Because($"Cell {cell.Address} styles differ");
             }
         }
@@ -580,7 +580,7 @@ public class XLWorksheetTests
                 await Assert.That(copy.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false)).IsEqualTo(original.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false));
             }
 
-            await Assert.That((copy.Style as XLStyle).Value).IsEqualTo((original.Style as XLStyle).Value);
+            await Assert.That((copy.Style as XLStyle)!.Value).IsEqualTo((original.Style as XLStyle)!.Value);
             await Assert.That(copy.Values.Single().Value.Value).IsEqualTo(original.Values.Single().Value.Value);
         }
     }
@@ -632,7 +632,7 @@ public class XLWorksheetTests
             await Assert.That(copy.ShowHeaderRow).IsEqualTo(original.ShowHeaderRow);
             await Assert.That(copy.ShowRowStripes).IsEqualTo(original.ShowRowStripes);
             await Assert.That(copy.ShowTotalsRow).IsEqualTo(original.ShowTotalsRow);
-            await Assert.That((copy.Style as XLStyle).Value).IsEqualTo((original.Style as XLStyle).Value);
+            await Assert.That((copy.Style as XLStyle)!.Value).IsEqualTo((original.Style as XLStyle)!.Value);
             await Assert.That(copy.Theme).IsEqualTo(original.Theme);
         }
     }

--- a/XLibur.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/XLibur.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -41,12 +41,12 @@ public class EnumerableExtensionsTests
         //check the beginning and the ending of the actual type
         var expectedTypeStart = "<>f__AnonymousType";
         var expectedTypeEnd = "`2[System.String,System.String]";
-        var actualType = anonymousIterator.GetItemType().ToString();
+        var actualType = anonymousIterator.GetItemType()!.ToString();
         await Assert.That(actualType.StartsWith(expectedTypeStart)).IsTrue();
         await Assert.That(actualType.EndsWith(expectedTypeEnd)).IsTrue();
 
         IEnumerable<object> obj = anonymousIterator;
-        actualType = obj.GetItemType().ToString();
+        actualType = obj.GetItemType()!.ToString();
         await Assert.That(actualType.StartsWith(expectedTypeStart)).IsTrue();
         await Assert.That(actualType.EndsWith(expectedTypeEnd)).IsTrue();
     }

--- a/XLibur.Tests/Extensions/ReflectionExtensionTests.cs
+++ b/XLibur.Tests/Extensions/ReflectionExtensionTests.cs
@@ -29,7 +29,7 @@ public class ReflectionExtensionTests
         public int InstanceProperty { get; set; }
         public int InstanceField = 0;
 
-        public event EventHandler<EventArgs> InstanceEvent;
+        public event EventHandler<EventArgs>? InstanceEvent;
 
 #pragma warning disable CA1822 // Intentionally non-static: test verifies IsStatic() returns false
         public void InstanceMethod()

--- a/XLibur.Tests/Extensions/ReflectionExtensionTests.cs
+++ b/XLibur.Tests/Extensions/ReflectionExtensionTests.cs
@@ -18,7 +18,7 @@ public class ReflectionExtensionTests
         public static int StaticProperty { get; set; }
         public static int StaticField = 0;
 
-        public static event EventHandler<EventArgs> StaticEvent;
+        public static event EventHandler<EventArgs>? StaticEvent;
 
         public static void StaticMethod()
         {

--- a/XLibur.Tests/Graphics/PictureInfoTests.cs
+++ b/XLibur.Tests/Graphics/PictureInfoTests.cs
@@ -224,7 +224,7 @@ public class PictureInfoTests
     {
         using var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream($"XLibur.Tests.Resource.Images.{imageName}");
         var engine = new DefaultGraphicEngine(DefaultFontEngine.Instance.Value);
-        var info = engine.GetPictureInfo(stream, XLPictureFormat.Unknown);
+        var info = engine.GetPictureInfo(stream!, XLPictureFormat.Unknown);
 
         await Assert.That(info.Format).IsEqualTo(expectedFormat);
         await Assert.That(info.SizePx).IsEqualTo(expectedPxSize);

--- a/XLibur.Tests/TestHelper.cs
+++ b/XLibur.Tests/TestHelper.cs
@@ -170,7 +170,7 @@ internal static class TestHelper
     /// </summary>
     // The assert callbacks take Func<..., Task> rather than Action: TUnit assertions are
     // awaitable, so a callback that asserts must be awaited or the assertion never runs.
-    public static async Task LoadAndAssert(Func<XLWorkbook, Task> assertWorkbook, string loadResourcePath, LoadOptions options = null)
+    public static async Task LoadAndAssert(Func<XLWorkbook, Task> assertWorkbook, string loadResourcePath, LoadOptions options = null!)
     {
         using var stream = GetStreamFromResource(GetResourcePath(loadResourcePath));
         using var wb = new XLWorkbook(stream, options ?? new LoadOptions());
@@ -182,7 +182,7 @@ internal static class TestHelper
     /// A testing method to load a workbook with a single worksheet from resource and assert
     /// the state of the loaded workbook.
     /// </summary>
-    public static async Task LoadAndAssert(Func<XLWorkbook, IXLWorksheet, Task> assertWorksheet, string loadResourcePath, LoadOptions options = null)
+    public static async Task LoadAndAssert(Func<XLWorkbook, IXLWorksheet, Task> assertWorksheet, string loadResourcePath, LoadOptions options = null!)
     {
         await LoadAndAssert(async wb =>
         {
@@ -207,7 +207,7 @@ internal static class TestHelper
         await Assert.That(() => _ = new XLWorkbook(stream)).ThrowsNothing();
     }
 
-    public static IEnumerable<string> ListResourceFiles(Func<string, bool> predicate = null)
+    public static IEnumerable<string> ListResourceFiles(Func<string, bool> predicate = null!)
     {
         return Extractor.GetFileNames(predicate);
     }

--- a/XLibur.Tests/Utils/PackageHelper.cs
+++ b/XLibur.Tests/Utils/PackageHelper.cs
@@ -252,7 +252,7 @@ public static class PackageHelper
     /// <param name="message"></param>
     public static bool Compare(Package left, Package right, bool compareToFirstDifference, out string message)
     {
-        return Compare(left, right, compareToFirstDifference, null, out message);
+        return Compare(left, right, compareToFirstDifference, null!, out message);
     }
 
     /// <summary>

--- a/XLibur.Tests/Utils/PackageHelper.cs
+++ b/XLibur.Tests/Utils/PackageHelper.cs
@@ -23,7 +23,7 @@ public static class PackageHelper
         serializer.Serialize(stream, content);
     }
 
-    public static object ReadXmlPart(Package package, Uri uri, XmlSerializer serializer)
+    public static object? ReadXmlPart(Package package, Uri uri, XmlSerializer serializer)
     {
         if (!package.PartExists(uri))
         {

--- a/XLibur.Tests/Utils/PivotTableComparer.cs
+++ b/XLibur.Tests/Utils/PivotTableComparer.cs
@@ -22,7 +22,7 @@ internal class PivotTableComparer : IEqualityComparer<XLPivotTable>
         _compareTargetCellAddress = compareTargetCellAddress;
     }
 
-    public bool Equals(XLPivotTable x, XLPivotTable y)
+    public bool Equals(XLPivotTable? x, XLPivotTable? y)
     {
         if (x == null && y == null) return true;
 

--- a/XLibur.Tests/Utils/ResourceFileExtractor.cs
+++ b/XLibur.Tests/Utils/ResourceFileExtractor.cs
@@ -44,7 +44,7 @@ public sealed class ResourceFileExtractor
 
     #region Private fields
 
-    private readonly ResourceFileExtractor _mBaseExtractor;
+    private readonly ResourceFileExtractor? _mBaseExtractor;
 
     #endregion Private fields
 
@@ -103,7 +103,7 @@ public sealed class ResourceFileExtractor
     /// </summary>
     /// <param name="assembly"></param>
     public ResourceFileExtractor(Assembly assembly)
-        : this(assembly ?? Assembly.GetCallingAssembly(), (ResourceFileExtractor)null)
+        : this(assembly ?? Assembly.GetCallingAssembly(), (ResourceFileExtractor?)null)
     {
     }
 
@@ -112,7 +112,7 @@ public sealed class ResourceFileExtractor
     /// </summary>
     /// <param name="assembly"></param>
     /// <param name="baseExtractor"></param>
-    public ResourceFileExtractor(Assembly assembly, ResourceFileExtractor baseExtractor)
+    public ResourceFileExtractor(Assembly assembly, ResourceFileExtractor? baseExtractor)
         : this(assembly ?? Assembly.GetCallingAssembly(), false, baseExtractor)
     {
     }
@@ -124,11 +124,11 @@ public sealed class ResourceFileExtractor
     /// <param name="isStatic"></param>
     /// <param name="baseExtractor"></param>
     /// <exception cref="ArgumentNullException">Argument is null.</exception>
-    private ResourceFileExtractor(Assembly assembly, bool isStatic, ResourceFileExtractor baseExtractor)
+    private ResourceFileExtractor(Assembly assembly, bool isStatic, ResourceFileExtractor? baseExtractor)
     {
         Assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
         _mBaseExtractor = baseExtractor;
-        AssemblyName = Assembly.GetName().Name;
+        AssemblyName = Assembly.GetName().Name!;
         IsStatic = isStatic;
         ResourceFilePath = ".Resources.";
     }

--- a/XLibur.Tests/Utils/ResourceFileExtractor.cs
+++ b/XLibur.Tests/Utils/ResourceFileExtractor.cs
@@ -31,7 +31,7 @@ public sealed class ResourceFileExtractor
             var key = assembly.GetName().FullName;
             if (extractors.TryGetValue(key, out var extractor)
                 || extractors.TryGetValue(key, out extractor)) return extractor;
-            extractor = new ResourceFileExtractor(assembly, true, null);
+            extractor = new ResourceFileExtractor(assembly, true, null!);
             extractors.Add(key, extractor);
 
             return extractor;
@@ -150,7 +150,7 @@ public sealed class ResourceFileExtractor
 
     public bool IsStatic { get; set; }
 
-    public IEnumerable<string> GetFileNames(Func<String, Boolean> predicate = null)
+    public IEnumerable<string> GetFileNames(Func<String, Boolean> predicate = null!)
     {
         predicate ??= (s => true);
 

--- a/XLibur.Tests/XLHelperTests.cs
+++ b/XLibur.Tests/XLHelperTests.cs
@@ -125,7 +125,7 @@ public class XLHelperTests
     [Arguments("null", null)]
     [Arguments("empty", "")]
     [Arguments("1234567890123456789012345678901", "1234567890123456789012345678901TOOLONG")]
-    public async Task CreateSafeSheetNames(string expected, string input)
+    public async Task CreateSafeSheetNames(string expected, string? input)
     {
         var actual = XLHelper.CreateSafeSheetName(input);
         await Assert.That(actual).IsEqualTo(expected);
@@ -148,7 +148,7 @@ public class XLHelperTests
     [Arguments(null, "null")]
     [Arguments("", "empty")]
     [Arguments("1234567890123456789012345678901TOOLONG", "1234567890123456789012345678901")]
-    public async Task CreateSafeSheetNamesWithUnderscore(string input, string expected)
+    public async Task CreateSafeSheetNamesWithUnderscore(string? input, string expected)
     {
         await Assert.That(XLHelper.CreateSafeSheetName(input, replaceChar: '_')).IsEqualTo(expected);
     }

--- a/XLibur.Tests/XLHelperTests.cs
+++ b/XLibur.Tests/XLHelperTests.cs
@@ -127,7 +127,7 @@ public class XLHelperTests
     [Arguments("1234567890123456789012345678901", "1234567890123456789012345678901TOOLONG")]
     public async Task CreateSafeSheetNames(string expected, string? input)
     {
-        var actual = XLHelper.CreateSafeSheetName(input);
+        var actual = XLHelper.CreateSafeSheetName(input!);
         await Assert.That(actual).IsEqualTo(expected);
     }
 
@@ -150,7 +150,7 @@ public class XLHelperTests
     [Arguments("1234567890123456789012345678901TOOLONG", "1234567890123456789012345678901")]
     public async Task CreateSafeSheetNamesWithUnderscore(string? input, string expected)
     {
-        await Assert.That(XLHelper.CreateSafeSheetName(input, replaceChar: '_')).IsEqualTo(expected);
+        await Assert.That(XLHelper.CreateSafeSheetName(input!, replaceChar: '_')).IsEqualTo(expected);
     }
 
     [Test]

--- a/XLibur/Excel/Ranges/IXLRange.cs
+++ b/XLibur/Excel/Ranges/IXLRange.cs
@@ -40,6 +40,7 @@ public interface IXLRange : IXLRangeBase
     /// <summary>Gets the cell at the specified address.</summary>
     /// <para>The cell address is relative to the parent range.</para>
     /// <param name="cellAddressInRange">The cell address in the parent range.</param>
+    /// <exception cref="ArgumentException">Address is not A1 or a named range.</exception>
     IXLCell Cell(string cellAddressInRange);
 
     /// <summary>
@@ -193,6 +194,7 @@ public interface IXLRange : IXLRangeBase
     /// <summary>Returns the specified range.</summary>
     /// <para>e.g. Range("A1"), Range("A1:C2")</para>
     /// <param name="rangeAddress">The range boundaries.</param>
+    /// <exception cref="FormatException"><paramref name="rangeAddress"/> is not a valid address.</exception>
     IXLRange Range(string rangeAddress);
 
     /// <summary>Returns the specified range.</summary>

--- a/XLibur/Excel/Ranges/XLRange.cs
+++ b/XLibur/Excel/Ranges/XLRange.cs
@@ -110,7 +110,12 @@ internal class XLRange : XLStoredRangeBase, IXLRange
 
     IXLCell IXLRange.Cell(string cellAddressInRange)
     {
-        return Cell(cellAddressInRange)!;
+        // IXLRange.Cell is annotated non-null, but the underlying lookup returns null for a string
+        // that is neither an A1 address nor a defined name. Throw here rather than forgiving the
+        // null, so the caller gets the failure at the call site instead of a NullReferenceException
+        // somewhere downstream. Matches IXLWorksheet.Cell.
+        return Cell(cellAddressInRange) ??
+               throw new ArgumentException($"'{cellAddressInRange}' is not A1 address or named range.");
     }
 
     IXLCell IXLRange.Cell(int row, string column)
@@ -130,7 +135,12 @@ internal class XLRange : XLStoredRangeBase, IXLRange
 
     IXLRange IXLRange.Range(string rangeAddress)
     {
-        return Range(rangeAddress)!;
+        // Defensive only, unlike Cell above. The virtual method is annotated nullable because
+        // XLWorksheet's override can return null, but this implementation cannot: a malformed
+        // address throws FormatException while being parsed, before there is anything to return.
+        // The guard is here so that stops being true silently rather than by handing back a null.
+        return Range(rangeAddress) ??
+               throw new ArgumentException($"'{rangeAddress}' is not a valid range address or named range.");
     }
 
     IXLRange IXLRange.Range(IXLCell firstCell, IXLCell lastCell)

--- a/XLibur/XLibur.csproj
+++ b/XLibur/XLibur.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <LangVersion>default</LangVersion>
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
-        <Nullable>enable</Nullable>
         <RootNamespace>XLibur</RootNamespace>
         <Company>XLibur</Company>
         <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>


### PR DESCRIPTION
Declares `<Nullable>enable</Nullable>` once in `Directory.Build.props` instead of per-project, then fixes everything that turned on. The solution builds with **0 warnings and 0 errors** in Debug and Release across every target framework.

## Why

`Nullable` was declared in 12 separate `.csproj` files and missing from several others, so whether a project got null analysis depended on which file you happened to be in. Moving it to `Directory.Build.props` makes it uniform — and made visible how much was previously unchecked.

## The damage, and the fix

Turning it on centrally surfaced **1,438 nullable warnings in `XLibur.Tests`** plus a smaller set in `XLibur.Examples` and `XLibur.Benchmarks`. All are now resolved.

The single highest-leverage change was **not** suppression. Twelve test helpers were declared as returning the concrete `XLWorksheet`, whose `Cell(string)` / `Range(string)` legitimately return `XLCell?` / `XLRange?`, rather than the `IXLWorksheet` interface, whose equivalents are non-null and throw on a bad address. Holding the interface where the concrete type was never needed cleared **1,005 of the 1,438** warnings with no null-forgiving operators at all.

Most of the remainder were similar type corrections:

- `as` casts that can only succeed became direct casts. `PivotTables.First() as XLPivotTable`, `ws.Range(addr) as XLRange` and `ws.Protection as XLSheetProtection` each produced a nullable the test then dereferenced anyway. A direct cast reports the real failure at the cast instead of a `NullReferenceException` further downstream.
- Return types that were lying were corrected — `FindSqref`, `PackageHelper.ReadXmlPart`, `ThreadedCommentsTests.FindEntry` and `EmptyDataValidationTests.ReadSqrefs` all returned a possible null through a non-nullable type.
- `PivotTableComparer.Equals` now takes `XLPivotTable?` on both sides, which is what `IEqualityComparer<T>` actually declares.

## One real defect in the shipping library

`XLRange`'s explicit implementations of `IXLRange.Cell(string)` and `IXLRange.Range(string)` are annotated non-null, but the underlying lookup returns null for a string that is neither an A1 address nor a defined name. They now throw `ArgumentException` at the call site, matching what `XLWorksheet` already did, instead of handing back a null that surfaces as a `NullReferenceException` somewhere else. `IXLRange`'s XML docs record the exceptions.

This is the only behavioural change to the library in this PR; everything else is test, example and benchmark code or build configuration.

## Verification

- 0 warnings / 0 errors solution-wide, `--no-incremental`, Debug and Release
- `SonarAnalyzer` **S8969 reports 0 redundant null-forgiving operators**. The probe build emits findings for 30+ other rules, so it is live rather than silently empty — bulk edits introduced redundant operators repeatedly during this work and each batch was swept before committing
- **11,813 core tests and 481 report tests pass**
- `git diff --numstat` shows no whole-file rewrites; CRLF endings verified against the committed blobs

## Notes for review

- `CLAUDE.md` gains a section on why `sed -i` must not be used on tracked files — it strips the CR that `.gitattributes` requires, turning a one-line change into a whole-file diff. This caused recurring `.csproj` churn in this repo.
- Commit `eec7670a` accidentally swept in two unrelated working-tree changes, including a deletion of `.github/CODEOWNERS`. Both are restored in `f21068bb`; the originals remain reachable in history if either is wanted separately.
- The four test and benchmark projects still set `TreatWarningsAsErrors=false`. Removing that exemption is the **stacked follow-up PR** based on this branch, kept separate so this one stays reviewable.
