### PR TITLE
chore(pivot): close the field-item validation TODO as will-not-do

### DIFF
--- a/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -695,7 +695,6 @@ internal static class PivotTableDefinitionPartReader
             Subtotals = subtotals,
         };
 
-        // Add indexes after the reference is initialized, so it can check values by cacheIndex/byPosition.
         foreach (var fieldItem in reference.OfType<FieldItem>())
         {
             var fieldItemValue = fieldItem.Val?.Value ?? throw PartStructureException.MissingAttribute();

--- a/XLibur/Excel/PivotTables/XLPivotReference.cs
+++ b/XLibur/Excel/PivotTables/XLPivotReference.cs
@@ -51,9 +51,15 @@ internal sealed class XLPivotReference
 
     internal HashSet<XLSubtotalFunction> Subtotals { get; init; } = new();
 
+    /// <remarks>
+    /// The value is stored as it is given. It is an index into one of three different collections
+    /// depending on the owning <see cref="XLPivotArea.CacheIndex"/> and on <see cref="ByPosition"/>,
+    /// but nothing here resolves it: the writer emits it verbatim and the area comparer only
+    /// compares it, so an index that points at nothing costs nothing to hold. Validating it would
+    /// mean refusing to load a file Excel opens, in exchange for no behaviour XLibur could improve.
+    /// </remarks>
     internal void AddFieldItem(uint fieldItem)
     {
-        // TODO: Check value by area.CacheIndex and ByPosition
         _fieldItems.Add(fieldItem);
     }
 }

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -114,7 +114,7 @@ its own period runs from this release.
 | #5 | 3 | Perf — register data-table formulas in the dependency tree | **Closed, will not do** — see below |
 | #6 | 1 | Perf — cache parsed reference addresses | **Merged** — [#286](https://github.com/XLibur/XLibur/pull/286) |
 | #7 | 12 | Cleanup — `CacheId` nullability | **Merged** — [#287](https://github.com/XLibur/XLibur/pull/287) |
-| #8 | 17 | Hardening — validate pivot field item values | Not started |
+| #8 | 17 | Hardening — validate pivot field item values | **Closed, will not do** — see below |
 | #9 | — | Decision — dispose of the orphan `IXLBaseCollection` interface | **Merged** — [#296](https://github.com/XLibur/XLibur/pull/296) |
 | #10 | 5, 8, 9, 13–16, 18–27 | Decision — removal release for 17 obsolete members | Decided — groups 1–3 removed in the next minor `v0.x`; removal not yet done |
 | #11 | — | Typo — `"Used"` → `"Use"` | **Merged** — [#292](https://github.com/XLibur/XLibur/pull/292) |
@@ -235,6 +235,40 @@ invalidating. The only gain is dropping the full-workbook `Recalculate` that
 **Decision (owner): closed, will not do.** Revisit only if that recalculation shows up as a real
 performance problem. The comment in `DependencyTree` now records why data tables are skipped.
 
+### Task #8 — closed, will not do
+
+The TODO was `// TODO: Check value by area.CacheIndex and ByPosition` on
+`XLPivotReference.AddFieldItem`. The triage called it hardening and flagged that it "risks
+rejecting files Excel accepts". Looked at properly, there is less here than that:
+
+- **It is not implementable as written.** `CacheIndex` lives on `XLPivotArea`, and
+  `XLPivotReference` holds no back-reference to its area. The loader builds the area first and
+  then calls `AddReference(LoadPivotReference(reference))`
+  (`PivotTableDefinitionPartReader.cs:674`); `LoadPivotReference` is `static` and takes only the
+  OpenXML element, so it has no area, no pivot table and no cache — which is where the bounds
+  would have to come from.
+- **Nothing dereferences the value.** The only consumers of `FieldItems` are
+  `PivotTableDefinitionPartWriter2` (emits `<x v="..."/>` verbatim) and `XLPivotAreaComparer`
+  (equality and hash). An out-of-range index causes no crash and no misbehaviour; it round-trips
+  faithfully and Excel decides what to make of it.
+- **Neither caller can supply a bad value.** The load path takes whatever the file says. The API
+  path (`XLPivotValueStyleFormat.GetCurrentArea`) feeds indexes XLibur derived itself from
+  `pivotField.GetAllItems(...)` and `DataFields.IndexOf(...)`, in range by construction, and
+  `ForValueField` already range-checks its own argument. That path also builds
+  `new XLPivotArea()`, so `CacheIndex` and `ByPosition` — the two discriminators the TODO names —
+  are both constant `false` there.
+
+So the change would convert "load the file" into "throw on load" and buy no behaviour XLibur
+could improve. For a reader, faithful round-tripping beats rejection.
+
+**Decision (owner): closed, will not do.** Revisit only if something starts resolving these
+indexes rather than passing them through. `AddFieldItem` now records why it stores the value
+unchecked.
+
+Corrected while closing this: `PivotTableDefinitionPartReader.cs:698` carried the comment
+*"Add indexes after the reference is initialized, so it can check values by
+cacheIndex/byPosition"*, describing a check that has never existed. Removed.
+
 ### Open bug found while investigating #5
 
 `DataTableFormulaFormat` (`XLCellFormula.cs:34`) is `"{{TABLE({0},{1}}}"`, which produces
