### PR TITLE
perf(io): add template round-trip benchmarks and cut fixed open/save overhead

### DIFF
--- a/XLibur.Benchmarks/CellStylingBenchmarks.cs
+++ b/XLibur.Benchmarks/CellStylingBenchmarks.cs
@@ -1,0 +1,148 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using XLibur.Excel;
+using XLibur.Fonts.SixLabors.V1;
+
+namespace XLibur.Benchmarks;
+
+/// <summary>
+/// The cost of styling cells one at a time, split by call shape, against the same writes unstyled.
+///
+/// Run with:
+/// dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- --filter '*CellStyling*'
+/// </summary>
+/// <remarks>
+/// Spec 18 task 2. <c>profile template</c> puts per-cell number formatting at ~2.3x the allocation of
+/// formatting the column once, and the repo's own <c>profile alloc</c> shows the formatted 50K-row
+/// create allocating 183 MB against 25 MB unformatted. Neither says *what* is being allocated, and
+/// the answer decides the fix.
+/// <para>
+/// The variants exist to separate three candidates that a single number cannot:
+/// </para>
+/// <list type="bullet">
+/// <item><see cref="ValueOnly"/> is the floor — cell lookup plus the value-slice write.</item>
+/// <item><see cref="StyleFacadePerCell"/> is the natural shape, and pays for the
+/// <c>XLStyle</c>/<c>XLNumberFormat</c> façade chain on each cell.</item>
+/// <item><see cref="StyleAssignedPerCell"/> writes the same style through a pre-built
+/// <see cref="IXLStyle"/>, so it pays the style-slice write without building any façade. The gap to
+/// <see cref="StyleFacadePerCell"/> is what the façades cost.</item>
+/// <item><see cref="TwoPropertiesPerCell"/> sets two properties on one cell. If the façade cost is
+/// per-cell it barely moves from <see cref="StyleFacadePerCell"/>; if it is per-property it roughly
+/// doubles.</item>
+/// <item><see cref="StyleOnColumn"/> is the fast path callers are told to use, for scale.</item>
+/// </list>
+/// </remarks>
+[MemoryDiagnoser]
+public class CellStylingBenchmarks
+{
+    private const int Rows = 20_000;
+    private const string DateFormat = "mmm/yyyy";
+
+    private XLWorkbook _workbook = null!;
+    private IXLWorksheet _worksheet = null!;
+    private IXLStyle _preBuiltStyle = null!;
+    private DateTime[] _dates = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        SixLaborsV1FontBootstrap.Register();
+
+        _dates = new DateTime[Rows];
+        var start = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Unspecified);
+        for (var i = 0; i < Rows; i++)
+            _dates[i] = start.AddMonths(i % 24);
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        _workbook = new XLWorkbook();
+        _worksheet = _workbook.AddWorksheet("Data");
+
+        // Built once, off the measured path: a style carrying the number format under test.
+        var donor = _workbook.AddWorksheet("Donor").Cell(1, 1);
+        donor.Style.NumberFormat.Format = DateFormat;
+        _preBuiltStyle = donor.Style;
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup() => _workbook.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public void ValueOnly()
+    {
+        for (var r = 0; r < Rows; r++)
+            _worksheet.Cell(r + 1, 1).Value = _dates[r];
+    }
+
+    [Benchmark]
+    public void StyleFacadePerCell()
+    {
+        for (var r = 0; r < Rows; r++)
+        {
+            var cell = _worksheet.Cell(r + 1, 1);
+            cell.Value = _dates[r];
+            cell.Style.NumberFormat.Format = DateFormat;
+        }
+    }
+
+    [Benchmark]
+    public void StyleAssignedPerCell()
+    {
+        for (var r = 0; r < Rows; r++)
+        {
+            var cell = _worksheet.Cell(r + 1, 1);
+            cell.Value = _dates[r];
+            cell.Style = _preBuiltStyle;
+        }
+    }
+
+    [Benchmark]
+    public void TwoPropertiesPerCell()
+    {
+        for (var r = 0; r < Rows; r++)
+        {
+            var cell = _worksheet.Cell(r + 1, 1);
+            cell.Value = _dates[r];
+            cell.Style.NumberFormat.Format = DateFormat;
+            cell.Style.Font.Bold = true;
+        }
+    }
+
+    /// <summary>Builds the <c>XLStyle</c> façade per cell and nothing else.</summary>
+    [Benchmark]
+    public void FacadeStyleOnly()
+    {
+        for (var r = 0; r < Rows; r++)
+        {
+            var cell = _worksheet.Cell(r + 1, 1);
+            cell.Value = _dates[r];
+            GC.KeepAlive(cell.Style);
+        }
+    }
+
+    /// <summary>
+    /// Builds the whole façade chain per cell, but sets nothing. The gap to
+    /// <see cref="FacadeStyleOnly"/> is the <c>XLNumberFormat</c> façade; the gap from here to
+    /// <see cref="StyleFacadePerCell"/> is the setter and the style write it triggers.
+    /// </summary>
+    [Benchmark]
+    public void FacadeChainOnly()
+    {
+        for (var r = 0; r < Rows; r++)
+        {
+            var cell = _worksheet.Cell(r + 1, 1);
+            cell.Value = _dates[r];
+            GC.KeepAlive(cell.Style.NumberFormat);
+        }
+    }
+
+    [Benchmark]
+    public void StyleOnColumn()
+    {
+        _worksheet.Column(1).Style.NumberFormat.Format = DateFormat;
+        for (var r = 0; r < Rows; r++)
+            _worksheet.Cell(r + 1, 1).Value = _dates[r];
+    }
+}

--- a/XLibur.Benchmarks/CellStylingBenchmarks.cs
+++ b/XLibur.Benchmarks/CellStylingBenchmarks.cs
@@ -35,7 +35,18 @@ namespace XLibur.Benchmarks;
 [MemoryDiagnoser]
 public class CellStylingBenchmarks
 {
-    private const int Rows = 20_000;
+    /// <summary>
+    /// Sized so a measured iteration runs long enough to swamp the per-iteration noise floor.
+    /// </summary>
+    /// <remarks>
+    /// At 20,000 rows the cheapest variant measured ~2.7 ms against BenchmarkDotNet's recommended
+    /// 100 ms, and the baseline's own samples scattered across 2.7–6.1 ms — wide enough to move
+    /// every <c>Ratio</c> in the table by more than the effects being chased. A re-run of the
+    /// spec-18 task 2 A/B disagreed with itself in opposite directions on two benchmarks because
+    /// of it.
+    /// </remarks>
+    private const int Rows = 100_000;
+
     private const string DateFormat = "mmm/yyyy";
 
     private XLWorkbook _workbook = null!;
@@ -66,8 +77,25 @@ public class CellStylingBenchmarks
         _preBuiltStyle = donor.Style;
     }
 
+    /// <summary>
+    /// Disposes the workbook and collects it here, outside the measured region.
+    /// </summary>
+    /// <remarks>
+    /// Each iteration builds a fresh workbook holding <see cref="Rows"/> cells, so without this the
+    /// previous iteration's garbage is reclaimed part-way through the next iteration's measurement
+    /// and lands on whichever variant happens to be running. That showed up as gen2 collections and
+    /// a scatter of high outliers on the cheapest benchmarks, which are exactly the ones used as the
+    /// ratio baseline.
+    /// </remarks>
     [IterationCleanup]
-    public void IterationCleanup() => _workbook.Dispose();
+    public void IterationCleanup()
+    {
+        _workbook.Dispose();
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+    }
 
     [Benchmark(Baseline = true)]
     public void ValueOnly()

--- a/XLibur.Benchmarks/Program.cs
+++ b/XLibur.Benchmarks/Program.cs
@@ -17,6 +17,8 @@ if (args.Length > 0 && args[0].Equals("profile", StringComparison.OrdinalIgnoreC
     //               model, optionally taking a row count
     //   structural  the cost of repeated row inserts split into its range-shift and
     //               formula-shift halves
+    //   template    the open->edit->save round trip of an existing workbook, split into parse
+    //               and serialise; optionally takes a path to a real .xlsx template
     // Every other mode attaches dotMemory and targets the load path.
     if (args.Length > 1 && args[1].Equals("alloc", StringComparison.OrdinalIgnoreCase))
         SaveAllocationProfile.Run();
@@ -26,6 +28,8 @@ if (args.Length > 0 && args[0].Equals("profile", StringComparison.OrdinalIgnoreC
         StreamingMemoryProfile.Run(args);
     else if (args.Length > 1 && args[1].Equals("structural", StringComparison.OrdinalIgnoreCase))
         StructuralEditProfile.Run();
+    else if (args.Length > 1 && args[1].Equals("template", StringComparison.OrdinalIgnoreCase))
+        TemplateRoundTripProfile.Run(args);
     else if (args.Length > 1 && args[1].Equals("shiftercorpus", StringComparison.OrdinalIgnoreCase))
         ShifterCorpusDump.Run();
     else

--- a/XLibur.Benchmarks/SheetGeometryBenchmarks.cs
+++ b/XLibur.Benchmarks/SheetGeometryBenchmarks.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using XLibur.Excel;
+using XLibur.Fonts.SixLabors.V1;
+
+namespace XLibur.Benchmarks;
+
+/// <summary>
+/// The same number of string cells written and saved in two shapes — one tall narrow column versus
+/// a short wide block — crossed with whether the strings repeat.
+///
+/// Run with:
+/// dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- --filter '*SheetGeometry*'
+/// </summary>
+/// <remarks>
+/// Spec 18 task 3. Refreshing a 10,000-value lookup column costs ~5.4 µs per cell where the wide
+/// grid path runs ~1.3 µs per cell, and the finding was recorded with two candidate causes and no
+/// evidence for either: shared-string pressure, because the lookup values are all distinct; or the
+/// sheet's geometry, because a single column pays whatever a row costs once per cell instead of
+/// once per twenty.
+/// <para>
+/// The two are crossed deliberately. Comparing only tall-versus-wide would confound geometry with
+/// string reuse, and comparing only unique-versus-repeated would confound it the other way; the
+/// 2×2 separates them. Cell count is held constant across all four, so a difference is a
+/// difference in cost *per cell*.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class SheetGeometryBenchmarks
+{
+    private const int Cells = 20_000;
+    private const int WideColumns = 20;
+
+    /// <summary>Distinct values in the repeated variants — enough to be a realistic lookup, few enough to share.</summary>
+    private const int RepeatedDistinctValues = 10;
+
+    private string[] _unique = null!;
+    private string[] _repeated = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        SixLaborsV1FontBootstrap.Register();
+
+        _unique = new string[Cells];
+        for (var i = 0; i < Cells; i++)
+            _unique[i] = $"Lookup value {i}";
+
+        _repeated = new string[Cells];
+        for (var i = 0; i < Cells; i++)
+            _repeated[i] = $"Lookup value {i % RepeatedDistinctValues}";
+    }
+
+    [Benchmark(Baseline = true)]
+    public void TallNarrow_Unique() => WriteAndSave(_unique, columns: 1);
+
+    [Benchmark]
+    public void TallNarrow_Repeated() => WriteAndSave(_repeated, columns: 1);
+
+    [Benchmark]
+    public void ShortWide_Unique() => WriteAndSave(_unique, WideColumns);
+
+    [Benchmark]
+    public void ShortWide_Repeated() => WriteAndSave(_repeated, WideColumns);
+
+    /// <summary>
+    /// The same writes with no save, to split the geometry penalty between the in-memory row
+    /// storage and the serialiser. A cost that survives here is the slice layout; one that only
+    /// appears in the saving variants is the <c>&lt;row&gt;</c> element per row.
+    /// </summary>
+    [Benchmark]
+    public void TallNarrow_Unique_WriteOnly() => Write(_unique, columns: 1);
+
+    [Benchmark]
+    public void ShortWide_Unique_WriteOnly() => Write(_unique, WideColumns);
+
+    private static void Write(string[] values, int columns)
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Data");
+
+        for (var i = 0; i < values.Length; i++)
+            sheet.Cell(i / columns + 1, i % columns + 1).Value = values[i];
+    }
+
+    private static void WriteAndSave(string[] values, int columns)
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Data");
+
+        for (var i = 0; i < values.Length; i++)
+            sheet.Cell(i / columns + 1, i % columns + 1).Value = values[i];
+
+        using var output = new MemoryStream();
+        workbook.SaveAs(output);
+    }
+}

--- a/XLibur.Benchmarks/TemplateFixture.cs
+++ b/XLibur.Benchmarks/TemplateFixture.cs
@@ -38,6 +38,18 @@ internal static class TemplateFixture
     /// </summary>
     public static byte[] Build(int sheetCount, int definedNames, int validations, int dataRows)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(sheetCount, 1);
+
+        // Every defined name spans a lookup column, and every validation points at the first
+        // defined name, so neither can be built without at least one lookup sheet. Rejecting the
+        // combination keeps a probe from quietly measuring a fixture that is not what it asked for.
+        if (sheetCount == 1 && (definedNames > 0 || validations > 0))
+        {
+            throw new ArgumentException(
+                "A single-sheet fixture has no lookup sheet to point at, so it cannot carry defined names or validations.",
+                nameof(sheetCount));
+        }
+
         using var workbook = new XLWorkbook();
 
         var data = workbook.AddWorksheet(DataSheet);
@@ -50,7 +62,10 @@ internal static class TemplateFixture
         if (dataRows > 0)
             WriteGrid(data, dataRows, GridColumns, perCellNumberFormat: true);
 
-        var lookupSheets = Math.Max(1, sheetCount - 1);
+        // The data sheet is one of the requested sheets, so the rest are lookups. sheetCount: 1 is
+        // the data sheet alone; anything else made the workbook one sheet wider than asked for,
+        // which mattered because the per-sheet cost is read off the slope between these counts.
+        var lookupSheets = sheetCount - 1;
         for (var s = 1; s <= lookupSheets; s++)
         {
             var lookup = workbook.AddWorksheet($"{LookupSheetPrefix}{s}");
@@ -60,14 +75,17 @@ internal static class TemplateFixture
                 lookup.Cell(HeaderRow + r, 1).Value = $"Sheet {s} value {r}";
         }
 
-        // The first defined name is the one the refresh probe repoints.
-        var firstLookup = workbook.Worksheet(FirstLookupSheet);
-        workbook.DefinedNames.Add(LookupRangeName, firstLookup.Range(HeaderRow + 1, 1, HeaderRow + LookupRows, 1));
-
-        for (var n = 1; n < definedNames; n++)
+        if (lookupSheets > 0)
         {
-            var sheet = workbook.Worksheet($"{LookupSheetPrefix}{(n % lookupSheets) + 1}");
-            workbook.DefinedNames.Add($"Name{n}", sheet.Range(HeaderRow + 1, 1, HeaderRow + LookupRows, 1));
+            // The first defined name is the one the refresh probe repoints.
+            var firstLookup = workbook.Worksheet(FirstLookupSheet);
+            workbook.DefinedNames.Add(LookupRangeName, firstLookup.Range(HeaderRow + 1, 1, HeaderRow + LookupRows, 1));
+
+            for (var n = 1; n < definedNames; n++)
+            {
+                var sheet = workbook.Worksheet($"{LookupSheetPrefix}{(n % lookupSheets) + 1}");
+                workbook.DefinedNames.Add($"Name{n}", sheet.Range(HeaderRow + 1, 1, HeaderRow + LookupRows, 1));
+            }
         }
 
         for (var v = 0; v < validations; v++)

--- a/XLibur.Benchmarks/TemplateFixture.cs
+++ b/XLibur.Benchmarks/TemplateFixture.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using XLibur.Excel;
+
+namespace XLibur.Benchmarks;
+
+/// <summary>
+/// Builds the synthetic reporting template the round-trip benchmarks and probes measure against,
+/// and the cell-writing routines that fill it.
+/// </summary>
+/// <remarks>
+/// A generated fixture is a poor stand-in for a genuine reporting workbook: shared strings,
+/// styles, tables, spilled dynamic-array formulas, conditional formatting, images and external
+/// links all live in a real template and none are reproduced here. Measured side by side against
+/// the template that motivated this work, the generated fixture round-tripped roughly an order of
+/// magnitude faster, so conclusions drawn from it alone understate real-world cost. It is used
+/// because it is reproducible and checked in; point <see cref="TemplateRoundTripProfile"/> at a
+/// real file when reproducing a production number matters.
+/// </remarks>
+internal static class TemplateFixture
+{
+    public const string DataSheet = "Data";
+    public const string LookupSheetPrefix = "Lookup";
+    public const string FirstLookupSheet = LookupSheetPrefix + "1";
+    public const string LookupRangeName = "LookupRange";
+    public const int HeaderRow = 1;
+    public const int FirstDataRow = 3;
+    public const int GridColumns = 21;
+    public const string DateFormat = "mmm/yyyy";
+
+    /// <summary>Rows per lookup sheet, enough that a defined name spans a realistic range.</summary>
+    private const int LookupRows = 100;
+
+    /// <summary>
+    /// Builds a workbook approximating a real reporting template: one data sheet plus a number of
+    /// lookup sheets, workbook-scoped defined names over the lookup columns, and list data
+    /// validations on the data sheet pointing at those names.
+    /// </summary>
+    public static byte[] Build(int sheetCount, int definedNames, int validations, int dataRows)
+    {
+        using var workbook = new XLWorkbook();
+
+        var data = workbook.AddWorksheet(DataSheet);
+        for (var c = 1; c <= GridColumns; c++)
+        {
+            data.Cell(HeaderRow, c).Value = $"Column{c}";
+            data.Cell(HeaderRow, c).Style.Font.Bold = true;
+        }
+
+        if (dataRows > 0)
+            WriteGrid(data, dataRows, GridColumns, perCellNumberFormat: true);
+
+        var lookupSheets = Math.Max(1, sheetCount - 1);
+        for (var s = 1; s <= lookupSheets; s++)
+        {
+            var lookup = workbook.AddWorksheet($"{LookupSheetPrefix}{s}");
+            lookup.Cell(HeaderRow, 1).Value = "Value";
+
+            for (var r = 1; r <= LookupRows; r++)
+                lookup.Cell(HeaderRow + r, 1).Value = $"Sheet {s} value {r}";
+        }
+
+        // The first defined name is the one the refresh probe repoints.
+        var firstLookup = workbook.Worksheet(FirstLookupSheet);
+        workbook.DefinedNames.Add(LookupRangeName, firstLookup.Range(HeaderRow + 1, 1, HeaderRow + LookupRows, 1));
+
+        for (var n = 1; n < definedNames; n++)
+        {
+            var sheet = workbook.Worksheet($"{LookupSheetPrefix}{(n % lookupSheets) + 1}");
+            workbook.DefinedNames.Add($"Name{n}", sheet.Range(HeaderRow + 1, 1, HeaderRow + LookupRows, 1));
+        }
+
+        for (var v = 0; v < validations; v++)
+        {
+            var column = (v % GridColumns) + 1;
+            var validation = data.Range(FirstDataRow, column, 1_000, column).CreateDataValidation();
+            validation.List($"={LookupRangeName}", true);
+        }
+
+        using var buffer = new MemoryStream();
+        workbook.SaveAs(buffer);
+        return buffer.ToArray();
+    }
+
+    /// <summary>Writes a wide grid of mixed cell types, the shape of a data export.</summary>
+    public static void WriteGrid(IXLWorksheet sheet, int rows, int columns, bool perCellNumberFormat)
+    {
+        var date = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
+        for (var r = 0; r < rows; r++)
+        {
+            var rowIndex = FirstDataRow + r;
+
+            for (var c = 1; c <= columns; c++)
+            {
+                var cell = sheet.Cell(rowIndex, c);
+
+                switch (c % 4)
+                {
+                    case 0:
+                        cell.Value = date.AddMonths(r % 24);
+                        if (perCellNumberFormat)
+                            cell.Style.NumberFormat.Format = DateFormat;
+                        break;
+                    case 1:
+                        cell.Value = $"Row {r} column {c} descriptive text";
+                        break;
+                    case 2:
+                        cell.Value = (r * c) % 100_000;
+                        break;
+                    default:
+                        cell.Value = r % 2 == 0 ? "Yes" : "No";
+                        break;
+                }
+            }
+        }
+    }
+
+    public static void WriteDateColumn(IXLWorksheet sheet, int rows, int column, bool perCellFormat)
+    {
+        var date = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
+        for (var r = 0; r < rows; r++)
+        {
+            var cell = sheet.Cell(FirstDataRow + r, column);
+            cell.Value = date.AddMonths(r % 24);
+
+            if (perCellFormat)
+                cell.Style.NumberFormat.Format = DateFormat;
+        }
+    }
+}

--- a/XLibur.Benchmarks/TemplateFixture.cs
+++ b/XLibur.Benchmarks/TemplateFixture.cs
@@ -28,25 +28,41 @@ internal static class TemplateFixture
     public const int GridColumns = 21;
     public const string DateFormat = "mmm/yyyy";
 
-    /// <summary>Rows per lookup sheet, enough that a defined name spans a realistic range.</summary>
-    private const int LookupRows = 100;
+    /// <summary>
+    /// Default rows per lookup sheet, enough that a defined name spans a realistic range.
+    /// </summary>
+    public const int DefaultLookupRows = 100;
 
     /// <summary>
     /// Builds a workbook approximating a real reporting template: one data sheet plus a number of
     /// lookup sheets, workbook-scoped defined names over the lookup columns, and list data
     /// validations on the data sheet pointing at those names.
     /// </summary>
-    public static byte[] Build(int sheetCount, int definedNames, int validations, int dataRows)
+    /// <param name="lookupRows">
+    /// Rows on each lookup sheet. Zero builds sheets that hold nothing but a header, which is what
+    /// isolates the structural cost of a worksheet from the cost of the rows on it — the two were
+    /// confounded while this was a constant, and the per-sheet slope was reported as a cost per
+    /// *empty* sheet when every sheet in it carried 101 rows.
+    /// </param>
+    public static byte[] Build(
+        int sheetCount,
+        int definedNames,
+        int validations,
+        int dataRows,
+        int lookupRows = DefaultLookupRows)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(sheetCount, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(lookupRows);
+
+        var lookupSheets = sheetCount - 1;
 
         // Every defined name spans a lookup column, and every validation points at the first
-        // defined name, so neither can be built without at least one lookup sheet. Rejecting the
+        // defined name, so neither can be built without a lookup sheet that has rows. Rejecting the
         // combination keeps a probe from quietly measuring a fixture that is not what it asked for.
-        if (sheetCount == 1 && (definedNames > 0 || validations > 0))
+        if ((lookupSheets == 0 || lookupRows == 0) && (definedNames > 0 || validations > 0))
         {
             throw new ArgumentException(
-                "A single-sheet fixture has no lookup sheet to point at, so it cannot carry defined names or validations.",
+                "Defined names and validations span a lookup range, so they need at least one lookup sheet with at least one row.",
                 nameof(sheetCount));
         }
 
@@ -65,26 +81,25 @@ internal static class TemplateFixture
         // The data sheet is one of the requested sheets, so the rest are lookups. sheetCount: 1 is
         // the data sheet alone; anything else made the workbook one sheet wider than asked for,
         // which mattered because the per-sheet cost is read off the slope between these counts.
-        var lookupSheets = sheetCount - 1;
         for (var s = 1; s <= lookupSheets; s++)
         {
             var lookup = workbook.AddWorksheet($"{LookupSheetPrefix}{s}");
             lookup.Cell(HeaderRow, 1).Value = "Value";
 
-            for (var r = 1; r <= LookupRows; r++)
+            for (var r = 1; r <= lookupRows; r++)
                 lookup.Cell(HeaderRow + r, 1).Value = $"Sheet {s} value {r}";
         }
 
-        if (lookupSheets > 0)
+        if (lookupSheets > 0 && lookupRows > 0)
         {
             // The first defined name is the one the refresh probe repoints.
             var firstLookup = workbook.Worksheet(FirstLookupSheet);
-            workbook.DefinedNames.Add(LookupRangeName, firstLookup.Range(HeaderRow + 1, 1, HeaderRow + LookupRows, 1));
+            workbook.DefinedNames.Add(LookupRangeName, firstLookup.Range(HeaderRow + 1, 1, HeaderRow + lookupRows, 1));
 
             for (var n = 1; n < definedNames; n++)
             {
                 var sheet = workbook.Worksheet($"{LookupSheetPrefix}{(n % lookupSheets) + 1}");
-                workbook.DefinedNames.Add($"Name{n}", sheet.Range(HeaderRow + 1, 1, HeaderRow + LookupRows, 1));
+                workbook.DefinedNames.Add($"Name{n}", sheet.Range(HeaderRow + 1, 1, HeaderRow + lookupRows, 1));
             }
         }
 

--- a/XLibur.Benchmarks/TemplateRoundTripBenchmarks.cs
+++ b/XLibur.Benchmarks/TemplateRoundTripBenchmarks.cs
@@ -47,7 +47,10 @@ public class TemplateRoundTripBenchmarks
     {
         SixLaborsV1FontBootstrap.Register();
         _template = TemplateFixture.Build(SheetCount, DefinedNames, Validations, dataRows: 0);
-        _rowHeavy = TemplateFixture.Build(sheetCount: 1, definedNames: 1, validations: 0, dataRows: HeavyRows);
+        // Two sheets: the data sheet under measurement plus the one lookup sheet the defined name
+        // spans. This asked for one sheet until the fixture's sheet count was corrected, and got
+        // two anyway, so the shape here is unchanged and the recorded baselines stay comparable.
+        _rowHeavy = TemplateFixture.Build(sheetCount: 2, definedNames: 1, validations: 0, dataRows: HeavyRows);
         _lookupValues = Enumerable.Range(1, LookupValues).Select(i => $"Lookup value {i}").ToArray();
     }
 

--- a/XLibur.Benchmarks/TemplateRoundTripBenchmarks.cs
+++ b/XLibur.Benchmarks/TemplateRoundTripBenchmarks.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using XLibur.Excel;
+using XLibur.Fonts.SixLabors.V1;
+
+namespace XLibur.Benchmarks;
+
+/// <summary>
+/// The fixed cost of touching an existing workbook: open a structurally realistic template,
+/// change little or nothing, save it again.
+/// </summary>
+/// <remarks>
+/// This is the statistically trustworthy counterpart to <see cref="TemplateRoundTripProfile"/>.
+/// The profile decomposes the round trip into many stages quickly, which is what makes it useful
+/// while iterating, but its fastest-of-N timings move by tens of percent between runs of
+/// identical code on a loaded machine — the same order as the effects worth chasing. Use the
+/// profile to find where the time goes and these benchmarks to claim that it moved.
+/// <para>
+/// The workload is deliberately small. Every benchmark here is dominated by cost that scales with
+/// the workbook's structure rather than its data, which is the cost a request-per-export service
+/// pays on every single request no matter how little it writes.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class TemplateRoundTripBenchmarks
+{
+    private const int SheetCount = 10;
+    private const int DefinedNames = 20;
+    private const int Validations = 26;
+    private const int LookupValues = 1_000;
+
+    private byte[] _template = null!;
+    private string[] _lookupValues = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        SixLaborsV1FontBootstrap.Register();
+        _template = TemplateFixture.Build(SheetCount, DefinedNames, Validations, dataRows: 0);
+        _lookupValues = Enumerable.Range(1, LookupValues).Select(i => $"Lookup value {i}").ToArray();
+    }
+
+    /// <summary>Parse only — the floor cost of reading the template.</summary>
+    [Benchmark]
+    public int Open()
+    {
+        using var input = new MemoryStream(_template, writable: false);
+        using var workbook = new XLWorkbook(input);
+        return workbook.Worksheets.Count;
+    }
+
+    /// <summary>
+    /// Parse and re-serialise with no modification at all. Everything this costs is overhead:
+    /// the caller has changed nothing.
+    /// </summary>
+    [Benchmark]
+    public void OpenAndSaveUnchanged()
+    {
+        using var input = new MemoryStream(_template, writable: false);
+        using var workbook = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        workbook.SaveAs(output);
+    }
+
+    /// <summary>
+    /// The realistic unit of work: refresh one lookup column and repoint the defined name over
+    /// it. The edit itself is trivial, so the gap to <see cref="OpenAndSaveUnchanged"/> is what
+    /// the actual work costs and everything below it is the round-trip floor.
+    /// </summary>
+    [Benchmark]
+    public void RefreshLookupColumn()
+    {
+        using var input = new MemoryStream(_template, writable: false);
+        using var workbook = new XLWorkbook(input);
+        var sheet = workbook.Worksheet(TemplateFixture.FirstLookupSheet);
+
+        var lastRow = sheet.LastRowUsed()?.RowNumber() ?? TemplateFixture.HeaderRow;
+        if (lastRow > TemplateFixture.HeaderRow)
+            sheet.Range(TemplateFixture.HeaderRow + 1, 1, lastRow, 1).Clear(XLClearOptions.Contents);
+
+        for (var i = 0; i < _lookupValues.Length; i++)
+            sheet.Cell(TemplateFixture.HeaderRow + 1 + i, 1).Value = _lookupValues[i];
+
+        if (workbook.DefinedNames.TryGetValue(TemplateFixture.LookupRangeName, out var definedName))
+        {
+            definedName.SetRefersTo(
+                sheet.Range(TemplateFixture.HeaderRow + 1, 1, TemplateFixture.HeaderRow + _lookupValues.Length, 1));
+        }
+
+        using var output = new MemoryStream();
+        workbook.SaveAs(output);
+    }
+}

--- a/XLibur.Benchmarks/TemplateRoundTripBenchmarks.cs
+++ b/XLibur.Benchmarks/TemplateRoundTripBenchmarks.cs
@@ -52,6 +52,24 @@ public class TemplateRoundTripBenchmarks
     }
 
     /// <summary>
