### PR TITLE
build: treat warnings as errors in the test and benchmark projects

### DIFF
--- a/XLibur.Benchmarks/XLibur.Benchmarks.csproj
+++ b/XLibur.Benchmarks/XLibur.Benchmarks.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <AssemblyName>XLibur.Benchmarks</AssemblyName>
     <RootNamespace>XLibur.Benchmarks</RootNamespace>

--- a/XLibur.Report.Benchmarks/XLibur.Report.Benchmarks.csproj
+++ b/XLibur.Report.Benchmarks/XLibur.Report.Benchmarks.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <AssemblyName>XLibur.Report.Benchmarks</AssemblyName>
     <RootNamespace>XLibur.Report.Benchmarks</RootNamespace>

--- a/XLibur.Report.Tests/XLibur.Report.Tests.csproj
+++ b/XLibur.Report.Tests/XLibur.Report.Tests.csproj
@@ -7,7 +7,6 @@
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <!-- CS4014 (call not awaited) must fail the build. TUnit assertions are awaitable, so an
          un-awaited assertion never executes and the test passes no matter what it asserts. -->
     <WarningsAsErrors>$(WarningsAsErrors);CS4014</WarningsAsErrors>

--- a/XLibur.Tests/XLibur.Tests.csproj
+++ b/XLibur.Tests/XLibur.Tests.csproj
@@ -7,12 +7,10 @@
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <!-- CS4014 (call not awaited) must fail the build. TUnit assertions are awaitable, so an
          un-awaited assertion never executes and the test passes no matter what it asserts.
-         The other test projects get this from TreatWarningsAsErrors in Directory.Build.props;
-         this project opts out of that, so the one warning that must not be ignored is
-         promoted explicitly. -->
+         TreatWarningsAsErrors in Directory.Build.props already covers this; the rule is kept
+         explicit so that it survives if that is ever relaxed again. -->
     <WarningsAsErrors>$(WarningsAsErrors);CS4014</WarningsAsErrors>
     <NoWarn>$(NoWarn);NU1605;CS1591;CS1658;CS1584;</NoWarn>
     <!-- TUnit runs on Microsoft.Testing.Platform rather than VSTest. -->


### PR DESCRIPTION
> **Stacked on #360.** Base branch is `chore/nullable-central`, so this PR shows only its own 4-file diff. Merge #360 first; this will then retarget to `main` automatically.

Removes the `TreatWarningsAsErrors=false` opt-out from the four projects that still carried it: `XLibur.Tests`, `XLibur.Report.Tests`, `XLibur.Benchmarks` and `XLibur.Report.Benchmarks`.

## Why now

`Directory.Build.props` has set `TreatWarningsAsErrors` repo-wide for a while, but these four opted out because they carried warnings — `XLibur.Tests` alone had 1,438 nullable warnings. #360 takes that to zero, so the exemption has nothing left to protect. Left in place, it means the next warning introduced in a test lands silently and stays.

## One deliberate redundancy kept

`XLibur.Tests` keeps its explicit `WarningsAsErrors;CS4014` promotion even though `TreatWarningsAsErrors` now covers it. TUnit assertions are awaitable, so an un-awaited assertion **never executes and the test passes regardless of what it asserts** — that failure mode is silent and expensive, and worth pinning independently of the blanket setting. The surrounding comment is updated to say that instead of describing an opt-out that no longer exists.

## Verification

- Solution builds with **0 warnings and 0 errors** in both Debug and Release, across every target framework, `--no-incremental`
- Enforcement checked empirically rather than assumed: injecting `string? n = null; return n;` into `XLibur.Tests` fails the build with **`error CS8603`**, not a warning
- 11,813 core tests pass
