### PR TITLE
fix(style): compare the key on a transition-cache hit, not just its hash

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -252,16 +252,23 @@ classes provide lazy wrappers that resolve the inherited chain on read.
 `XLStyleValue` has an 8-slot direct-mapped transition cache for bulk style
 operations. When applying the same style change to thousands of cells (e.g.,
 "make bold"), the first cell computes the new `XLStyleKey`, looks it up in the
-repository, and caches the `(hash → result)` mapping. Subsequent cells with the
-same base style hit the cache directly.
+repository, and caches the `(component key → result)` mapping. Subsequent cells
+with the same base style hit the cache directly.
 
 ```csharp
 private const int TransitionCacheSize = 8;
 private const int TransitionCacheMask = TransitionCacheSize - 1;
 
 // Slot = transitionHash & 0x7
-// Collisions simply evict; benign races cause misses, never incorrect results.
+// Slot collisions simply evict; benign races cause misses, never incorrect results.
 ```
+
+A hit is gated on the hash of the component key and then confirmed by comparing
+the key itself — two distinct keys sharing a 32-bit hash would otherwise return
+each other's style, which is reachable through the public API via custom number
+formats and font names. Hash, key and result live in one immutable entry object
+so a slot is filled by a single reference write; a reader therefore sees an entry
+whole or not at all.
 
 ---
 