+    /// Open a workbook that already holds many rows and save it again without touching anything.
+    /// </summary>
+    /// <remarks>
+    /// The realistic template-export shape, and the only benchmark here whose *stored* part is
+    /// row-heavy — <see cref="OpenAndSaveUnchanged"/> saves a fixture whose sheets are nearly
+    /// empty on disk, so it cannot see any save cost that scales with the rows already in the
+    /// part. Compare against <see cref="LoadRowHeavy"/> to separate the save half from the parse.
+    /// </remarks>
+    [Benchmark]
+    public void OpenAndSaveRowHeavyUnchanged()
+    {
+        using var input = new MemoryStream(_rowHeavy, writable: false);
+        using var workbook = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        workbook.SaveAs(output);
+    }
+
+    /// <summary>
     /// Parse a sheet whose cost is dominated by rows rather than structure.
     /// </summary>
     /// <remarks>

--- a/XLibur.Benchmarks/TemplateRoundTripBenchmarks.cs
+++ b/XLibur.Benchmarks/TemplateRoundTripBenchmarks.cs
@@ -31,7 +31,15 @@ public class TemplateRoundTripBenchmarks
     private const int Validations = 26;
     private const int LookupValues = 1_000;
 
+    /// <summary>
+    /// Rows in the <see cref="LoadRowHeavy"/> fixture. Large enough that per-row costs in the
+    /// loader dominate the per-workbook ones, small enough to benchmark in reasonable time —
+    /// <c>XLiburReadBenchmarks</c> covers the 250,000-row end.
+    /// </summary>
+    private const int HeavyRows = 20_000;
+
     private byte[] _template = null!;
+    private byte[] _rowHeavy = null!;
     private string[] _lookupValues = null!;
 
     [GlobalSetup]
@@ -39,7 +47,24 @@ public class TemplateRoundTripBenchmarks
     {
         SixLaborsV1FontBootstrap.Register();
         _template = TemplateFixture.Build(SheetCount, DefinedNames, Validations, dataRows: 0);
+        _rowHeavy = TemplateFixture.Build(sheetCount: 1, definedNames: 1, validations: 0, dataRows: HeavyRows);
         _lookupValues = Enumerable.Range(1, LookupValues).Select(i => $"Lookup value {i}").ToArray();
+    }
+
+    /// <summary>
+    /// Parse a sheet whose cost is dominated by rows rather than structure.
+    /// </summary>
+    /// <remarks>
+    /// Guards the cost of getting the SDK reader past <c>&lt;sheetData&gt;</c> in the loader's
+    /// first pass. That is per-row work which does not show up in the other benchmarks here, all
+    /// of which use structurally rich but nearly empty sheets.
+    /// </remarks>
+    [Benchmark]
+    public int LoadRowHeavy()
+    {
+        using var input = new MemoryStream(_rowHeavy, writable: false);
+        using var workbook = new XLWorkbook(input);
+        return workbook.Worksheets.Count;
     }
 
     /// <summary>Parse only — the floor cost of reading the template.</summary>

--- a/XLibur.Benchmarks/TemplateRoundTripProfile.cs
+++ b/XLibur.Benchmarks/TemplateRoundTripProfile.cs
@@ -109,11 +109,20 @@ public static class TemplateRoundTripProfile
 
     /// <summary>
     /// Attributes the round trip between parse and serialise. Save is reported as
-    /// (open+save) − (open) rather than measured directly, because a workbook cannot currently be
-    /// saved twice: <c>SaveAs</c> disposes the source stream, so a second call throws
-    /// <see cref="ObjectDisposedException"/>. Every probe here therefore opens a fresh workbook
-    /// per iteration.
+    /// (open+save) − (open) rather than measured directly, because a second save of the same
+    /// instance is not the same operation as the first: <c>SaveAs</c> adopts its destination as
+    /// the workbook's origin, so the next save edits the package it just wrote instead of the
+    /// template. Every probe therefore opens a fresh workbook per iteration.
     /// </summary>
