### PR TITLE
chore(docs-website): pin js-yaml >= 4.3.1 and nanoid >= 3.3.17, bump search-local

### DIFF
--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@docusaurus/core": "3.10.2",
     "@docusaurus/preset-classic": "3.10.2",
-    "@easyops-cn/docusaurus-search-local": "^0.55.2",
+    "@easyops-cn/docusaurus-search-local": "^0.55.3",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",

--- a/docs-website/pnpm-lock.yaml
+++ b/docs-website/pnpm-lock.yaml
@@ -9,6 +9,8 @@ overrides:
   brace-expansion: '>=5.0.9'
   uuid: '>=11.1.1'
   fast-uri: '>=3.1.5 <4'
+  js-yaml: '>=4.3.1 <5'
+  nanoid: '>=3.3.17 <4'
 
 importers:
 
@@ -21,8 +23,8 @@ importers:
         specifier: 3.10.2
         version: 3.10.2(@algolia/client-search@5.56.0)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@6.0.3)
       '@easyops-cn/docusaurus-search-local':
-        specifier: ^0.55.2
-        version: 0.55.2(@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+        specifier: ^0.55.3
+        version: 0.55.3(@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.1(@types/react@19.2.17)(react@19.2.8)
@@ -1236,8 +1238,8 @@ packages:
   '@easyops-cn/autocomplete.js@0.38.1':
     resolution: {integrity: sha512-drg76jS6syilOUmVNkyo1c7ZEBPcPuK+aJA7AksM5ZIIbV57DMHCywiCr+uHyv8BE5jUTU98j/H7gVrkHrWW3Q==}
 
-  '@easyops-cn/docusaurus-search-local@0.55.2':
-    resolution: {integrity: sha512-dI/riu+MbDxkAjAHAdc0uahjXRaWKvbIPe9IAmA6AGcUfnVb9xd8s2I/6wEPTOXsAd6eFqn4Yis3WBWh3KUd3g==}
+  '@easyops-cn/docusaurus-search-local@0.55.3':
+    resolution: {integrity: sha512-PlMKmxuonvZ1C+/zJS1hJaF1xaxD1TsUvOMzpP6DdQMtZqmTaYjcLGM12ePzl0m1rp3AgfTBeDbFNHQhwnH/dA==}
     engines: {node: '>=12'}
     peerDependencies:
       '@docusaurus/theme-common': ^2 || ^3
@@ -3308,8 +3310,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3749,8 +3751,8 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5280,7 +5282,7 @@ snapshots:
 
   '@11ty/gray-matter@1.0.0':
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -6800,7 +6802,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.4.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -7355,7 +7357,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       fs-extra: 11.4.0
       joi: 17.13.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7389,7 +7391,7 @@ snapshots:
       github-slugger: 1.5.0
       globby: 11.1.0
       jiti: 1.21.7
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -7422,7 +7424,7 @@ snapshots:
       cssesc: 3.0.0
       immediate: 3.3.0
 
-  '@easyops-cn/docusaurus-search-local@0.55.2(@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)':
+  '@easyops-cn/docusaurus-search-local@0.55.3(@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
       '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.8))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
@@ -8739,7 +8741,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -9810,7 +9812,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -10489,7 +10491,7 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -11131,7 +11133,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/docs-website/pnpm-workspace.yaml
+++ b/docs-website/pnpm-workspace.yaml
@@ -19,12 +19,26 @@ allowBuilds:
 #   brace-expansion       serve-handler > minimatch                   GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895
 #   uuid                  webpack-dev-server > sockjs                 GHSA-w5hq-g745-h8pq
 #   fast-uri              webpack > schema-utils > ajv                GHSA-7p8r-x3mc-p8w7
+#   js-yaml               @docusaurus/utils, cosmiconfig, and 3 more  GHSA-5p4m-2wfm-xmqj
+#   nanoid                postcss                                     GHSA-2v37-7h3g-55p8
 #
-# fast-uri is held below 4 because ajv declares ^3.0.1 and uses it to resolve schema $refs. The
-# advisory is fixed in 3.1.5, so there is nothing to gain from crossing a major its only dependent
-# does not claim to support.
+# Each override is capped below the next major, because an uncapped floor resolves to the newest
+# release rather than the oldest fixed one and would cross a major that no dependent here claims to
+# support. fast-uri is held below 4 because ajv declares ^3.0.1 and uses it to resolve schema $refs;
+# the advisory is fixed in 3.1.5. js-yaml is held below 5 because all five of its dependents declare
+# ^4.1.0, and nanoid below 4 because postcss declares ^3.3.16. Uncapped, those two would resolve to
+# js-yaml 5.2.3 and nanoid 6.0.1.
+#
+# image-size, reached through @docusaurus/mdx-loader, has two open high-severity advisories with no
+# fix available -- GHSA-w3rx-r6r6-pgpr (ICNS parser) and GHSA-5p2g-fcmc-qvqq (JXL and HEIF parsers),
+# both infinite loops on malformed input. Every published version including the latest, 2.0.2, is in
+# the vulnerable range, so there is no version to pin to and no entry below. Both are denial of
+# service through a crafted image, and the only images this site measures are the ones committed to
+# this repository, so nothing untrusted reaches those parsers. Add a pin here once a fix ships.
 overrides:
   serialize-javascript: '>=7.0.5'
   brace-expansion: '>=5.0.9'
   uuid: '>=11.1.1'
   fast-uri: '>=3.1.5 <4'
+  js-yaml: '>=4.3.1 <5'
+  nanoid: '>=3.3.17 <4'


### PR DESCRIPTION
Clears **2 of the 4** open high-severity Dependabot alerts on `docs-website/pnpm-lock.yaml`. The other two are not fixable — see below.

### Fixed

| Package | Was | Now | Advisory |
| --- | --- | --- | --- |
| js-yaml | 4.3.0 | 4.3.1 | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU consumption in `!!omap` resolution |
| nanoid | 3.3.16 | 3.3.18 | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators loop indefinitely when size is zero |

Neither has a direct dependent, so both go in the `pnpm-workspace.yaml` overrides block alongside the four already there. js-yaml reaches us through five dependents (`@docusaurus/utils`, `@docusaurus/utils-validation`, `@docusaurus/plugin-content-docs`, `@11ty/gray-matter`, `cosmiconfig`); nanoid through `postcss`.

Both are **capped below the next major**, for the reason the existing `fast-uri` entry records: an uncapped floor resolves to the newest release, not the oldest fixed one. Left bare these would take js-yaml 5.2.3 and nanoid 6.0.1, while every dependent declares `^4.1.0` and `^3.3.16`.

### Not fixed — no fix exists

The remaining two alerts are both `image-size`, reached through `@docusaurus/mdx-loader`:

- [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) — ICNS parser infinite loop
- [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) — JXL and HEIF parser infinite loops

**Every published version, including the latest (2.0.2), is inside the vulnerable range** (`<= 2.0.2`), and GitHub lists no patched version. There is nothing to pin to, so there is no entry for it. Both are denial of service through a crafted image, and the only images this site measures are the ones committed to this repository, so nothing untrusted reaches those parsers. A comment in `pnpm-workspace.yaml` records this so the gap is not mistaken for an oversight — these two alerts will stay open until upstream ships a fix.

### Also included

`@easyops-cn/docusaurus-search-local` 0.55.2 → 0.55.3, requested separately and unrelated to the advisories.

### Lockfile edited by hand

Same reasoning as 59fe8d47, and it still holds: regenerating here rewrote **1,391 lines**, dropping the `(supports-color@8.1.1)`, `(clean-css@5.3.3)`, `(cssnano@6.1.2)`, `(csso@5.0.5)` and `(html-minifier-terser@7.2.0)` peer suffixes throughout, which would quietly change how peers resolve for everyone. Edited instead: the overrides block, three package entries with their published integrity hashes, three snapshot entries, and the seven references — 36 lines.

### Verification

The three steps `docs.yml` runs, in order:

| Step | Result |
| --- | --- |
| `pnpm install --frozen-lockfile --ignore-scripts` | `Lockfile is up to date` |
| `pnpm run typecheck` | clean |
| `pnpm run build` | client and server compile |

`--frozen-lockfile` passing is the check that matters for a hand edit — it fails if the lockfile disagrees with `package.json` or the overrides. Installed on disk are js-yaml 4.3.1 and nanoid 3.3.18, one copy of each. The build reads YAML through Docusaurus config and frontmatter loading, and runs postcss over every stylesheet, so both are exercised rather than merely present.