@@ -254,8 +288,6 @@ depends on the current value.
   the test files that still call `NamedRange`/`NamedRanges`.
 - **#3** — the largest job left. `CT_PivotFilter` carries a required full `autoFilter` subtree,
   so it needs real OpenXML modelling rather than another pass of the `formats` pattern.
-- **#8** — smallest, but needs pivot-table/cache context threaded into a static loader to
-  validate input, and risks rejecting files Excel accepts. Worth weighing before doing.
 - **The `DataTableFormulaFormat` bug** above, if the intended display text can be settled.
 
-Tasks #1, #2, #4, #6, #7, #9 and #11 are done; #5 is closed as will-not-do.
+Tasks #1, #2, #4, #6, #7, #9 and #11 are done; #5 and #8 are closed as will-not-do.


### PR DESCRIPTION
## Summary

Closes TODO triage task **#8** — "Hardening: validate pivot field item values" — as will-not-do, and removes the TODO it came from.

The TODO was `// TODO: Check value by area.CacheIndex and ByPosition` on `XLPivotReference.AddFieldItem`, inherited from ClosedXML `e2fc8cfa` (Jan 2024). The triage in `docs/todos.md` already flagged that it "risks rejecting files Excel accepts". Looking at it properly, there is less here than that:

**It is not implementable as written.** `CacheIndex` lives on `XLPivotArea`, and `XLPivotReference` holds no back-reference to its area. The loader builds the area first and then calls `AddReference(LoadPivotReference(reference))` (`PivotTableDefinitionPartReader.cs:674`); `LoadPivotReference` is `static` and takes only the OpenXML element, so it has no area, no pivot table and no cache — which is where the bounds would have to come from.

**Nothing dereferences the value.** The only consumers of `FieldItems` are `PivotTableDefinitionPartWriter2` (emits `<x v="..."/>` verbatim) and `XLPivotAreaComparer` (equality and hash). An out-of-range index causes no crash and no misbehaviour; it round-trips faithfully and Excel decides what to make of it.

**Neither caller can supply a bad value.** The load path takes whatever the file says. The API path (`XLPivotValueStyleFormat.GetCurrentArea`) feeds indexes XLibur derived itself from `pivotField.GetAllItems(...)` and `DataFields.IndexOf(...)`, in range by construction, and `ForValueField` already range-checks its own argument. That path also builds `new XLPivotArea()`, so `CacheIndex` and `ByPosition` — the two discriminators the TODO names — are both constant `false` there.

So the change would convert "load the file" into "throw on load" and buy no behaviour XLibur could improve. For a reader, faithful round-tripping beats rejection.

## Changes

- **`XLPivotReference.AddFieldItem`** — TODO removed, replaced by a `<remarks>` recording why the value is stored unchecked, so the question does not get reopened from scratch.
- **`PivotTableDefinitionPartReader.cs:698`** — removed a comment that justified the loop ordering by a check that has never existed (*"Add indexes after the reference is initialized, so it can check values by cacheIndex/byPosition"*). The ordering is unchanged; only the false claim about it is gone.
- **`docs/todos.md`** — task #8 marked closed with the reasoning, following the same shape as the task #5 closure. Removed from "Still to do".

No behaviour change.

## Related Issues

Task #8 in `docs/todos.md`, from the TODO triage started in #285.

## Testing

- [ ] Added or updated unit tests
- [x] All existing tests pass
- [ ] Tested manually

No tests added: comments and a doc, with no behaviour to cover. Full suite green — 11,827 passed, 0 failed, 4 skipped.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced
- [x] PR targets the `main` branch