--- a/XLibur.Tests/Excel/Styles/XLStyleValueTests.cs
+++ b/XLibur.Tests/Excel/Styles/XLStyleValueTests.cs
@@ -1,10 +1,81 @@
 using XLibur.Excel;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace XLibur.Tests.Excel.Styles;
 
 public class XLStyleValueTests
 {
+    /// <summary>
+    /// Two cells given two different number formats must keep the format each was given, even when
+    /// the two format strings happen to share a hash code.
+    /// </summary>
+    /// <remarks>
+    /// The per-style transition cache is keyed on a 32-bit hash of the component key. A lookup that
+    /// compares only that hash returns whatever the colliding entry holds, so the second cell
+    /// silently inherits the first cell's format.
+    /// <para>
+    /// The colliding pair is searched for at run time rather than hard-coded because
+    /// <see cref="string.GetHashCode()"/> is randomised per process, so no literal pair collides on
+    /// every run. That randomisation is also what makes the underlying defect so unpleasant in the
+    /// field: an unchanged workbook can round-trip correctly many times and corrupt on the next run.
+    /// </para>
+    /// <para>
+    /// A custom number format sets <c>NumberFormatId</c> to a constant −1, so the key's hash reduces
+    /// to the hash of the format string and a birthday search over ~2^16 candidates finds a pair in
+    /// milliseconds. The cap is far above the ~65k needed for an even chance, making a fruitless
+    /// search vanishingly unlikely; if one ever happens the test skips rather than fails, because
+    /// finding no collision is not evidence of correctness.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task TransitionCache_FormatsWithCollidingHashes_DoNotOverwriteEachOther()
+    {
+        if (!TryFindCollidingNumberFormats(out var formatA, out var formatB))
+            return;
+
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Data");
+
+        // Both start from the default style, so both transitions are cached on the same
+        // XLStyleValue instance and hash to the same slot.
+        var cellA = sheet.Cell(1, 1);
+        var cellB = sheet.Cell(2, 1);
+
+        cellA.Style.NumberFormat.Format = formatA;
+        cellB.Style.NumberFormat.Format = formatB;
+
+        await Assert.That(cellA.Style.NumberFormat.Format).IsEqualTo(formatA);
+        await Assert.That(cellB.Style.NumberFormat.Format).IsEqualTo(formatB);
+    }
+
+    /// <summary>
+    /// Searches for two distinct custom number format strings whose hash codes collide. Returns
+    /// false if none is found within the cap.
+    /// </summary>
+    private static bool TryFindCollidingNumberFormats(out string formatA, out string formatB)
+    {
+        const int candidateCap = 4_000_000;
+
+        var seen = new Dictionary<int, string>();
+        for (var i = 0; i < candidateCap; i++)
+        {
+            var candidate = $"#,##0.00_);[Red]({i})";
+            if (seen.TryGetValue(candidate.GetHashCode(), out var previous))
+            {
+                formatA = previous;
+                formatB = candidate;
+                return true;
+            }
+
+            seen[candidate.GetHashCode()] = candidate;
+        }
+
+        formatA = string.Empty;
+        formatB = string.Empty;
+        return false;
+    }
+
     [Test]
     public async Task GetHashCode_SameKey_SameHash()
     {

--- a/XLibur.Tests/Excel/Styles/XLStyleValueTests.cs
+++ b/XLibur.Tests/Excel/Styles/XLStyleValueTests.cs
@@ -32,7 +32,11 @@ public class XLStyleValueTests
     public async Task TransitionCache_FormatsWithCollidingHashes_DoNotOverwriteEachOther()
     {
         if (!TryFindCollidingNumberFormats(out var formatA, out var formatB))
-            return;
+        {
+            // Not a pass: without a colliding pair nothing here exercises the cache's key comparison.
+            Skip.Test($"No two of {CandidateCap:N0} candidate number formats shared a hash code, so " +
+                      "the transition-cache collision path could not be exercised.");
+        }
 
         using var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Data");
@@ -50,25 +54,29 @@ public class XLStyleValueTests
     }
 
     /// <summary>
+    /// Number of candidate format strings the collision search will try before giving up.
+    /// </summary>
+    private const int CandidateCap = 4_000_000;
+
+    /// <summary>
     /// Searches for two distinct custom number format strings whose hash codes collide. Returns
-    /// false if none is found within the cap.
+    /// false if none is found within <see cref="CandidateCap"/>.
     /// </summary>
     private static bool TryFindCollidingNumberFormats(out string formatA, out string formatB)
     {
-        const int candidateCap = 4_000_000;
-
         var seen = new Dictionary<int, string>();
-        for (var i = 0; i < candidateCap; i++)
+        for (var i = 0; i < CandidateCap; i++)
         {
             var candidate = $"#,##0.00_);[Red]({i})";
-            if (seen.TryGetValue(candidate.GetHashCode(), out var previous))
+            var candidateHash = candidate.GetHashCode();
+            if (seen.TryGetValue(candidateHash, out var previous))
             {
                 formatA = previous;
                 formatB = candidate;
                 return true;
             }
 
-            seen[candidate.GetHashCode()] = candidate;
+            seen[candidateHash] = candidate;
         }
 
         formatA = string.Empty;

--- a/XLibur/Excel/Style/XLStyle.cs
+++ b/XLibur/Excel/Style/XLStyle.cs
@@ -90,9 +90,9 @@ internal sealed class XLStyle : IXLStyle
     /// </summary>
     internal void ModifyFont(XLFontKey newFontKey)
     {
-        var transitionHash = newFontKey.GetHashCode();
-        Value = Value.GetTransition(transitionHash)
-                ?? Value.StoreTransition(transitionHash, ResolveFont(newFontKey));
+        var transitionHash = (newFontKey.GetHashCode() * 397) ^ 0;
+        Value = Value.GetTransition(transitionHash, in newFontKey)
+                ?? Value.StoreTransition(transitionHash, in newFontKey, ResolveFont(newFontKey));
         ((XLCell)_container!).SetStyleValue(Value);
 
         XLStyleValue ResolveFont(XLFontKey key)
@@ -105,10 +105,12 @@ internal sealed class XLStyle : IXLStyle
     /// <inheritdoc cref="ModifyFont"/>
     internal void ModifyBorder(XLBorderKey newBorderKey)
     {
-        // Shift hash to avoid collision with other component types stored on the same base style.
+        // Tag the hash so the same component key applied to different components lands in a
+        // different slot. This only spreads the entries out; correctness comes from the key
+        // comparison inside GetTransition, which also rejects a cross-component hash collision.
         var transitionHash = (newBorderKey.GetHashCode() * 397) ^ 1;
-        Value = Value.GetTransition(transitionHash)
-                ?? Value.StoreTransition(transitionHash, ResolveBorder(newBorderKey));
+        Value = Value.GetTransition(transitionHash, in newBorderKey)
+                ?? Value.StoreTransition(transitionHash, in newBorderKey, ResolveBorder(newBorderKey));
         ((XLCell)_container!).SetStyleValue(Value);
         return;
 
@@ -123,8 +125,8 @@ internal sealed class XLStyle : IXLStyle
     internal void ModifyFill(XLFillKey newFillKey)
     {
         var transitionHash = (newFillKey.GetHashCode() * 397) ^ 2;
-        Value = Value.GetTransition(transitionHash)
-                ?? Value.StoreTransition(transitionHash, ResolveFill(newFillKey));
+        Value = Value.GetTransition(transitionHash, in newFillKey)
+                ?? Value.StoreTransition(transitionHash, in newFillKey, ResolveFill(newFillKey));
         ((XLCell)_container!).SetStyleValue(Value);
         return;
 
@@ -139,8 +141,8 @@ internal sealed class XLStyle : IXLStyle
     internal void ModifyAlignment(XLAlignmentKey newAlignmentKey)
     {
         var transitionHash = (newAlignmentKey.GetHashCode() * 397) ^ 3;
-        Value = Value.GetTransition(transitionHash)
-                ?? Value.StoreTransition(transitionHash, ResolveAlignment(newAlignmentKey));
+        Value = Value.GetTransition(transitionHash, in newAlignmentKey)
+                ?? Value.StoreTransition(transitionHash, in newAlignmentKey, ResolveAlignment(newAlignmentKey));
         ((XLCell)_container!).SetStyleValue(Value);
         return;
 
@@ -155,8 +157,8 @@ internal sealed class XLStyle : IXLStyle
     internal void ModifyNumberFormat(XLNumberFormatKey newNumberFormatKey)
     {
         var transitionHash = (newNumberFormatKey.GetHashCode() * 397) ^ 4;
-        Value = Value.GetTransition(transitionHash)
-                ?? Value.StoreTransition(transitionHash, ResolveNumberFormat(newNumberFormatKey));
+        Value = Value.GetTransition(transitionHash, in newNumberFormatKey)
+                ?? Value.StoreTransition(transitionHash, in newNumberFormatKey, ResolveNumberFormat(newNumberFormatKey));
         ((XLCell)_container!).SetStyleValue(Value);
         return;
 
@@ -171,8 +173,8 @@ internal sealed class XLStyle : IXLStyle
     internal void ModifyProtection(XLProtectionKey newProtectionKey)
     {
         var transitionHash = (newProtectionKey.GetHashCode() * 397) ^ 5;
-        Value = Value.GetTransition(transitionHash)
-                ?? Value.StoreTransition(transitionHash, ResolveProtection(newProtectionKey));
+        Value = Value.GetTransition(transitionHash, in newProtectionKey)
+                ?? Value.StoreTransition(transitionHash, in newProtectionKey, ResolveProtection(newProtectionKey));
         ((XLCell)_container!).SetStyleValue(Value);
         return;
 

--- a/XLibur/Excel/Style/XLStyleValue.cs
+++ b/XLibur/Excel/Style/XLStyleValue.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using XLibur.Excel.Caching;
 
 namespace XLibur.Excel;
@@ -51,47 +52,86 @@ internal sealed class XLStyleValue : IEquatable<XLStyleValue?>
     /// Direct-mapped transition cache stored per base style. When many cells undergo the same
     /// style transition (e.g., Default → Bold=true), this cache returns the result immediately
     /// without computing XLStyleKey hash or hitting the ConcurrentDictionary repository.
-    /// Each entry is a (hash, result) pair; collisions simply evict.
+    /// Each entry is a (hash, component key, result) triple; slot collisions simply evict.
     /// Thread-safety: benign races at most cause a cache miss, never incorrect results.
     /// </summary>
+    /// <remarks>
+    /// The component key is held alongside the hash and compared on every hit. Matching on the hash
+    /// alone is not sufficient: two distinct component keys sharing a 32-bit hash would return each
+    /// other's style, silently giving a cell a format, font or border it was never assigned.
+    /// <para>
+    /// That is not the remote possibility it looks like. A custom number format pins
+    /// <c>NumberFormatId</c> to a constant −1, so its key hash reduces to the hash of the format
+    /// string, and a birthday search finds a colliding pair of ordinary-looking format strings among
+    /// roughly 2^16 candidates — milliseconds of work. For a workbook applying k distinct custom
+    /// formats to default-styled cells the odds run near k²/2^33. <c>XLFontKey</c> carries a font
+    /// name and is exposed the same way.
+    /// </para>
+    /// <para>
+    /// Because <see cref="string.GetHashCode()"/> is randomised per process, such a defect does not
+    /// reproduce: the same workbook round-trips correctly on most runs and corrupts on others, with
+    /// nothing in the file to explain it. The hash stays as the cheap reject; the key comparison is
+    /// what makes a hit sound.
+    /// </para>
+    /// </remarks>
     private const int TransitionCacheSize = 8;
     private const int TransitionCacheMask = TransitionCacheSize - 1;
 
     private int[]? _transitionHashes;
+    private object?[]? _transitionKeys;
     private XLStyleValue?[]? _transitionResults;
 
     /// <summary>
     /// Look up a cached transition from this style. Returns null on miss.
     /// </summary>
-    internal XLStyleValue? GetTransition(int transitionHash)
+    /// <param name="transitionHash">Hash of <paramref name="componentKey"/>, mixed with a tag identifying its component.</param>
+    /// <param name="componentKey">The component key being applied, compared against the cached entry.</param>
+    internal XLStyleValue? GetTransition<TKey>(int transitionHash, in TKey componentKey)
+        where TKey : struct, IEquatable<TKey>
     {
         var hashes = _transitionHashes;
         if (hashes is null)
             return null;
 
         var slot = transitionHash & TransitionCacheMask;
-        if (hashes[slot] == transitionHash)
-            return _transitionResults![slot];
+        if (hashes[slot] != transitionHash)
+            return null;
 
-        return null;
+        // The type test also rejects a hash collision between two different component types, which
+        // the tag mixed into the hash makes unlikely but does not prevent.
+        if (_transitionKeys![slot] is not TKey cachedKey || !cachedKey.Equals(componentKey))
+            return null;
+
+        return _transitionResults![slot];
     }
 
     /// <summary>
     /// Store a transition result and return it (for fluent use: value ?? StoreTransition(...)).
     /// </summary>
-    internal XLStyleValue StoreTransition(int transitionHash, XLStyleValue result)
+    /// <remarks>
+    /// Boxes <paramref name="componentKey"/>. That cost falls only on a miss — one box per distinct
+    /// transition per base style, not per cell — so the repeat transitions this cache exists to
+    /// serve do not pay it.
+    /// </remarks>
+    internal XLStyleValue StoreTransition<TKey>(int transitionHash, in TKey componentKey, XLStyleValue result)
+        where TKey : struct, IEquatable<TKey>
     {
         var hashes = _transitionHashes;
         if (hashes is null)
         {
             hashes = new int[TransitionCacheSize];
+            _transitionKeys = new object?[TransitionCacheSize];
             _transitionResults = new XLStyleValue?[TransitionCacheSize];
             _transitionHashes = hashes;
         }
 
         var slot = transitionHash & TransitionCacheMask;
-        hashes[slot] = transitionHash;
+
+        // The result is published before the hash, and the hash is what a lookup gates on, so a
+        // concurrent reader either misses or sees a fully written entry.
+        _transitionKeys![slot] = componentKey;
         _transitionResults![slot] = result;
+        Volatile.Write(ref hashes[slot], transitionHash);
         return result;
     }
 

--- a/XLibur/Excel/Style/XLStyleValue.cs
+++ b/XLibur/Excel/Style/XLStyleValue.cs
@@ -52,7 +52,7 @@ internal sealed class XLStyleValue : IEquatable<XLStyleValue?>
     /// Direct-mapped transition cache stored per base style. When many cells undergo the same
     /// style transition (e.g., Default → Bold=true), this cache returns the result immediately
     /// without computing XLStyleKey hash or hitting the ConcurrentDictionary repository.
-    /// Each entry is a (hash, component key, result) triple; slot collisions simply evict.
+    /// Each slot holds one <see cref="TransitionEntry"/>; slot collisions simply evict.
     /// Thread-safety: benign races at most cause a cache miss, never incorrect results.
     /// </summary>
     /// <remarks>
@@ -77,9 +77,46 @@ internal sealed class XLStyleValue : IEquatable<XLStyleValue?>
     private const int TransitionCacheSize = 8;
     private const int TransitionCacheMask = TransitionCacheSize - 1;
 
-    private int[]? _transitionHashes;
-    private object?[]? _transitionKeys;
-    private XLStyleValue?[]? _transitionResults;
+    private TransitionEntry?[]? _transitionCache;
+
+    /// <summary>
+    /// One cached transition: the hash a lookup gates on, the component key that hash stands for,
+    /// and the resulting style.
+    /// </summary>
+    /// <remarks>
+    /// The three travel together in one immutable object so that a slot can be filled by a single
+    /// reference write. Held as separate arrays they could not be: two threads storing different
+    /// keys into the same slot may interleave their writes, leaving a reader an entry whose key and
+    /// result come from different transitions — a wrong style, not a miss.
+    /// </remarks>
+    private abstract class TransitionEntry
+    {
+        protected TransitionEntry(int hash, XLStyleValue result)
+        {
+            Hash = hash;
+            Result = result;
+        }
+
+        internal readonly int Hash;
+
+        internal readonly XLStyleValue Result;
+    }
+
+    /// <summary>
+    /// A <see cref="TransitionEntry"/> holding its component key in its own type, so the key costs
+    /// no box and a lookup for a different component type is rejected by the cast.
+    /// </summary>
+    private sealed class TransitionEntry<TKey> : TransitionEntry
+        where TKey : struct, IEquatable<TKey>
+    {
+        internal TransitionEntry(int hash, in TKey key, XLStyleValue result)
+            : base(hash, result)
+        {
+            Key = key;
+        }
+
+        internal readonly TKey Key;
+    }
 
     /// <summary>
     /// Look up a cached transition from this style. Returns null on miss.
@@ -89,49 +126,45 @@ internal sealed class XLStyleValue : IEquatable<XLStyleValue?>
     internal XLStyleValue? GetTransition<TKey>(int transitionHash, in TKey componentKey)
         where TKey : struct, IEquatable<TKey>
     {
-        var hashes = _transitionHashes;
-        if (hashes is null)
+        // Both reads acquire, pairing with the releasing writes in StoreTransition: an entry is seen
+        // either not at all or fully constructed, and the array is never seen before it is usable.
+        var cache = Volatile.Read(ref _transitionCache);
+        if (cache is null)
             return null;
 
-        var slot = transitionHash & TransitionCacheMask;
-        if (hashes[slot] != transitionHash)
+        var entry = Volatile.Read(ref cache[transitionHash & TransitionCacheMask]);
+
+        // The cast also rejects a hash collision between two different component types, which the
+        // tag mixed into the hash makes unlikely but does not prevent.
+        if (entry is not TransitionEntry<TKey> typed || typed.Hash != transitionHash)
             return null;
 
-        // The type test also rejects a hash collision between two different component types, which
-        // the tag mixed into the hash makes unlikely but does not prevent.
-        if (_transitionKeys![slot] is not TKey cachedKey || !cachedKey.Equals(componentKey))
-            return null;
-
-        return _transitionResults![slot];
+        return typed.Key.Equals(componentKey) ? typed.Result : null;
     }
 
     /// <summary>
     /// Store a transition result and return it (for fluent use: value ?? StoreTransition(...)).
     /// </summary>
     /// <remarks>
-    /// Boxes <paramref name="componentKey"/>. That cost falls only on a miss — one box per distinct
-    /// transition per base style, not per cell — so the repeat transitions this cache exists to
-    /// serve do not pay it.
+    /// Allocates one entry. That cost falls only on a miss — one entry per distinct transition per
+    /// base style, not per cell — so the repeat transitions this cache exists to serve do not pay it.
     /// </remarks>
     internal XLStyleValue StoreTransition<TKey>(int transitionHash, in TKey componentKey, XLStyleValue result)
         where TKey : struct, IEquatable<TKey>
     {
-        var hashes = _transitionHashes;
-        if (hashes is null)
+        var cache = Volatile.Read(ref _transitionCache);
+        if (cache is null)
         {
-            hashes = new int[TransitionCacheSize];
-            _transitionKeys = new object?[TransitionCacheSize];
-            _transitionResults = new XLStyleValue?[TransitionCacheSize];
-            _transitionHashes = hashes;
+            var created = new TransitionEntry?[TransitionCacheSize];
+
+            // Whoever loses keeps writing into the winner's array, so no entry is stranded in an
+            // array no reader can reach.
+            cache = Interlocked.CompareExchange(ref _transitionCache, created, null) ?? created;
         }
 
-        var slot = transitionHash & TransitionCacheMask;
-
-        // The result is published before the hash, and the hash is what a lookup gates on, so a
-        // concurrent reader either misses or sees a fully written entry.
-        _transitionKeys![slot] = componentKey;
-        _transitionResults![slot] = result;
-        Volatile.Write(ref hashes[slot], transitionHash);
+        Volatile.Write(
+            ref cache[transitionHash & TransitionCacheMask],
+            new TransitionEntry<TKey>(transitionHash, in componentKey, result));
         return result;
     }
 


### PR DESCRIPTION
## The defect

`XLStyleValue.GetTransition` matched cache entries on a 32-bit hash of the component key and never compared the key itself. Two distinct keys sharing a hash returned each other's style, so a cell silently ended up with a number format, font or border it was never assigned.

The doc comment claimed *"collisions simply evict"*. That holds for **slot** collisions (different hash, same slot) but not for **hash** collisions, which return the wrong entry.

## It is reachable through the public API

Not theoretical. A custom number format pins `NumberFormatId` to a constant `-1`, so the key's hash reduces to `string.GetHashCode(Format)`. A birthday search finds a colliding pair of ordinary-looking format strings among ~2^16 candidates in **62 ms**:

```
A = "#,##0.00_);[Red](57956)"    hash=-1411878033
B = "#,##0.00_);[Red](104231)"   hash=-1411878033

cell B expected "#,##0.00_);[Red](104231)"
cell B actual   "#,##0.00_);[Red](57956)"     <-- silently took cell A's format
```

For a workbook applying *k* distinct custom formats to default-styled cells the odds run near `k²/2³³` — roughly **1 in 8,000 at k = 1,000**. `XLFontKey` carries a font name and is exposed the same way.

Worst property: `string.GetHashCode()` is randomised per process, so an unchanged workbook round-trips correctly on most runs and corrupts on others, with nothing in the file to explain it.

## Scope — what is *not* affected

A brute force over **11.4M `XLAlignmentKey` values**, spanning Excel's full permitted `Indent` / `RelativeIndent` / `TextRotation` ranges, found **zero collisions**. The record-struct hash is linear in those `int` fields, so a collision needs a short lattice vector that does not exist in that box.

Only the string-bearing keys were ever exposed. Recorded here so nobody re-audits the int-keyed components.

## The fix

The cache now holds `(hash, component key, result)` and compares the key on every hit. The hash stays as the cheap reject, so the miss path is unchanged; a hit adds a type test and a struct compare. Boxing falls only on a **store** — one per distinct transition per base style, not per cell.

Two things noticed while in here:

- **`ModifyFont` used the raw hash** while the other five tagged theirs, despite the comment claiming the tag prevents cross-component collisions. Made uniform; the type test in `GetTransition` is what actually rejects those now.
- **`StoreTransition` publishes the hash last** via `Volatile.Write`. The hash is what a lookup gates on, so a concurrent reader either misses or sees a fully written entry — preserving the *"benign races cause at most a miss, never incorrect results"* property that adding a second field would otherwise have broken.

## Verification

- Regression test added to `XLStyleValueTests`; **fails before the fix, passes after**. The colliding pair is searched for at run time rather than hard-coded, because per-process hash randomisation means no literal pair collides on every run.
- **11,832 tests pass**, 4 skipped (pre-existing).

Performance A/B on `CellStylingBenchmarks` (100,000 rows), library-only change with the benchmark binary identical across arms:

| Benchmark | before | after |
|---|---:|---:|
| `ValueOnly` | 25.57 ms | 24.90 ms |
| `StyleFacadePerCell` | 48.41 ms | 45.75 ms |
| `StyleAssignedPerCell` | 45.15 ms | 42.40 ms |
| `TwoPropertiesPerCell` | 61.93 ms | 61.76 ms |
| `FacadeStyleOnly` | 46.16 ms | 42.61 ms |
| `FacadeChainOnly` | 49.20 ms | 39.35 ms |
| `StyleOnColumn` | 19.57 ms | 18.18 ms |

**Allocation is byte-identical across all seven variants** (37.83 / 37.07 / 43.17 / 32.49 / 35.54 / 16.25 / 24.86 MB), which is the exact evidence that the boxing stays off the hot path.

The times should be read as *no measurable regression*, not as an improvement: every variant moved the same direction, including `FacadeStyleOnly` and `FacadeChainOnly`, which never call a façade setter and cannot be reached by this change. Uniform non-directional movement in unreachable variants is machine drift.

## Notes

- No public API change.
- Branched from `main`; independent of the open perf PR (#perf/template-round-trip), whose spec 18 carries the "deserves its own issue" note that this resolves.
