### PR TITLE
fix(richtext): give XLPhonetics the Equals override its IEquatable promised

### DIFF
--- a/XLibur/Excel/RichText/XLPhonetics.cs
+++ b/XLibur/Excel/RichText/XLPhonetics.cs
@@ -244,6 +244,8 @@ internal sealed class XLPhonetics : IXLPhonetics, IEquatable<XLPhonetics>
         return GetEnumerator();
     }
 
+    public override bool Equals(object? obj) => Equals(obj as XLPhonetics);
+
     public bool Equals(IXLPhonetics? other) => Equals(other as XLPhonetics);
 
     public bool Equals(XLPhonetics? other)
@@ -261,5 +263,13 @@ internal sealed class XLPhonetics : IXLPhonetics, IEquatable<XLPhonetics>
             _font.Key.Equals(other._font.Key) &&
             Type == other.Type &&
             Alignment == other.Alignment;
+    }
+
+    public override int GetHashCode()
+    {
+        // Every component of equality here — the phonetic runs, the font key, Type and Alignment —
+        // is mutable, so a computed hash would go stale the moment the instance is edited. Constant,
+        // as XLRichString is for the same reason. Don't ever use this class as a dictionary key.
+        return 4; // Chosen by fair dice roll. Guaranteed to be random.
     }
 }


### PR DESCRIPTION
Clears the review warning: *Type `XLibur.Excel.RichText.XLPhonetics` should override Equals because it implements `IEquatable<T>`.*

## The defect

`XLPhonetics` implements `IEquatable<XLPhonetics>`, and `IXLPhonetics` is itself `IEquatable<IXLPhonetics>` — so the type carried two typed `Equals` overloads doing real value comparison over the phonetic runs, font key, `Type` and `Alignment`. It never overrode `object.Equals`, and had no `GetHashCode` at all.

Value equality therefore applied only where the static type was known. Everywhere else — an `object`-typed reference, `object.Equals(a, b)`, a non-generic collection — fell through to reference equality, and hashing was identity-based. Two phonetics with identical runs and font compared equal or not depending entirely on how the caller happened to be holding them.

## The fix

Adds the missing pair, following `XLRichString` (`XLRichString.cs:269-289`) rather than inventing a pattern. It is the same shape — sealed internal, `IXLRichString` plus `IEquatable<XLRichString>`, fully mutable — and already solves this exact problem.

```csharp
public override bool Equals(object? obj) => Equals(obj as XLPhonetics);

public override int GetHashCode()
{
    // Every component of equality here — the phonetic runs, the font key, Type and Alignment —
    // is mutable, so a computed hash would go stale the moment the instance is edited. Constant,
    // as XLRichString is for the same reason. Don't ever use this class as a dictionary key.
    return 4; // Chosen by fair dice roll. Guaranteed to be random.
}
```

The constant hash is deliberate, and the reasoning is carried across with it: every field feeding equality is mutable, so a computed hash goes stale on the first edit. Degenerate-but-correct beats a hash that silently loses entries.

## Blast radius

This is a behaviour change, not a suppression, so I checked what depends on the old semantics:

- The only equality call site is `XLFormattedText.cs:354`, which invokes the typed overload directly — unaffected.
- `XLPhonetics` is never used as a dictionary or hash-set key.

Nothing in tree shifts. The type *is* reachable through `IXLFormattedText.Phonetics`, so consumer code hashing one would see the difference — worth a line in the changelog if you consider that surface public enough.

## Scope

`XLPhonetics` was the only concrete type with this defect. I swept the rest: the other 15 `IEquatable<>` hits are interfaces declaring it as a base (no override needed) or the repository bases constraining `where Tkey : struct, IEquatable<Tkey>`.

## Verification

- Build clean — 0 warnings, with `TreatWarningsAsErrors=true`
- 44 rich-text tests pass (`--treenode-filter "/*/*RichText*/*/*"`)