+    /// <remarks>
+    /// The adoption is also a trap worth knowing about when writing probes. Because the previous
+    /// destination becomes the origin, disposing it — which a <c>using</c> on a scratch
+    /// <see cref="MemoryStream"/> does — makes the <em>next</em> <c>SaveAs</c> throw
+    /// <see cref="ObjectDisposedException"/> ("Cannot access a closed Stream") from deep inside,
+    /// where it reads that origin back. It is not that saving twice is unsupported: two saves to
+    /// two streams that both stay alive succeed, and the stream a workbook was loaded from is
+    /// left readable.
+    /// </remarks>
     private static void OpenVersusSaveAttribution(string? template)
     {
         Header("open versus save attribution");
@@ -363,7 +372,8 @@ public static class TemplateRoundTripProfile
 
     /// <summary>
     /// As <see cref="Measure"/>, but with per-iteration setup held outside the measurement.
-    /// Setup is unavoidable for the split probes: a workbook cannot be saved twice, so each pass
+    /// Setup is unavoidable for the split probes: a saved workbook has adopted its destination as
+    /// its origin and would not save the same work a second time, so each pass
     /// has to open a fresh one, and that open would otherwise swamp what is being measured.
     /// </summary>
     private static Sample MeasureExcludingSetup<TState>(Func<TState> setup, Action<TState> action)

--- a/XLibur.Benchmarks/TemplateRoundTripProfile.cs
+++ b/XLibur.Benchmarks/TemplateRoundTripProfile.cs
@@ -161,21 +161,26 @@ public static class TemplateRoundTripProfile
     {
         Header("open + save, unmodified");
 
-        foreach (var (sheets, names, validations) in new[]
+        foreach (var (sheets, names, validations, lookupRows) in new[]
                  {
-                     // The first three vary only the sheet count, so the marginal cost of one
-                     // structurally empty worksheet — the part of the bill that scales with
-                     // nothing a caller controls — falls out of the slope.
-                     (1, 0, 0),
-                     (10, 0, 0),
-                     (40, 0, 0),
-                     (10, 20, 0),
-                     (10, 20, 26),
-                     (10, 20, 100),
+                     // Two sheet-count sweeps at different lookup-row counts. The header-only sweep
+                     // isolates what a worksheet costs structurally; the 100-row sweep is the same
+                     // sheets carrying data. Running only the latter confounds the two, and did:
+                     // the resulting slope was reported as the cost of an *empty* sheet when every
+                     // sheet in it held 101 rows.
+                     (1, 0, 0, 0),
+                     (10, 0, 0, 0),
+                     (40, 0, 0, 0),
+                     (1, 0, 0, TemplateFixture.DefaultLookupRows),
+                     (10, 0, 0, TemplateFixture.DefaultLookupRows),
+                     (40, 0, 0, TemplateFixture.DefaultLookupRows),
+                     (10, 20, 0, TemplateFixture.DefaultLookupRows),
+                     (10, 20, 26, TemplateFixture.DefaultLookupRows),
+                     (10, 20, 100, TemplateFixture.DefaultLookupRows),
                  })
         {
-            var bytes = GetFixture(template, sheets, names, validations, dataRows: 0);
-            Row($"sheets={sheets} names={names} validations={validations}",
+            var bytes = GetFixture(template, sheets, names, validations, dataRows: 0, lookupRows);
+            Row($"sheets={sheets} names={names} val={validations} lookupRows={lookupRows}",
                 Measure(() => RoundTrip(bytes)), bytes.Length);
         }
     }
@@ -390,10 +395,16 @@ public static class TemplateRoundTripProfile
     /// <em>build</em> a fixture, so they have no effect on an external template — cases that
     /// differ only in those values become repeat samples of one measurement.
     /// </summary>
-    private static byte[] GetFixture(string? template, int sheetCount, int definedNames, int validations, int dataRows) =>
+    private static byte[] GetFixture(
+        string? template,
+        int sheetCount,
+        int definedNames,
+        int validations,
+        int dataRows,
+        int lookupRows = TemplateFixture.DefaultLookupRows) =>
         template is not null
             ? File.ReadAllBytes(template)
-            : Build(sheetCount, definedNames, validations, dataRows);
+            : Build(sheetCount, definedNames, validations, dataRows, lookupRows);
 
     private static void RoundTrip(byte[] bytes)
     {

--- a/XLibur.Benchmarks/TemplateRoundTripProfile.cs
+++ b/XLibur.Benchmarks/TemplateRoundTripProfile.cs
@@ -64,6 +64,12 @@ public static class TemplateRoundTripProfile
         if (template is not null)
             Console.WriteLine($"fixture: {template} (generated-fixture parameters ignored)");
 
+        if (args.Length > 2 && args[2].Equals("loop", StringComparison.OrdinalIgnoreCase))
+        {
+            Loop(template, phase: args.Length > 3 ? args[3] : "roundtrip");
+            return;
+        }
+
         RoundTripCost(template);
         OpenVersusSaveAttribution(template);
         LookupColumnRefresh(template);
@@ -75,6 +81,56 @@ public static class TemplateRoundTripProfile
         Console.WriteLine("Bytes are exact. Times are medians of "
             + $"{Iterations} passes after a warm-up — use BenchmarkDotNet for time claims.");
     }
+
+    /// <summary>
+    /// Repeats one phase for a fixed wall-clock window so an external profiler can be attached to
+    /// it, e.g.
+    /// <code>
+    /// dotnet-trace collect --format speedscope -- XLibur.Benchmarks.exe profile template loop open
+    /// </code>
+    /// </summary>
+    /// <remarks>
+    /// The table-producing probes are the wrong shape to profile: they interleave six unrelated
+    /// workloads with forced gen2 collections between every pass, so a captured trace mixes them
+    /// together and the GC work swamps the code under study. This runs one phase and nothing else.
+    /// </remarks>
+    private static void Loop(string? template, string phase)
+    {
+        var bytes = GetFixture(template, sheetCount: 10, definedNames: 20, validations: 26, dataRows: 0);
+        RoundTrip(bytes); // JIT warm-up, so start-up does not colour the trace.
+
+        Console.WriteLine($"looping '{phase}' for {LoopSeconds}s...");
+        var elapsed = Stopwatch.StartNew();
+        var iterations = 0;
+
+        while (elapsed.Elapsed.TotalSeconds < LoopSeconds)
+        {
+            switch (phase)
+            {
+                case "open":
+                    using (var input = new MemoryStream(bytes, writable: false))
+                    using (var workbook = new XLWorkbook(input))
+                        _ = workbook.Worksheets.Count;
+                    break;
+
+                case "save":
+                    using (var state = Open(bytes))
+                    using (var sink = new MemoryStream())
+                        state.Workbook.SaveAs(sink);
+                    break;
+
+                default:
+                    RoundTrip(bytes);
+                    break;
+            }
+
+            iterations++;
+        }
+
+        Console.WriteLine($"{iterations:N0} iterations in {elapsed.Elapsed.TotalSeconds:F1}s");
+    }
+
+    private const int LoopSeconds = 20;
 
     // ── 1. Round-trip cost ────────────────────────────────────────────────────
 
@@ -295,8 +351,12 @@ public static class TemplateRoundTripProfile
 
     private static string? ResolveTemplatePath(string[] args)
     {
-        // `profile template <path>` wins over the environment variable.
-        var path = args.Length > 2 ? args[2] : Environment.GetEnvironmentVariable("XLIBUR_PERF_TEMPLATE");
+        // `profile template <path>` wins over the environment variable. "loop" is the profiler
+        // sub-command rather than a path, so it falls through to the environment variable.
+        var argPath = args.Length > 2 && !args[2].Equals("loop", StringComparison.OrdinalIgnoreCase)
+            ? args[2]
+            : null;
+        var path = argPath ?? Environment.GetEnvironmentVariable("XLIBUR_PERF_TEMPLATE");
 
         if (string.IsNullOrWhiteSpace(path))
             return null;

--- a/XLibur.Benchmarks/TemplateRoundTripProfile.cs
+++ b/XLibur.Benchmarks/TemplateRoundTripProfile.cs
@@ -1,0 +1,443 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using XLibur.Excel;
+using XLibur.Fonts.SixLabors.V1;
+using static XLibur.Benchmarks.TemplateFixture;
+
+namespace XLibur.Benchmarks;
+
+/// <summary>
+/// Cost of the template-driven export shape: open an existing workbook, change a little, save it
+/// again. Decomposed so the fixed per-request overhead — the part that scales with neither rows
+/// written nor data changed — can be separated from the cost of the edit itself.
+///
+/// Run with: dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile template [path-to.xlsx]
+///
+/// The decomposition is the point. Profiling a template-driven export in a consuming application
+/// put roughly 300 ms per request into opening and re-saving a 124 KB workbook carrying ~10
+/// sheets, ~20 defined names and ~26 data validations, purely to write a single column of lookup
+/// values. A combined number cannot say whether that lands in the parse or the serialise, nor
+/// which structural feature drives it, so each probe below isolates one candidate.
+/// </summary>
+/// <remarks>
+/// By default the fixture is generated. A synthetic fixture is a poor stand-in for a real
+/// reporting template — shared strings, styles, tables, spilled dynamic-array formulas,
+/// conditional formatting, images and external links all live in a real file and none are
+/// reproduced here — so measurements against it understate real-world cost. Point the probe at an
+/// actual file to reproduce production numbers, either by argument or by environment variable:
+/// <code>
+/// $env:XLIBUR_PERF_TEMPLATE = "C:\path\to\Template.xlsx"
+/// </code>
+/// </remarks>
+public static class TemplateRoundTripProfile
+{
+    /// <summary>
+    /// Timed passes per probe. Nine rather than a handful because the spread between passes on a
+    /// loaded desktop is comfortably wider than the effect sizes worth chasing here — a five-pass
+    /// median moved by ±15% run to run, enough to invent regressions that were not there.
+    /// </summary>
+    private const int Iterations = 9;
+
+    public static void Run(string[] args)
+    {
+        SixLaborsV1FontBootstrap.Register();
+
+        var template = ResolveTemplatePath(args);
+
+        // Warm up the JIT, the style repository and the font engine so their one-time cost does
+        // not land on whichever probe runs first. The fixture deliberately exercises every
+        // structural feature the probes use, and runs more than once: an earlier version warmed
+        // up on a bare two-sheet workbook and left enough un-jitted code that the first real probe
+        // read ~30% slow, which is the same size as the effects being measured.
+        var warmup = Build(sheetCount: 4, definedNames: 4, validations: 4, dataRows: 20);
+        for (var i = 0; i < 3; i++)
+        {
+            using var state = Open(warmup);
+            WriteGrid(ResolveDataSheet(state.Workbook), rows: 50, GridColumns, perCellNumberFormat: true);
+            using var sink = new MemoryStream();
+            state.Workbook.SaveAs(sink);
+        }
+
+        if (template is not null)
+            Console.WriteLine($"fixture: {template} (generated-fixture parameters ignored)");
+
+        RoundTripCost(template);
+        OpenVersusSaveAttribution(template);
+        LookupColumnRefresh(template);
+        DataGridWrite(template);
+        NumberFormatPerCellVersusPerColumn(template);
+        FullCycle(template);
+
+        Console.WriteLine();
+        Console.WriteLine("Bytes are exact. Times are medians of "
+            + $"{Iterations} passes after a warm-up — use BenchmarkDotNet for time claims.");
+    }
+
+    // ── 1. Round-trip cost ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Opens a workbook and saves it again with no modification whatsoever. This is the floor cost
+    /// every caller pays just to touch a file, and in the profiled application it was the single
+    /// largest contributor. The cases vary the workbook's structural weight to show which feature
+    /// drives the cost.
+    /// </summary>
+    private static void RoundTripCost(string? template)
+    {
+        Header("open + save, unmodified");
+
+        foreach (var (sheets, names, validations) in new[]
+                 {
+                     // The first three vary only the sheet count, so the marginal cost of one
+                     // structurally empty worksheet — the part of the bill that scales with
+                     // nothing a caller controls — falls out of the slope.
+                     (1, 0, 0),
+                     (10, 0, 0),
+                     (40, 0, 0),
+                     (10, 20, 0),
+                     (10, 20, 26),
+                     (10, 20, 100),
+                 })
+        {
+            var bytes = GetFixture(template, sheets, names, validations, dataRows: 0);
+            Row($"sheets={sheets} names={names} validations={validations}",
+                Measure(() => RoundTrip(bytes)), bytes.Length);
+        }
+    }
+
+    /// <summary>
+    /// Attributes the round trip between parse and serialise. Save is reported as
+    /// (open+save) − (open) rather than measured directly, because a workbook cannot currently be
+    /// saved twice: <c>SaveAs</c> disposes the source stream, so a second call throws
+    /// <see cref="ObjectDisposedException"/>. Every probe here therefore opens a fresh workbook
+    /// per iteration.
+    /// </summary>
+    private static void OpenVersusSaveAttribution(string? template)
+    {
+        Header("open versus save attribution");
+
+        var bytes = GetFixture(template, sheetCount: 10, definedNames: 20, validations: 26, dataRows: 0);
+
+        var open = Measure(() =>
+        {
+            using var input = new MemoryStream(bytes, writable: false);
+            using var workbook = new XLWorkbook(input);
+            _ = workbook.Worksheets.Count;
+        });
+
+        var roundTrip = Measure(() => RoundTrip(bytes));
+
+        Row("open only", open, bytes.Length);
+        Row("open + save", roundTrip, bytes.Length);
+        Row("save (by subtraction)", roundTrip - open, bytes.Length);
+    }
+
+    // ── 2. Single-column lookup refresh ───────────────────────────────────────
+
+    /// <summary>
+    /// The "refresh one lookup column" shape: clear a column, write N strings, repoint a defined
+    /// name, save. The write itself is trivial, so anything above the round-trip floor is
+    /// attributable to the edit.
+    /// </summary>
+    private static void LookupColumnRefresh(string? template)
+    {
+        Header("lookup refresh (open -> clear -> write -> repoint name -> save)");
+
+        var bytes = GetFixture(template, sheetCount: 10, definedNames: 20, validations: 26, dataRows: 0);
+
+        foreach (var values in new[] { 100, 1_000, 10_000 })
+        {
+            var items = Enumerable.Range(1, values).Select(i => $"Lookup value {i}").ToArray();
+
+            Row($"values={values:N0}", Measure(() =>
+            {
+                using var input = new MemoryStream(bytes, writable: false);
+                using var workbook = new XLWorkbook(input);
+                var sheet = ResolveLookupSheet(workbook);
+
+                var lastRow = sheet.LastRowUsed()?.RowNumber() ?? HeaderRow;
+                if (lastRow > HeaderRow)
+                    sheet.Range(HeaderRow + 1, 1, lastRow, 1).Clear(XLClearOptions.Contents);
+
+                for (var i = 0; i < items.Length; i++)
+                    sheet.Cell(HeaderRow + 1 + i, 1).Value = items[i];
+
+                if (workbook.DefinedNames.TryGetValue(LookupRangeName, out var definedName))
+                    definedName.SetRefersTo(sheet.Range(HeaderRow + 1, 1, HeaderRow + items.Length, 1));
+
+                using var output = new MemoryStream();
+                workbook.SaveAs(output);
+            }), bytes.Length);
+        }
+    }
+
+    // ── 3. Bulk grid write ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Writes a wide grid of mixed cell types, the shape of a data export. Isolates per-cell write
+    /// throughput from the round-trip floor by timing the in-memory writes separately from the
+    /// save; the open that precedes each stays outside the measurement.
+    /// </summary>
+    private static void DataGridWrite(string? template)
+    {
+        Header("grid write, split into cell writes and save");
+
+        var bytes = GetFixture(template, sheetCount: 10, definedNames: 20, validations: 26, dataRows: 0);
+
+        foreach (var rows in new[] { 1_000, 5_000, 20_000 })
+        {
+            var write = MeasureExcludingSetup(
+                () => Open(bytes),
+                state => WriteGrid(ResolveDataSheet(state.Workbook), rows, GridColumns, perCellNumberFormat: false));
+
+            var save = MeasureExcludingSetup(
+                () =>
+                {
+                    var state = Open(bytes);
+                    WriteGrid(ResolveDataSheet(state.Workbook), rows, GridColumns, perCellNumberFormat: false);
+                    return state;
+                },
+                state =>
+                {
+                    using var output = new MemoryStream();
+                    state.Workbook.SaveAs(output);
+                });
+
+            Row($"rows={rows:N0} cols={GridColumns} (cells only)", write, bytes.Length);
+            Row($"rows={rows:N0} cols={GridColumns} (save only)", save, bytes.Length);
+        }
+    }
+
+    // ── 4. Per-cell versus per-column styling ─────────────────────────────────
+
+    /// <summary>
+    /// A/B on number-format application. Setting <c>Style.NumberFormat.Format</c> on every cell is
+    /// the natural way to write a formatted column and is what the profiled application did;
+    /// setting it once on the column is the alternative. If per-cell styling is materially slower,
+    /// style resolution or the style cache is a bottleneck worth attention.
+    /// </summary>
+    private static void NumberFormatPerCellVersusPerColumn(string? template)
+    {
+        Header("date column, per-cell versus per-column number format");
+
+        var bytes = GetFixture(template, sheetCount: 10, definedNames: 20, validations: 26, dataRows: 0);
+
+        foreach (var rows in new[] { 1_000, 5_000, 20_000 })
+        {
+            var perCell = MeasureExcludingSetup(
+                () => Open(bytes),
+                state => WriteDateColumn(ResolveDataSheet(state.Workbook), rows, column: 1, perCellFormat: true));
+
+            var perColumn = MeasureExcludingSetup(
+                () => Open(bytes),
+                state =>
+                {
+                    var sheet = ResolveDataSheet(state.Workbook);
+                    sheet.Column(1).Style.NumberFormat.Format = DateFormat;
+                    WriteDateColumn(sheet, rows, column: 1, perCellFormat: false);
+                });
+
+            Row($"rows={rows:N0} per-cell", perCell, bytes.Length);
+            Row($"rows={rows:N0} per-column", perColumn, bytes.Length);
+            Console.WriteLine(
+                $"| {"  ratio per-cell / per-column",-49} | {SafeRatio(perCell.Milliseconds, perColumn.Milliseconds),7:F2}x | {SafeRatio(perCell.FastestMs, perColumn.FastestMs),7:F2}x | {SafeRatio(perCell.Bytes, perColumn.Bytes),7:F2}x |             |");
+        }
+    }
+
+    // ── 5. End-to-end ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The complete shape the profiled application performs per request: open a template, clear
+    /// stale rows, write the grid, save. Provided so a change inside the library can be judged
+    /// against the whole operation rather than one stage.
+    /// </summary>
+    private static void FullCycle(string? template)
+    {
+        Header("full cycle (open -> clear -> write -> save)");
+
+        var bytes = GetFixture(template, sheetCount: 10, definedNames: 20, validations: 26, dataRows: 200);
+
+        foreach (var rows in new[] { 1_000, 5_000 })
+        {
+            Row($"rows={rows:N0}", Measure(() =>
+            {
+                using var input = new MemoryStream(bytes, writable: false);
+                using var workbook = new XLWorkbook(input);
+                var sheet = ResolveDataSheet(workbook);
+
+                var lastRow = sheet.LastRowUsed()?.RowNumber() ?? HeaderRow;
+                if (lastRow >= FirstDataRow)
+                {
+                    var lastColumn = sheet.LastColumnUsed()?.ColumnNumber() ?? 1;
+                    sheet.Range(FirstDataRow, 1, lastRow, lastColumn).Clear(XLClearOptions.Contents);
+                }
+
+                WriteGrid(sheet, rows, GridColumns, perCellNumberFormat: true);
+
+                using var output = new MemoryStream();
+                workbook.SaveAs(output);
+            }), bytes.Length);
+        }
+    }
+
+    // ── fixture ───────────────────────────────────────────────────────────────
+
+    private static string? ResolveTemplatePath(string[] args)
+    {
+        // `profile template <path>` wins over the environment variable.
+        var path = args.Length > 2 ? args[2] : Environment.GetEnvironmentVariable("XLIBUR_PERF_TEMPLATE");
+
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"Template fixture points at a missing file: {path}", path);
+
+        return path;
+    }
+
+    /// <summary>
+    /// Returns the fixture workbook: the external template when one was supplied, otherwise a
+    /// generated one. The sheetCount / definedNames / validations parameters describe how to
+    /// <em>build</em> a fixture, so they have no effect on an external template — cases that
+    /// differ only in those values become repeat samples of one measurement.
+    /// </summary>
+    private static byte[] GetFixture(string? template, int sheetCount, int definedNames, int validations, int dataRows) =>
+        template is not null
+            ? File.ReadAllBytes(template)
+            : Build(sheetCount, definedNames, validations, dataRows);
+
+    private static void RoundTrip(byte[] bytes)
+    {
+        using var input = new MemoryStream(bytes, writable: false);
+        using var workbook = new XLWorkbook(input);
+        using var output = new MemoryStream();
+        workbook.SaveAs(output);
+    }
+
+    /// <summary>
+    /// Opening produces two disposables that must outlive the measured call, because
+    /// <see cref="XLWorkbook"/> reads lazily from the stream it was constructed over.
+    /// </summary>
+    private readonly record struct OpenWorkbook(MemoryStream Input, XLWorkbook Workbook) : IDisposable
+    {
+        public void Dispose()
+        {
+            Workbook.Dispose();
+            Input.Dispose();
+        }
+    }
+
+    private static OpenWorkbook Open(byte[] bytes)
+    {
+        var input = new MemoryStream(bytes, writable: false);
+        return new OpenWorkbook(input, new XLWorkbook(input));
+    }
+
+    // ── measurement ───────────────────────────────────────────────────────────
+
+    /// <param name="Milliseconds">Median of the timed passes.</param>
+    /// <param name="FastestMs">
+    /// Fastest timed pass. The least-disturbed sample, and in practice the more stable estimator
+    /// of the two: it is bounded below by the real work, whereas the median still drifts with
+    /// whatever else the machine is doing. Compare this one across builds.
+    /// </param>
+    /// <param name="Bytes">Allocation of the median pass. Exact, and not subject to timing noise.</param>
+    private readonly record struct Sample(double Milliseconds, double FastestMs, long Bytes)
+    {
+        public static Sample operator -(Sample left, Sample right) =>
+            new(left.Milliseconds - right.Milliseconds,
+                left.FastestMs - right.FastestMs,
+                left.Bytes - right.Bytes);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="action"/> for <see cref="Iterations"/> timed passes and returns the
+    /// median time with the allocation of the median pass. Median rather than mean so a single GC
+    /// pause does not dominate the result.
+    /// </summary>
+    private static Sample Measure(Action action) =>
+        MeasureExcludingSetup<object?>(() => null, _ => action());
+
+    /// <summary>
+    /// As <see cref="Measure"/>, but with per-iteration setup held outside the measurement.
+    /// Setup is unavoidable for the split probes: a workbook cannot be saved twice, so each pass
+    /// has to open a fresh one, and that open would otherwise swamp what is being measured.
+    /// </summary>
+    private static Sample MeasureExcludingSetup<TState>(Func<TState> setup, Action<TState> action)
+    {
+        var times = new double[Iterations];
+        var allocations = new long[Iterations];
+
+        for (var i = 0; i < Iterations; i++)
+        {
+            var state = setup();
+            try
+            {
+                ForceGC();
+
+                var before = GC.GetTotalAllocatedBytes(precise: true);
+                var watch = Stopwatch.StartNew();
+                action(state);
+                watch.Stop();
+
+                times[i] = watch.Elapsed.TotalMilliseconds;
+                allocations[i] = GC.GetTotalAllocatedBytes(precise: true) - before;
+            }
+            finally
+            {
+                (state as IDisposable)?.Dispose();
+            }
+        }
+
+        // Sorted independently: the median allocation is wanted as a robust figure in its own
+        // right, not as the allocation that happened to accompany the median time.
+        Array.Sort(times);
+        Array.Sort(allocations);
+        return new Sample(times[Iterations / 2], times[0], allocations[Iterations / 2]);
+    }
+
+    private static void ForceGC()
+    {
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+    }
+
+    /// <summary>
+    /// The sheet the grid probes write into: the generated fixture's data sheet when present,
+    /// otherwise the first worksheet. Falling back positionally is what lets an arbitrary external
+    /// template be used without knowing its sheet names.
+    /// </summary>
+    private static IXLWorksheet ResolveDataSheet(IXLWorkbook workbook) =>
+        workbook.Worksheets.TryGetWorksheet(DataSheet, out var sheet)
+            ? sheet
+            : workbook.Worksheets.First();
+
+    /// <summary>
+    /// The sheet the lookup probe writes into: the generated fixture's first lookup sheet when
+    /// present, otherwise the last worksheet — chosen so it is not the same sheet as
+    /// <see cref="ResolveDataSheet"/> in a multi-sheet template.
+    /// </summary>
+    private static IXLWorksheet ResolveLookupSheet(IXLWorkbook workbook) =>
+        workbook.Worksheets.TryGetWorksheet(FirstLookupSheet, out var sheet)
+            ? sheet
+            : workbook.Worksheets.Last();
+
+    private static double SafeRatio(double numerator, double denominator) =>
+        denominator <= 0 ? double.NaN : numerator / denominator;
+
+    private static void Header(string title)
+    {
+        Console.WriteLine();
+        Console.WriteLine(title);
+        Console.WriteLine("| Probe                                             |   median |  fastest |    Alloc |   Fixture   |");
+        Console.WriteLine("|---------------------------------------------------|----------|----------|----------|-------------|");
+    }
+
+    private static void Row(string label, Sample sample, int fixtureBytes) =>
+        Console.WriteLine(
+            $"| {label,-49} | {sample.Milliseconds,7:F1}m | {sample.FastestMs,7:F1}m | {sample.Bytes / 1048576.0,5:F1} MB | {fixtureBytes,8:N0} B |");
+}

--- a/XLibur.Benchmarks/TemplateRoundTripProfile.cs
+++ b/XLibur.Benchmarks/TemplateRoundTripProfile.cs
@@ -66,7 +66,7 @@ public static class TemplateRoundTripProfile
 
         if (args.Length > 2 && args[2].Equals("loop", StringComparison.OrdinalIgnoreCase))
         {
-            Loop(template, phase: args.Length > 3 ? args[3] : "roundtrip");
+            Loop(template, phase: args.Length > 3 ? args[3] : DefaultPhase);
             return;
         }
 
@@ -96,6 +96,21 @@ public static class TemplateRoundTripProfile
     /// </remarks>
     private static void Loop(string? template, string phase)
     {
+        // Matched case-insensitively, like the `profile <mode>` dispatch this arrives through, and
+        // an unrecognised phase stops rather than quietly running something else: a profile of the
+        // wrong workload looks entirely plausible, so a typo would otherwise cost a whole
+        // collect-and-analyse cycle before anyone noticed.
+        if (!Phases.Contains(phase, StringComparer.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine(
+                $"Unknown phase '{phase}'. Expected one of: {string.Join(", ", Phases)}.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var isOpen = phase.Equals("open", StringComparison.OrdinalIgnoreCase);
+        var isSave = phase.Equals("save", StringComparison.OrdinalIgnoreCase);
+
         var bytes = GetFixture(template, sheetCount: 10, definedNames: 20, validations: 26, dataRows: 0);
         RoundTrip(bytes); // JIT warm-up, so start-up does not colour the trace.
 
@@ -105,23 +120,21 @@ public static class TemplateRoundTripProfile
 
         while (elapsed.Elapsed.TotalSeconds < LoopSeconds)
         {
-            switch (phase)
+            if (isOpen)
             {
-                case "open":
-                    using (var input = new MemoryStream(bytes, writable: false))
-                    using (var workbook = new XLWorkbook(input))
-                        _ = workbook.Worksheets.Count;
-                    break;
-
-                case "save":
-                    using (var state = Open(bytes))
-                    using (var sink = new MemoryStream())
-                        state.Workbook.SaveAs(sink);
-                    break;
-
-                default:
-                    RoundTrip(bytes);
-                    break;
+                using var input = new MemoryStream(bytes, writable: false);
+                using var workbook = new XLWorkbook(input);
+                _ = workbook.Worksheets.Count;
+            }
+            else if (isSave)
+            {
+                using var state = Open(bytes);
+                using var sink = new MemoryStream();
+                state.Workbook.SaveAs(sink);
+            }
+            else
+            {
+                RoundTrip(bytes);
             }
 
             iterations++;
@@ -129,6 +142,10 @@ public static class TemplateRoundTripProfile
 
         Console.WriteLine($"{iterations:N0} iterations in {elapsed.Elapsed.TotalSeconds:F1}s");
     }
+
+    private const string DefaultPhase = "roundtrip";
+
+    private static readonly string[] Phases = ["open", "save", DefaultPhase];
 
     private const int LoopSeconds = 20;
 
@@ -307,7 +324,7 @@ public static class TemplateRoundTripProfile
             Row($"rows={rows:N0} per-cell", perCell, bytes.Length);
             Row($"rows={rows:N0} per-column", perColumn, bytes.Length);
             Console.WriteLine(
-                $"| {"  ratio per-cell / per-column",-49} | {SafeRatio(perCell.Milliseconds, perColumn.Milliseconds),7:F2}x | {SafeRatio(perCell.FastestMs, perColumn.FastestMs),7:F2}x | {SafeRatio(perCell.Bytes, perColumn.Bytes),7:F2}x |             |");
+                $"| {"  ratio per-cell / per-column",-49} | {SafeRatio(perCell.Milliseconds, perColumn.Milliseconds),8:F2}x | {SafeRatio(perCell.FastestMs, perColumn.FastestMs),9:F2}x | {SafeRatio(perCell.Bytes, perColumn.Bytes),7:F2}x |             |");
         }
     }
 
@@ -503,11 +520,13 @@ public static class TemplateRoundTripProfile
     {
         Console.WriteLine();
         Console.WriteLine(title);
-        Console.WriteLine("| Probe                                             |   median |  fastest |    Alloc |   Fixture   |");
-        Console.WriteLine("|---------------------------------------------------|----------|----------|----------|-------------|");
+        // Units live in the header so the cells can stay bare numbers. A per-cell "m" suffix
+        // reads as minutes.
+        Console.WriteLine("| Probe                                             | median ms | fastest ms |    Alloc |   Fixture   |");
+        Console.WriteLine("|---------------------------------------------------|-----------|------------|----------|-------------|");
     }
 
     private static void Row(string label, Sample sample, int fixtureBytes) =>
         Console.WriteLine(
-            $"| {label,-49} | {sample.Milliseconds,7:F1}m | {sample.FastestMs,7:F1}m | {sample.Bytes / 1048576.0,5:F1} MB | {fixtureBytes,8:N0} B |");
+            $"| {label,-49} | {sample.Milliseconds,9:F1} | {sample.FastestMs,10:F1} | {sample.Bytes / 1048576.0,5:F1} MB | {fixtureBytes,9:N0} B |");
 }

--- a/XLibur.Examples/XLibur.Examples.csproj
+++ b/XLibur.Examples/XLibur.Examples.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/XLibur.Report.Benchmarks/XLibur.Report.Benchmarks.csproj
+++ b/XLibur.Report.Benchmarks/XLibur.Report.Benchmarks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/XLibur.Report.Examples/XLibur.Report.Examples.csproj
+++ b/XLibur.Report.Examples/XLibur.Report.Examples.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/XLibur/Excel/ContentManagers/XLBaseContentManager.cs
+++ b/XLibur/Excel/ContentManagers/XLBaseContentManager.cs
@@ -1,33 +1,61 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using DocumentFormat.OpenXml;
 
 namespace XLibur.Excel.ContentManagers;
 
+/// <summary>
+/// Tracks, for one OpenXML container, which element currently occupies each schema-ordered slot,
+/// so a writer inserting a new element can find the element it must follow.
+/// </summary>
+/// <remarks>
+/// Backed by a dense array indexed by the enum value rather than a dictionary. The slots are a
+/// small contiguous range known at construction, so the array costs one allocation, needs no
+/// hashing, and lets <see cref="GetPreviousElementFor"/> walk backwards without allocating —
+/// it previously ran a LINQ <c>Where</c>/<c>DefaultIfEmpty</c>/<c>MaxBy</c> chain over the whole
+/// dictionary on every call, and writers call it once per element they emit.
+/// </remarks>
 internal abstract class XLBaseContentManager<T>
     where T : struct, Enum
-
 {
-    protected readonly Dictionary<T, OpenXmlElement?> contents = new();
+    private readonly OpenXmlElement?[] _contents;
 
-    public OpenXmlElement? GetPreviousElementFor(T content)
+    /// <param name="highestSlot">
+    /// The largest value of <typeparamref name="T"/>. Slots are addressed by their numeric value,
+    /// so gaps in the enum simply stay null.
+    /// </param>
+    protected XLBaseContentManager(T highestSlot)
     {
-        // JIT will recognize the conversion for identity and removes it (for int enums).
-        var i = (int)(ValueType)content;
-
-        var previousElements = contents
-            .Where(kv => (int)(ValueType)kv.Key < i && kv.Value is not null);
-
-        // If there is no previous element, return null.
-        var previousElement = previousElements
-            .DefaultIfEmpty(new KeyValuePair<T, OpenXmlElement?>(default, null))
-            .MaxBy(kv => kv.Key).Value;
-        return previousElement;
+        _contents = new OpenXmlElement?[Index(highestSlot) + 1];
     }
 
-    public void SetElement(T content, OpenXmlElement? element)
+    /// <summary>
+    /// The element occupying the highest-numbered slot below <paramref name="content"/>, or null
+    /// when nothing precedes it.
+    /// </summary>
+    public OpenXmlElement? GetPreviousElementFor(T content)
     {
-        contents[content] = element;
+        for (var i = Index(content) - 1; i >= 0; i--)
+        {
+            if (_contents[i] is { } element)
+                return element;
+        }
+
+        return null;
+    }
+
+    public void SetElement(T content, OpenXmlElement? element) => _contents[Index(content)] = element;
+
+    /// <summary>
+    /// Reinterprets the enum as its underlying <see cref="int"/>. Casting through
+    /// <see cref="ValueType"/> would box on every call, which matters because writers call
+    /// <see cref="GetPreviousElementFor"/> once per emitted element.
+    /// </summary>
+    private static int Index(T content)
+    {
+        Debug.Assert(Enum.GetUnderlyingType(typeof(T)) == typeof(int),
+            $"{typeof(T).Name} must be int-backed for the reinterpret cast to be valid.");
+        return Unsafe.As<T, int>(ref content);
     }
 }

--- a/XLibur/Excel/ContentManagers/XLBaseContentManager.cs
+++ b/XLibur/Excel/ContentManagers/XLBaseContentManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using DocumentFormat.OpenXml;
 
@@ -19,6 +18,23 @@ namespace XLibur.Excel.ContentManagers;
 internal abstract class XLBaseContentManager<T>
     where T : struct, Enum
 {
+    /// <summary>
+    /// Enforces the precondition of <see cref="Index"/> once per closed generic type, in every
+    /// build configuration. A <c>Debug.Assert</c> would not do: it compiles out of Release,
+    /// so declaring a future slot enum with a non-<see cref="int"/> underlying type would silently
+    /// index the wrong slot — or past the end of the array — in exactly the builds that ship.
+    /// </summary>
+    static XLBaseContentManager()
+    {
+        var underlying = Enum.GetUnderlyingType(typeof(T));
+        if (underlying != typeof(int))
+        {
+            throw new InvalidOperationException(
+                $"{typeof(T).Name} is backed by {underlying.Name}, but {nameof(XLBaseContentManager<T>)} " +
+                "reinterprets its slot enum as int. Declare the enum with the default int underlying type.");
+        }
+    }
+
     private readonly OpenXmlElement?[] _contents;
 
     /// <param name="highestSlot">
@@ -50,12 +66,8 @@ internal abstract class XLBaseContentManager<T>
     /// <summary>
     /// Reinterprets the enum as its underlying <see cref="int"/>. Casting through
     /// <see cref="ValueType"/> would box on every call, which matters because writers call
-    /// <see cref="GetPreviousElementFor"/> once per emitted element.
+    /// <see cref="GetPreviousElementFor"/> once per emitted element. The static constructor
+    /// guarantees the reinterpret is valid.
     /// </summary>
-    private static int Index(T content)
-    {
-        Debug.Assert(Enum.GetUnderlyingType(typeof(T)) == typeof(int),
-            $"{typeof(T).Name} must be int-backed for the reinterpret cast to be valid.");
-        return Unsafe.As<T, int>(ref content);
-    }
+    private static int Index(T content) => Unsafe.As<T, int>(ref content);
 }

--- a/XLibur/Excel/ContentManagers/XLSheetViewContentManager.cs
+++ b/XLibur/Excel/ContentManagers/XLSheetViewContentManager.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace XLibur.Excel.ContentManagers;
@@ -13,11 +12,19 @@ internal enum XLSheetViewContents
 
 internal sealed class XLSheetViewContentManager : XLBaseContentManager<XLSheetViewContents>
 {
+    /// <inheritdoc cref="XLWorksheetContentManager(Worksheet)"/>
     public XLSheetViewContentManager(SheetView sheetView)
+        : base(XLSheetViewContents.ExtensionList)
     {
-        contents.Add(XLSheetViewContents.Pane, sheetView.Elements<Pane>().LastOrDefault());
-        contents.Add(XLSheetViewContents.Selection, sheetView.Elements<Selection>().LastOrDefault());
-        contents.Add(XLSheetViewContents.PivotSelection, sheetView.Elements<PivotSelection>().LastOrDefault());
-        contents.Add(XLSheetViewContents.ExtensionList, sheetView.Elements<ExtensionList>().LastOrDefault());
+        foreach (var child in sheetView.ChildElements)
+        {
+            switch (child)
+            {
+                case Pane: SetElement(XLSheetViewContents.Pane, child); break;
+                case Selection: SetElement(XLSheetViewContents.Selection, child); break;
+                case PivotSelection: SetElement(XLSheetViewContents.PivotSelection, child); break;
+                case ExtensionList: SetElement(XLSheetViewContents.ExtensionList, child); break;
+            }
+        }
     }
 }

--- a/XLibur/Excel/ContentManagers/XLWorksheetContentManager.cs
+++ b/XLibur/Excel/ContentManagers/XLWorksheetContentManager.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
 
@@ -50,47 +49,71 @@ internal enum XLWorksheetContents
 
 internal sealed class XLWorksheetContentManager : XLBaseContentManager<XLWorksheetContents>
 {
+    /// <remarks>
+    /// One pass over the children, keeping the last element seen for each slot. This used to run
+    /// <c>Elements&lt;T&gt;().LastOrDefault()</c> once per slot — thirty-nine filtered traversals
+    /// of the same child list, each allocating its own iterator — which made building the manager
+    /// a significant share of the per-worksheet save cost. The last-wins behaviour is preserved
+    /// because a later child simply overwrites its slot.
+    /// <para>
+    /// <see cref="XLWorksheetContents.SmartTags"/> is deliberately not mapped, matching the
+    /// original: that slot stays empty so it never becomes an insertion anchor.
+    /// </para>
+    /// </remarks>
     public XLWorksheetContentManager(Worksheet opWorksheet)
+        : base(XLWorksheetContents.WorksheetExtensionList)
     {
-        contents.Add(XLWorksheetContents.SheetProperties, opWorksheet.Elements<SheetProperties>().LastOrDefault());
-        contents.Add(XLWorksheetContents.SheetDimension, opWorksheet.Elements<SheetDimension>().LastOrDefault());
-        contents.Add(XLWorksheetContents.SheetViews, opWorksheet.Elements<SheetViews>().LastOrDefault());
-        contents.Add(XLWorksheetContents.SheetFormatProperties, opWorksheet.Elements<SheetFormatProperties>().LastOrDefault());
-        contents.Add(XLWorksheetContents.Columns, opWorksheet.Elements<Columns>().LastOrDefault());
-        contents.Add(XLWorksheetContents.SheetData, opWorksheet.Elements<SheetData>().LastOrDefault());
-        contents.Add(XLWorksheetContents.SheetCalculationProperties, opWorksheet.Elements<SheetCalculationProperties>().LastOrDefault());
-        contents.Add(XLWorksheetContents.SheetProtection, opWorksheet.Elements<SheetProtection>().LastOrDefault());
-        contents.Add(XLWorksheetContents.ProtectedRanges, opWorksheet.Elements<ProtectedRanges>().LastOrDefault());
-        contents.Add(XLWorksheetContents.Scenarios, opWorksheet.Elements<Scenarios>().LastOrDefault());
-        contents.Add(XLWorksheetContents.AutoFilter, opWorksheet.Elements<AutoFilter>().LastOrDefault());
-        contents.Add(XLWorksheetContents.SortState, opWorksheet.Elements<SortState>().LastOrDefault());
-        contents.Add(XLWorksheetContents.DataConsolidate, opWorksheet.Elements<DataConsolidate>().LastOrDefault());
-        contents.Add(XLWorksheetContents.CustomSheetViews, opWorksheet.Elements<CustomSheetViews>().LastOrDefault());
-        contents.Add(XLWorksheetContents.MergeCells, opWorksheet.Elements<MergeCells>().LastOrDefault());
-        contents.Add(XLWorksheetContents.PhoneticProperties, opWorksheet.Elements<PhoneticProperties>().LastOrDefault());
-        contents.Add(XLWorksheetContents.ConditionalFormatting, opWorksheet.Elements<ConditionalFormatting>().LastOrDefault());
-        contents.Add(XLWorksheetContents.DataValidations, opWorksheet.Elements<DataValidations>().LastOrDefault());
-        contents.Add(XLWorksheetContents.Hyperlinks, opWorksheet.Elements<Hyperlinks>().LastOrDefault());
-        contents.Add(XLWorksheetContents.PrintOptions, opWorksheet.Elements<PrintOptions>().LastOrDefault());
-        contents.Add(XLWorksheetContents.PageMargins, opWorksheet.Elements<PageMargins>().LastOrDefault());
-        contents.Add(XLWorksheetContents.PageSetup, opWorksheet.Elements<PageSetup>().LastOrDefault());
-        contents.Add(XLWorksheetContents.HeaderFooter, opWorksheet.Elements<HeaderFooter>().LastOrDefault());
-        contents.Add(XLWorksheetContents.RowBreaks, opWorksheet.Elements<RowBreaks>().LastOrDefault());
-        contents.Add(XLWorksheetContents.ColumnBreaks, opWorksheet.Elements<ColumnBreaks>().LastOrDefault());
-        contents.Add(XLWorksheetContents.CustomProperties, opWorksheet.Elements<CustomProperties>().LastOrDefault());
-        contents.Add(XLWorksheetContents.CellWatches, opWorksheet.Elements<CellWatches>().LastOrDefault());
-        contents.Add(XLWorksheetContents.IgnoredErrors, opWorksheet.Elements<IgnoredErrors>().LastOrDefault());
-        //contents.Add(XLWSContents.SmartTags, opWorksheet.Elements<SmartTags>().LastOrDefault());
-        contents.Add(XLWorksheetContents.Drawing, opWorksheet.Elements<Drawing>().LastOrDefault());
-        contents.Add(XLWorksheetContents.LegacyDrawing, opWorksheet.Elements<LegacyDrawing>().LastOrDefault());
-        contents.Add(XLWorksheetContents.LegacyDrawingHeaderFooter, opWorksheet.Elements<LegacyDrawingHeaderFooter>().LastOrDefault());
-        contents.Add(XLWorksheetContents.DrawingHeaderFooter, opWorksheet.Elements<DrawingHeaderFooter>().LastOrDefault());
-        contents.Add(XLWorksheetContents.Picture, opWorksheet.Elements<Picture>().LastOrDefault());
-        contents.Add(XLWorksheetContents.OleObjects, opWorksheet.Elements<OleObjects>().LastOrDefault());
-        contents.Add(XLWorksheetContents.Controls, opWorksheet.Elements<Controls>().LastOrDefault());
-        contents.Add(XLWorksheetContents.AlternateContent, opWorksheet.Elements<AlternateContent>().LastOrDefault());
-        contents.Add(XLWorksheetContents.WebPublishItems, opWorksheet.Elements<WebPublishItems>().LastOrDefault());
-        contents.Add(XLWorksheetContents.TableParts, opWorksheet.Elements<TableParts>().LastOrDefault());
-        contents.Add(XLWorksheetContents.WorksheetExtensionList, opWorksheet.Elements<WorksheetExtensionList>().LastOrDefault());
+        foreach (var child in opWorksheet.ChildElements)
+        {
+            if (SlotOf(child) is { } slot)
+                SetElement(slot, child);
+        }
     }
+
+    /// <summary>
+    /// The schema slot an element belongs to, or null when the element is not tracked.
+    /// </summary>
+    private static XLWorksheetContents? SlotOf(OpenXmlElement child) => child switch
+    {
+        SheetProperties => XLWorksheetContents.SheetProperties,
+        SheetDimension => XLWorksheetContents.SheetDimension,
+        SheetViews => XLWorksheetContents.SheetViews,
+        SheetFormatProperties => XLWorksheetContents.SheetFormatProperties,
+        Columns => XLWorksheetContents.Columns,
+        SheetData => XLWorksheetContents.SheetData,
+        SheetCalculationProperties => XLWorksheetContents.SheetCalculationProperties,
+        SheetProtection => XLWorksheetContents.SheetProtection,
+        ProtectedRanges => XLWorksheetContents.ProtectedRanges,
+        Scenarios => XLWorksheetContents.Scenarios,
+        AutoFilter => XLWorksheetContents.AutoFilter,
+        SortState => XLWorksheetContents.SortState,
+        DataConsolidate => XLWorksheetContents.DataConsolidate,
+        CustomSheetViews => XLWorksheetContents.CustomSheetViews,
+        MergeCells => XLWorksheetContents.MergeCells,
+        PhoneticProperties => XLWorksheetContents.PhoneticProperties,
+        ConditionalFormatting => XLWorksheetContents.ConditionalFormatting,
+        DataValidations => XLWorksheetContents.DataValidations,
+        Hyperlinks => XLWorksheetContents.Hyperlinks,
+        PrintOptions => XLWorksheetContents.PrintOptions,
+        PageMargins => XLWorksheetContents.PageMargins,
+        PageSetup => XLWorksheetContents.PageSetup,
+        HeaderFooter => XLWorksheetContents.HeaderFooter,
+        RowBreaks => XLWorksheetContents.RowBreaks,
+        ColumnBreaks => XLWorksheetContents.ColumnBreaks,
+        CustomProperties => XLWorksheetContents.CustomProperties,
+        CellWatches => XLWorksheetContents.CellWatches,
+        IgnoredErrors => XLWorksheetContents.IgnoredErrors,
+        Drawing => XLWorksheetContents.Drawing,
+        LegacyDrawing => XLWorksheetContents.LegacyDrawing,
+        LegacyDrawingHeaderFooter => XLWorksheetContents.LegacyDrawingHeaderFooter,
+        DrawingHeaderFooter => XLWorksheetContents.DrawingHeaderFooter,
+        Picture => XLWorksheetContents.Picture,
+        OleObjects => XLWorksheetContents.OleObjects,
+        Controls => XLWorksheetContents.Controls,
+        AlternateContent => XLWorksheetContents.AlternateContent,
+        WebPublishItems => XLWorksheetContents.WebPublishItems,
+        TableParts => XLWorksheetContents.TableParts,
+        WorksheetExtensionList => XLWorksheetContents.WorksheetExtensionList,
+        _ => null,
+    };
 }

--- a/XLibur/Excel/IO/ConditionalFormattingWriter.cs
+++ b/XLibur/Excel/IO/ConditionalFormattingWriter.cs
@@ -21,6 +21,19 @@ internal static class ConditionalFormattingWriter
         XLWorksheet xlWorksheet,
         SaveContext context)
     {
+        // Fast path for the overwhelmingly common worksheet that carries no conditional
+        // formatting at all. The general path below allocates a hash set, a cast iterator, a
+        // concat iterator, an ordered sequence and a list before it can discover there is
+        // nothing to write, and that is per worksheet on every save. Nothing is skipped: with
+        // both collections empty the priority renumbering below is a no-op.
+        // The explicit type argument disambiguates XLPivotTables' two IEnumerable<T> implementations.
+        if (!xlWorksheet.ConditionalFormats.Any() && !xlWorksheet.PivotTables.Any<XLPivotTable>())
+        {
+            worksheet.RemoveAllChildren<ConditionalFormatting>();
+            cm.SetElement(XLWorksheetContents.ConditionalFormatting, null);
+            return;
+        }
+
         var xlSheetPivotCfs = xlWorksheet.PivotTables
             .SelectMany<XLPivotTable, XLConditionalFormat>(pt => pt.ConditionalFormats.Select(cf => cf.Format))
             .ToHashSet();

--- a/XLibur/Excel/IO/ConditionalFormattingWriter.cs
+++ b/XLibur/Excel/IO/ConditionalFormattingWriter.cs
@@ -24,10 +24,15 @@ internal static class ConditionalFormattingWriter
         // Fast path for the overwhelmingly common worksheet that carries no conditional
         // formatting at all. The general path below allocates a hash set, a cast iterator, a
         // concat iterator, an ordered sequence and a list before it can discover there is
-        // nothing to write, and that is per worksheet on every save. Nothing is skipped: with
-        // both collections empty the priority renumbering below is a no-op.
+        // nothing to write, and that is per worksheet on every save. Nothing is skipped: with no
+        // conditional formats from either source the general path reaches the same
+        // RemoveAllChildren/SetElement pair below, via a zero-length list.
+        // A pivot table only contributes here if it carries conditional formats, so testing for
+        // the formats rather than for the table keeps the fast path open to the common sheet that
+        // has pivots but no pivot CF.
         // The explicit type argument disambiguates XLPivotTables' two IEnumerable<T> implementations.
-        if (!xlWorksheet.ConditionalFormats.Any() && !xlWorksheet.PivotTables.Any<XLPivotTable>())
+        if (!xlWorksheet.ConditionalFormats.Any() &&
+            !xlWorksheet.PivotTables.Any<XLPivotTable>(pt => pt.ConditionalFormats.Any()))
         {
             worksheet.RemoveAllChildren<ConditionalFormatting>();
             cm.SetElement(XLWorksheetContents.ConditionalFormatting, null);

--- a/XLibur/Excel/IO/OpenXmlConst.cs
+++ b/XLibur/Excel/IO/OpenXmlConst.cs
@@ -25,6 +25,9 @@ internal static class OpenXmlConst
 
     public const string RichData2Ns = "http://schemas.microsoft.com/office/spreadsheetml/2017/richdata2";
 
+    /// <summary>DrawingML main namespace, used by the theme part.</summary>
+    public const string DrawingMain2006Ns = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
     /// <summary>
     /// Valid and shorter than normal true.
     /// </summary>

--- a/XLibur/Excel/IO/PartXmlReader.cs
+++ b/XLibur/Excel/IO/PartXmlReader.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using System.Xml;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Creates the <see cref="XmlReader"/>s XLibur opens over package parts, with one consistent
+/// hardening policy.
+/// </summary>
+/// <remarks>
+/// A package part is untrusted input: it is whatever the producer of the file put there, and
+/// XLibur is routinely pointed at documents from outside the caller's control. Every reader
+/// therefore refuses DTDs outright and carries no resolver, so no part can pull in an external
+/// entity or expand one internally.
+/// <para>
+/// .NET already defaults <see cref="XmlReaderSettings.DtdProcessing"/> to
+/// <see cref="DtdProcessing.Prohibit"/> and <see cref="XmlReaderSettings.XmlResolver"/> to null,
+/// so this is not fixing a live hole. It is stated explicitly and in one place so the guarantee
+/// is auditable and cannot be lost by a settings object that someone later builds by hand.
+/// </para>
+/// </remarks>
+internal static class PartXmlReader
+{
+    /// <summary>
+    /// A reader for XLibur's own streaming parse paths, which look only at elements, attributes
+    /// and text.
+    /// </summary>
+    /// <param name="stream">The part stream to read. Left open when the reader is disposed.</param>
+    /// <param name="ignoreWhitespace">
+    /// False where whitespace is content — a shared-string <c>&lt;t&gt;</c> holding only spaces is
+    /// legitimate text and must survive.
+    /// </param>
+    internal static XmlReader Create(Stream stream, bool ignoreWhitespace = true) =>
+        XmlReader.Create(stream, new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            IgnoreWhitespace = ignoreWhitespace,
+            IgnoreComments = true,
+            IgnoreProcessingInstructions = true,
+            CloseInput = false,
+        });
+
+    /// <summary>
+    /// A reader that preserves comments, processing instructions and whitespace, for callers that
+    /// build a document model from the part rather than scanning it.
+    /// </summary>
+    internal static XmlReader CreateVerbatim(Stream stream) =>
+        XmlReader.Create(stream, new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            CloseInput = false,
+        });
+}

--- a/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/XLibur/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -695,7 +695,6 @@ internal static class PivotTableDefinitionPartReader
             Subtotals = subtotals,
         };
 
-        // Add indexes after the reference is initialized, so it can check values by cacheIndex/byPosition.
         foreach (var fieldItem in reference.OfType<FieldItem>())
         {
             var fieldItemValue = fieldItem.Val?.Value ?? throw PartStructureException.MissingAttribute();

--- a/XLibur/Excel/IO/RichDataReader.cs
+++ b/XLibur/Excel/IO/RichDataReader.cs
@@ -103,7 +103,7 @@ internal static class RichDataReader
     private static int FindLocalImageStructureIndex(OpenXmlPart part)
     {
         using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
-        using var reader = XmlReader.Create(stream);
+        using var reader = PartXmlReader.CreateVerbatim(stream);
 
         var structureIndex = 0;
         while (reader.Read())
@@ -129,7 +129,7 @@ internal static class RichDataReader
         var relIds = new List<string>();
 
         using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
-        using var reader = XmlReader.Create(stream);
+        using var reader = PartXmlReader.CreateVerbatim(stream);
 
         while (reader.Read())
         {
@@ -156,7 +156,7 @@ internal static class RichDataReader
         var entries = new List<XLCellImage?>();
 
         using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
-        using var reader = XmlReader.Create(stream);
+        using var reader = PartXmlReader.CreateVerbatim(stream);
 
         while (reader.Read())
         {

--- a/XLibur/Excel/IO/SharedStringReader.cs
+++ b/XLibur/Excel/IO/SharedStringReader.cs
@@ -55,14 +55,8 @@ internal static class SharedStringReader
     internal static SharedStringEntry[] Read(SharedStringTablePart part)
     {
         using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
-        using var reader = XmlReader.Create(stream, new XmlReaderSettings
-        {
-            // Whitespace must NOT be ignored: a <t> holding only spaces is legitimate text content.
-            IgnoreWhitespace = false,
-            IgnoreComments = true,
-            IgnoreProcessingInstructions = true,
-            CloseInput = false
-        });
+        // Whitespace must NOT be ignored: a <t> holding only spaces is legitimate text content.
+        using var reader = PartXmlReader.Create(stream, ignoreWhitespace: false);
 
         while (reader.Read())
         {

--- a/XLibur/Excel/IO/WorksheetPartWriter.cs
+++ b/XLibur/Excel/IO/WorksheetPartWriter.cs
@@ -26,6 +26,110 @@ internal static class WorksheetPartWriter
         StreamToPart(worksheetDom, worksheetPart, xlWorksheet, context, options);
     }
 
+    /// <summary>
+    /// Reads the existing worksheet part into a detached DOM, substituting an empty
+    /// <see cref="SheetData"/> for the stored one.
+    /// </summary>
+    /// <remarks>
+    /// Reading the part as it stands and calling <c>LoadCurrentElement</c> on
+    /// <c>&lt;worksheet&gt;</c> materialises the entire part — every <c>&lt;row&gt;</c> and every
+    /// <c>&lt;c&gt;</c> as an OpenXML object — and <see cref="StreamToPart"/> then discards all of
+    /// it, because cells are streamed from the value slices instead. On a workbook holding
+    /// 20,000 x 21 cells that discarded DOM was most of the ~1.3 s and ~278 MB it took to save a
+    /// file nobody had changed; even on a template whose sheets hold 100 rows it was 41% of save
+    /// time. It also defeated the memory intent already recorded against the SheetData region
+    /// below.
+    /// <para>
+    /// An empty <see cref="SheetData"/> satisfies everything downstream: it is what
+    /// <c>Elements&lt;SheetData&gt;().First()</c> finds, what the content manager anchors
+    /// insertions on, and what <see cref="StreamToPart"/> matches to know where to splice the
+    /// streamed cells in.
+    /// </para>
+    /// <para>
+    /// Accessing the part through <c>worksheetPart.Worksheet</c> is not an option: that creates an
+    /// attached DOM which the SDK tracks and writes back to the part on its own.
+    /// </para>
+    /// </remarks>
+    private static Worksheet ReadWorksheetDomWithoutSheetData(WorksheetPart worksheetPart)
+    {
+        using var withoutRows = CopyPartWithEmptySheetData(worksheetPart);
+        using var reader = new OpenXmlPartReader(withoutRows, worksheetPart.Features, default);
+
+        // Create reads the XML declaration only, so the first Read lands on <worksheet>.
+        if (!reader.Read())
+            throw new ArgumentException("Worksheet part should contain worksheet xml, but is empty.");
+
+        return (Worksheet)reader.LoadCurrentElement()!;
+    }
+
+    /// <summary>
+    /// Copies the worksheet part into memory with <c>&lt;sheetData&gt;</c> reduced to an empty
+    /// element, leaving every other byte of markup as it was.
+    /// </summary>
+    /// <remarks>
+    /// The DOM is still built by a single <c>LoadCurrentElement</c> over a single document, and
+    /// that is what makes this safe. Loading the top-level children individually instead — each
+    /// appended to a hand-built root — is faster still, but it changes what gets written: a child
+    /// parsed on its own records the namespace declarations it needs rather than inheriting the
+    /// root's, so a part whose root uses a default namespace round-trips its
+    /// <c>mc:AlternateContent</c> subtrees as <c>&lt;controls xmlns="…"&gt;</c> where the file had
+    /// <c>&lt;x:controls&gt;</c>. Equivalent XML, different bytes, and this library holds itself to
+    /// byte-level round-trip fidelity.
+    /// <para>
+    /// The expensive part is skipped either way: rows are tokenised once by a raw reader instead
+    /// of being materialised into OpenXML objects the caller discards. What gets copied twice is
+    /// everything *except* <c>&lt;sheetData&gt;</c>, which on any sheet worth optimising is a
+    /// rounding error.
+    /// </para>
+    /// </remarks>
+    private static MemoryStream CopyPartWithEmptySheetData(WorksheetPart worksheetPart)
+    {
+        var buffer = new MemoryStream();
+
+        using (var partStream = worksheetPart.GetStream(FileMode.Open, FileAccess.Read))
+        using (var reader = PartXmlReader.CreateVerbatim(partStream))
+        using (var writer = XmlWriter.Create(buffer, new XmlWriterSettings
+               {
+                   CloseOutput = false,
+                   Encoding = XLHelper.NoBomUTF8,
+               }))
+        {
+            if (reader.MoveToContent() != XmlNodeType.Element)
+                throw new ArgumentException("Worksheet part should contain worksheet xml, but is empty.");
+
+            writer.WriteStartElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+            writer.WriteAttributes(reader, defattr: true);
+
+            if (!reader.IsEmptyElement)
+            {
+                reader.Read(); // Into the first child.
+
+                // WriteNode and Skip both leave the reader on the next node, so nothing in this
+                // loop calls Read again.
+                while (!reader.EOF && reader.NodeType != XmlNodeType.EndElement)
+                {
+                    if (reader.NodeType == XmlNodeType.Element &&
+                        reader.LocalName == "sheetData" &&
+                        reader.NamespaceURI == Main2006SsNs)
+                    {
+                        writer.WriteStartElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+                        writer.WriteEndElement();
+                        reader.Skip();
+                    }
+                    else
+                    {
+                        writer.WriteNode(reader, defattr: true);
+                    }
+                }
+            }
+
+            writer.WriteEndElement();
+        }
+
+        buffer.Position = 0;
+        return buffer;
+    }
+
     private static Worksheet GetWorksheetDom(
         bool partIsEmpty,
         WorksheetPart worksheetPart,
@@ -40,25 +144,7 @@ internal static class WorksheetPartWriter
 
         #region Worksheet
 
-        Worksheet worksheet;
-        if (!partIsEmpty)
-        {
-            // Accessing the worksheet through worksheetPart.Worksheet creates an attached DOM
-            // worksheet that is tracked and later saved automatically to the part.
-            // Using the reader, we get a detached DOM.
-            // The OpenXmlReader.Create method only reads XML declaration but doesn't read content.
-            using var reader = OpenXmlReader.Create(worksheetPart);
-            if (!reader.Read())
-            {
-                throw new ArgumentException("Worksheet part should contain worksheet xml, but is empty.");
-            }
-
-            worksheet = (Worksheet)reader.LoadCurrentElement()!;
-        }
-        else
-        {
-            worksheet = new Worksheet();
-        }
+        var worksheet = partIsEmpty ? new Worksheet() : ReadWorksheetDomWithoutSheetData(worksheetPart);
 
         if (worksheet.NamespaceDeclarations.All(ns => ns.Value != RelationshipsNs))
             worksheet.AddNamespaceDeclaration("r", RelationshipsNs);

--- a/XLibur/Excel/PivotTables/XLPivotReference.cs
+++ b/XLibur/Excel/PivotTables/XLPivotReference.cs
@@ -51,9 +51,15 @@ internal sealed class XLPivotReference
 
     internal HashSet<XLSubtotalFunction> Subtotals { get; init; } = new();
 
+    /// <remarks>
+    /// The value is stored as it is given. It is an index into one of three different collections
+    /// depending on the owning <see cref="XLPivotArea.CacheIndex"/> and on <see cref="ByPosition"/>,
+    /// but nothing here resolves it: the writer emits it verbatim and the area comparer only
+    /// compares it, so an index that points at nothing costs nothing to hold. Validating it would
+    /// mean refusing to load a file Excel opens, in exchange for no behaviour XLibur could improve.
+    /// </remarks>
     internal void AddFieldItem(uint fieldItem)
     {
-        // TODO: Check value by area.CacheIndex and ByPosition
         _fieldItems.Add(fieldItem);
     }
 }

--- a/XLibur/Excel/Style/XLAlignment.cs
+++ b/XLibur/Excel/Style/XLAlignment.cs
@@ -302,10 +302,22 @@ internal sealed class XLAlignment : IXLAlignment
 
     #endregion
 
+    /// <summary>
+    /// Apply a new component key to the cell this facade is attached to.
+    /// </summary>
+    /// <remarks>
+    /// The new key is deliberately <em>not</em> interned before being applied. Assigning it to
+    /// <c>Key</c> first would run a repository lookup -- hashing the key and probing a dictionary --
+    /// whose result is then thrown away: on a transition-cache hit <c>ModifyAlignment</c> never needs the
+    /// component value at all, and on a miss it interns the component anyway inside
+    /// <c>XLStyleValue.FromKey</c>. Taking the interned value back off the resulting style instead
+    /// leaves the facade just as correct for later reads, at no lookup. Measured over 20,000 cells
+    /// setting one property each, this was the single largest cost on the per-cell styling path.
+    /// </remarks>
     private void SetKey(XLAlignmentKey newKey)
     {
-        Key = newKey;
-        _style.ModifyAlignment(Key);
+        _style.ModifyAlignment(newKey);
+        _value = _style.Value.Alignment;
     }
 
     private void Modify(Func<XLAlignmentKey, XLAlignmentKey> modification)

--- a/XLibur/Excel/Style/XLBorder.cs
+++ b/XLibur/Excel/Style/XLBorder.cs
@@ -508,10 +508,22 @@ internal sealed class XLBorder : IXLBorder
 
     #endregion IXLBorder Members
 
+    /// <summary>
+    /// Apply a new component key to the cell this facade is attached to.
+    /// </summary>
+    /// <remarks>
+    /// The new key is deliberately <em>not</em> interned before being applied. Assigning it to
+    /// <c>Key</c> first would run a repository lookup -- hashing the key and probing a dictionary --
+    /// whose result is then thrown away: on a transition-cache hit <c>ModifyBorder</c> never needs the
+    /// component value at all, and on a miss it interns the component anyway inside
+    /// <c>XLStyleValue.FromKey</c>. Taking the interned value back off the resulting style instead
+    /// leaves the facade just as correct for later reads, at no lookup. Measured over 20,000 cells
+    /// setting one property each, this was the single largest cost on the per-cell styling path.
+    /// </remarks>
     private void SetKey(XLBorderKey newKey)
     {
-        Key = newKey;
-        _style.ModifyBorder(Key);
+        _style.ModifyBorder(newKey);
+        _value = _style.Value.Border;
     }
 
     /// <summary>

--- a/XLibur/Excel/Style/XLFill.cs
+++ b/XLibur/Excel/Style/XLFill.cs
@@ -59,10 +59,22 @@ internal sealed class XLFill : IXLFill
 
     internal void SyncValue(XLFillValue value) { _value = value; }
 
+    /// <summary>
+    /// Apply a new component key to the cell this facade is attached to.
+    /// </summary>
+    /// <remarks>
+    /// The new key is deliberately <em>not</em> interned before being applied. Assigning it to
+    /// <c>Key</c> first would run a repository lookup -- hashing the key and probing a dictionary --
+    /// whose result is then thrown away: on a transition-cache hit <c>ModifyFill</c> never needs the
+    /// component value at all, and on a miss it interns the component anyway inside
+    /// <c>XLStyleValue.FromKey</c>. Taking the interned value back off the resulting style instead
+    /// leaves the facade just as correct for later reads, at no lookup. Measured over 20,000 cells
+    /// setting one property each, this was the single largest cost on the per-cell styling path.
+    /// </remarks>
     private void SetKey(XLFillKey newKey)
     {
-        Key = newKey;
-        _style.ModifyFill(Key);
+        _style.ModifyFill(newKey);
+        _value = _style.Value.Fill;
     }
 
     private void Modify(Func<XLFillKey, XLFillKey> modification)

--- a/XLibur/Excel/Style/XLFont.cs
+++ b/XLibur/Excel/Style/XLFont.cs
@@ -110,10 +110,22 @@ internal sealed class XLFont : IXLFont
     /// <summary>
     /// Cell-container fast path: no Func&lt;&gt; allocation.
     /// </summary>
+    /// <summary>
+    /// Apply a new component key to the cell this facade is attached to.
+    /// </summary>
+    /// <remarks>
+    /// The new key is deliberately <em>not</em> interned before being applied. Assigning it to
+    /// <c>Key</c> first would run a repository lookup -- hashing the key and probing a dictionary --
+    /// whose result is then thrown away: on a transition-cache hit <c>ModifyFont</c> never needs the
+    /// component value at all, and on a miss it interns the component anyway inside
+    /// <c>XLStyleValue.FromKey</c>. Taking the interned value back off the resulting style instead
+    /// leaves the facade just as correct for later reads, at no lookup. Measured over 20,000 cells
+    /// setting one property each, this was the single largest cost on the per-cell styling path.
+    /// </remarks>
     private void SetKey(XLFontKey newKey)
     {
-        Key = newKey;
-        _style.ModifyFont(Key);
+        _style.ModifyFont(newKey);
+        _value = _style.Value.Font;
     }
 
     /// <summary>

--- a/XLibur/Excel/Style/XLFont.cs
+++ b/XLibur/Excel/Style/XLFont.cs
@@ -108,12 +108,13 @@ internal sealed class XLFont : IXLFont
     }
 
     /// <summary>
-    /// Cell-container fast path: no Func&lt;&gt; allocation.
-    /// </summary>
-    /// <summary>
     /// Apply a new component key to the cell this facade is attached to.
     /// </summary>
     /// <remarks>
+    /// The cell-container fast path, so it takes the key directly rather than a
+    /// <see cref="Func{T,TResult}"/> delta and allocates no closure. Contrast <see cref="Modify"/>,
+    /// which ranges and worksheets need.
+    /// <para>
     /// The new key is deliberately <em>not</em> interned before being applied. Assigning it to
     /// <c>Key</c> first would run a repository lookup -- hashing the key and probing a dictionary --
     /// whose result is then thrown away: on a transition-cache hit <c>ModifyFont</c> never needs the
@@ -121,6 +122,7 @@ internal sealed class XLFont : IXLFont
     /// <c>XLStyleValue.FromKey</c>. Taking the interned value back off the resulting style instead
     /// leaves the facade just as correct for later reads, at no lookup. Measured over 20,000 cells
     /// setting one property each, this was the single largest cost on the per-cell styling path.
+    /// </para>
     /// </remarks>
     private void SetKey(XLFontKey newKey)
     {

--- a/XLibur/Excel/Style/XLNumberFormat.cs
+++ b/XLibur/Excel/Style/XLNumberFormat.cs
@@ -126,10 +126,22 @@ internal sealed class XLNumberFormat : IXLNumberFormat
 
     #endregion IXLNumberFormat Members
 
+    /// <summary>
+    /// Apply a new component key to the cell this facade is attached to.
+    /// </summary>
+    /// <remarks>
+    /// The new key is deliberately <em>not</em> interned before being applied. Assigning it to
+    /// <c>Key</c> first would run a repository lookup -- hashing the key and probing a dictionary --
+    /// whose result is then thrown away: on a transition-cache hit <c>ModifyNumberFormat</c> never needs the
+    /// component value at all, and on a miss it interns the component anyway inside
+    /// <c>XLStyleValue.FromKey</c>. Taking the interned value back off the resulting style instead
+    /// leaves the facade just as correct for later reads, at no lookup. Measured over 20,000 cells
+    /// setting one property each, this was the single largest cost on the per-cell styling path.
+    /// </remarks>
     private void SetKey(XLNumberFormatKey newKey)
     {
-        Key = newKey;
-        _style.ModifyNumberFormat(Key);
+        _style.ModifyNumberFormat(newKey);
+        _value = _style.Value.NumberFormat;
     }
 
     private void Modify(Func<XLNumberFormatKey, XLNumberFormatKey> modification)

--- a/XLibur/Excel/Style/XLProtection.cs
+++ b/XLibur/Excel/Style/XLProtection.cs
@@ -112,10 +112,22 @@ internal sealed class XLProtection : IXLProtection
 
     #endregion IXLProtection Members
 
+    /// <summary>
+    /// Apply a new component key to the cell this facade is attached to.
+    /// </summary>
+    /// <remarks>
+    /// The new key is deliberately <em>not</em> interned before being applied. Assigning it to
+    /// <c>Key</c> first would run a repository lookup -- hashing the key and probing a dictionary --
+    /// whose result is then thrown away: on a transition-cache hit <c>ModifyProtection</c> never needs the
+    /// component value at all, and on a miss it interns the component anyway inside
+    /// <c>XLStyleValue.FromKey</c>. Taking the interned value back off the resulting style instead
+    /// leaves the facade just as correct for later reads, at no lookup. Measured over 20,000 cells
+    /// setting one property each, this was the single largest cost on the per-cell styling path.
+    /// </remarks>
     private void SetKey(XLProtectionKey newKey)
     {
-        Key = newKey;
-        _style.ModifyProtection(Key);
+        _style.ModifyProtection(newKey);
+        _value = _style.Value.Protection;
     }
 
     private void Modify(Func<XLProtectionKey, XLProtectionKey> modification)

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -385,13 +385,7 @@ public partial class XLWorkbook
         ref WorksheetSheetDataReader.SheetDataReadState state)
     {
         using var stream = worksheetPart.GetStream(FileMode.Open, FileAccess.Read);
-        using var reader = XmlReader.Create(stream, new XmlReaderSettings
-        {
-            IgnoreWhitespace = true,
-            IgnoreComments = true,
-            IgnoreProcessingInstructions = true,
-            CloseInput = false
-        });
+        using var reader = PartXmlReader.Create(stream);
 
         while (reader.Read())
         {
@@ -985,13 +979,7 @@ public partial class XLWorkbook
         if (tp is null) return;
 
         using var stream = tp.GetStream(FileMode.Open, FileAccess.Read);
-        using var reader = XmlReader.Create(stream, new XmlReaderSettings
-        {
-            IgnoreWhitespace = true,
-            IgnoreComments = true,
-            IgnoreProcessingInstructions = true,
-            CloseInput = false,
-        });
+        using var reader = PartXmlReader.Create(stream);
 
         // <a:theme> (0) / <a:themeElements> (1) / <a:clrScheme> (2). Matching on depth as well as
         // name is what keeps the scan off the <a:clrScheme> nested inside <a:extraClrSchemeLst>,

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -1008,7 +1008,19 @@ public partial class XLWorkbook
             if (string.IsNullOrEmpty(hex))
                 continue;
 
-            var color = XLColor.FromHexRgb(hex);
+            // A theme is decoration, so a malformed slot should cost that one colour rather than
+            // the whole workbook. FromHexRgb throws FormatException both for a value that is not
+            // six characters and for one containing a non-hex character.
+            XLColor color;
+            try
+            {
+                color = XLColor.FromHexRgb(hex);
+            }
+            catch (FormatException)
+            {
+                continue;
+            }
+
             switch (slot)
             {
                 case "lt1": theme.Background1 = color; break;

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -975,29 +975,127 @@ public partial class XLWorkbook
         return defaultColumnWidth;
     }
 
+    /// <summary>
+    /// Reads the twelve theme colours out of <c>&lt;a:clrScheme&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a raw <see cref="XmlReader"/> rather than <c>tp.Theme</c>. Touching the DOM
+    /// property materialises the whole theme part — font scheme, format scheme, gradient fills,
+    /// effect styles, and often an <c>extraClrSchemeLst</c> — which for a stock Excel theme is
+    /// ~7 KB of dense XML built into an object graph, all to read twelve hex strings. That is a
+    /// fixed cost paid on every workbook load regardless of its size, and it measured at ~8% of
+    /// total load time for a small workbook.
+    /// <para>
+    /// Only <c>&lt;a:srgbClr&gt;</c> is honoured, matching the DOM version this replaced: a slot
+    /// carrying <c>&lt;a:sysClr&gt;</c> leaves the corresponding <see cref="XLWorkbook.Theme"/>
+    /// property at its default.
+    /// </para>
+    /// </remarks>
     private static void LoadWorkbookTheme(ThemePart? tp, XLWorkbook wb)
     {
-        var colorScheme = tp?.Theme?.ThemeElements?.ColorScheme;
-        if (colorScheme == null) return;
+        if (tp is null) return;
 
-        static void SetIfPresent(string? hex, Action<XLColor> setter)
+        using var stream = tp.GetStream(FileMode.Open, FileAccess.Read);
+        using var reader = XmlReader.Create(stream, new XmlReaderSettings
         {
-            if (!string.IsNullOrEmpty(hex))
-                setter(XLColor.FromHexRgb(hex));
+            IgnoreWhitespace = true,
+            IgnoreComments = true,
+            IgnoreProcessingInstructions = true,
+            CloseInput = false,
+        });
+
+        // <a:theme> (0) / <a:themeElements> (1) / <a:clrScheme> (2). Matching on depth as well as
+        // name is what keeps the scan off the <a:clrScheme> nested inside <a:extraClrSchemeLst>,
+        // which lives a level deeper and would otherwise overwrite the real scheme.
+        if (!MoveToThemeElement(reader, "theme", depth: 0) ||
+            !MoveToThemeElement(reader, "themeElements", depth: 1) ||
+            !MoveToThemeElement(reader, "clrScheme", depth: 2) ||
+            reader.IsEmptyElement)
+            return;
+
+        var schemeDepth = reader.Depth;
+        var theme = wb.Theme;
+
+        while (reader.Read())
+        {
+            if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == schemeDepth)
+                break;
+
+            if (reader.NodeType != XmlNodeType.Element ||
+                reader.NamespaceURI != OpenXmlConst.DrawingMain2006Ns)
+                continue;
+
+            // ReadSlotColor consumes the slot's subtree, so the next Read lands on the next slot.
+            var slot = reader.LocalName;
+            var hex = ReadSlotColor(reader);
+            if (string.IsNullOrEmpty(hex))
+                continue;
+
+            var color = XLColor.FromHexRgb(hex);
+            switch (slot)
+            {
+                case "lt1": theme.Background1 = color; break;
+                case "dk1": theme.Text1 = color; break;
+                case "lt2": theme.Background2 = color; break;
+                case "dk2": theme.Text2 = color; break;
+                case "accent1": theme.Accent1 = color; break;
+                case "accent2": theme.Accent2 = color; break;
+                case "accent3": theme.Accent3 = color; break;
+                case "accent4": theme.Accent4 = color; break;
+                case "accent5": theme.Accent5 = color; break;
+                case "accent6": theme.Accent6 = color; break;
+                case "hlink": theme.Hyperlink = color; break;
+                case "folHlink": theme.FollowedHyperlink = color; break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Advances to the next DrawingML element with the given name at the given depth, giving up
+    /// once the reader leaves the current parent.
+    /// </summary>
+    private static bool MoveToThemeElement(XmlReader reader, string localName, int depth)
+    {
+        while (reader.Read())
+        {
+            if (reader.Depth < depth)
+                return false;
+
+            if (reader.NodeType == XmlNodeType.Element &&
+                reader.Depth == depth &&
+                reader.LocalName == localName &&
+                reader.NamespaceURI == OpenXmlConst.DrawingMain2006Ns)
+                return true;
         }
 
-        SetIfPresent(colorScheme.Light1Color?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Background1 = c);
-        SetIfPresent(colorScheme.Dark1Color?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Text1 = c);
-        SetIfPresent(colorScheme.Light2Color?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Background2 = c);
-        SetIfPresent(colorScheme.Dark2Color?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Text2 = c);
-        SetIfPresent(colorScheme.Accent1Color?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Accent1 = c);
-        SetIfPresent(colorScheme.Accent2Color?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Accent2 = c);
-        SetIfPresent(colorScheme.Accent3Color?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Accent3 = c);
-        SetIfPresent(colorScheme.Accent4Color?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Accent4 = c);
-        SetIfPresent(colorScheme.Accent5Color?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Accent5 = c);
-        SetIfPresent(colorScheme.Accent6Color?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Accent6 = c);
-        SetIfPresent(colorScheme.Hyperlink?.RgbColorModelHex?.Val?.Value, c => wb.Theme.Hyperlink = c);
-        SetIfPresent(colorScheme.FollowedHyperlinkColor?.RgbColorModelHex?.Val?.Value, c => wb.Theme.FollowedHyperlink = c);
+        return false;
+    }
+
+    /// <summary>
+    /// Reads the <c>val</c> of the first <c>&lt;a:srgbClr&gt;</c> inside the colour slot the
+    /// reader is positioned on, consuming the slot's subtree.
+    /// </summary>
+    private static string? ReadSlotColor(XmlReader reader)
+    {
+        if (reader.IsEmptyElement)
+            return null;
+
+        var slotDepth = reader.Depth;
+        string? hex = null;
+
+        while (reader.Read())
+        {
+            if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == slotDepth)
+                break;
+
+            if (hex is null &&
+                reader.NodeType == XmlNodeType.Element &&
+                reader.LocalName == "srgbClr" &&
+                reader.NamespaceURI == OpenXmlConst.DrawingMain2006Ns)
+                hex = reader.GetAttribute("val");
+        }
+
+        return hex;
     }
 
     private static void LoadWorkbookProtection(WorkbookProtection? wp, XLWorkbook wb)

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -348,15 +348,13 @@ public partial class XLWorkbook
         {
             while (reader.Read())
             {
-                // Custom sheet views contain their own auto filter data, and more, which should be ignored for now
-                while (reader.ElementType == typeof(CustomSheetViews))
+                // Skipped wholesale, without descending:
+                //  - CustomSheetViews carries its own auto filter data and more, ignored for now.
+                //  - SheetData is read in pass 2 by the raw reader.
+                // ReadNextSibling leaves the reader *on* the next sibling rather than needing
+                // another Read, which is why this is a leading loop rather than a `continue`.
+                while (reader.ElementType == typeof(CustomSheetViews) || reader.ElementType == typeof(SheetData))
                     reader.ReadNextSibling();
-
-                if (reader.ElementType == typeof(SheetData))
-                {
-                    SkipSheetData(reader);
-                    continue;
-                }
 
                 if (reader.ElementType == typeof(SheetProperties))
                 {
@@ -373,24 +371,15 @@ public partial class XLWorkbook
     }
 
     /// <summary>
-    /// Advances the SDK reader past the entire <c>&lt;sheetData&gt;</c> subtree without
-    /// materializing rows/cells. The reader is positioned on <c>&lt;sheetData&gt;</c>; on return it
-    /// is on the <c>&lt;/sheetData&gt;</c> end element so the caller's <c>Read()</c> continues with
-    /// the next sibling. Rows are skipped individually (mirroring <see cref="LoadMergeCellsStreaming"/>)
-    /// because <see cref="OpenXmlPartReader.Skip"/> leaves the reader on the next sibling.
-    /// </summary>
-    private static void SkipSheetData(OpenXmlPartReader reader)
-    {
-        reader.MoveAhead(); // Move into <sheetData> (first <row> or </sheetData>).
-
-        while (reader.IsStartElement("row"))
-            reader.Skip();
-    }
-
-    /// <summary>
     /// Reads the <c>&lt;sheetData&gt;</c> rows and cells from a raw <see cref="XmlReader"/> opened
     /// over the worksheet part stream. See <see cref="WorksheetSheetDataReader.LoadSheetDataRows"/>.
     /// </summary>
+    /// <remarks>
+    /// Opening a second stream over the part and rescanning to <c>&lt;sheetData&gt;</c> is close to
+    /// free — measured at 0.05–0.65 ms per load across sheet shapes, because everything ahead of
+    /// <c>&lt;sheetData&gt;</c> is small. Collapsing the two passes into one is therefore not worth
+    /// the loader rewrite it would take.
+    /// </remarks>
     private static void LoadSheetDataRaw(WorksheetPart worksheetPart,
         in WorksheetSheetDataReader.SheetDataReadContext context,
         ref WorksheetSheetDataReader.SheetDataReadState state)

--- a/XLibur/Extensions/XDocumentExtensions.cs
+++ b/XLibur/Extensions/XDocumentExtensions.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Xml;
 using System.Xml.Linq;
+using XLibur.Excel.IO;
 
 namespace XLibur.Extensions;
 
@@ -8,7 +9,7 @@ internal static class XDocumentExtensions
 {
     public static XDocument? Load(Stream stream)
     {
-        using var reader = XmlReader.Create(stream);
+        using var reader = PartXmlReader.CreateVerbatim(stream);
         try
         {
             return XDocument.Load(reader);

--- a/XLibur/XLibur.csproj
+++ b/XLibur/XLibur.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <LangVersion>default</LangVersion>

--- a/docs/sonar.md
+++ b/docs/sonar.md
@@ -1,4 +1,4 @@
-﻿# SonarQube issues — XLibur_XLibur
+# SonarQube issues — XLibur_XLibur
 
 This file covers two exports. The 278-issue sweep is first; the earlier 150-issue
 `MEDIUM` triage follows it, unchanged.

--- a/docs/specs/18-template-round-trip-overhead.md
+++ b/docs/specs/18-template-round-trip-overhead.md
@@ -241,11 +241,11 @@ is machine variance, not a new win — identical allocation says it is the same 
 profiled application. Against a 10-sheet fixture: 0 names → 3.2 MB, 20 names → 3.3 MB; then 0 → 26 → 100
 validations holds flat at 3.3 MB. Allocation is reported exactly by the probe, so this part is solid.
 
-**Their time cost is not established either way, and one run should not be trusted here.** A first
-decomposition put 20 names *below* 0 names (28.5 ms against 30.6 ms); a second, over a byte-identical
-fixture (22,725 B both times), put it 70% *above* (46.3 ms against 27.2 ms). Nothing changed but the
-machine. Anyone wanting a time answer for names or validations needs a BenchmarkDotNet case, not this
-probe — see the measurement warning under task 0, which exists because this spec has already published two
+**Their time cost is not established, and one run should not be trusted here.** Three decompositions over a
+byte-identical fixture (22,725 B every time) put 20 names at 28.5 ms against 30.6 ms for none, then 46.3
+against 27.2, then 25.9 against 27.6. Two of the three say free and one says 70% dearer; nothing changed
+but the machine. Anyone wanting a time answer for names or validations needs a BenchmarkDotNet case, not
+this probe — see the measurement warning under task 0, which exists because this spec has already published
 figures that did not survive re-measurement.
 
 What the sheet-count slope shows is robust because it is read across three points that all move together
@@ -253,31 +253,37 @@ and is corroborated by allocation. The rest of the table is not.
 
 Left unchased by scope, as instructed: `System.IO.Packaging` buffering and `XmlWriter` internals (Spec 01/03).
 
-### Task 5 — Each additional worksheet costs ~2.2 ms and ~0.24 MB to round-trip ⬜ (attributed)
+### Task 5 — A worksheet costs ~1.0 ms and ~0.19 MB structurally, before any row on it ⬜ (attributed)
 
-> **Correction.** This task was first written as "each *structurally empty* worksheet". That is wrong, and
-> the trace is what caught it. `TemplateFixture` gives every lookup sheet `LookupRows = 100` rows plus a
-> header, so the sheets whose count the slope varies each carry 101 rows of a one-column string table —
-> `LoadRowXml` and `LoadCellXml` together account for 18.6% of the trace on a fixture described as having
-> no data. The slope below is real, but it is the cost of *a lookup sheet*, not of an empty one. The true
-> structural floor is still unmeasured; it needs a fixture whose lookup row count is a parameter.
+> **Correction.** This task first claimed ~2.2 ms per *structurally empty* worksheet. It was measuring
+> sheets that each held 101 rows: `TemplateFixture` hard-coded `LookupRows = 100`, so sheet count and row
+> count moved together and the slope charged the rows to the sheet. `LoadRowXml` and `LoadCellXml` being
+> 18.6% of a trace of a fixture described as having no data is what exposed it. `lookupRows` is now a
+> parameter and the two are separated below.
 
-`profile template`, varying only the sheet count with zero data rows:
+`profile template`, two sheet-count sweeps differing only in rows per lookup sheet:
 
-| sheets | round trip | alloc | fixture on disk |
-|---:|---:|---:|---:|
-| 1 | 7.3 ms | 1.1 MB | 6,437 B |
-| 10 | 27.2 ms | 3.2 MB | 22,581 B |
-| 40 | 101.1 ms | 10.6 MB | 76,074 B |
+| sheets | header-only | 100 rows/sheet |
+|---:|---:|---:|
+| 1 | 6.3 ms / 1.1 MB / 6,437 B | 7.5 ms / 1.1 MB / 6,437 B |
+| 10 | 15.1 ms / 2.8 MB / 12,766 B | 27.6 ms / 3.2 MB / 22,581 B |
+| 40 | 46.8 ms / 8.5 MB / 33,749 B | 94.4 ms / 10.6 MB / 76,074 B |
 
-The slope is consistent across both intervals — 2.21 ms / 0.23 MB per sheet from 1→10, and 2.46 ms /
-0.25 MB per sheet from 10→40. Each worksheet carries ~1.8 KB of XML, so this is roughly **130× the
-on-disk size in allocation**, and costs about what 1,300 grid cells cost, for a sheet containing no cells
-at all.
+| | per sheet, time | per sheet, alloc |
+|---|---:|---:|
+| **structural (header-only)** | **~1.0 ms** | **~0.19 MB** |
+| the 100 rows on top | ~1.2 ms | ~0.05 MB |
+| *(total, as previously reported)* | ~2.2 ms | ~0.24 MB |
 
-It is the dominant remaining term on any template-shaped workbook: on the 10-sheet fixture it is roughly
-20 of the 27.2 ms round trip. Unlike rows and distinct strings (task 3), it scales with nothing the caller
-can reduce — the sheets are already empty.
+Both slopes hold across both intervals — 0.98 and 1.06 ms/sheet header-only, 2.23 and 2.23 with rows — so
+the split is real. At `sheets=1` the two sweeps build a byte-identical fixture (6,437 B) and still measured
+6.3 against 7.5 ms, which sets the probe's noise floor at ~1.2 ms here; the slopes come from differences of
+8.8 and 31.7 ms, well clear of it.
+
+**The structural half is the interesting one.** A header-only worksheet adds ~703 B to the file and ~0.19 MB
+of allocation — roughly **270× its on-disk size**, for a sheet holding one cell. Allocation is where the
+split is starkest: rows contribute only ~21% of the per-sheet bytes. Unlike rows and distinct strings
+(task 3), this scales with nothing the caller can reduce.
 
 #### Attribution
 

--- a/docs/specs/18-template-round-trip-overhead.md
+++ b/docs/specs/18-template-round-trip-overhead.md
@@ -3,7 +3,7 @@
 **Area:** Performance (read + write time, memory)
 **Effort:** M (task 1 is the bulk of the win; 2–4 are independent follow-ons)
 **Dependencies:** Touches `WorksheetPartWriter` and the style façades. Coordinate with Spec 03 (both touch the save path) and Spec 11 (create-path allocations); no overlap with the `SheetDataWriter` cell loop, which is already tuned.
-**Status:** Tasks 0–2 done — see [Results](#results). Tasks 3–4 open.
+**Status:** Tasks 0–3 done — see [Results](#results). Task 4 open.
 
 ## Summary
 
@@ -42,7 +42,7 @@ dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile
 | 0 | Benchmarks + decomposition probe that expose all of this | ✅ Done | S |
 | 1 | Stop materialising `<sheetData>` into a DOM on save | ✅ Done (`26b248d9`) | M |
 | 2 | Per-cell styling: CPU cost in the façade setters | ✅ Done (`4d98f127`) — allocation share found inherent | M |
-| 3 | Lookup-column refresh costs ~3× per cell versus the grid path — cause unknown | ⬜ Needs investigation | S |
+| 3 | Lookup-column refresh costs ~3× per cell versus the grid path | ✅ Explained — inherent, no fix | S |
 | 4 | Re-verify and file the remainder | ⬜ Proposed | S |
 
 ---
@@ -159,11 +159,33 @@ The lookup is waste in both directions `ModifyXxx` can go: on a transition-cache
 
 **Noted while here, not fixed:** `XLStyleValue.GetTransition` matches on the 32-bit transition hash alone and never compares the key, so two component keys sharing a hash *and* a cache slot would hand back the wrong style. The window is small — an 8-entry direct-mapped cache — and the risk predates this work, but it is a correctness bug rather than a performance one and deserves its own issue.
 
-### Task 3 — Lookup refresh costs ~3× per cell ⬜
+### Task 3 — Lookup refresh costs ~3× per cell ✅ Explained — not a defect
 
-`profile template`, lookup refresh: 10,000 values cost ~38 ms above the round-trip floor, ≈3.8 µs per cell, where the grid path runs ≈1.3 µs per cell for write + save. Candidate causes, none yet confirmed: 10,000 *unique* strings pressuring the shared-string table where the grid repeats `"Yes"`/`"No"`; or extending the used range from 100 to 10,000 rows interacting with the 26 data validations and 20 defined names on the fixture.
+`profile template`, lookup refresh: the 1,000 → 10,000 step costs ≈5.4 µs per cell where the grid path runs ≈1.3 µs per cell for write + save. Two causes were proposed and neither had evidence: shared-string pressure, because the lookup values are all distinct; or the sheet's geometry, because a single column pays whatever a row costs once per cell instead of once per twenty.
 
-**Measure before designing.** This is the one finding here with no established mechanism.
+`SheetGeometryBenchmarks` crosses the two — 20,000 string cells in every variant, so a difference is a difference *per cell*:
+
+| variant | mean | allocated |
+|---|---:|---:|
+| `TallNarrow_Unique` | 40.73 ms | 17.42 MB |
+| `TallNarrow_Repeated` | 29.71 ms | 9.96 MB |
+| `ShortWide_Unique` | 30.74 ms | 12.85 MB |
+| `ShortWide_Repeated` | 17.70 ms | 5.50 MB |
+
+**Both effects are real, roughly equal, independent, and they compound.** Geometry costs 25–40%; string uniqueness costs 27–42%; together the worst quadrant is 2.3× the best in time and 3.2× in allocation. Neither candidate was "the" cause, which is why crossing them mattered — either comparison alone would have confounded the two and produced a confident wrong answer.
+
+Splitting the geometry penalty by phase (unique strings) locates it:
+
+| phase | tall narrow | short wide | penalty |
+|---|---:|---:|---:|
+| write only | 10.45 ms / 7.45 MB | 8.38 ms / 6.15 MB | +2.07 ms — 19% |
+| save (by subtraction) | 30.98 ms / 9.97 MB | 22.12 ms / 6.70 MB | **+8.86 ms — 81%** |
+
+So it is mostly the `<row>` element and its bookkeeping, ~443 ns per row, not the row storage. The string effect is a flat ~7.4 MB per 20,000 distinct values (~373 B each) whichever way the sheet is shaped, exactly as one shared-string entry plus one `<si>` per distinct value should behave.
+
+**Conclusion: there is nothing to fix.** Both costs are inherent to the data's shape — a row costs what a row costs, and a distinct string has to be stored and written once. The lookup refresh simply sits in the worst quadrant of both while the grid sits near the best: 21 columns wide, and only about a quarter of its cells are unique strings (the rest are numbers, dates and a repeated `"Yes"`/`"No"`). That accounts for the ~4× without any defect. `SheetDataWriter.WriteStartRow` was inspected and is already tight — it early-outs before touching row attributes when no `XLRow` exists.
+
+**Guidance rather than a code change:** cost scales with rows and with *distinct* values, not with cells. A caller refreshing a tall single-column lookup is on the most expensive path there is, and the lever available to them is the data, not the library.
 
 ### Task 4 — Re-verify and file the remainder ⬜
 

--- a/docs/specs/18-template-round-trip-overhead.md
+++ b/docs/specs/18-template-round-trip-overhead.md
@@ -3,7 +3,7 @@
 **Area:** Performance (read + write time, memory)
 **Effort:** M (task 1 is the bulk of the win; 2–4 are independent follow-ons)
 **Dependencies:** Touches `WorksheetPartWriter` and the style façades. Coordinate with Spec 03 (both touch the save path) and Spec 11 (create-path allocations); no overlap with the `SheetDataWriter` cell loop, which is already tuned.
-**Status:** Tasks 0 and 1 done — see [Results](#results). Tasks 2–4 open.
+**Status:** Tasks 0–2 done — see [Results](#results). Tasks 3–4 open.
 
 ## Summary
 
@@ -41,7 +41,7 @@ dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile
 |---|------|--------|------|
 | 0 | Benchmarks + decomposition probe that expose all of this | ✅ Done | S |
 | 1 | Stop materialising `<sheetData>` into a DOM on save | ✅ Done (`26b248d9`) | M |
-| 2 | Per-cell styling costs ~2.3× because the wrapper caches never hit | ⬜ Proposed | M |
+| 2 | Per-cell styling: CPU cost in the façade setters | ✅ Done (`4d98f127`) — allocation share found inherent | M |
 | 3 | Lookup-column refresh costs ~3× per cell versus the grid path — cause unknown | ⬜ Needs investigation | S |
 | 4 | Re-verify and file the remainder | ⬜ Proposed | S |
 
@@ -114,16 +114,50 @@ BenchmarkDotNet, net10.0 Release, before/after task 1:
 
 `LoadRowHeavy` is load-only and unaffected, as expected; it is listed as the control.
 
-### Task 2 — Per-cell styling costs ~2.3× ⬜
+### Task 2 — Per-cell styling costs ~2.3× ✅ (partly; see below)
 
-Corroborated twice:
+The symptom was corroborated twice:
 
 - `profile template` — per-cell vs per-column number format is **2.1–2.6× time and a stable 2.3× allocation** across 1,000/5,000/20,000 rows.
 - `profile alloc` — `CreateFormattedAndSave` allocates **183.3 MB** in the create phase against **25.1 MB** for the same rows unformatted.
 
-**Mechanism.** `XLStylizedBase` caches its `XLStyle` façade in `_cachedStyle`, and `XLStyle` caches `_cachedNumberFormat`; `XLStyleValue` additionally memoises key transitions (`StoreTransition`). The machinery is already designed to avoid this cost — but `worksheet.Cell(r, c)` returns a **fresh `XLCell` on every call**, so those per-object caches are always cold. Each formatted cell therefore allocates the cell plus a fresh façade chain.
+**The mechanism first recorded here was wrong**, and it is worth saying why rather than quietly deleting it. It claimed the façade objects were the cost, because `Cell(r, c)` returns a fresh `XLCell` whose `_cachedStyle` is therefore always cold. Two things are wrong with that. `XLCellsCollection.GetCell` already keeps a direct-mapped `XLCell` cache; and, more importantly, the façades barely allocate.
 
-Options, in rough order of appeal: cache the façade per worksheet keyed by nothing (re-target the wrapper's container on access); pool/cache `XLCell` instances from `Cell(r, c)`; or add a bulk styling API and document per-column styling as the fast path. Needs a design decision before implementation — note that `Cell(r,c)` returning a stable instance has semantics implications well beyond styling.
+`CellStylingBenchmarks` splits the path. Per 20,000 cells, against an unstyled write of the same values:
+
+| step | time | allocated |
+|---|---:|---:|
+| `XLStyle` façade | 21 ns/cell | 76 B/cell |
+| `XLNumberFormat` façade | 6 ns/cell | 31 B/cell |
+| the `.Format = x` setter | **163 ns/cell** | 23 B/cell |
+| *(for scale: assigning a pre-built `IXLStyle` instead)* | 59 ns/cell | 123 B/cell |
+
+So the whole façade chain is ~2% of the styling **allocation** and ~14% of its **time**. The allocation is the style-slice write, and it is inherent: a distinct style per cell is N slice entries, exactly as `BulkStyleBenchmarks` already concluded for spec 05's criterion 3. **There is no allocation win available here.** Per-column styling stays 2.3× leaner because it writes one style, not 20,000.
+
+What *was* available was CPU, in the setter. Every façade applied a component key by interning it and then handing it straight back:
+
+```csharp
+private void SetKey(XLNumberFormatKey newKey)
+{
+    Key = newKey;                    // XLNumberFormatValue.FromKey -> repository lookup
+    _style.ModifyNumberFormat(Key);  // hashes the same key again
+}
+```
+
+The lookup is waste in both directions `ModifyXxx` can go: on a transition-cache hit it never needs the component value, and on a miss it interns the component anyway inside `XLStyleValue.FromKey`. All six façades shared the pattern. Fixed in `4d98f127` by applying the modification first and taking the interned value back off the resulting style.
+
+`CellStylingBenchmarks`, ratio against the unstyled write in the same run:
+
+| Benchmark | before | after |
+|---|---|---|
+| `StyleFacadePerCell` | 2.38 (median 6.56 ms) | **1.57** (median 4.38 ms) |
+| `TwoPropertiesPerCell` | 2.66 (median 7.28 ms) | **2.11** (median 6.06 ms) |
+
+≈328 → ≈219 ns per styled cell. Allocation unchanged at 7.58 MB.
+
+**Still open.** The setter is now ~82 ns/cell against ~59 ns/cell for assigning a pre-built style, so roughly 23 ns/cell of key-hashing and transition machinery remains. Diminishing, and worth measuring before assuming it is reachable.
+
+**Noted while here, not fixed:** `XLStyleValue.GetTransition` matches on the 32-bit transition hash alone and never compares the key, so two component keys sharing a hash *and* a cache slot would hand back the wrong style. The window is small — an 8-entry direct-mapped cache — and the risk predates this work, but it is a correctness bug rather than a performance one and deserves its own issue.
 
 ### Task 3 — Lookup refresh costs ~3× per cell ⬜
 

--- a/docs/specs/18-template-round-trip-overhead.md
+++ b/docs/specs/18-template-round-trip-overhead.md
@@ -3,7 +3,7 @@
 **Area:** Performance (read + write time, memory)
 **Effort:** M (task 1 is the bulk of the win; 2–4 are independent follow-ons)
 **Dependencies:** Touches `WorksheetPartWriter` and the style façades. Coordinate with Spec 03 (both touch the save path) and Spec 11 (create-path allocations); no overlap with the `SheetDataWriter` cell loop, which is already tuned.
-**Status:** Tasks 0–3 done — see [Results](#results). Task 4 open.
+**Status:** Tasks 0–4 done — see [Results](#results). Task 5 open (the dominant remaining cost).
 
 ## Summary
 
@@ -41,9 +41,10 @@ dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile
 |---|------|--------|------|
 | 0 | Benchmarks + decomposition probe that expose all of this | ✅ Done | S |
 | 1 | Stop materialising `<sheetData>` into a DOM on save | ✅ Done (`26b248d9`) | M |
-| 2 | Per-cell styling: CPU cost in the façade setters | ✅ Done (`4d98f127`) — allocation share found inherent | M |
+| 2 | Per-cell styling: CPU cost in the façade setters | ✅ Done (`4d98f127`) — allocation share found inherent; **win restated at −13% by task 4** | M |
 | 3 | Lookup-column refresh costs ~3× per cell versus the grid path | ✅ Explained — inherent, no fix | S |
-| 4 | Re-verify and file the remainder | ⬜ Proposed | S |
+| 4 | Re-verify and file the remainder | ✅ Done | S |
+| 5 | Each structurally empty worksheet costs ~2.2 ms / ~0.24 MB to round-trip | ⬜ Proposed | M |
 
 ---
 
@@ -54,6 +55,10 @@ dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile
 - `XLibur.Benchmarks/TemplateFixture.cs` — the shared synthetic template.
 
 **Do not use the probe's timings to claim a change.** On the reference machine they move by tens of percent between runs of identical code — the same order as the effects being chased. The probe locates cost and reports exact allocation; BenchmarkDotNet proves movement. An early iteration of this work reported a 30% win that BenchmarkDotNet then showed to be ~0%.
+
+**BenchmarkDotNet is not automatically trustworthy either** — it is only trustworthy when its warnings are clear. Task 2's win was overstated by 2.5× because its benchmark ran 2.7 ms iterations against the recommended 100 ms and divided by a baseline that scattered 2.7–6.1 ms; BDN said so in a `MinIterationTime` warning that went unread. Before believing a `Ratio`, check three things: that the `MinIterationTime` warning is absent or the iteration is comfortably long, that the *baseline's* removed outliers do not span an appreciable fraction of its mean, and — for anything with `[IterationSetup]` — that the previous iteration's garbage is collected in `[IterationCleanup]` rather than inside the next measurement.
+
+**A/B the controls, not just the target.** The reliable signal in the task 2 re-run was not the two benchmarks that improved; it was the five that did not move while they did. A change that appears to shift every variant in the table, or that shifts variants it cannot reach, is measuring the machine.
 
 ### Task 1 — Stop materialising `<sheetData>` into a DOM on save ✅
 
@@ -146,16 +151,45 @@ private void SetKey(XLNumberFormatKey newKey)
 
 The lookup is waste in both directions `ModifyXxx` can go: on a transition-cache hit it never needs the component value, and on a miss it interns the component anyway inside `XLStyleValue.FromKey`. All six façades shared the pattern. Fixed in `4d98f127` by applying the modification first and taking the interned value back off the resulting style.
 
-`CellStylingBenchmarks`, ratio against the unstyled write in the same run:
+The fix is real but smaller than first reported. **Task 4 re-ran the A/B and the original figures did not
+reproduce; they are corrected here.** What was recorded — 2.38 → 1.57, ≈328 → ≈219 ns per styled cell —
+came from a benchmark whose iterations ran 2.7–5.8 ms against BenchmarkDotNet's recommended 100 ms, and
+whose `ValueOnly` baseline scattered across 2.7–6.1 ms. Since every `Ratio` in the table divides by that
+baseline, the reported win was mostly baseline movement. A first re-run disagreed with itself in opposite
+directions on two benchmarks, which is what exposed it.
 
-| Benchmark | before | after |
-|---|---|---|
-| `StyleFacadePerCell` | 2.38 (median 6.56 ms) | **1.57** (median 4.38 ms) |
-| `TwoPropertiesPerCell` | 2.66 (median 7.28 ms) | **2.11** (median 6.06 ms) |
+Re-measured at 100,000 rows with a forced gen2 collection in `IterationCleanup` (so the previous
+iteration's workbook is reclaimed outside the measured region), A/B against `4d98f127~1` with the
+benchmark project byte-identical across both arms:
 
-≈328 → ≈219 ns per styled cell. Allocation unchanged at 7.58 MB.
+| Benchmark | setter per cell | before | after | Δ |
+|---|---|---:|---:|---:|
+| `StyleFacadePerCell` | 1× | 48.26 ms | **43.76 ms** | −4.50 |
+| `TwoPropertiesPerCell` | 2× | 58.95 ms | **54.23 ms** | −4.72 |
+| `ValueOnly` *(control)* | — | 24.57 ms | 23.05 ms | −1.52 |
+| `FacadeStyleOnly` *(control)* | — | 42.00 ms | 42.46 ms | +0.46 |
+| `FacadeChainOnly` *(control)* | — | 40.22 ms | 40.37 ms | +0.15 |
+| `StyleAssignedPerCell` *(control)* | — | 43.46 ms | 43.28 ms | −0.18 |
+| `StyleOnColumn` *(control)* | — | 18.11 ms | 18.13 ms | +0.02 |
 
-**Still open.** The setter is now ~82 ns/cell against ~59 ns/cell for assigning a pre-built style, so roughly 23 ns/cell of key-hashing and transition machinery remains. Diminishing, and worth measuring before assuming it is reachable.
+The five controls never call a façade setter and scatter within ±1.5 ms in both directions; the two that
+do call it both improve, with non-overlapping error bars. Measured against each run's own baseline the
+styling overhead falls **237 → 207 ns/cell** for one property (−13%) and 344 → 312 ns/cell for two
+(−9%). Allocation is unchanged, as expected for a pure lookup elision.
+
+**The per-step split above is regime-dependent — do not read it as fixed.** Re-measuring at 100,000 rows
+inverts it: `FacadeStyleOnly` rises to ratio 1.85 and `FacadeChainOnly` to 1.76, i.e. building the façade
+and setting *nothing* costs nearly as much as the whole styled write, and `FacadeChainOnly` comes out
+*cheaper* than `FacadeStyleOnly` despite doing strictly more work. The GC columns explain it: every styled
+variant runs 2× the baseline's Gen0 collections plus Gen1 collections the baseline never triggers, so past
+~20K styled cells the measurement is dominated by reclaiming the extra allocation rather than by the style
+code. The 21/6/163 ns attribution holds at 20K rows and nowhere else. Allocation ratios, by contrast, are
+stable across both sizes (1.52 / 1.49 / 1.74 / 1.31 / 1.43 / 0.65) — that part of the conclusion was always
+sound.
+
+**Still open.** Roughly 207 ns/cell of styling overhead remains against 20 ns/cell for the value write.
+Whether any of it is reachable is unmeasured; the transition machinery is the obvious suspect, but see the
+regime warning above before trusting any per-step number that motivates chasing it.
 
 **Noted while here, not fixed:** `XLStyleValue.GetTransition` matches on the 32-bit transition hash alone and never compares the key, so two component keys sharing a hash *and* a cache slot would hand back the wrong style. The window is small — an 8-entry direct-mapped cache — and the risk predates this work, but it is a correctness bug rather than a performance one and deserves its own issue.
 
@@ -187,9 +221,52 @@ So it is mostly the `<row>` element and its bookkeeping, ~443 ns per row, not th
 
 **Guidance rather than a code change:** cost scales with rows and with *distinct* values, not with cells. A caller refreshing a tall single-column lookup is on the most expensive path there is, and the lever available to them is the data, not the library.
 
-### Task 4 — Re-verify and file the remainder ⬜
+### Task 4 — Re-verify and file the remainder ✅
 
-After tasks 1–3, re-run the benchmark set and the `profile template` decomposition. File follow-ups for anything ≥ 5% of what remains. Note but do not chase `System.IO.Packaging` buffering and `XmlWriter` internals — that is Spec 01/03 territory.
+**Tasks 1 and 3 reproduce exactly.** All five `TemplateRoundTripBenchmarks` match their recorded post-fix
+values with allocation identical to the byte (`OpenAndSaveRowHeavyUnchanged` 921.3 ms / 88.83 MB,
+`LoadRowHeavy` 389.8 ms / 55.4 MB, `Open` 4.22 ms / 1.67 MB, `OpenAndSaveUnchanged` 7.89 ms / 3.17 MB,
+`RefreshLookupColumn` 9.91 ms / 3.83 MB). All six `SheetGeometryBenchmarks` land within noise of theirs,
+allocation again identical to the byte. Times sit 5–7% below the recorded figures across the board, which
+is machine variance, not a new win — identical allocation says it is the same code path.
+
+**Task 2 did not reproduce and has been corrected above**, along with the benchmark that produced it.
+
+**Filed as task 5:** per-worksheet round-trip cost, the dominant remaining term.
+
+**Ruled out by the same decomposition**, both previously plausible suspects from the profiled application:
+
+- **Defined names are free.** 10 sheets with 0 names round-trips in 30.6 ms; with 20 names, 28.5 ms.
+- **Data validations are free.** 0 → 26 → 100 validations moves 28.5 → 28.3 → 29.6 ms, inside probe noise.
+
+So the template that triggered this spec — ~10 sheets, ~20 defined names, ~26 validations — pays for its
+sheet *count* and essentially nothing for the features that looked like the obvious cause.
+
+Left unchased by scope, as instructed: `System.IO.Packaging` buffering and `XmlWriter` internals (Spec 01/03).
+
+### Task 5 — Each structurally empty worksheet costs ~2.2 ms and ~0.24 MB to round-trip ⬜
+
+`profile template`, varying only the sheet count with zero data rows:
+
+| sheets | round trip | alloc | fixture on disk |
+|---:|---:|---:|---:|
+| 1 | 10.9 ms | 1.3 MB | 8,312 B |
+| 10 | 30.6 ms | 3.2 MB | 22,581 B |
+| 40 | 96.9 ms | 10.6 MB | 76,074 B |
+
+The slope is linear and consistent across both intervals — 2.19 ms / 0.21 MB per sheet from 1→10, and
+2.21 ms / 0.25 MB per sheet from 10→40. Each worksheet carries ~1.8 KB of XML, so this is roughly **135×
+the on-disk size in allocation**, and costs about what 1,370 grid cells cost, for a sheet containing no
+cells at all.
+
+It is the dominant remaining term on any template-shaped workbook: on the 10-sheet fixture it is 22 of the
+30.6 ms round trip. Unlike rows and distinct strings (task 3), it scales with nothing the caller can
+reduce — the sheets are already empty.
+
+**Not yet attributed.** `profile template loop roundtrip` uses exactly this fixture (10 sheets, 0 data
+rows) and is the right workload to trace. The split to establish first is packaging versus XLibur: a part
+per sheet through `System.IO.Packaging` is Spec 01/03 territory and out of scope here, whereas per-sheet
+DOM and content-manager work is not. Do that attribution before designing anything.
 
 ## Already ruled out
 

--- a/docs/specs/18-template-round-trip-overhead.md
+++ b/docs/specs/18-template-round-trip-overhead.md
@@ -253,7 +253,14 @@ and is corroborated by allocation. The rest of the table is not.
 
 Left unchased by scope, as instructed: `System.IO.Packaging` buffering and `XmlWriter` internals (Spec 01/03).
 
-### Task 5 — Each structurally empty worksheet costs ~2.2 ms and ~0.24 MB to round-trip ⬜
+### Task 5 — Each additional worksheet costs ~2.2 ms and ~0.24 MB to round-trip ⬜ (attributed)
+
+> **Correction.** This task was first written as "each *structurally empty* worksheet". That is wrong, and
+> the trace is what caught it. `TemplateFixture` gives every lookup sheet `LookupRows = 100` rows plus a
+> header, so the sheets whose count the slope varies each carry 101 rows of a one-column string table —
+> `LoadRowXml` and `LoadCellXml` together account for 18.6% of the trace on a fixture described as having
+> no data. The slope below is real, but it is the cost of *a lookup sheet*, not of an empty one. The true
+> structural floor is still unmeasured; it needs a fixture whose lookup row count is a parameter.
 
 `profile template`, varying only the sheet count with zero data rows:
 
@@ -272,10 +279,34 @@ It is the dominant remaining term on any template-shaped workbook: on the 10-she
 20 of the 27.2 ms round trip. Unlike rows and distinct strings (task 3), it scales with nothing the caller
 can reduce — the sheets are already empty.
 
-**Not yet attributed.** `profile template loop roundtrip` uses exactly this fixture (10 sheets, 0 data
-rows) and is the right workload to trace. The split to establish first is packaging versus XLibur: a part
-per sheet through `System.IO.Packaging` is Spec 01/03 territory and out of scope here, whereas per-sheet
-DOM and content-manager work is not. Do that attribution before designing anything.
+#### Attribution
+
+`dotnet-trace --format speedscope` over `profile template loop roundtrip` (10 sheets, 20 names, 26
+validations), 21,253 ms sampled. Inclusive shares of the whole trace:
+
+| | share | what it is |
+|---|---:|---|
+| `LoadWorksheetElements` | 23.7% | per sheet — **XLibur** |
+| `GenerateWorksheetPartContent` | 10.2% | per sheet — **XLibur** |
+| zip deflate/inflate + the `Monitor` contention under it | ~8.5% | per part — packaging |
+| `Path.GetTempFileName` + `CreateFile` | 7.8% | **once per package**, not per sheet |
+
+**The per-sheet cost is roughly 4:1 XLibur's own work over packaging, so task 5 is in scope** rather than
+Spec 01/03 territory as originally guessed. Splitting the two was the point of the trace and it came out
+the opposite way to the assumption.
+
+Two things worth recording separately:
+
+- **Array growth dominates.** `Thread.PollGCWorker` is 30.3% of the trace, and its call sites are almost
+  entirely `Array.Resize` / `Array.Copy` / `Buffer.Memmove` — `LoadCellXml` resizing (11.5%),
+  `Slice<T>.Lut<T>.SetValue` resizing (10.7%), and `XmlTextReaderImpl.AllocNode` growing the reader's node
+  buffer (10.1%). Time parks on the GC poll at safepoints inside those copy loops, so this is the
+  allocation the benchmarks measure showing up as wall clock. Pre-sizing the per-sheet slices is the
+  obvious first move, and it is squarely XLibur's code.
+- **The temp file is the SDK's, and it is per workbook.** `WriteableStreamExtensions.EnableWriteableStream`
+  calls `Path.GetTempFileName` to make the package writeable — 7.8% of the trace, but fixed per round trip
+  rather than scaling with sheets, so it is not part of this slope. Worth its own note; `GetTempFileName`
+  on Windows probes for an unused name and degrades as `%TEMP%` fills.
 
 ## Already ruled out
 

--- a/docs/specs/18-template-round-trip-overhead.md
+++ b/docs/specs/18-template-round-trip-overhead.md
@@ -303,16 +303,46 @@ the opposite way to the assumption.
 
 Two things worth recording separately:
 
-- **Array growth dominates.** `Thread.PollGCWorker` is 30.3% of the trace, and its call sites are almost
-  entirely `Array.Resize` / `Array.Copy` / `Buffer.Memmove` — `LoadCellXml` resizing (11.5%),
-  `Slice<T>.Lut<T>.SetValue` resizing (10.7%), and `XmlTextReaderImpl.AllocNode` growing the reader's node
-  buffer (10.1%). Time parks on the GC poll at safepoints inside those copy loops, so this is the
-  allocation the benchmarks measure showing up as wall clock. Pre-sizing the per-sheet slices is the
-  obvious first move, and it is squarely XLibur's code.
+- **Array growth dominates the *row* cost, not the structural one.** `Thread.PollGCWorker` is 30.3% of the
+  trace, and its call sites are almost entirely `Array.Resize` / `Array.Copy` / `Buffer.Memmove` —
+  `LoadCellXml` resizing (11.5%), `Slice<T>.Lut<T>.SetValue` resizing (10.7%), and
+  `XmlTextReaderImpl.AllocNode` growing the reader's node buffer (10.1%). **This trace ran on the 100-row
+  fixture, so that resizing is the rows, not the sheets.** Pre-sizing the per-sheet slices looked like the
+  obvious first move on this evidence and it is not — see the breakdown below, which was measured
+  afterwards and rules it out. Recorded as a caution: this is the second wrong conclusion in this spec
+  drawn from a fixture whose sheet count and row count moved together.
 - **The temp file is the SDK's, and it is per workbook.** `WriteableStreamExtensions.EnableWriteableStream`
   calls `Path.GetTempFileName` to make the package writeable — 7.8% of the trace, but fixed per round trip
   rather than scaling with sheets, so it is not part of this slope. Worth its own note; `GetTempFileName`
   on Windows probes for an unused name and degrades as `%TEMP%` fills.
+
+#### Where the structural bytes actually go
+
+Exact allocation (`GC.GetTotalAllocatedBytes(precise: true)`), read as the 10→40 delta over header-only
+sheets, so it is per worksheet with no rows on it:
+
+| component | per sheet | share |
+|---|---:|---:|
+| model construction (`AddWorksheet` + one cell) | ~23.5 KB | 12% |
+| load, beyond the model | ~82 KB | 41% |
+| save baseline (DOM, content manager, writer, zip entry) | ~58.5 KB | 29% |
+| reading the existing part for save | ~17.6 KB | 9% |
+| the byte-fidelity copy from task 1 | ~20 KB | 10% |
+| **total** | **~202 KB** | |
+
+Against ~699 B of XML on disk, so ~289×.
+
+**This rules out pre-sizing the slices.** The entire in-memory model is 12% of the bill and the slices are
+only part of that, so no amount of pre-sizing moves the per-sheet number meaningfully. The load side, at
+41%, is the largest untouched term and is where a follow-up should start.
+
+The task 1 figure was measured by temporarily restoring the direct read `main` uses: the round trip fell
+from 202,237 to 182,093 B per sheet. **Task 1 therefore costs ~20 KB per worksheet on small sheets**, in
+exchange for 334 MB → 89 MB on row-heavy ones and byte fidelity. The cost is the `XmlReader`/`XmlWriter`
+buffers, which expose no public size knob, rather than the `MemoryStream`. A part-size threshold would
+recover it — the direct read is byte-faithful, being what `main` does — but that reintroduces a heuristic
+on the path whose fidelity took three failed designs to get right, for 10% of a per-sheet cost. Left
+undone deliberately; the trade is a reviewer's call, not an obvious win.
 
 ## Already ruled out
 

--- a/docs/specs/18-template-round-trip-overhead.md
+++ b/docs/specs/18-template-round-trip-overhead.md
@@ -29,7 +29,7 @@ Reference point for task 1: writing those same 420,000 cells into a workbook who
 
 Reproduce with:
 
-```
+```bash
 dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- --filter "*TemplateRoundTripBenchmarks*"
 dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile template
 dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile template loop save   # for a profiler
@@ -52,7 +52,10 @@ dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile
 
 - `XLibur.Benchmarks/TemplateRoundTripBenchmarks.cs` — the trustworthy numbers.
 - `XLibur.Benchmarks/TemplateRoundTripProfile.cs` — `profile template [path.xlsx]` decomposes the round trip; `profile template loop <open|save|roundtrip>` runs one phase so a profiler can attach.
-- `XLibur.Benchmarks/TemplateFixture.cs` — the shared synthetic template.
+- `XLibur.Benchmarks/TemplateFixture.cs` — the shared synthetic template. `sheetCount` built one sheet
+  too many until review caught it (`Math.Max(1, sheetCount - 1)` lookup sheets, so `sheetCount: 1` gave
+  two). Only the `sheets=1` row was affected — 10 and 40 were always right — and the task 5 figures below
+  are the corrected ones.
 
 **Do not use the probe's timings to claim a change.** On the reference machine they move by tens of percent between runs of identical code — the same order as the effects being chased. The probe locates cost and reports exact allocation; BenchmarkDotNet proves movement. An early iteration of this work reported a 30% win that BenchmarkDotNet then showed to be ~0%.
 
@@ -234,13 +237,19 @@ is machine variance, not a new win — identical allocation says it is the same 
 
 **Filed as task 5:** per-worksheet round-trip cost, the dominant remaining term.
 
-**Ruled out by the same decomposition**, both previously plausible suspects from the profiled application:
+**Neither defined names nor data validations allocate measurably**, the two plausible suspects from the
+profiled application. Against a 10-sheet fixture: 0 names → 3.2 MB, 20 names → 3.3 MB; then 0 → 26 → 100
+validations holds flat at 3.3 MB. Allocation is reported exactly by the probe, so this part is solid.
 
-- **Defined names are free.** 10 sheets with 0 names round-trips in 30.6 ms; with 20 names, 28.5 ms.
-- **Data validations are free.** 0 → 26 → 100 validations moves 28.5 → 28.3 → 29.6 ms, inside probe noise.
+**Their time cost is not established either way, and one run should not be trusted here.** A first
+decomposition put 20 names *below* 0 names (28.5 ms against 30.6 ms); a second, over a byte-identical
+fixture (22,725 B both times), put it 70% *above* (46.3 ms against 27.2 ms). Nothing changed but the
+machine. Anyone wanting a time answer for names or validations needs a BenchmarkDotNet case, not this
+probe — see the measurement warning under task 0, which exists because this spec has already published two
+figures that did not survive re-measurement.
 
-So the template that triggered this spec — ~10 sheets, ~20 defined names, ~26 validations — pays for its
-sheet *count* and essentially nothing for the features that looked like the obvious cause.
+What the sheet-count slope shows is robust because it is read across three points that all move together
+and is corroborated by allocation. The rest of the table is not.
 
 Left unchased by scope, as instructed: `System.IO.Packaging` buffering and `XmlWriter` internals (Spec 01/03).
 
@@ -250,18 +259,18 @@ Left unchased by scope, as instructed: `System.IO.Packaging` buffering and `XmlW
 
 | sheets | round trip | alloc | fixture on disk |
 |---:|---:|---:|---:|
-| 1 | 10.9 ms | 1.3 MB | 8,312 B |
-| 10 | 30.6 ms | 3.2 MB | 22,581 B |
-| 40 | 96.9 ms | 10.6 MB | 76,074 B |
+| 1 | 7.3 ms | 1.1 MB | 6,437 B |
+| 10 | 27.2 ms | 3.2 MB | 22,581 B |
+| 40 | 101.1 ms | 10.6 MB | 76,074 B |
 
-The slope is linear and consistent across both intervals — 2.19 ms / 0.21 MB per sheet from 1→10, and
-2.21 ms / 0.25 MB per sheet from 10→40. Each worksheet carries ~1.8 KB of XML, so this is roughly **135×
-the on-disk size in allocation**, and costs about what 1,370 grid cells cost, for a sheet containing no
-cells at all.
+The slope is consistent across both intervals — 2.21 ms / 0.23 MB per sheet from 1→10, and 2.46 ms /
+0.25 MB per sheet from 10→40. Each worksheet carries ~1.8 KB of XML, so this is roughly **130× the
+on-disk size in allocation**, and costs about what 1,300 grid cells cost, for a sheet containing no cells
+at all.
 
-It is the dominant remaining term on any template-shaped workbook: on the 10-sheet fixture it is 22 of the
-30.6 ms round trip. Unlike rows and distinct strings (task 3), it scales with nothing the caller can
-reduce — the sheets are already empty.
+It is the dominant remaining term on any template-shaped workbook: on the 10-sheet fixture it is roughly
+20 of the 27.2 ms round trip. Unlike rows and distinct strings (task 3), it scales with nothing the caller
+can reduce — the sheets are already empty.
 
 **Not yet attributed.** `profile template loop roundtrip` uses exactly this fixture (10 sheets, 0 data
 rows) and is the right workload to trace. The split to establish first is packaging versus XLibur: a part

--- a/docs/specs/18-template-round-trip-overhead.md
+++ b/docs/specs/18-template-round-trip-overhead.md
@@ -1,0 +1,124 @@
+# Spec 18 — Template Round-Trip Overhead (open → small edit → save)
+
+**Area:** Performance (read + write time, memory)
+**Effort:** M (task 1 is the bulk of the win; 2–4 are independent follow-ons)
+**Dependencies:** Touches `WorksheetPartWriter` and the style façades. Coordinate with Spec 03 (both touch the save path) and Spec 11 (create-path allocations); no overlap with the `SheetDataWriter` cell loop, which is already tuned.
+**Status:** Task 0 done; task 1 in progress.
+
+## Summary
+
+The cost of *touching* an existing workbook — open it, change little or nothing, save it again — is dominated by work that scales with the workbook's structure and stored contents rather than with what the caller changed. A request-per-export service pays this on every request no matter how little it writes.
+
+The trigger was a profiled export in a consuming application: ~300 ms per request went on opening and re-saving a 124 KB template (~10 sheets, ~20 defined names, ~26 data validations) purely to write one column of lookup values.
+
+The headline defect: **saving a workbook that was loaded from a file re-materialises every stored row and cell as an OpenXML DOM, then throws it away.** Re-saving an untouched 20,000 × 21 workbook costs 1.73 s and 334 MB, of which roughly 1.33 s and 278 MB is the save half — for zero changes.
+
+## Measured baselines
+
+BenchmarkDotNet, `XLibur.Benchmarks.TemplateRoundTripBenchmarks`, net10.0 Release:
+
+| Benchmark | Mean | Allocated |
+|---|---:|---:|
+| `Open` (10 sheets × 100 rows, 20 names, 26 validations) | 4.67 ms | 1.67 MB |
+| `OpenAndSaveUnchanged` (same fixture) | 10.42 ms | 3.89 MB |
+| `RefreshLookupColumn` (1,000 values) | 11.49 ms | 4.55 MB |
+| `LoadRowHeavy` (20,000 × 21, stored) | 402.4 ms | 55.40 MB |
+| **`OpenAndSaveRowHeavyUnchanged`** | **1,729.6 ms** | **333.68 MB** |
+
+Reference point for task 1: writing those same 420,000 cells into a workbook whose *stored* part is empty saves in **428 ms** (`profile template`, "grid save"). The gap to the 1,330 ms save half above is the discarded DOM, not the writing.
+
+Reproduce with:
+
+```
+dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- --filter "*TemplateRoundTripBenchmarks*"
+dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile template
+dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile template loop save   # for a profiler
+```
+
+## Findings and work plan
+
+| # | Task | Status | Size |
+|---|------|--------|------|
+| 0 | Benchmarks + decomposition probe that expose all of this | ✅ Done | S |
+| 1 | Stop materialising `<sheetData>` into a DOM on save | 🔵 In progress | M |
+| 2 | Per-cell styling costs ~2.3× because the wrapper caches never hit | ⬜ Proposed | M |
+| 3 | Lookup-column refresh costs ~3× per cell versus the grid path — cause unknown | ⬜ Needs investigation | S |
+| 4 | Re-verify and file the remainder | ⬜ Proposed | S |
+
+---
+
+### Task 0 — Measurement tooling ✅
+
+- `XLibur.Benchmarks/TemplateRoundTripBenchmarks.cs` — the trustworthy numbers.
+- `XLibur.Benchmarks/TemplateRoundTripProfile.cs` — `profile template [path.xlsx]` decomposes the round trip; `profile template loop <open|save|roundtrip>` runs one phase so a profiler can attach.
+- `XLibur.Benchmarks/TemplateFixture.cs` — the shared synthetic template.
+
+**Do not use the probe's timings to claim a change.** On the reference machine they move by tens of percent between runs of identical code — the same order as the effects being chased. The probe locates cost and reports exact allocation; BenchmarkDotNet proves movement. An early iteration of this work reported a 30% win that BenchmarkDotNet then showed to be ~0%.
+
+### Task 1 — Stop materialising `<sheetData>` into a DOM on save 🔵
+
+**Current state.** `XLibur/Excel/IO/WorksheetPartWriter.cs`, `GetWorksheetDom` (~line 42):
+
+```csharp
+using var reader = OpenXmlReader.Create(worksheetPart);
+if (!reader.Read()) throw new ArgumentException(...);
+worksheet = (Worksheet)reader.LoadCurrentElement()!;
+```
+
+`LoadCurrentElement()` on `<worksheet>` builds the **entire** worksheet DOM, including every `<row>` and `<c>` in `<sheetData>`, as OpenXML objects. `StreamToPart` (~line 239) then walks the top-level children and, for the `SheetData` child, **ignores it** and calls `SheetDataWriter.StreamSheetData` instead. Every one of those row and cell objects is discarded.
+
+The intent is already stated in the code (~line 108): *"Sheet data is not updated in the Worksheet DOM here, because it is later being streamed directly to the file without an intermediate DOM representation. This is done to save memory, which is especially problematic for large sheets."* That intent is defeated whenever the part is non-empty — i.e. on every save of a workbook that was loaded, and on every save after the first.
+
+A trace of `profile template loop save` puts `GetWorksheetDom` at **41% of `SaveAs`** even on the 10-sheet fixture whose sheets hold only 100 rows each.
+
+**Design.** Build the detached DOM child by child instead of in one call, substituting an empty `SheetData`:
+
+1. Position the reader on `<worksheet>`; create `new Worksheet()`.
+2. Copy the root's namespace declarations and attributes from the reader.
+3. Walk the top-level children. For `SheetData`, append `new SheetData()` and skip the subtree with `ReadNextSibling()` — one raw `XmlReader.Skip`, no per-row object. For everything else, `LoadCurrentElement()` and append.
+
+Everything downstream is satisfied by an empty `SheetData`: `worksheet.Elements<SheetData>().First()` still finds it, `XLWorksheetContentManager` still anchors on it, and `StreamToPart`'s `child is SheetData` test still fires in the right position.
+
+This is the save-side twin of the load-side fix already made in `XLWorkbook_Load.LoadWorksheetElements`, where `<sheetData>` was being skipped one row at a time.
+
+**Risks.**
+- **Root element identity.** `StreamToPart` writes the root from `worksheet.Prefix`, `LocalName`, `NamespaceUri`, `NamespaceDeclarations` and `GetAttributes()`. A hand-built `Worksheet` must reproduce all of these. Prefix is the awkward one: most producers use the default namespace, but a `x:worksheet` root exists in the wild and would be re-emitted unprefixed. Same effective namespace, different bytes — acceptable for correctness, but confirm against the round-trip corpus.
+- **Unknown/`AlternateContent` top-level children** must still round-trip; they go through `LoadCurrentElement()` unchanged.
+- **Empty part** (`partIsEmpty`) path is untouched.
+
+**Acceptance criteria.**
+1. `OpenAndSaveRowHeavyUnchanged` allocation reduced ≥ 50% (333.68 MB → ≤ 165 MB); mean time reduced ≥ 40%.
+2. `OpenAndSaveUnchanged` allocation not regressed.
+3. Saved output semantically identical to main across the full corpus — `ExcelDocsComparerTests` and the round-trip suites green.
+4. All tests green; no public API change.
+
+### Task 2 — Per-cell styling costs ~2.3× ⬜
+
+Corroborated twice:
+
+- `profile template` — per-cell vs per-column number format is **2.1–2.6× time and a stable 2.3× allocation** across 1,000/5,000/20,000 rows.
+- `profile alloc` — `CreateFormattedAndSave` allocates **183.3 MB** in the create phase against **25.1 MB** for the same rows unformatted.
+
+**Mechanism.** `XLStylizedBase` caches its `XLStyle` façade in `_cachedStyle`, and `XLStyle` caches `_cachedNumberFormat`; `XLStyleValue` additionally memoises key transitions (`StoreTransition`). The machinery is already designed to avoid this cost — but `worksheet.Cell(r, c)` returns a **fresh `XLCell` on every call**, so those per-object caches are always cold. Each formatted cell therefore allocates the cell plus a fresh façade chain.
+
+Options, in rough order of appeal: cache the façade per worksheet keyed by nothing (re-target the wrapper's container on access); pool/cache `XLCell` instances from `Cell(r, c)`; or add a bulk styling API and document per-column styling as the fast path. Needs a design decision before implementation — note that `Cell(r,c)` returning a stable instance has semantics implications well beyond styling.
+
+### Task 3 — Lookup refresh costs ~3× per cell ⬜
+
+`profile template`, lookup refresh: 10,000 values cost ~38 ms above the round-trip floor, ≈3.8 µs per cell, where the grid path runs ≈1.3 µs per cell for write + save. Candidate causes, none yet confirmed: 10,000 *unique* strings pressuring the shared-string table where the grid repeats `"Yes"`/`"No"`; or extending the used range from 100 to 10,000 rows interacting with the 26 data validations and 20 defined names on the fixture.
+
+**Measure before designing.** This is the one finding here with no established mechanism.
+
+### Task 4 — Re-verify and file the remainder ⬜
+
+After tasks 1–3, re-run the benchmark set and the `profile template` decomposition. File follow-ups for anything ≥ 5% of what remains. Note but do not chase `System.IO.Packaging` buffering and `XmlWriter` internals — that is Spec 01/03 territory.
+
+## Already ruled out
+
+- **The two-pass loader is not worth collapsing.** `LoadWorksheetElements` reads structural elements with the SDK reader and `LoadSheetDataRaw` re-opens the part for a raw pass over `<sheetData>`. The second stream open plus rescan measures **0.05–0.65 ms per load** across sheet shapes, because everything ahead of `<sheetData>` is small. The waste was entirely in *getting past* `<sheetData>` in pass 1, which is fixed.
+- **The `SheetDataWriter` cell loop.** Spec 03 tasks 3–6 are implemented: raw slice enumerator (no `XLCell` per cell), table-totals guard, single-entry style memo, blank short-circuit.
+- **`SaveAs` is not single-use** and does not dispose the source stream, contrary to a note inherited with the original harness. It adopts its destination as the workbook origin, so a second `SaveAs` throws `ObjectDisposedException` only if the caller disposed that previous destination. Behaviour is coherent; only the diagnostic is poor.
+
+## Measurement protocol
+
+Every PR in this spec carries a before/after BenchmarkDotNet table for at least `OpenAndSaveRowHeavyUnchanged`, `OpenAndSaveUnchanged` and `LoadRowHeavy`. A/B a library change by stashing only the library (`git stash push -- XLibur/`) so the benchmark project is byte-identical across both runs.

--- a/docs/specs/18-template-round-trip-overhead.md
+++ b/docs/specs/18-template-round-trip-overhead.md
@@ -3,7 +3,7 @@
 **Area:** Performance (read + write time, memory)
 **Effort:** M (task 1 is the bulk of the win; 2–4 are independent follow-ons)
 **Dependencies:** Touches `WorksheetPartWriter` and the style façades. Coordinate with Spec 03 (both touch the save path) and Spec 11 (create-path allocations); no overlap with the `SheetDataWriter` cell loop, which is already tuned.
-**Status:** Task 0 done; task 1 in progress.
+**Status:** Tasks 0 and 1 done — see [Results](#results). Tasks 2–4 open.
 
 ## Summary
 
@@ -40,7 +40,7 @@ dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile
 | # | Task | Status | Size |
 |---|------|--------|------|
 | 0 | Benchmarks + decomposition probe that expose all of this | ✅ Done | S |
-| 1 | Stop materialising `<sheetData>` into a DOM on save | 🔵 In progress | M |
+| 1 | Stop materialising `<sheetData>` into a DOM on save | ✅ Done (`26b248d9`) | M |
 | 2 | Per-cell styling costs ~2.3× because the wrapper caches never hit | ⬜ Proposed | M |
 | 3 | Lookup-column refresh costs ~3× per cell versus the grid path — cause unknown | ⬜ Needs investigation | S |
 | 4 | Re-verify and file the remainder | ⬜ Proposed | S |
@@ -55,7 +55,7 @@ dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile
 
 **Do not use the probe's timings to claim a change.** On the reference machine they move by tens of percent between runs of identical code — the same order as the effects being chased. The probe locates cost and reports exact allocation; BenchmarkDotNet proves movement. An early iteration of this work reported a 30% win that BenchmarkDotNet then showed to be ~0%.
 
-### Task 1 — Stop materialising `<sheetData>` into a DOM on save 🔵
+### Task 1 — Stop materialising `<sheetData>` into a DOM on save ✅
 
 **Current state.** `XLibur/Excel/IO/WorksheetPartWriter.cs`, `GetWorksheetDom` (~line 42):
 
@@ -86,11 +86,33 @@ This is the save-side twin of the load-side fix already made in `XLWorkbook_Load
 - **Unknown/`AlternateContent` top-level children** must still round-trip; they go through `LoadCurrentElement()` unchanged.
 - **Empty part** (`partIsEmpty`) path is untouched.
 
-**Acceptance criteria.**
-1. `OpenAndSaveRowHeavyUnchanged` allocation reduced ≥ 50% (333.68 MB → ≤ 165 MB); mean time reduced ≥ 40%.
-2. `OpenAndSaveUnchanged` allocation not regressed.
-3. Saved output semantically identical to main across the full corpus — `ExcelDocsComparerTests` and the round-trip suites green.
-4. All tests green; no public API change.
+**Acceptance criteria.** All met — see [Results](#results).
+1. ✅ `OpenAndSaveRowHeavyUnchanged` allocation reduced ≥ 50% (333.68 MB → ≤ 165 MB); mean time reduced ≥ 40%.
+2. ✅ `OpenAndSaveUnchanged` allocation not regressed.
+3. ✅ Saved output semantically identical to main across the full corpus.
+4. ✅ All tests green; no public API change.
+
+**Outcome.** The part is copied into memory with `<sheetData>` reduced to an empty element, and the DOM is built from that copy. Rows are tokenised once by a raw reader rather than becoming objects nobody reads.
+
+Assembling the root by hand and appending each top-level child — the design sketched above — was implemented first and is faster still, but it is **not byte-faithful**, and the risk anticipated above turned out to be the wrong one. The root's own prefix reproduced fine; what broke was descendants. A child parsed on its own records the namespace declarations it needs rather than inheriting the root's, so a part whose root uses a *default* namespace round-trips its `mc:AlternateContent` subtrees as `<controls xmlns="…">` where the file had `<x:controls>` (caught by `SavingTests.FormControlsArePreserved`). Two further traps found on the way, worth not re-deriving:
+
+- `reader.Prefix` on `OpenXmlPartReader` is the *element's resolved* prefix, not the one the file used. It falls back to the SDK's canonical `x` for the spreadsheet namespace even when the part declared none.
+- A *default* namespace declaration never appears in `reader.NamespaceDeclarations`. That list is filled by testing for the `xmlns` prefix, which `xmlns="…"` does not have, so it surfaces among the attributes under the reserved local name `xmlns`. `AddNamespaceDeclaration` cannot put it back either — it rejects an empty prefix.
+
+Copying the part keeps the SDK doing one parse of one document, so the emitted bytes are unchanged by construction. The copy covers everything except `<sheetData>`; it measured at 991.7 ms against 917.4 ms for the unfaithful version, inside that version's own 76 ms standard deviation.
+
+## Results
+
+BenchmarkDotNet, net10.0 Release, before/after task 1:
+
+| Benchmark | before | after | Δ time | Δ allocated |
+|---|---|---|---|---|
+| `OpenAndSaveRowHeavyUnchanged` | 1,729.6 ms / 333.68 MB | 991.7 ms / 88.83 MB | −43% | **−73%** |
+| `OpenAndSaveUnchanged` | 10.42 ms / 3.89 MB | 8.42 ms / 3.17 MB | −19% | −19% |
+| `RefreshLookupColumn` | 11.49 ms / 4.55 MB | 10.08 ms / 3.83 MB | −12% | −16% |
+| `LoadRowHeavy` | 402.4 ms / 55.40 MB | 406.4 ms / 55.40 MB | — | — |
+
+`LoadRowHeavy` is load-only and unaffected, as expected; it is listed as the control.
 
 ### Task 2 — Per-cell styling costs ~2.3× ⬜
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -27,7 +27,7 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 15 | [Shapes & text boxes](15-shapes-and-text-boxes.md) | Feature · Compat | L | Proposed (**needs 16 first**) | 1–3 one stream; then 4/5 parallel |
 | 16 | [Shared DrawingML infrastructure](16-drawingml-infrastructure.md) | Arch · Refactor | S–M | Proposed | 3 PRs; harness first, then 2/3 independent |
 | 17 | [Picture styling & fidelity](17-picture-styling.md) | Feature · Compat · **Defect** | M–L | Proposed (**needs 16 first**) | Task 1 (fidelity fix) first and standalone; 3/4/5 parallel after 2 |
-| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Tasks 0-1 done (see Results) | Task 1 first (biggest win); 2/3 independent after |
+| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Tasks 0�2 done (see Results) | Task 1 first (biggest win); 2/3 independent after |
 
 Spec 15 closes the last hole in the drawing surface: XLibur can add pictures and charts but no shape of
 any kind, so a floating text box, callout or arrow cannot be created at all. Shapes that already exist in

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -27,7 +27,7 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 15 | [Shapes & text boxes](15-shapes-and-text-boxes.md) | Feature · Compat | L | Proposed (**needs 16 first**) | 1–3 one stream; then 4/5 parallel |
 | 16 | [Shared DrawingML infrastructure](16-drawingml-infrastructure.md) | Arch · Refactor | S–M | Proposed | 3 PRs; harness first, then 2/3 independent |
 | 17 | [Picture styling & fidelity](17-picture-styling.md) | Feature · Compat · **Defect** | M–L | Proposed (**needs 16 first**) | Task 1 (fidelity fix) first and standalone; 3/4/5 parallel after 2 |
-| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Task 0 done; task 1 in progress | Task 1 first (biggest win); 2/3 independent after |
+| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Tasks 0-1 done (see Results) | Task 1 first (biggest win); 2/3 independent after |
 
 Spec 15 closes the last hole in the drawing surface: XLibur can add pictures and charts but no shape of
 any kind, so a floating text box, callout or arrow cannot be created at all. Shapes that already exist in

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -27,7 +27,7 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 15 | [Shapes & text boxes](15-shapes-and-text-boxes.md) | Feature · Compat | L | Proposed (**needs 16 first**) | 1–3 one stream; then 4/5 parallel |
 | 16 | [Shared DrawingML infrastructure](16-drawingml-infrastructure.md) | Arch · Refactor | S–M | Proposed | 3 PRs; harness first, then 2/3 independent |
 | 17 | [Picture styling & fidelity](17-picture-styling.md) | Feature · Compat · **Defect** | M–L | Proposed (**needs 16 first**) | Task 1 (fidelity fix) first and standalone; 3/4/5 parallel after 2 |
-| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Tasks 0-3 done (see Results) | Task 1 first (biggest win); 2/3 independent after |
+| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Tasks 0–3 done (see Results) | Task 1 first (biggest win); 2/3 independent after |
 
 Spec 15 closes the last hole in the drawing surface: XLibur can add pictures and charts but no shape of
 any kind, so a floating text box, callout or arrow cannot be created at all. Shapes that already exist in

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -27,7 +27,7 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 15 | [Shapes & text boxes](15-shapes-and-text-boxes.md) | Feature · Compat | L | Proposed (**needs 16 first**) | 1–3 one stream; then 4/5 parallel |
 | 16 | [Shared DrawingML infrastructure](16-drawingml-infrastructure.md) | Arch · Refactor | S–M | Proposed | 3 PRs; harness first, then 2/3 independent |
 | 17 | [Picture styling & fidelity](17-picture-styling.md) | Feature · Compat · **Defect** | M–L | Proposed (**needs 16 first**) | Task 1 (fidelity fix) first and standalone; 3/4/5 parallel after 2 |
-| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Tasks 0�2 done (see Results) | Task 1 first (biggest win); 2/3 independent after |
+| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Tasks 0-3 done (see Results) | Task 1 first (biggest win); 2/3 independent after |
 
 Spec 15 closes the last hole in the drawing surface: XLibur can add pictures and charts but no shape of
 any kind, so a floating text box, callout or arrow cannot be created at all. Shapes that already exist in

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -27,6 +27,7 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 15 | [Shapes & text boxes](15-shapes-and-text-boxes.md) | Feature · Compat | L | Proposed (**needs 16 first**) | 1–3 one stream; then 4/5 parallel |
 | 16 | [Shared DrawingML infrastructure](16-drawingml-infrastructure.md) | Arch · Refactor | S–M | Proposed | 3 PRs; harness first, then 2/3 independent |
 | 17 | [Picture styling & fidelity](17-picture-styling.md) | Feature · Compat · **Defect** | M–L | Proposed (**needs 16 first**) | Task 1 (fidelity fix) first and standalone; 3/4/5 parallel after 2 |
+| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Task 0 done; task 1 in progress | Task 1 first (biggest win); 2/3 independent after |
 
 Spec 15 closes the last hole in the drawing surface: XLibur can add pictures and charts but no shape of
 any kind, so a floating text box, callout or arrow cannot be created at all. Shapes that already exist in

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,6 +1,6 @@
 # XLibur Improvement Roadmap
 
-Seventeen prioritized, self-contained specs covering features, compatibility, architecture, and performance (memory + read/write times). Each spec is written to be handed to an independent agent/model: it states the problem with measured numbers, points at the exact files, prescribes a design, breaks the work into PR-sized tasks, and defines measurable acceptance criteria.
+Eighteen prioritized, self-contained specs covering features, compatibility, architecture, and performance (memory + read/write times). Each spec is written to be handed to an independent agent/model: it states the problem with measured numbers, points at the exact files, prescribes a design, breaks the work into PR-sized tasks, and defines measurable acceptance criteria.
 
 Specs 01–10 are the original top-ten set; spec 11 is a follow-on that came out of implementing spec 03 (see below).
 
@@ -27,7 +27,7 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 15 | [Shapes & text boxes](15-shapes-and-text-boxes.md) | Feature · Compat | L | Proposed (**needs 16 first**) | 1–3 one stream; then 4/5 parallel |
 | 16 | [Shared DrawingML infrastructure](16-drawingml-infrastructure.md) | Arch · Refactor | S–M | Proposed | 3 PRs; harness first, then 2/3 independent |
 | 17 | [Picture styling & fidelity](17-picture-styling.md) | Feature · Compat · **Defect** | M–L | Proposed (**needs 16 first**) | Task 1 (fidelity fix) first and standalone; 3/4/5 parallel after 2 |
-| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Tasks 0–3 done (see Results) | Task 1 first (biggest win); 2/3 independent after |
+| 18 | [Template round-trip overhead](18-template-round-trip-overhead.md) | Perf (read + write) · **Defect** | M | Tasks 0–4 done (see Results) | Task 5 is the remaining cost; independent |
 
 Spec 15 closes the last hole in the drawing surface: XLibur can add pictures and charts but no shape of
 any kind, so a floating text box, callout or arrow cannot be created at all. Shapes that already exist in

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -110,7 +110,7 @@ its own period runs from this release.
 | #1 | 7 | Bug — empty data validations written with empty `sqref` | **Merged** — [#290](https://github.com/XLibur/XLibur/pull/290) |
 | #2 | 10 | Feature — pivot `chartFormats` round trip | **Merged** — [#294](https://github.com/XLibur/XLibur/pull/294) |
 | #3 | 11 | Feature — pivot `filters` round trip | **Merged** — [#300](https://github.com/XLibur/XLibur/pull/300); `autoFilter` modelled rather than preserved as a string in [#301](https://github.com/XLibur/XLibur/issues/301) |
-| #4 | 2, 4 | Correctness — structured references in the dependency tree | In review — [#297](https://github.com/XLibur/XLibur/pull/297) |
+| #4 | 2, 4 | Correctness — structured references in the dependency tree | **Merged** — [#297](https://github.com/XLibur/XLibur/pull/297) |
 | #5 | 3 | Perf — register data-table formulas in the dependency tree | **Closed, will not do** — see below |
 | #6 | 1 | Perf — cache parsed reference addresses | **Merged** — [#286](https://github.com/XLibur/XLibur/pull/286) |
 | #7 | 12 | Cleanup — `CacheId` nullability | **Merged** — [#287](https://github.com/XLibur/XLibur/pull/287) |
@@ -138,7 +138,7 @@ changes that mostly touch different files.
 | [#294](https://github.com/XLibur/XLibur/pull/294) | Task #2 (replaces #291, which was stacked on #287) | Merged |
 | [#295](https://github.com/XLibur/XLibur/pull/295) | Correction to the task #9 finding | Merged |
 | [#296](https://github.com/XLibur/XLibur/pull/296) | Task #9, plus the #9 and #10 decisions | Merged |
-| [#297](https://github.com/XLibur/XLibur/pull/297) | Task #4, plus the task #5 correction | Open |
+| [#297](https://github.com/XLibur/XLibur/pull/297) | Task #4, plus the task #5 correction | Merged |
 
 ### Task #6 — reference resolution (#286)
 

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -114,7 +114,7 @@ its own period runs from this release.
 | #5 | 3 | Perf — register data-table formulas in the dependency tree | **Closed, will not do** — see below |
 | #6 | 1 | Perf — cache parsed reference addresses | **Merged** — [#286](https://github.com/XLibur/XLibur/pull/286) |
 | #7 | 12 | Cleanup — `CacheId` nullability | **Merged** — [#287](https://github.com/XLibur/XLibur/pull/287) |
-| #8 | 17 | Hardening — validate pivot field item values | Not started |
+| #8 | 17 | Hardening — validate pivot field item values | **Closed, will not do** — see below |
 | #9 | — | Decision — dispose of the orphan `IXLBaseCollection` interface | **Merged** — [#296](https://github.com/XLibur/XLibur/pull/296) |
 | #10 | 5, 8, 9, 13–16, 18–27 | Decision — removal release for 17 obsolete members | Decided — groups 1–3 removed in the next minor `v0.x`; removal not yet done |
 | #11 | — | Typo — `"Used"` → `"Use"` | **Merged** — [#292](https://github.com/XLibur/XLibur/pull/292) |
@@ -235,6 +235,40 @@ invalidating. The only gain is dropping the full-workbook `Recalculate` that
 **Decision (owner): closed, will not do.** Revisit only if that recalculation shows up as a real
 performance problem. The comment in `DependencyTree` now records why data tables are skipped.
 
+### Task #8 — closed, will not do
+
+The TODO was `// TODO: Check value by area.CacheIndex and ByPosition` on
+`XLPivotReference.AddFieldItem`. The triage called it hardening and flagged that it "risks
+rejecting files Excel accepts". Looked at properly, there is less here than that:
+
+- **It is not implementable as written.** `CacheIndex` lives on `XLPivotArea`, and
+  `XLPivotReference` holds no back-reference to its area. The loader builds the area first and
+  then calls `AddReference(LoadPivotReference(reference))`
+  (`PivotTableDefinitionPartReader.cs:674`); `LoadPivotReference` is `static` and takes only the
+  OpenXML element, so it has no area, no pivot table and no cache — which is where the bounds
+  would have to come from.
+- **Nothing dereferences the value.** The only consumers of `FieldItems` are
+  `PivotTableDefinitionPartWriter2` (emits `<x v="..."/>` verbatim) and `XLPivotAreaComparer`
+  (equality and hash). An out-of-range index causes no crash and no misbehaviour; it round-trips
+  faithfully and Excel decides what to make of it.
+- **Neither caller can supply a bad value.** The load path takes whatever the file says. The API
+  path (`XLPivotValueStyleFormat.GetCurrentArea`) feeds indexes XLibur derived itself from
+  `pivotField.GetAllItems(...)` and `DataFields.IndexOf(...)`, in range by construction, and
+  `ForValueField` already range-checks its own argument. That path also builds
+  `new XLPivotArea()`, so `CacheIndex` and `ByPosition` — the two discriminators the TODO names —
+  are both constant `false` there.
+
+So the change would convert "load the file" into "throw on load" and buy no behaviour XLibur
+could improve. For a reader, faithful round-tripping beats rejection.
+
+**Decision (owner): closed, will not do.** Revisit only if something starts resolving these
+indexes rather than passing them through. `AddFieldItem` now records why it stores the value
+unchecked.
+
+Corrected while closing this: `PivotTableDefinitionPartReader.cs:698` carried the comment
+*"Add indexes after the reference is initialized, so it can check values by
+cacheIndex/byPosition"*, describing a check that has never existed. Removed.
+
 ### Open bug found while investigating #5
 
 `DataTableFormulaFormat` (`XLCellFormula.cs:34`) is `"{{TABLE({0},{1}}}"`, which produces
@@ -254,8 +288,6 @@ depends on the current value.
   the test files that still call `NamedRange`/`NamedRanges`.
 - **#3** — the largest job left. `CT_PivotFilter` carries a required full `autoFilter` subtree,
   so it needs real OpenXML modelling rather than another pass of the `formats` pattern.
-- **#8** — smallest, but needs pivot-table/cache context threaded into a static loader to
-  validate input, and risks rejecting files Excel accepts. Worth weighing before doing.
 - **The `DataTableFormulaFormat` bug** above, if the intended display text can be settled.
 
-Tasks #1, #2, #4, #6, #7, #9 and #11 are done; #5 is closed as will-not-do.
+Tasks #1, #2, #4, #6, #7, #9 and #11 are done; #5 and #8 are closed as will-not-do.


### PR DESCRIPTION
Ports an external performance harness into `XLibur.Benchmarks`, then acts on what it found.

The harness came from profiling a template-driven export in a consuming application, where roughly 300 ms per request went on opening and re-saving a 124 KB workbook — ~10 sheets, ~20 defined names, ~26 data validations — purely to write a single column of lookup values. That cost scaled with neither the rows written nor the amount of data changed, so it is pure per-request overhead.

## Where the harness landed

It arrived as xUnit; this repo uses TUnit, and a multi-iteration timing loop over 20k-row grids does not belong in a serial test suite. `XLibur.Benchmarks` already hosts exactly this shape of work, so it went there as **two** tools, because they answer different questions:

- **`TemplateRoundTripProfile`** — `profile template [path.xlsx]`. Decomposes the round trip into parse/serialise, lookup refresh, bulk grid write, per-cell vs per-column styling, and the full cycle. Fast enough to iterate against, and it accepts a real `.xlsx` (argument or `XLIBUR_PERF_TEMPLATE`) because the generated fixture is far lighter than a genuine reporting template.
- **`TemplateRoundTripBenchmarks`** — the BenchmarkDotNet counterpart, for claims about time.
- **`profile template loop <open|save|roundtrip>`** — runs one phase and nothing else, so a profiler can be attached to it. The table-producing probes interleave six workloads with forced gen2 collections between passes, which makes a captured trace useless.

## What changed in the library

Four inefficiencies in cost that scales with a workbook's structure rather than its data:

- **`LoadWorkbookTheme`** touched `tp.Theme`, materialising the entire theme part — font scheme, format scheme, gradient fills, effect styles — as an object graph, to read twelve hex strings out of `<a:clrScheme>`. Replaced with a raw `XmlReader`. Depth matching keeps the scan off the `a:clrScheme` nested inside `extraClrSchemeLst`, which sits a level deeper and would otherwise overwrite the real scheme.
- **`XLWorksheetContentManager`** ran `Elements<T>().LastOrDefault()` once per slot — thirty-nine filtered traversals of the same child list, each allocating an iterator, per worksheet per save. Now one pass. `XLSheetViewContentManager` likewise.
- **`XLBaseContentManager`** backed its slots with a dictionary and answered `GetPreviousElementFor` with a `Where`/`DefaultIfEmpty`/`MaxBy` chain, allocating on every call while writers call it once per emitted element. The slots are a small contiguous enum range, so a dense array serves better and the lookup walks backwards without allocating. Also drops a box-per-call from casting the enum through `ValueType`.
- **`ConditionalFormattingWriter`** built a hash set, a cast, a concat, an ordering and a list before it could discover that a worksheet carries no conditional formatting at all. Added an early-out; with both collections empty the priority renumbering it skips is a no-op.

## Measurements

BenchmarkDotNet, 10-sheet template with 20 defined names and 26 validations:

| Benchmark | before | after |
|---|---|---|
| `Open` | 4.758 ms / 1.96 MB | 4.695 ms / 1.89 MB |
| `OpenAndSaveUnchanged` | 9.998 ms / 4.28 MB | 10.108 ms / 4.11 MB |
| `RefreshLookupColumn` | 11.851 ms / 4.94 MB | 11.495 ms / 4.77 MB |

**~4% allocation reduction. Time moved less than the run-to-run noise, so no time claim is made.**

Worth stating plainly: an earlier read of the ported harness suggested ~30% gains. That was measurement artefact — the benchmark machine varies by up to 40% between runs of identical code, which is far wider than the effects being chased. The harness was hardened afterwards (nine passes, a `fastest` column, a warm-up that exercises every structural feature) and its docs now say that time claims belong to BenchmarkDotNet and the probe is for locating cost, not proving it moved.

## A correction to the harness's own notes

The harness concluded that `SaveAs` is single-use per workbook instance and disposes the source stream. Both are wrong, measured directly:

- two `SaveAs` calls to two streams that both stay alive succeed;
- the stream a workbook was loaded from is still readable afterwards;
- the failure reproduces on a brand-new workbook, so it is not about loading.

`SaveAs(Stream)` adopts its destination as the workbook origin, which is what lets a later `Save()` write back there. The next `SaveAs` seeks that origin to copy it forward, and a caller who wrapped the destination in a `using` has already disposed it — hence `ObjectDisposedException` from `MemoryStream.set_Position`. The behaviour is coherent; only the diagnostic is poor. No library change made for it here.

## Not done — the biggest remaining win

Every worksheet part is decompressed and XML-tokenised **twice** per load. `LoadWorksheetElements` runs pass 1 with `OpenXmlPartReader` for structural elements, skipping `<sheetData>` row by row — which still fully tokenises it — and then `LoadSheetDataRaw` opens a *fresh* part stream and rescans from the top to find `<sheetData>`. The skip alone measured ~24% of load time.

Fixing it means a genuine single-pass read: a raw `XmlReader` throughout, materialising non-`sheetData` elements into SDK objects on demand. That is a large, correctness-sensitive refactor of the loader touching every worksheet structural feature, so it is called out here rather than attempted.

## Verification

All 11,831 tests pass (net10.0, Release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved loading and round-trip handling for large or row-heavy workbooks.
  * Reduced overhead when applying cell, column, and multi-property formatting.
  * Added profiling coverage for worksheet layouts, templates, formatting, and lookup updates.

* **Reliability & Security**
  * Hardened workbook XML processing by restricting unsafe external document features.
  * Improved preservation of worksheet content, themes, formatting, and conditional formatting during load and save.

* **Documentation**
  * Added guidance and benchmarks for template round-trip performance.
  * Updated project task tracking and resolved an obsolete pivot-field validation item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->