### PR TITLE
chore(docs-website): pin fast-uri >= 3.1.5 and brace-expansion >= 5.0.9

### DIFF
--- a/docs-website/pnpm-lock.yaml
+++ b/docs-website/pnpm-lock.yaml
@@ -6,8 +6,9 @@ settings:
 
 overrides:
   serialize-javascript: '>=7.0.5'
-  brace-expansion: '>=5.0.8'
+  brace-expansion: '>=5.0.9'
   uuid: '>=11.1.1'
+  fast-uri: '>=3.1.5 <4'
 
 importers:
 
@@ -2072,8 +2073,8 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -2786,8 +2787,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -8296,7 +8297,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8471,7 +8472,7 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9230,7 +9231,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -10459,7 +10460,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/docs-website/pnpm-workspace.yaml
+++ b/docs-website/pnpm-workspace.yaml
@@ -16,9 +16,15 @@ allowBuilds:
 #
 # Drop an entry once the upstream dependent has moved past it on its own:
 #   serialize-javascript  @docusaurus/bundler > copy-webpack-plugin   GHSA-5c6j-r48x-rmvq, GHSA-qj8w-gfj5-8c6v
-#   brace-expansion       serve-handler > minimatch                   GHSA-mh99-v99m-4gvg
+#   brace-expansion       serve-handler > minimatch                   GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895
 #   uuid                  webpack-dev-server > sockjs                 GHSA-w5hq-g745-h8pq
+#   fast-uri              webpack > schema-utils > ajv                GHSA-7p8r-x3mc-p8w7
+#
+# fast-uri is held below 4 because ajv declares ^3.0.1 and uses it to resolve schema $refs. The
+# advisory is fixed in 3.1.5, so there is nothing to gain from crossing a major its only dependent
+# does not claim to support.
 overrides:
   serialize-javascript: '>=7.0.5'
-  brace-expansion: '>=5.0.8'
+  brace-expansion: '>=5.0.9'
   uuid: '>=11.1.1'
+  fast-uri: '>=3.1.5 <4'


### PR DESCRIPTION
Clears both open high-severity Dependabot alerts on `docs-website/pnpm-lock.yaml`.

| Package | Vulnerable | Patched | Advisory |
|---|---|---|---|
| `fast-uri` | `>= 3.0.0, < 3.1.5` | 3.1.5 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — host confusion via backslash authority introducer |
| `brace-expansion` | `>= 4.0.0, < 5.0.9` | 5.0.9 | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation |

Neither has a direct dependent here, so both go in the `pnpm-workspace.yaml` overrides block alongside the three already there. `brace-expansion` already had an entry — the `>=5.0.8` pin that closed GHSA-mh99-v99m-4gvg is what the new advisory reports as bypassable, so it moves up one patch. `fast-uri` is new, reaching us through `webpack > schema-utils > ajv`.

## fast-uri is capped below 4

Left as a bare `>=3.1.5` it resolved to **4.1.2**. `ajv` declares `^3.0.1` and uses fast-uri to resolve schema `$ref`s, so there is nothing to gain from crossing a major its only dependent does not claim to support — the advisory is fixed in 3.1.5. Pinned `'>=3.1.5 <4'`.

Worth knowing separately: the other entries in this file are uncapped and one has drifted a long way — `uuid: '>=11.1.1'` currently resolves to **14.0.1**. Not this PR's business, but someone may want to look at it.

## The lockfile is hand-edited, not regenerated

A local `pnpm install` re-resolves peer suffixes differently from whatever produced the committed lockfile: all 614 `(supports-color@8.1.1)` suffixes disappear, turning a two-package bump into 1,378 lines of unrelated churn — which would also quietly change how peers resolve for everyone. The cause is environmental rather than anything in this change, so I left it alone and edited the lockfile directly: the overrides block, the two package entries with their published integrity hashes, the two snapshot entries, and the two references (`ajv > fast-uri`, `minimatch > brace-expansion`). Ten lines.

## Verification

The three steps `docs.yml` runs, in order:

| Step | Result |
|---|---|
| `pnpm install --frozen-lockfile --ignore-scripts` | `Lockfile is up to date` |
| `pnpm run typecheck` | clean |
| `pnpm run build` | client and server compile |

`--frozen-lockfile` passing is the check that matters for a hand edit — it fails if the lockfile disagrees with `package.json` or the overrides. Installed versions on disk are `fast-uri 3.1.5` and `brace-expansion 5.0.9`. The webpack build validates loader and plugin options through `schema-utils > ajv`, so fast-uri is exercised rather than merely present.
