### PR TITLE
docs(changelog): record the SkiaSharp 4.151.1 bump under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 ## Unreleased
 
+A dependency release: `XLibur.Fonts.SkiaSharp` moves to SkiaSharp 4.151.1, a patch bump. No new features, no bug fixes and no breaking changes.
+
+### 🔧 Dependencies
+
+- **`XLibur.Fonts.SkiaSharp` moves to SkiaSharp 4.151.1** (from 4.151.0), with the Linux native asset package following. The font engine decides text metrics, so the thing to watch in a bump like this is column widths and row heights moving; the tests covering them pass unchanged. ([#384](https://github.com/XLibur/XLibur/pull/384), [#385](https://github.com/XLibur/XLibur/pull/385) by [@dependabot](https://github.com/apps/dependabot))
+
 ## v0.311.0 - 2026-08-08
 
 A performance release for cell styles, with two breaking changes. Style data now uses about half the memory it used before, and XLibur compares and looks up styles faster. `XLColor.Color` no longer returns a named colour, and the two alignment style types are now internal; each needs a small code change if you use it. Four bug fixes: an edge with no border line now always reports the same colour, setting an edge's colour before its line style no longer loses the colour, and an out-of-range value cast into a border, colour or alignment enum is now rejected instead of silently aliasing a different one.


### PR DESCRIPTION
Adds an `Unreleased` entry for the dependency PRs merged since `v0.311.0`.

Only the SkiaSharp bump is user-facing, so it is the only entry. It combines #384 and #385, which are one upgrade split across two packages — matching how the `v0.200.0` release documented SkiaSharp and its native assets on a single line.

### Left out

The other four dependency PRs from the same batch are not user-facing, consistent with earlier releases (which document OpenMcdf and SkiaSharp, but no CI or test bumps):

| PR | Bump | Why omitted |
| --- | --- | --- |
| #381 | pnpm/action-setup | CI only |
| #382 | actions/setup-java | CI only |
| #386 | TUnit | Test projects only |
| #383 | Polyfill | `PrivateAssets=all` source package; never reaches a consumer dependency graph |

Polyfill is the debatable one — its source is compiled into `XLibur`, so it is not purely a build tool. It is left out because no past release documents a Polyfill or MinVer bump. Happy to add it if you disagree.

### On the metrics claim

The entry says the tests covering column widths and row heights pass unchanged. That rests on `build-and-test` going green on both #384 and #385; the suite asserts widths and heights in `ColumnTests`, `RowTests` and `MiscTests`. No separate font-metric comparison was run.

### Checks

- Diff is 6 added / 0 removed — no line-ending churn.
- Every table-of-contents anchor still resolves; no new heading was added, since `Unreleased` already existed.