### PR TITLE
docs(ranges): describe what IXLRange.Range(string) actually throws

### DIFF
--- a/XLibur/Excel/Ranges/IXLRange.cs
+++ b/XLibur/Excel/Ranges/IXLRange.cs
@@ -194,7 +194,16 @@ public interface IXLRange : IXLRangeBase
     /// <summary>Returns the specified range.</summary>
     /// <para>e.g. Range("A1"), Range("A1:C2")</para>
     /// <param name="rangeAddress">The range boundaries.</param>
-    /// <exception cref="FormatException"><paramref name="rangeAddress"/> is not a valid address.</exception>
+    /// <remarks>
+    /// An unparseable <paramref name="rangeAddress"/> throws, but the type depends on how the
+    /// parse fails rather than on a single documented contract: <see cref="FormatException"/>
+    /// for a malformed address, <see cref="OverflowException"/> for row or column numbers past
+    /// the sheet limits, <see cref="ArgumentOutOfRangeException"/> for a name that is neither an
+    /// address nor a defined name, and <see cref="IndexOutOfRangeException"/> for an empty
+    /// string. Do not write a caller that catches one of these expecting to have covered the
+    /// rest. Contrast <see cref="Cell(string)"/>, which throws
+    /// <see cref="ArgumentException"/> for every bad input.
+    /// </remarks>
     IXLRange Range(string rangeAddress);
 
     /// <summary>Returns the specified range.</summary>


### PR DESCRIPTION
Follow-up to #360. The `<exception>` tag that PR added to `IXLRange.Range(string)` named `FormatException` as though it were the contract. It isn't.

## What it actually throws

Probing the failure shapes against a real range:

| input | thrown |
|---|---|
| `"not an address"` | `FormatException` |
| `"ZZZZZZ9999999"` | `OverflowException` |
| `"NoSuchDefinedName"` | `ArgumentOutOfRangeException` |
| `""` | `IndexOutOfRangeException` |

A caller who wrote `catch (FormatException)` on the strength of the old doc would have missed the other three. The doc now lists all four and says explicitly not to catch one expecting to have covered the rest.

## Two things deliberately not in the list

**`ArgumentException`**, raised by the guard in `XLRange`'s explicit implementation, is unreachable — every bad input throws during parsing, before the null check is reached. The guard stays as an assertion, which is what its comment already claims it is.

**`Cell(string)`** is unaffected. It really does throw `ArgumentException` for every bad input, so that doc was correct; the contrast is now noted here since the two methods sit next to each other and behave differently.

## Note

`IndexOutOfRangeException` leaking out of a public API for an empty string is an internal detail escaping, and arguably a bug in its own right. This PR only documents current behaviour — changing it would be a behavioural break and belongs in its own change.

Found during code review of #360. The review reported it as a doc/implementation mismatch on `ArgumentException`; the real defect turned out to be that no single type is correct.
