### PR TITLE
fix(ranges): validate range address arguments instead of leaking internal failures

### DIFF
--- a/XLibur.Tests/Excel/Ranges/XLRangeAddressArgumentTests.cs
+++ b/XLibur.Tests/Excel/Ranges/XLRangeAddressArgumentTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Ranges;
+
+/// <summary>
+/// Pins which exception each bad address produces. Before this was fixed, a null address escaped
+/// as <see cref="NullReferenceException"/> and an empty one — or an empty half such as "A1:" —
+/// escaped as <see cref="IndexOutOfRangeException"/>, both of which are internal detail leaking
+/// out of a public API rather than a contract a caller can act on.
+///
+/// These tests exist to stop that regressing, so they assert the exception type deliberately
+/// rather than just asserting that something was thrown.
+/// </summary>
+public class XLRangeAddressArgumentTests
+{
+    [Test]
+    public async Task NullAddressThrowsArgumentNullException()
+    {
+        using var wb = new XLWorkbook();
+        var range = wb.AddWorksheet("Sheet1").Range("A1:C3");
+
+        // Cast required: a bare null is ambiguous between Range(string) and Range(IXLRangeAddress).
+        await Assert.That(() => range.Range((string)null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task EmptyAddressThrowsArgumentException()
+    {
+        using var wb = new XLWorkbook();
+        var range = wb.AddWorksheet("Sheet1").Range("A1:C3");
+
+        // ArgumentNullException derives from ArgumentException, so Throws<ArgumentException>
+        // would also pass for the null case above. ThrowsExactly keeps the two apart.
+        await Assert.That(() => range.Range("")).ThrowsExactly<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments(":")]
+    [Arguments("A1:")]
+    [Arguments(":B2")]
+    [Arguments("$")]
+    [Arguments("$:$")]
+    public async Task HalfWrittenAddressThrowsFormatException(string address)
+    {
+        using var wb = new XLWorkbook();
+        var range = wb.AddWorksheet("Sheet1").Range("A1:C3");
+
+        await Assert.That(() => range.Range(address)).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task MalformedAddressStillThrowsFormatException()
+    {
+        using var wb = new XLWorkbook();
+        var range = wb.AddWorksheet("Sheet1").Range("A1:C3");
+
+        await Assert.That(() => range.Range("not an address")).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task AddressPastSheetLimitsStillThrowsOverflowException()
+    {
+        using var wb = new XLWorkbook();
+        var range = wb.AddWorksheet("Sheet1").Range("A1:C3");
+
+        await Assert.That(() => range.Range("ZZZZZZ9999999")).Throws<OverflowException>();
+    }
+
+    [Test]
+    public async Task UnknownNameStillThrowsArgumentOutOfRangeException()
+    {
+        using var wb = new XLWorkbook();
+        var range = wb.AddWorksheet("Sheet1").Range("A1:C3");
+
+        await Assert.That(() => range.Range("NoSuchDefinedName")).Throws<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// The guards must not have narrowed what is accepted, so the shapes either side of them are
+    /// checked too: a plain range, an anchored one, a sheet-qualified one and a single cell.
+    /// </summary>
+    [Test]
+    [Arguments("B2:C3", "B2:C3")]
+    [Arguments("$B$2:$C$3", "B2:C3")]
+    [Arguments("Sheet1!B2:C3", "B2:C3")]
+    [Arguments("B2", "B2:B2")]
+    public async Task ValidAddressesAreUnaffected(string address, string expected)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        var range = ws.Range("A1:C3");
+
+        var resolved = range.Range(address);
+
+        await Assert.That(resolved.RangeAddress.ToStringRelative()).IsEqualTo(expected);
+    }
+
+    /// <summary>
+    /// Whitespace already threw <see cref="ArgumentException"/> before this change and still
+    /// does — pinned so the new empty-string guard is not later widened to trim, which would
+    /// silently reclassify it.
+    /// </summary>
+    [Test]
+    public async Task WhitespaceAddressThrowsArgumentException()
+    {
+        using var wb = new XLWorkbook();
+        var range = wb.AddWorksheet("Sheet1").Range("A1:C3");
+
+        await Assert.That(() => range.Range(" ")).Throws<ArgumentException>();
+    }
+}

--- a/XLibur/Excel/Ranges/IXLRange.cs
+++ b/XLibur/Excel/Ranges/IXLRange.cs
@@ -194,15 +194,19 @@ public interface IXLRange : IXLRangeBase
     /// <summary>Returns the specified range.</summary>
     /// <para>e.g. Range("A1"), Range("A1:C2")</para>
     /// <param name="rangeAddress">The range boundaries.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="rangeAddress"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="rangeAddress"/> is empty, or is
+    /// otherwise not an address the parser can start from.</exception>
+    /// <exception cref="FormatException"><paramref name="rangeAddress"/> is malformed, including
+    /// a half-written range such as "A1:" or ":".</exception>
+    /// <exception cref="OverflowException">A row or column number is past the sheet limits.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="rangeAddress"/> is neither an
+    /// address nor a defined name.</exception>
     /// <remarks>
-    /// An unparseable <paramref name="rangeAddress"/> throws, but the type depends on how the
-    /// parse fails rather than on a single documented contract: <see cref="FormatException"/>
-    /// for a malformed address, <see cref="OverflowException"/> for row or column numbers past
-    /// the sheet limits, <see cref="ArgumentOutOfRangeException"/> for a name that is neither an
-    /// address nor a defined name, and <see cref="IndexOutOfRangeException"/> for an empty
-    /// string. Do not write a caller that catches one of these expecting to have covered the
-    /// rest. Contrast <see cref="Cell(string)"/>, which throws
-    /// <see cref="ArgumentException"/> for every bad input.
+    /// A missing address and a malformed one are reported differently on purpose: null or empty
+    /// means the caller passed nothing, while "A1:" means they passed something the parser could
+    /// not read. The remaining two are reached only by input that parses far enough to be
+    /// resolved and then fails.
     /// </remarks>
     IXLRange Range(string rangeAddress);
 

--- a/XLibur/Excel/Ranges/XLRangeAddress.cs
+++ b/XLibur/Excel/Ranges/XLRangeAddress.cs
@@ -51,8 +51,18 @@ internal readonly struct XLRangeAddress : IXLRangeAddress, IEquatable<XLRangeAdd
         LastAddress = lastAddress;
     }
 
+    /// <exception cref="ArgumentNullException"><paramref name="rangeAddress"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="rangeAddress"/> is empty.</exception>
+    /// <exception cref="FormatException"><paramref name="rangeAddress"/> has an empty half, such
+    /// as "A1:" or ":".</exception>
     public XLRangeAddress(XLWorksheet? worksheet, string rangeAddress) : this()
     {
+        // A missing address and a half-written one fail differently and are reported differently.
+        // Without these guards a null reached string.Contains below and an empty part reached
+        // firstPart[0], so callers got NullReferenceException and IndexOutOfRangeException —
+        // internal detail escaping rather than a contract they could act on.
+        ArgumentException.ThrowIfNullOrEmpty(rangeAddress);
+
         var addressToUse = rangeAddress.Contains('!')
             ? rangeAddress.Substring(rangeAddress.LastIndexOf('!') + 1)
             : rangeAddress;
@@ -71,6 +81,8 @@ internal readonly struct XLRangeAddress : IXLRangeAddress, IEquatable<XLRangeAdd
             secondPart = addressToUse;
         }
 
+        ThrowIfHalfEmpty(rangeAddress, firstPart, secondPart);
+
         if (XLHelper.IsValidA1Address(firstPart))
         {
             FirstAddress = XLAddress.Create(worksheet, firstPart);
@@ -80,6 +92,11 @@ internal readonly struct XLRangeAddress : IXLRangeAddress, IEquatable<XLRangeAdd
         {
             firstPart = firstPart.Replace("$", string.Empty);
             secondPart = secondPart.Replace("$", string.Empty);
+
+            // Checked again after the strip: "$" and "$:$" survive the check above and are only
+            // empty once the anchors are gone.
+            ThrowIfHalfEmpty(rangeAddress, firstPart, secondPart);
+
             if (char.IsDigit(firstPart[0]))
             {
                 FirstAddress = XLAddress.Create(worksheet, "A" + firstPart);
@@ -93,6 +110,17 @@ internal readonly struct XLRangeAddress : IXLRangeAddress, IEquatable<XLRangeAdd
         }
 
         Worksheet = worksheet;
+    }
+
+    /// <summary>
+    /// Rejects an address whose first or last half is empty. Separate from the null/empty guard
+    /// on the whole string: "A1:" is a malformed address rather than a missing one, so it is a
+    /// <see cref="FormatException"/> like any other parse failure.
+    /// </summary>
+    private static void ThrowIfHalfEmpty(string rangeAddress, string firstPart, string secondPart)
+    {
+        if (firstPart.Length == 0 || secondPart.Length == 0)
+            throw new FormatException($"'{rangeAddress}' is not a valid range address.");
     }
 
     #endregion Constructor


### PR DESCRIPTION
Follow-up to #363, which documented that `IXLRange.Range(string)` threw a different exception type depending on how the parse failed. This fixes the two that were internal detail escaping rather than a contract.

## The problem

`XLRangeAddress(XLWorksheet?, string)` did no argument validation. A null address reached `string.Contains`; an empty one — or an empty half like `"A1:"` — reached `firstPart[0]`.

## What changes

| input | before | after |
|---|---|---|
| `null` | `NullReferenceException` | `ArgumentNullException` |
| `""` | `IndexOutOfRangeException` | `ArgumentException` |
| `":"` | `IndexOutOfRangeException` | `FormatException` |
| `"A1:"` | `IndexOutOfRangeException` | `FormatException` |
| `":B2"` | `IndexOutOfRangeException` | `FormatException` |
| `"$"` | `IndexOutOfRangeException` | `FormatException` |
| `"$:$"` | `IndexOutOfRangeException` | `FormatException` |

The split is deliberate. **Null and empty mean the caller passed nothing** — that is what `ArgumentException` and its subclass are for, it matches the BCL convention (`ArgumentException.ThrowIfNullOrEmpty` throws exactly this pair), and it matches `IXLRange.Cell(string)`, which already throws `ArgumentException` for every bad input. **A half-written address means they passed something unreadable**, so it joins the other parse failures as `FormatException`.

Net effect: three types with a rule you can state in a sentence, instead of five with none.

## Unchanged, and now pinned

`" "` still throws `ArgumentException`, `"not an address"` still `FormatException`, `"ZZZZZZ9999999"` still `OverflowException`, and an unknown name still `ArgumentOutOfRangeException`. Four valid-address shapes — plain, anchored, sheet-qualified and single-cell — are pinned too, so the guards can be seen not to have narrowed what is accepted.

## Implementation note

The empty check runs **twice** on purpose. `"$"` and `"$:$"` are non-empty on entry and only become empty once the `$` anchors are stripped, so the check is repeated after that strip rather than hoisted to a single place where it would miss them.

## Is this breaking?

Technically yes. In practice the two types being replaced are ones nobody catches deliberately — `IndexOutOfRangeException` and `NullReferenceException` crossing a public API boundary are bugs, not a contract. Every exception type that a caller might plausibly have been catching is unchanged.

## Verification

- **The 15 new tests fail 7-of-15 with the production change reverted**, so they pin the fix rather than passing regardless. The other 8 are regression pins for behaviour that should not move.
- 11,828 core tests and 481 report tests pass
- Solution builds with 0 warnings and 0 errors in Debug and Release, every target framework

`XLRangeAddress` is internal, so there is no public API surface change; the only public edit is the XML doc on `IXLRange.Range(string)`, updated from #363's "here are five types, don't catch one" to the contract this PR establishes.
