### PR TITLE
refactor(io): the worksheet element load gets one interface (spec 24)

### DIFF
--- a/XLibur.Tests/Excel/IO/WorksheetElementRoundTripTests.cs
+++ b/XLibur.Tests/Excel/IO/WorksheetElementRoundTripTests.cs
@@ -1,0 +1,100 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.IO;
+
+/// <summary>
+/// One workbook carrying every worksheet element the loader dispatches on, round-tripped and read
+/// back. Spec 24 moves that dispatch from XLWorkbook_Load into WorksheetElementReader; this test is
+/// what proves no element was dropped on the way.
+/// </summary>
+public class WorksheetElementRoundTripTests
+{
+    private static MemoryStream BuildWorkbookWithEveryElement()
+    {
+        var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+
+            // SheetFormatProperties
+            ws.RowHeight = 22;
+            ws.ColumnWidth = 14;
+
+            // Columns
+            ws.Column(2).Width = 33;
+
+            // SheetData + MergeCells
+            ws.Cell("A1").Value = "Header";
+            ws.Cell("B1").Value = 42;
+            ws.Range("D1:E1").Merge();
+
+            // SheetViews
+            ws.SheetView.FreezeRows(1);
+
+            // AutoFilter
+            ws.Range("A1:B1").SetAutoFilter();
+
+            // SheetProtection
+            ws.Protect("pw");
+
+            // DataValidations
+            ws.Range("A5:A6").CreateDataValidation().WholeNumber.Between(1, 10);
+
+            // Hyperlinks
+            ws.Cell("A8").SetValue("link").SetHyperlink(
+                new XLHyperlink("https://example.invalid/"));
+
+            // ConditionalFormatting
+            ws.Range("B5:B6").AddConditionalFormat().WhenGreaterThan(5).Fill
+                .SetBackgroundColor(XLColor.Red);
+
+            // PrintOptions, PageMargins, PageSetup, HeaderFooter, breaks
+            ws.PageSetup.CenterHorizontally = true;
+            ws.PageSetup.Margins.Top = 1.25;
+            ws.PageSetup.PaperSize = XLPaperSize.A4Paper;
+            ws.PageSetup.Header.Left.AddText("hdr");
+            ws.PageSetup.AddHorizontalPageBreak(3);
+            ws.PageSetup.AddVerticalPageBreak(3);
+
+            // SheetProperties -> tab colour
+            ws.TabColor = XLColor.Blue;
+
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    [Test]
+    public async Task Every_worksheet_element_survives_a_round_trip()
+    {
+        using var ms = BuildWorkbookWithEveryElement();
+        using var wb = new XLWorkbook(ms);
+        var ws = wb.Worksheet("Sheet1");
+
+        await Assert.That(ws.RowHeight).IsEqualTo(22d);                       // SheetFormatProperties
+        await Assert.That(ws.Column(2).Width).IsEqualTo(33d).Within(0.01);    // Columns
+        await Assert.That(ws.Cell("A1").GetString()).IsEqualTo("Header");     // SheetData
+        await Assert.That(ws.MergedRanges.Count).IsEqualTo(1);                // MergeCells
+        await Assert.That(ws.SheetView.SplitRow).IsEqualTo(1);                // SheetViews
+        await Assert.That(ws.AutoFilter.IsEnabled).IsTrue();                  // AutoFilter
+        await Assert.That(ws.Protection.IsProtected).IsTrue();                // SheetProtection
+        await Assert.That(ws.DataValidations.Count()).IsEqualTo(1);           // DataValidations
+        await Assert.That(ws.Cell("A8").HasHyperlink).IsTrue();               // Hyperlinks
+        await Assert.That(ws.ConditionalFormats.Count()).IsEqualTo(1);        // ConditionalFormatting
+        await Assert.That(ws.PageSetup.CenterHorizontally).IsTrue();          // PrintOptions
+        await Assert.That(ws.PageSetup.Margins.Top).IsEqualTo(1.25).Within(0.01); // PageMargins
+        await Assert.That(ws.PageSetup.PaperSize).IsEqualTo(XLPaperSize.A4Paper); // PageSetup
+        // HeaderFooter. AddText(text) fans "AllPages" out into the three concrete occurrences, so
+        // AllPages is never a key GetText can read back — ask for one of the concrete ones.
+        await Assert.That(ws.PageSetup.Header.Left.GetText(XLHFOccurrence.OddPages))
+            .IsEqualTo("hdr");
+        await Assert.That(ws.PageSetup.RowBreaks.Count).IsEqualTo(1);         // RowBreaks
+        await Assert.That(ws.PageSetup.ColumnBreaks.Count).IsEqualTo(1);      // ColumnBreaks
+        await Assert.That(ws.TabColor).IsEqualTo(XLColor.Blue);               // SheetProperties
+    }
+}

--- a/XLibur.Tests/Excel/IO/WorksheetElementRoundTripTests.cs
+++ b/XLibur.Tests/Excel/IO/WorksheetElementRoundTripTests.cs
@@ -59,6 +59,13 @@ public class WorksheetElementRoundTripTests
             ws.PageSetup.AddHorizontalPageBreak(3);
             ws.PageSetup.AddVerticalPageBreak(3);
 
+            // LegacyDrawing. A note is backed by a VML part, and the relationship to it is what
+            // <legacyDrawing> carries.
+            ws.Cell("A10").CreateComment().AddText("note");
+
+            // WorksheetExtensionList. A sparkline group is written into the worksheet <extLst>.
+            ws.SparklineGroups.Add("C10", "D10:F10");
+
             // SheetProperties -> tab colour
             ws.TabColor = XLColor.Blue;
 
@@ -95,6 +102,14 @@ public class WorksheetElementRoundTripTests
             .IsEqualTo("hdr");
         await Assert.That(ws.PageSetup.RowBreaks.Count).IsEqualTo(1);         // RowBreaks
         await Assert.That(ws.PageSetup.ColumnBreaks.Count).IsEqualTo(1);      // ColumnBreaks
+        await Assert.That(ws.Cell("A10").HasComment).IsTrue();                // the note itself
+        await Assert.That(ws.SparklineGroups.Count()).IsEqualTo(1);           // WorksheetExtensionList
+
+        // LegacyDrawing. Asserted on the relationship id rather than on HasComment: the note is
+        // read from the comments part by a different path, so it survives even if this element is
+        // dropped. LegacyDrawingId is what <legacyDrawing> alone carries, and losing it orphans the
+        // VML part on the next save.
+        await Assert.That(((XLWorksheet)ws).LegacyDrawingId).IsNotNullOrEmpty();
         await Assert.That(ws.TabColor).IsEqualTo(XLColor.Blue);               // SheetProperties
     }
 }

--- a/XLibur/Excel/IO/WorksheetElementContext.cs
+++ b/XLibur/Excel/IO/WorksheetElementContext.cs
@@ -1,0 +1,26 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Everything a worksheet element handler needs and cannot change. Passed by <c>in</c> so the
+/// struct is not copied per element.
+/// </summary>
+internal readonly struct WorksheetElementContext
+{
+    internal required WorksheetPart Part { get; init; }
+    internal required XLWorksheet Worksheet { get; init; }
+    internal required StylesheetData Styles { get; init; }
+    internal required LoadContext Load { get; init; }
+    internal required XLWorkbook Workbook { get; init; }
+}
+
+/// <summary>
+/// What one worksheet element hands to a later one. <c>sheetPr</c> produces the page-setup
+/// properties that <c>pageSetup</c> consumes, so the two are ordered and this carrier is mutable.
+/// </summary>
+internal struct WorksheetElementState
+{
+    internal PageSetupProperties? PageSetupProperties;
+}

--- a/XLibur/Excel/IO/WorksheetElementReader.cs
+++ b/XLibur/Excel/IO/WorksheetElementReader.cs
@@ -15,7 +15,84 @@ namespace XLibur.Excel.IO;
 /// </summary>
 internal static class WorksheetElementReader
 {
-    internal static void LoadSheetViews(SheetViews sheetViews, XLWorksheet ws)
+    /// <summary>
+    /// Reads the element the reader is positioned on into the worksheet model.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the element was recognised and consumed; <c>false</c> if it was not, in which
+    /// case the reader has not been touched.
+    /// </returns>
+    /// <remarks>
+    /// Only recognised types are materialised. Calling <c>LoadCurrentElement()</c> on a wrapper such
+    /// as <c>sheetData</c> would consume all of its children and starve the caller's loop, which is
+    /// why every branch below names a concrete type.
+    /// </remarks>
+    // S3776: a flat dispatch over element types is the clearest form this can take; splitting it
+    // by an arbitrary cut is what put the element names in a different module from the element
+    // bodies in the first place.
+#pragma warning disable S3776
+    internal static bool TryLoad(
+        OpenXmlPartReader reader,
+        in WorksheetElementContext context,
+        ref WorksheetElementState state)
+    {
+        var elementType = reader.ElementType;
+        var ws = context.Worksheet;
+
+        if (elementType == typeof(SheetProperties))
+        {
+            LoadSheetProperties((SheetProperties)reader.LoadCurrentElement()!, ws,
+                out var pageSetupProperties);
+            state.PageSetupProperties = pageSetupProperties;
+        }
+        else if (elementType == typeof(SheetFormatProperties))
+            context.Workbook.LoadSheetFormatProperties(
+                (SheetFormatProperties)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(MergeCells))
+            XLWorkbook.LoadMergeCellsStreaming(reader, ws);
+        else if (elementType == typeof(SheetViews))
+            LoadSheetViews((SheetViews)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(Columns))
+            WorksheetSheetDataReader.LoadColumns(context.Styles, ws,
+                (Columns)reader.LoadCurrentElement()!);
+        else if (elementType == typeof(AutoFilter))
+            LoadAutoFilter((AutoFilter)reader.LoadCurrentElement()!, ws,
+                context.Styles.DifferentialFormats);
+        else if (elementType == typeof(SheetProtection))
+            LoadSheetProtection((SheetProtection)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(DataValidations))
+            LoadDataValidations((DataValidations)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(LegacyDrawing))
+            ws.LegacyDrawingId = ((LegacyDrawing)reader.LoadCurrentElement()!).Id?.Value;
+        else if (elementType == typeof(ConditionalFormatting))
+            ConditionalFormatReader.LoadConditionalFormatting(
+                (ConditionalFormatting)reader.LoadCurrentElement()!, ws,
+                context.Styles.DifferentialFormats, context.Load);
+        else if (elementType == typeof(Hyperlinks))
+            LoadHyperlinks((Hyperlinks)reader.LoadCurrentElement()!, context.Part, ws);
+        else if (elementType == typeof(PrintOptions))
+            LoadPrintOptions((PrintOptions)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(PageMargins))
+            LoadPageMargins((PageMargins)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(PageSetup))
+            LoadPageSetup((PageSetup)reader.LoadCurrentElement()!, ws, state.PageSetupProperties);
+        else if (elementType == typeof(HeaderFooter))
+            LoadHeaderFooter((HeaderFooter)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(RowBreaks))
+            LoadRowBreaks((RowBreaks)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(ColumnBreaks))
+            LoadColumnBreaks((ColumnBreaks)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(WorksheetExtensionList))
+            ConditionalFormatReader.LoadExtensions(
+                (WorksheetExtensionList)reader.LoadCurrentElement()!, ws, context.Workbook);
+        else
+            return false;
+
+        return true;
+    }
+#pragma warning restore S3776
+
+    private static void LoadSheetViews(SheetViews sheetViews, XLWorksheet ws)
     {
         ArgumentNullException.ThrowIfNull(ws);
 
@@ -88,7 +165,7 @@ internal static class WorksheetElementReader
         }
     }
 
-    internal static void LoadPrintOptions(PrintOptions printOptions, XLWorksheet ws)
+    private static void LoadPrintOptions(PrintOptions printOptions, XLWorksheet ws)
     {
         ArgumentNullException.ThrowIfNull(printOptions);
 
@@ -102,7 +179,7 @@ internal static class WorksheetElementReader
             ws.PageSetup.ShowRowAndColumnHeadings = printOptions.Headings;
     }
 
-    internal static void LoadPageMargins(PageMargins pageMargins, XLWorksheet ws)
+    private static void LoadPageMargins(PageMargins pageMargins, XLWorksheet ws)
     {
         ArgumentNullException.ThrowIfNull(pageMargins);
 
@@ -120,7 +197,7 @@ internal static class WorksheetElementReader
             ws.PageSetup.Margins.Top = pageMargins.Top;
     }
 
-    internal static void LoadPageSetup(PageSetup pageSetup, XLWorksheet ws, PageSetupProperties? pageSetupProperties)
+    private static void LoadPageSetup(PageSetup pageSetup, XLWorksheet ws, PageSetupProperties? pageSetupProperties)
     {
         ArgumentNullException.ThrowIfNull(pageSetup);
 
@@ -162,7 +239,7 @@ internal static class WorksheetElementReader
             ws.PageSetup.FirstPageNumber = (int)pageSetup.FirstPageNumber.Value;
     }
 
-    internal static void LoadHeaderFooter(HeaderFooter headerFooter, XLWorksheet ws)
+    private static void LoadHeaderFooter(HeaderFooter headerFooter, XLWorksheet ws)
     {
         ArgumentNullException.ThrowIfNull(headerFooter);
 
@@ -203,7 +280,7 @@ internal static class WorksheetElementReader
         ((XLHeaderFooter)ws.PageSetup.Footer).SetAsInitial();
     }
 
-    internal static void LoadSheetProperties(SheetProperties sheetProperty, XLWorksheet ws,
+    private static void LoadSheetProperties(SheetProperties sheetProperty, XLWorksheet ws,
         out PageSetupProperties? pageSetupProperties)
     {
         ArgumentNullException.ThrowIfNull(ws);
@@ -233,7 +310,7 @@ internal static class WorksheetElementReader
             pageSetupProperties = sheetProperty.PageSetupProperties;
     }
 
-    internal static void LoadRowBreaks(RowBreaks rowBreaks, XLWorksheet ws)
+    private static void LoadRowBreaks(RowBreaks rowBreaks, XLWorksheet ws)
     {
         ArgumentNullException.ThrowIfNull(rowBreaks);
 
@@ -241,7 +318,7 @@ internal static class WorksheetElementReader
             ws.PageSetup.RowBreaks.Add(int.Parse(rowBreak.Id!.InnerText!));
     }
 
-    internal static void LoadColumnBreaks(ColumnBreaks columnBreaks, XLWorksheet ws)
+    private static void LoadColumnBreaks(ColumnBreaks columnBreaks, XLWorksheet ws)
     {
         ArgumentNullException.ThrowIfNull(columnBreaks);
         foreach (var columnBreak in columnBreaks.Elements<Break>().Where(columnBreak => columnBreak.Id != null))
@@ -250,7 +327,7 @@ internal static class WorksheetElementReader
         }
     }
 
-    internal static void LoadSheetProtection(SheetProtection sp, XLWorksheet ws)
+    private static void LoadSheetProtection(SheetProtection sp, XLWorksheet ws)
     {
         ArgumentNullException.ThrowIfNull(ws);
 
@@ -303,7 +380,7 @@ internal static class WorksheetElementReader
             !OpenXmlHelper.GetBooleanValueAsBool(sp.SelectUnlockedCells, false));
     }
 
-    internal static void LoadDataValidations(DataValidations dataValidations, XLWorksheet ws)
+    private static void LoadDataValidations(DataValidations dataValidations, XLWorksheet ws)
     {
         ArgumentNullException.ThrowIfNull(ws);
 
@@ -337,7 +414,7 @@ internal static class WorksheetElementReader
         if (dvs.Formula2 != null) dvt.MaxValue = dvs.Formula2.Text;
     }
 
-    internal static void LoadHyperlinks(Hyperlinks hyperlinks, WorksheetPart worksheetPart, XLWorksheet ws)
+    private static void LoadHyperlinks(Hyperlinks hyperlinks, WorksheetPart worksheetPart, XLWorksheet ws)
     {
         ArgumentNullException.ThrowIfNull(ws);
         ArgumentNullException.ThrowIfNull(hyperlinks);
@@ -362,7 +439,7 @@ internal static class WorksheetElementReader
         }
     }
 
-    internal static void LoadAutoFilter(AutoFilter af, XLWorksheet ws,
+    private static void LoadAutoFilter(AutoFilter af, XLWorksheet ws,
         Dictionary<int, DifferentialFormat> differentialFormats)
     {
         if (af != null)
@@ -603,7 +680,7 @@ internal static class WorksheetElementReader
         return fontColor is not null ? fontColor.ToXLiburColor() : XLColor.Automatic;
     }
 
-    internal static void LoadAutoFilterSort(AutoFilter af, XLWorksheet ws, XLAutoFilter autoFilter)
+    private static void LoadAutoFilterSort(AutoFilter af, XLWorksheet ws, XLAutoFilter autoFilter)
     {
         var sort = af.Elements<SortState>().FirstOrDefault();
         if (sort != null)

--- a/XLibur/Excel/IO/WorksheetElementReader.cs
+++ b/XLibur/Excel/IO/WorksheetElementReader.cs
@@ -6,6 +6,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel.AutoFilters;
+using XLibur.Extensions;
 using XLibur.Utils;
 
 namespace XLibur.Excel.IO;
@@ -46,10 +47,10 @@ internal static class WorksheetElementReader
             state.PageSetupProperties = pageSetupProperties;
         }
         else if (elementType == typeof(SheetFormatProperties))
-            context.Workbook.LoadSheetFormatProperties(
-                (SheetFormatProperties)reader.LoadCurrentElement()!, ws);
+            LoadSheetFormatProperties((SheetFormatProperties)reader.LoadCurrentElement()!, ws,
+                context.Workbook);
         else if (elementType == typeof(MergeCells))
-            XLWorkbook.LoadMergeCellsStreaming(reader, ws);
+            LoadMergeCellsStreaming(reader, ws);
         else if (elementType == typeof(SheetViews))
             LoadSheetViews((SheetViews)reader.LoadCurrentElement()!, ws);
         else if (elementType == typeof(Columns))
@@ -91,6 +92,44 @@ internal static class WorksheetElementReader
         return true;
     }
 #pragma warning restore S3776
+
+    private static void LoadSheetFormatProperties(SheetFormatProperties sfp, XLWorksheet ws,
+        XLWorkbook workbook)
+    {
+        if (sfp.DefaultRowHeight is not null)
+            ws.RowHeight = sfp.DefaultRowHeight;
+
+        ws.RowHeightChanged = sfp.CustomHeight is not null && sfp.CustomHeight.Value;
+
+        if (sfp.DefaultColumnWidth is not null)
+            ws.ColumnWidth = XLHelper.ConvertWidthToNoC(sfp.DefaultColumnWidth.Value,
+                ws.Style.Font, workbook);
+        else if (sfp.BaseColumnWidth is not null)
+            ws.ColumnWidth = XLWorkbook.CalculateColumnWidth(sfp.BaseColumnWidth.Value,
+                ws.Style.Font, workbook);
+    }
+
+    /// <summary>
+    /// Reads <c>&lt;mergeCells&gt;</c> using the streaming <see cref="OpenXmlPartReader"/>
+    /// instead of building the full DOM via <c>LoadCurrentElement()</c>. Each
+    /// <c>&lt;mergeCell ref="..."/&gt;</c> child has a single attribute, so streaming
+    /// avoids allocating the parent <see cref="MergeCells"/> collection and all
+    /// child <see cref="MergeCell"/> DOM objects.
+    /// </summary>
+    private static void LoadMergeCellsStreaming(OpenXmlPartReader reader, XLWorksheet ws)
+    {
+        // We're positioned at <mergeCells>. Move into children.
+        reader.MoveAhead();
+
+        while (reader.IsStartElement("mergeCell"))
+        {
+            var reference = reader.Attributes.GetAttribute("ref");
+            if (!string.IsNullOrEmpty(reference))
+                ws.Range(reference)!.Merge(false);
+
+            reader.Skip();
+        }
+    }
 
     private static void LoadSheetViews(SheetViews sheetViews, XLWorksheet ws)
     {

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -333,11 +333,19 @@ public partial class XLWorkbook
         var styles = context.Styles;
         var sharedFormulasR1C1 = new Dictionary<uint, string>();
         var numberDataTypeCache = new Dictionary<XLNumberFormatValue, XLDataType>();
-        PageSetupProperties? pageSetupProperties = null;
         var sheetDataContext = new WorksheetSheetDataReader.SheetDataReadContext(
             styles, ws, sharedStrings, sharedFormulasR1C1, context.StyleCache, numberDataTypeCache,
             Use1904DateSystem, context.DynamicArrayCmIndexes);
         var sheetDataState = new WorksheetSheetDataReader.SheetDataReadState();
+        var elementContext = new WorksheetElementContext
+        {
+            Part = worksheetPart,
+            Worksheet = ws,
+            Styles = styles,
+            Load = context,
+            Workbook = this,
+        };
+        var elementState = default(WorksheetElementState);
 
         // Pass 1: structural elements via the OpenXML SDK reader (the proven DOM path). The
         // <sheetData> hot path is skipped here — it is read in pass 2 with a raw XmlReader, which
@@ -356,13 +364,7 @@ public partial class XLWorkbook
                 while (reader.ElementType == typeof(CustomSheetViews) || reader.ElementType == typeof(SheetData))
                     reader.ReadNextSibling();
 
-                if (reader.ElementType == typeof(SheetProperties))
-                {
-                    WorksheetElementReader.LoadSheetProperties((SheetProperties)reader.LoadCurrentElement()!, ws, out pageSetupProperties);
-                    continue;
-                }
-
-                LoadWorksheetElement(reader, worksheetPart, ws, styles, pageSetupProperties, context);
+                WorksheetElementReader.TryLoad(reader, in elementContext, ref elementState);
             }
         }
 
@@ -402,92 +404,7 @@ public partial class XLWorkbook
         }
     }
 
-    private void LoadWorksheetElement(
-        OpenXmlPartReader reader,
-        WorksheetPart worksheetPart,
-        XLWorksheet ws,
-        StylesheetData styles,
-        PageSetupProperties? pageSetupProperties,
-        LoadContext context)
-    {
-        // Only call LoadCurrentElement() for recognized types. Calling it on
-        // wrapper elements like SheetData would consume all child elements
-        // (e.g., Row), preventing the main loop from processing them.
-        var elementType = reader.ElementType;
-
-        if (!LoadStructureElement(reader, elementType, ws, styles))
-            LoadPrintAndExtensionElement(reader, elementType, worksheetPart, ws, styles, pageSetupProperties, context);
-    }
-
-    /// <summary>
-    /// Loads worksheet structure elements (format, merge, views, columns, filter, protection, validation, legacy drawing).
-    /// </summary>
-    /// <returns><c>true</c> if the element was handled; <c>false</c> to try the next group.</returns>
-    private bool LoadStructureElement(OpenXmlPartReader reader, Type elementType, XLWorksheet ws, StylesheetData styles)
-    {
-        // Only call LoadCurrentElement() for recognized types. Calling it on
-        // wrapper elements like SheetData would consume all child elements
-        // (e.g., Row), preventing the main loop from processing them.
-        if (elementType == typeof(SheetFormatProperties))
-            LoadSheetFormatProperties((SheetFormatProperties)reader.LoadCurrentElement()!, ws);
-        else if (elementType == typeof(MergeCells))
-            LoadMergeCellsStreaming(reader, ws);
-        else if (elementType == typeof(SheetViews))
-            WorksheetElementReader.LoadSheetViews((SheetViews)reader.LoadCurrentElement()!, ws);
-        else if (elementType == typeof(Columns))
-            WorksheetSheetDataReader.LoadColumns(styles, ws, (Columns)reader.LoadCurrentElement()!);
-        else if (elementType == typeof(AutoFilter))
-            WorksheetElementReader.LoadAutoFilter((AutoFilter)reader.LoadCurrentElement()!, ws, styles.DifferentialFormats);
-        else if (elementType == typeof(SheetProtection))
-            WorksheetElementReader.LoadSheetProtection((SheetProtection)reader.LoadCurrentElement()!, ws);
-        else if (elementType == typeof(DataValidations))
-            WorksheetElementReader.LoadDataValidations((DataValidations)reader.LoadCurrentElement()!, ws);
-        else if (elementType == typeof(LegacyDrawing))
-            ws.LegacyDrawingId = ((LegacyDrawing)reader.LoadCurrentElement()!).Id?.Value;
-        else
-            return false;
-
-        return true;
-    }
-
-    /// <summary>
-    /// Loads print-related and extension elements (conditional formatting, hyperlinks, print options,
-    /// page margins/setup, header/footer, breaks, extensions).
-    /// </summary>
-    private void LoadPrintAndExtensionElement(
-        OpenXmlPartReader reader,
-        Type elementType,
-        WorksheetPart worksheetPart,
-        XLWorksheet ws,
-        StylesheetData styles,
-        PageSetupProperties? pageSetupProperties,
-        LoadContext context)
-    {
-        // Only call LoadCurrentElement() for recognized types. Calling it on
-        // wrapper elements like SheetData would consume all child elements
-        // (e.g., Row), preventing the main loop from processing them.
-        if (elementType == typeof(ConditionalFormatting))
-            ConditionalFormatReader.LoadConditionalFormatting((ConditionalFormatting)reader.LoadCurrentElement()!, ws,
-                styles.DifferentialFormats, context);
-        else if (elementType == typeof(Hyperlinks))
-            WorksheetElementReader.LoadHyperlinks((Hyperlinks)reader.LoadCurrentElement()!, worksheetPart, ws);
-        else if (elementType == typeof(PrintOptions))
-            WorksheetElementReader.LoadPrintOptions((PrintOptions)reader.LoadCurrentElement()!, ws);
-        else if (elementType == typeof(PageMargins))
-            WorksheetElementReader.LoadPageMargins((PageMargins)reader.LoadCurrentElement()!, ws);
-        else if (elementType == typeof(PageSetup))
-            WorksheetElementReader.LoadPageSetup((PageSetup)reader.LoadCurrentElement()!, ws, pageSetupProperties);
-        else if (elementType == typeof(HeaderFooter))
-            WorksheetElementReader.LoadHeaderFooter((HeaderFooter)reader.LoadCurrentElement()!, ws);
-        else if (elementType == typeof(RowBreaks))
-            WorksheetElementReader.LoadRowBreaks((RowBreaks)reader.LoadCurrentElement()!, ws);
-        else if (elementType == typeof(ColumnBreaks))
-            WorksheetElementReader.LoadColumnBreaks((ColumnBreaks)reader.LoadCurrentElement()!, ws);
-        else if (elementType == typeof(WorksheetExtensionList))
-            ConditionalFormatReader.LoadExtensions((WorksheetExtensionList)reader.LoadCurrentElement()!, ws, this);
-    }
-
-    private void LoadSheetFormatProperties(SheetFormatProperties sfp, XLWorksheet ws)
+    internal void LoadSheetFormatProperties(SheetFormatProperties sfp, XLWorksheet ws)
     {
         if (sfp.DefaultRowHeight is not null)
             ws.RowHeight = sfp.DefaultRowHeight;
@@ -507,7 +424,7 @@ public partial class XLWorkbook
     /// avoids allocating the parent <see cref="MergeCells"/> collection and all
     /// child <see cref="MergeCell"/> DOM objects.
     /// </summary>
-    private static void LoadMergeCellsStreaming(OpenXmlPartReader reader, XLWorksheet ws)
+    internal static void LoadMergeCellsStreaming(OpenXmlPartReader reader, XLWorksheet ws)
     {
         // We're positioned at <mergeCells>. Move into children.
         reader.MoveAhead();

--- a/XLibur/Excel/XLWorkbook_Load.cs
+++ b/XLibur/Excel/XLWorkbook_Load.cs
@@ -404,41 +404,6 @@ public partial class XLWorkbook
         }
     }
 
-    internal void LoadSheetFormatProperties(SheetFormatProperties sfp, XLWorksheet ws)
-    {
-        if (sfp.DefaultRowHeight is not null)
-            ws.RowHeight = sfp.DefaultRowHeight;
-
-        ws.RowHeightChanged = sfp.CustomHeight is not null && sfp.CustomHeight.Value;
-
-        if (sfp.DefaultColumnWidth is not null)
-            ws.ColumnWidth = XLHelper.ConvertWidthToNoC(sfp.DefaultColumnWidth.Value, ws.Style.Font, this);
-        else if (sfp.BaseColumnWidth is not null)
-            ws.ColumnWidth = CalculateColumnWidth(sfp.BaseColumnWidth.Value, ws.Style.Font, this);
-    }
-
-    /// <summary>
-    /// Reads <c>&lt;mergeCells&gt;</c> using the streaming <see cref="OpenXmlPartReader"/>
-    /// instead of building the full DOM via <c>LoadCurrentElement()</c>. Each
-    /// <c>&lt;mergeCell ref="..."/&gt;</c> child has a single attribute, so streaming
-    /// avoids allocating the parent <see cref="MergeCells"/> collection and all
-    /// child <see cref="MergeCell"/> DOM objects.
-    /// </summary>
-    internal static void LoadMergeCellsStreaming(OpenXmlPartReader reader, XLWorksheet ws)
-    {
-        // We're positioned at <mergeCells>. Move into children.
-        reader.MoveAhead();
-
-        while (reader.IsStartElement("mergeCell"))
-        {
-            var reference = reader.Attributes.GetAttribute("ref");
-            if (!string.IsNullOrEmpty(reference))
-                ws.Range(reference)!.Merge(false);
-
-            reader.Skip();
-        }
-    }
-
     private static void LoadRichValueImages(LoadContext context, XLWorksheet ws)
     {
         // Hydrate in-cell images from rich data metadata
@@ -859,7 +824,7 @@ public partial class XLWorkbook
     /// Calculate expected column width as a number displayed in the column in Excel from
     /// the number of characters that should fit into the width and a font.
     /// </summary>
-    private static double CalculateColumnWidth(double charWidth, IXLFont font, XLWorkbook workbook)
+    internal static double CalculateColumnWidth(double charWidth, IXLFont font, XLWorkbook workbook)
     {
         // Convert width as a number of characters and translate it into a given number of pixels.
         var mdw = workbook.FontEngine.GetMaxDigitWidth(font, workbook.DpiX).RoundToInt();

--- a/docs/specs/24-worksheet-element-dispatch.md
+++ b/docs/specs/24-worksheet-element-dispatch.md
@@ -1,0 +1,690 @@
+# Spec 24 — The worksheet element load gets one interface
+
+**Area:** Architecture · Refactor
+**Effort:** S–M (~3–4 days)
+**Dependencies:** None hard. **Conflicts with spec 18 task 5** — both work inside
+`LoadWorksheetElements`. See Conflicts.
+**Status:** Done (2026-08-23).
+
+## Goal
+
+Move the worksheet element-name dispatch inside the reader that owns the element bodies, so
+`WorksheetElementReader`'s interface goes from **14 entry points to 1** and adding a worksheet
+element touches one module instead of two.
+
+## Why this spec exists
+
+Reading a worksheet element is split across a seam for no reason the code gives:
+
+- **`XLWorkbook_Load.cs`** holds the element-name → handler dispatch, as an `if`/`else if` chain on
+  `reader.ElementType`, split across two methods (`LoadStructureElement`,
+  `LoadPrintAndExtensionElement`) purely to stay under a cognitive-complexity limit.
+- **`WorksheetElementReader.cs`** holds 14 element bodies, one `internal static LoadX` each, and
+  knows nothing about which element name reaches it.
+
+Adding a worksheet element means editing both. Neither module is independently comprehensible: the
+loader names elements it cannot read, and the reader reads elements it cannot name.
+
+Applying the deletion test to `WorksheetElementReader`: deleting it would move 624 lines into
+`XLWorkbook_Load` and concentrate nothing. Its interface is 14 wide and each implementation is
+small — a shallow module, and the only one of its kind in the IO layer. Every other reader and
+writer under `XLibur/Excel/IO/` exposes one or two entry points.
+
+The dispatch is also spread wider than the two named modules. The 17 element types are handled by
+**four** different owners:
+
+| Owner | Elements |
+|---|---|
+| `WorksheetElementReader` | `SheetViews`, `AutoFilter`, `SheetProtection`, `DataValidations`, `Hyperlinks`, `PrintOptions`, `PageMargins`, `PageSetup`, `HeaderFooter`, `RowBreaks`, `ColumnBreaks`, `SheetProperties` |
+| `WorksheetSheetDataReader` | `Columns` |
+| `ConditionalFormatReader` | `ConditionalFormatting`, `WorksheetExtensionList` |
+| `XLWorkbook_Load` itself | `SheetFormatProperties`, `MergeCells`, `LegacyDrawing` |
+
+## Non-goals
+
+- **No change to the two-pass load.** `<sheetData>` is deliberately skipped in pass 1 and read in
+  pass 2 with a raw `XmlReader` (`XLWorkbook_Load.cs:343`, `:369`). The remarks on `LoadSheetDataRaw`
+  record that rescanning the part is 0.05–0.65 ms and that collapsing the passes is not worth the
+  rewrite. This spec does not revisit that.
+- **No behaviour change.** Same elements read, same order, same results.
+- **No performance work.** Spec 18 task 5 owns the per-sheet cost. This spec must not make it worse
+  and does not try to make it better — see task 4.
+- **No public API change.**
+
+## Current state
+
+Verified against the tree at `d05b0753` (2026-08-23).
+
+- `LoadWorksheetElements` — `XLWorkbook_Load.cs:327-370`, the two-pass driver
+- `LoadWorksheetElement` — `:404-419`, calls the two dispatch halves
+- `LoadStructureElement` — `:421-450`, 8 element types, returns `bool` handled
+- `LoadPrintAndExtensionElement` — `:452-487`, 9 element types
+- `LoadSheetFormatProperties` — `:490`, `private void`, uses `this` only as an `XLWorkbook` argument
+- `LoadMergeCellsStreaming` — `:510`, already `private static`
+- `CalculateColumnWidth` — `:945`, `private static (double, IXLFont, XLWorkbook)`
+- `WorksheetElementReader.cs` — 624 lines, 14 `internal static` entry points
+
+`pageSetupProperties` is threaded through the dispatch: `SheetProperties` produces it in the main
+loop (`:361`), `PageSetup` consumes it (`:479`). That ordering dependency is real and must survive.
+
+## The design
+
+Mirror the pattern `WorksheetSheetDataReader` already uses — `in <Context>, ref <State>` — so the two
+readers in the load path read the same way.
+
+```csharp
+/// <summary>Everything a worksheet element handler needs and cannot change.</summary>
+internal readonly struct WorksheetElementContext
+{
+    internal required WorksheetPart Part { get; init; }
+    internal required XLWorksheet Worksheet { get; init; }
+    internal required StylesheetData Styles { get; init; }
+    internal required LoadContext Load { get; init; }
+    internal required XLWorkbook Workbook { get; init; }
+}
+
+/// <summary>
+/// What one element hands to a later one. <c>c:sheetPr</c> produces the page-setup properties that
+/// <c>c:pageSetup</c> consumes, so the two are ordered and the carrier is mutable.
+/// </summary>
+internal struct WorksheetElementState
+{
+    internal PageSetupProperties? PageSetupProperties;
+}
+```
+
+`WorksheetElementReader` gains one entry point and loses fourteen:
+
+```csharp
+/// <summary>
+/// Reads the element the reader is currently positioned on into the worksheet model.
+/// </summary>
+/// <returns>
+/// <c>true</c> if the element was recognised and consumed; <c>false</c> if the caller should
+/// leave it alone. A <c>false</c> return has not touched the reader.
+/// </returns>
+internal static bool TryLoad(
+    OpenXmlPartReader reader,
+    in WorksheetElementContext context,
+    ref WorksheetElementState state);
+```
+
+The 14 `LoadX` methods become `private static`. The dispatch chain moves in with them.
+
+`SheetProperties` stops being special-cased in the main loop: it is dispatched like every other
+element, and writes its output into `state.PageSetupProperties`.
+
+## File structure
+
+```
+XLibur/Excel/IO/WorksheetElementContext.cs   new — the context and state structs
+XLibur/Excel/IO/WorksheetElementReader.cs    modified — gains TryLoad, 14 methods go private
+XLibur/Excel/XLWorkbook_Load.cs              modified — dispatch deleted, ~70 lines lighter
+```
+
+## Global constraints
+
+- Warnings are errors; nullable enabled.
+- Branch per task; never commit to main. Commit prefix `refactor:`.
+- No compound shell commands (`&&`, `;`) in agent tool calls.
+- Build: `dotnet build XLibur/XLibur.csproj -c Release -v q`
+- Tests: `dotnet test XLibur.Tests/XLibur.Tests.csproj -f net10.0`
+- Use `--treenode-filter`, never `--filter`. Never filter at solution level.
+- `required` members need C# 11+; the repo targets net8.0/net9.0/net10.0, so this is available. If
+  the language version is pinned lower, drop `required` and validate in `TryLoad` instead.
+
+## Work plan
+
+| # | Task | Size | Gate |
+|---|---|---|---|
+| 1 | Characterization test: every element survives a round trip | S | New test green on unmodified code |
+| 2 | Context and state structs; `TryLoad` with the dispatch moved in | M | Suite green |
+| 3 | Move the three orphan handlers off `XLWorkbook_Load` | S | Suite green |
+| 4 | Confirm the per-sheet load cost is unchanged | S | Within noise of baseline |
+
+---
+
+### Task 1 — Characterization test
+
+The refactor is behaviour-preserving, so it needs a test that would notice if an element stopped
+being read. No single existing test covers all 17 at once.
+
+**Files:**
+- Create: `XLibur.Tests/Excel/IO/WorksheetElementRoundTripTests.cs`
+
+**Interfaces:**
+- Produces: `Every_worksheet_element_survives_a_round_trip`, the gate for tasks 2 and 3.
+
+- [x] **Step 1: Write the test**
+
+```csharp
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.IO;
+
+/// <summary>
+/// One workbook carrying every worksheet element the loader dispatches on, round-tripped and read
+/// back. Spec 24 moves that dispatch from XLWorkbook_Load into WorksheetElementReader; this test is
+/// what proves no element was dropped on the way.
+/// </summary>
+public class WorksheetElementRoundTripTests
+{
+    private static MemoryStream BuildWorkbookWithEveryElement()
+    {
+        var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+
+            // SheetFormatProperties
+            ws.RowHeight = 22;
+            ws.ColumnWidth = 14;
+
+            // Columns
+            ws.Column(2).Width = 33;
+
+            // SheetData + MergeCells
+            ws.Cell("A1").Value = "Header";
+            ws.Cell("B1").Value = 42;
+            ws.Range("D1:E1").Merge();
+
+            // SheetViews
+            ws.SheetView.FreezeRows(1);
+
+            // AutoFilter
+            ws.Range("A1:B1").SetAutoFilter();
+
+            // SheetProtection
+            ws.Protect("pw");
+
+            // DataValidations
+            ws.Range("A5:A6").CreateDataValidation().WholeNumber.Between(1, 10);
+
+            // Hyperlinks
+            ws.Cell("A8").SetValue("link").SetHyperlink(
+                new XLHyperlink("https://example.invalid/"));
+
+            // ConditionalFormatting
+            ws.Range("B5:B6").AddConditionalFormat().WhenGreaterThan(5).Fill
+                .SetBackgroundColor(XLColor.Red);
+
+            // PrintOptions, PageMargins, PageSetup, HeaderFooter, breaks
+            ws.PageSetup.CenterHorizontally = true;
+            ws.PageSetup.Margins.Top = 1.25;
+            ws.PageSetup.PaperSize = XLPaperSize.A4Paper;
+            ws.PageSetup.Header.Left.AddText("hdr");
+            ws.PageSetup.AddHorizontalPageBreak(3);
+            ws.PageSetup.AddVerticalPageBreak(3);
+
+            // SheetProperties -> tab colour
+            ws.TabColor = XLColor.Blue;
+
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    [Test]
+    public async Task Every_worksheet_element_survives_a_round_trip()
+    {
+        using var ms = BuildWorkbookWithEveryElement();
+        using var wb = new XLWorkbook(ms);
+        var ws = wb.Worksheet("Sheet1");
+
+        await Assert.That(ws.RowHeight).IsEqualTo(22d);                       // SheetFormatProperties
+        await Assert.That(ws.Column(2).Width).IsEqualTo(33d).Within(0.01);    // Columns
+        await Assert.That(ws.Cell("A1").GetString()).IsEqualTo("Header");     // SheetData
+        await Assert.That(ws.MergedRanges.Count).IsEqualTo(1);                // MergeCells
+        await Assert.That(ws.SheetView.SplitRow).IsEqualTo(1);                // SheetViews
+        await Assert.That(ws.AutoFilter.IsEnabled).IsTrue();                  // AutoFilter
+        await Assert.That(ws.Protection.IsProtected).IsTrue();                // SheetProtection
+        await Assert.That(ws.DataValidations.Count()).IsEqualTo(1);           // DataValidations
+        await Assert.That(ws.Cell("A8").HasHyperlink).IsTrue();               // Hyperlinks
+        await Assert.That(ws.ConditionalFormats.Count()).IsEqualTo(1);        // ConditionalFormatting
+        await Assert.That(ws.PageSetup.CenterHorizontally).IsTrue();          // PrintOptions
+        await Assert.That(ws.PageSetup.Margins.Top).IsEqualTo(1.25).Within(0.01); // PageMargins
+        await Assert.That(ws.PageSetup.PaperSize).IsEqualTo(XLPaperSize.A4Paper); // PageSetup
+        await Assert.That(ws.PageSetup.Header.Left.GetText()).IsEqualTo("hdr");   // HeaderFooter
+        await Assert.That(ws.PageSetup.RowBreaks.Count).IsEqualTo(1);         // RowBreaks
+        await Assert.That(ws.PageSetup.ColumnBreaks.Count).IsEqualTo(1);      // ColumnBreaks
+        await Assert.That(ws.TabColor).IsEqualTo(XLColor.Blue);               // SheetProperties
+    }
+}
+```
+
+- [x] **Step 2: Run it and fix any API mismatches**
+
+Run: `dotnet test XLibur.Tests/XLibur.Tests.csproj -f net10.0 --treenode-filter "/*/*/WorksheetElementRoundTripTests/*"`
+Expected: PASS.
+
+Some of the builder calls above are written from the public surface as documented; if one does not
+compile, find the equivalent in `XLibur.Tests/Excel/` — every element here is already exercised
+somewhere in the suite — and use that form. **Do not weaken an assertion to make it pass.** If an
+element genuinely does not round-trip today, that is a pre-existing defect: record it, replace the
+assertion with the current behaviour plus a comment naming the gap, and report it.
+
+- [x] **Step 3: Verify the gate bites**
+
+In `XLWorkbook_Load.LoadPrintAndExtensionElement`, temporarily comment out the `RowBreaks` branch.
+Re-run.
+Expected: FAIL on the `RowBreaks` assertion. Restore the branch.
+
+- [x] **Step 4: Commit**
+
+```bash
+git add XLibur.Tests/Excel/IO/WorksheetElementRoundTripTests.cs
+git commit -m 'test(io): round-trip every worksheet element in one workbook (spec 24 task 1)'
+```
+
+---
+
+### Task 2 — Context, state, and `TryLoad`
+
+**Files:**
+- Create: `XLibur/Excel/IO/WorksheetElementContext.cs`
+- Modify: `XLibur/Excel/IO/WorksheetElementReader.cs`
+- Modify: `XLibur/Excel/XLWorkbook_Load.cs:327-487`
+
+**Interfaces:**
+- Produces: `WorksheetElementContext`, `WorksheetElementState`,
+  `WorksheetElementReader.TryLoad(OpenXmlPartReader, in WorksheetElementContext, ref WorksheetElementState) → bool`.
+
+- [x] **Step 1: Create the context and state structs**
+
+```csharp
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace XLibur.Excel.IO;
+
+/// <summary>
+/// Everything a worksheet element handler needs and cannot change. Passed by <c>in</c> so the
+/// struct is not copied per element.
+/// </summary>
+internal readonly struct WorksheetElementContext
+{
+    internal required WorksheetPart Part { get; init; }
+    internal required XLWorksheet Worksheet { get; init; }
+    internal required StylesheetData Styles { get; init; }
+    internal required LoadContext Load { get; init; }
+    internal required XLWorkbook Workbook { get; init; }
+}
+
+/// <summary>
+/// What one worksheet element hands to a later one. <c>sheetPr</c> produces the page-setup
+/// properties that <c>pageSetup</c> consumes, so the two are ordered and this carrier is mutable.
+/// </summary>
+internal struct WorksheetElementState
+{
+    internal PageSetupProperties? PageSetupProperties;
+}
+```
+
+- [x] **Step 2: Add `TryLoad` to `WorksheetElementReader` with the dispatch moved in**
+
+```csharp
+    /// <summary>
+    /// Reads the element the reader is positioned on into the worksheet model.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the element was recognised and consumed; <c>false</c> if it was not, in which
+    /// case the reader has not been touched.
+    /// </returns>
+    /// <remarks>
+    /// Only recognised types are materialised. Calling <c>LoadCurrentElement()</c> on a wrapper such
+    /// as <c>sheetData</c> would consume all of its children and starve the caller's loop, which is
+    /// why every branch below names a concrete type.
+    /// </remarks>
+    internal static bool TryLoad(
+        OpenXmlPartReader reader,
+        in WorksheetElementContext context,
+        ref WorksheetElementState state)
+    {
+        var elementType = reader.ElementType;
+        var ws = context.Worksheet;
+
+        if (elementType == typeof(SheetProperties))
+        {
+            LoadSheetProperties((SheetProperties)reader.LoadCurrentElement()!, ws,
+                out var pageSetupProperties);
+            state.PageSetupProperties = pageSetupProperties;
+        }
+        else if (elementType == typeof(SheetFormatProperties))
+            LoadSheetFormatProperties((SheetFormatProperties)reader.LoadCurrentElement()!, ws,
+                context.Workbook);
+        else if (elementType == typeof(MergeCells))
+            LoadMergeCellsStreaming(reader, ws);
+        else if (elementType == typeof(SheetViews))
+            LoadSheetViews((SheetViews)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(Columns))
+            WorksheetSheetDataReader.LoadColumns(context.Styles, ws,
+                (Columns)reader.LoadCurrentElement()!);
+        else if (elementType == typeof(AutoFilter))
+            LoadAutoFilter((AutoFilter)reader.LoadCurrentElement()!, ws,
+                context.Styles.DifferentialFormats);
+        else if (elementType == typeof(SheetProtection))
+            LoadSheetProtection((SheetProtection)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(DataValidations))
+            LoadDataValidations((DataValidations)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(LegacyDrawing))
+            ws.LegacyDrawingId = ((LegacyDrawing)reader.LoadCurrentElement()!).Id?.Value;
+        else if (elementType == typeof(ConditionalFormatting))
+            ConditionalFormatReader.LoadConditionalFormatting(
+                (ConditionalFormatting)reader.LoadCurrentElement()!, ws,
+                context.Styles.DifferentialFormats, context.Load);
+        else if (elementType == typeof(Hyperlinks))
+            LoadHyperlinks((Hyperlinks)reader.LoadCurrentElement()!, context.Part, ws);
+        else if (elementType == typeof(PrintOptions))
+            LoadPrintOptions((PrintOptions)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(PageMargins))
+            LoadPageMargins((PageMargins)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(PageSetup))
+            LoadPageSetup((PageSetup)reader.LoadCurrentElement()!, ws, state.PageSetupProperties);
+        else if (elementType == typeof(HeaderFooter))
+            LoadHeaderFooter((HeaderFooter)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(RowBreaks))
+            LoadRowBreaks((RowBreaks)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(ColumnBreaks))
+            LoadColumnBreaks((ColumnBreaks)reader.LoadCurrentElement()!, ws);
+        else if (elementType == typeof(WorksheetExtensionList))
+            ConditionalFormatReader.LoadExtensions(
+                (WorksheetExtensionList)reader.LoadCurrentElement()!, ws, context.Workbook);
+        else
+            return false;
+
+        return true;
+    }
+```
+
+Sonar's cognitive-complexity rule is what split this chain in two in `XLWorkbook_Load`. A flat
+dispatch chain is the clearest form it can take, so suppress the rule at the method with a reason,
+matching how the repo handles `S4136` in `XLCellFormulaShifter`:
+
+```csharp
+    // S3776: a flat dispatch over element types is the clearest form this can take; splitting it
+    // by an arbitrary cut is what put the element names in a different module from the element
+    // bodies in the first place.
+#pragma warning disable S3776
+```
+
+`LoadSheetFormatProperties` and `LoadMergeCellsStreaming` are referenced above but still live on
+`XLWorkbook_Load` — task 3 moves them. Until then, make them `internal static` on `XLWorkbook` and
+call them qualified, or do task 3 first. **Doing task 3 first is cleaner if the build complains.**
+
+- [x] **Step 3: Make the 14 existing entry points private**
+
+Every `internal static void LoadX` in `WorksheetElementReader.cs` becomes `private static void`,
+except `LoadAutoFilterColumns` and `LoadAutoFilterSort`, which are called from elsewhere. Confirm
+which with:
+
+Run: `grep -rn 'WorksheetElementReader\.' XLibur --include=*.cs`
+
+Anything still called from outside stays `internal`; everything else goes `private`.
+
+- [x] **Step 4: Collapse the loader**
+
+Replace `LoadWorksheetElements`' pass-1 loop, and delete `LoadWorksheetElement`,
+`LoadStructureElement` and `LoadPrintAndExtensionElement` entirely:
+
+```csharp
+        var elementContext = new WorksheetElementContext
+        {
+            Part = worksheetPart,
+            Worksheet = ws,
+            Styles = styles,
+            Load = context,
+            Workbook = this,
+        };
+        var elementState = default(WorksheetElementState);
+
+        // Pass 1: structural elements via the OpenXML SDK reader (the proven DOM path). The
+        // <sheetData> hot path is skipped here — it is read in pass 2 with a raw XmlReader, which
+        // is ~4x faster and allocates ~5x less than materializing every cell through the SDK
+        // reader's object model. Structural elements such as <cols> are parsed here (before pass 2
+        // runs), so column styles are already available when cells resolve their inherited style.
+        using (var reader = new OpenXmlPartReader(worksheetPart))
+        {
+            while (reader.Read())
+            {
+                // Skipped wholesale, without descending:
+                //  - CustomSheetViews carries its own auto filter data and more, ignored for now.
+                //  - SheetData is read in pass 2 by the raw reader.
+                // ReadNextSibling leaves the reader *on* the next sibling rather than needing
+                // another Read, which is why this is a leading loop rather than a `continue`.
+                while (reader.ElementType == typeof(CustomSheetViews)
+                       || reader.ElementType == typeof(SheetData))
+                    reader.ReadNextSibling();
+
+                WorksheetElementReader.TryLoad(reader, in elementContext, ref elementState);
+            }
+        }
+
+        // Pass 2: read <sheetData> rows/cells directly from a raw XmlReader.
+        LoadSheetDataRaw(worksheetPart, in sheetDataContext, ref sheetDataState);
+```
+
+Note what disappears: the `SheetProperties` special case at `:359-365` is gone — it is now one branch
+among the rest, and `pageSetupProperties` lives in `elementState` rather than as a local threaded
+through four signatures.
+
+- [x] **Step 5: Build and run the full suite**
+
+Run: `dotnet build XLibur/XLibur.csproj -c Release -v q`
+Run: `dotnet test XLibur.Tests/XLibur.Tests.csproj -f net10.0`
+Expected: PASS, including task 1's round-trip test.
+
+- [x] **Step 6: Commit**
+
+```bash
+git add XLibur/Excel/IO/WorksheetElementContext.cs XLibur/Excel/IO/WorksheetElementReader.cs XLibur/Excel/XLWorkbook_Load.cs
+git commit -m 'refactor(io): move the worksheet element dispatch into its reader (spec 24 task 2)'
+```
+
+---
+
+### Task 3 — Move the three orphan handlers
+
+`SheetFormatProperties`, `MergeCells` and `LegacyDrawing` are read by `XLWorkbook_Load` itself. With
+the dispatch gone they are the only reason it still knows about worksheet elements.
+
+**Files:**
+- Modify: `XLibur/Excel/XLWorkbook_Load.cs` — delete `LoadSheetFormatProperties` (`:490`) and
+  `LoadMergeCellsStreaming` (`:510`); widen `CalculateColumnWidth` (`:945`) to `internal static`
+- Modify: `XLibur/Excel/IO/WorksheetElementReader.cs` — receive both
+
+- [x] **Step 1: Move `LoadMergeCellsStreaming` verbatim**
+
+It is already `private static (OpenXmlPartReader, XLWorksheet)` and has no dependency on the
+workbook. Cut it into `WorksheetElementReader` as `private static`, unchanged.
+
+- [x] **Step 2: Move `LoadSheetFormatProperties`, taking the workbook explicitly**
+
+It is `private void` today and uses `this` only as an argument. Move it as:
+
+```csharp
+    private static void LoadSheetFormatProperties(SheetFormatProperties sfp, XLWorksheet ws,
+        XLWorkbook workbook)
+    {
+        if (sfp.DefaultRowHeight is not null)
+            ws.RowHeight = sfp.DefaultRowHeight;
+
+        ws.RowHeightChanged = sfp.CustomHeight is not null && sfp.CustomHeight.Value;
+
+        if (sfp.DefaultColumnWidth is not null)
+            ws.ColumnWidth = XLHelper.ConvertWidthToNoC(sfp.DefaultColumnWidth.Value,
+                ws.Style.Font, workbook);
+        else if (sfp.BaseColumnWidth is not null)
+            ws.ColumnWidth = XLWorkbook.CalculateColumnWidth(sfp.BaseColumnWidth.Value,
+                ws.Style.Font, workbook);
+
+        // ... remainder moved verbatim
+    }
+```
+
+Widen `CalculateColumnWidth` from `private static` to `internal static` on `XLWorkbook`. It already
+takes the workbook as a parameter, so nothing else changes.
+
+- [x] **Step 3: Confirm `XLWorkbook_Load` no longer names a worksheet element**
+
+Run: `grep -nE 'typeof\((SheetFormatProperties|MergeCells|LegacyDrawing|SheetViews|PageSetup|HeaderFooter|RowBreaks|ColumnBreaks|Hyperlinks|PrintOptions|PageMargins|AutoFilter|SheetProtection|DataValidations|ConditionalFormatting|WorksheetExtensionList|SheetProperties|Columns)\)' XLibur/Excel/XLWorkbook_Load.cs`
+
+Expected: no output. `CustomSheetViews` and `SheetData` may still appear — they are the two the
+loader deliberately skips, which is sequencing, not element knowledge.
+
+- [x] **Step 4: Build and run the full suite on both frameworks**
+
+Run: `dotnet build XLibur/XLibur.csproj -c Release -v q`
+Run: `dotnet test XLibur.Tests/XLibur.Tests.csproj`
+Expected: PASS on net8.0 and net10.0.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add XLibur/Excel/IO/WorksheetElementReader.cs XLibur/Excel/XLWorkbook_Load.cs
+git commit -m 'refactor(io): move the last three element handlers off the loader (spec 24 task 3)'
+```
+
+---
+
+### Task 4 — Confirm the per-sheet load cost is unchanged
+
+`LoadWorksheetElements` is 23.7% of the template round-trip trace (spec 18 task 5). This spec
+restructures it, so the cost must be shown not to have moved.
+
+- [x] **Step 1: Measure the merge-base**
+
+```
+dotnet run -c Release --project XLibur.Benchmarks/XLibur.Benchmarks.csproj -- profile template
+```
+
+Record the header-only sheet sweep (1 / 10 / 40 sheets) from spec 18 task 5's table.
+
+- [x] **Step 2: Measure the branch**
+
+Same command, same fixture.
+
+- [x] **Step 3: Compare the per-sheet slope**
+
+Expected: ~1.0 ms and ~0.19 MB per header-only sheet, unchanged.
+
+The context struct is passed by `in` and the state struct by `ref`, so neither is copied per
+element and neither allocates. If allocation per sheet has risen, the likely cause is the context
+struct being copied — check that every call site uses `in`, not a bare argument.
+
+**Decision rule.** A per-sheet regression above the ~1.2 ms probe noise floor that spec 18 records
+must be explained before this spec lands, not after. Record the numbers in a Results section either
+way.
+
+- [x] **Step 4: Commit the Results section**
+
+```bash
+git add docs/specs/24-worksheet-element-dispatch.md
+git commit -m 'docs(specs): record the per-sheet load numbers for spec 24'
+```
+
+---
+
+## Results
+
+### Per-sheet load cost (task 4)
+
+`profile template`, net10.0, Release. Base is the merge-base `1b41cadd`; branch is this spec's
+three commits. The `sheets=N names=0 val=0 lookupRows=0` rows — the header-only sweep that isolates
+what a worksheet costs structurally.
+
+**Measured by interleaving**: base and branch alternated within one session, four pairs, median of
+the four run-medians (each run-median is itself the median of 9 passes after a warm-up).
+
+| Sheets | base median ms | branch median ms | base alloc | branch alloc |
+|---|---|---|---|---|
+| 1 | 6.5 | 6.2 | 1.0 MB | 1.0 MB |
+| 10 | 12.8 | 13.0 | 2.6 MB | 2.6 MB |
+| 40 | 40.1 | 38.4 | 8.4 MB | 8.4 MB |
+
+Per-sheet slope over 1 → 40 sheets:
+
+| | ms / sheet | MB / sheet |
+|---|---|---|
+| base | 0.86 | 0.19 |
+| branch | 0.83 | 0.19 |
+
+**Verdict: unchanged.** The branch's slope is 0.03 ms/sheet *below* the base's — well inside the
+~1.2 ms probe noise floor spec 18 records, and in the wrong direction to be a regression.
+Allocation is byte-for-byte identical at every sheet count, which is the part that would have
+caught a copied context struct: `in`/`ref` hold, nothing is copied per element.
+
+Note the ~0.19 MB/sheet matches spec 18 task 5, but the ~0.86 ms/sheet is below the ~1.0 ms that
+task recorded. That gap predates this spec — both arms measure it.
+
+### Measurement note: run the arms interleaved, not in blocks
+
+A first attempt measured six consecutive runs of the branch, then six of the base. That produced an
+apparent **+10% per-sheet regression** on the branch (0.93 vs 0.83 ms/sheet) which did not survive
+interleaving. Two things were wrong with the block method on this machine:
+
+- `... | Select-Object -First N` stops the upstream pipeline and leaves the benchmark process
+  **orphaned and still running**, so later runs in the block compete with earlier ones. Capture the
+  whole run to a file instead.
+- Even without that, the machine drifts enough across a multi-minute block to swamp a 3 ms
+  difference on a 38 ms probe.
+
+The mechanism check was what flagged it as suspect before the interleaved run confirmed it: 0.1 ms
+per sheet spread over ~10 elements is 10 µs per element, which is orders of magnitude more than a
+static call and a 40-byte `in` struct can cost. A regression with no plausible mechanism is a
+measurement artefact until proven otherwise.
+
+### Interface
+
+- `WorksheetElementReader`: 14 `internal static` entry points → 2. `TryLoad` is the dispatch;
+  `LoadAutoFilterColumns` stays `internal` because `XLWorkbook_Load.LoadSingleTable` reads a table's
+  own `<autoFilter>` through it. The other twelve, plus the two handlers moved off the loader, are
+  `private`.
+- `XLWorkbook_Load.cs`: 95 lines lighter in task 2, 36 more in task 3. It names no worksheet element
+  type at all now — `CustomSheetViews` and `SheetData` appear only in the pass-1 skip loop.
+- `pageSetupProperties` is gone as a threaded local; it lives in `WorksheetElementState`.
+
+### Tests
+
+- `WorksheetElementRoundTripTests.Every_worksheet_element_survives_a_round_trip` — 17 elements in
+  one workbook, saved and read back. Gate proven to bite by removing the `RowBreaks` branch, which
+  failed the test on that assertion alone.
+- One assertion differs from the spec's draft, without weakening: the header text is read back with
+  `GetText(XLHFOccurrence.OddPages)`, not `AllPages`. `XLHFItem.AddText` fans `AllPages` out into the
+  three concrete occurrences and never stores `AllPages` as a key, so `GetText(AllPages)` returns
+  `""` for any header. That is existing behaviour of the accessor, not a round-trip gap.
+- Full suite green on net8.0 and net10.0: 23,738 tests, 0 failed, 8 skipped (pre-existing).
+
+---
+
+## Acceptance criteria
+
+1. `WorksheetElementReader` exposes **one** dispatch entry point, `TryLoad`, plus only those members
+   proven to have external callers in task 2 step 3.
+2. `XLWorkbook_Load.cs` names no worksheet element type except `CustomSheetViews` and `SheetData`.
+3. `LoadWorksheetElement`, `LoadStructureElement` and `LoadPrintAndExtensionElement` no longer exist.
+4. `pageSetupProperties` is no longer a local threaded through four signatures.
+5. Task 1's round-trip test passes, with no assertion weakened.
+6. Full suite green on net8.0 and net10.0.
+7. Per-sheet structural load cost within spec 18's noise floor of its pre-spec value.
+8. No public API change.
+
+## Conflicts
+
+- **Spec 18 task 5** is the live conflict. It owns the per-sheet structural cost and attributes
+  23.7% of the template trace to `LoadWorksheetElements` — the exact method this spec restructures.
+  The two cannot run concurrently.
+
+  **Recommended order: this spec first.** It is behaviour-preserving and mechanical, and it leaves
+  spec 18 task 5 a single method to optimise instead of four spread across two modules. Spec 18
+  task 5 is still only "attributed", not designed, so it has nothing to rebase yet.
+
+  If spec 18 task 5 starts first, this spec waits — do not rebase a performance change onto a
+  structural one.
+- **Spec 02** (load-path allocations) is done and touches `WorksheetSheetDataReader`, not this
+  dispatch. `WorksheetSheetDataReader.LoadColumns` is called from `TryLoad` but not modified.
+- No other spec touches `WorksheetElementReader.cs`.

--- a/docs/specs/24-worksheet-element-dispatch.md
+++ b/docs/specs/24-worksheet-element-dispatch.md
@@ -116,7 +116,7 @@ element, and writes its output into `state.PageSetupProperties`.
 
 ## File structure
 
-```
+```text
 XLibur/Excel/IO/WorksheetElementContext.cs   new — the context and state structs
 XLibur/Excel/IO/WorksheetElementReader.cs    modified — gains TryLoad, 14 methods go private
 XLibur/Excel/XLWorkbook_Load.cs              modified — dispatch deleted, ~70 lines lighter
@@ -558,7 +558,7 @@ restructures it, so the cost must be shown not to have moved.
 
 - [x] **Step 1: Measure the merge-base**
 
-```
+```bash
 dotnet run -c Release --project XLibur.Benchmarks/XLibur.Benchmarks.csproj -- profile template
 ```
 
@@ -653,6 +653,15 @@ measurement artefact until proven otherwise.
 - `WorksheetElementRoundTripTests.Every_worksheet_element_survives_a_round_trip` — 17 elements in
   one workbook, saved and read back. Gate proven to bite by removing the `RowBreaks` branch, which
   failed the test on that assertion alone.
+- Two elements needed a producer the first draft did not have: `<legacyDrawing>` is written only for
+  a sheet with VML, so the fixture carries a note; the worksheet `<extLst>` is written only for x14
+  data validations, x14 data bars or sparklines, so the fixture carries a sparkline group.
+- The `LegacyDrawing` assertion is on `LegacyDrawingId`, not on `HasComment`. `HasComment` was tried
+  first and **does not bite**: the note is read from the comments part by a separate path and
+  survives with the `LegacyDrawing` branch deleted. `LegacyDrawingId` is what the element alone
+  carries — losing it orphans the VML part on the next save — and removing the branch does fail on
+  it. A passing assertion is not proof a branch is covered; each of the two new ones was checked by
+  deleting its branch.
 - One assertion differs from the spec's draft, without weakening: the header text is read back with
   `GetText(XLHFOccurrence.OddPages)`, not `AllPages`. `XLHFItem.AddText` fans `AllPages` out into the
   three concrete occurrences and never stores `AllPages` as a key, so `GetText(AllPages)` returns


### PR DESCRIPTION
Implements [spec 24](docs/specs/24-worksheet-element-dispatch.md), tasks 1–4.

Reading a worksheet element was split across a seam for no reason the code gave: `XLWorkbook_Load` held the element-name dispatch, split across two methods purely to stay under a cognitive-complexity limit, while `WorksheetElementReader` held the 14 element bodies and knew nothing about which name reached it. Adding an element meant editing both, and neither module was independently comprehensible — the loader named elements it could not read, the reader read elements it could not name.

The dispatch now lives with the element bodies.

## What changed

- **New** `XLibur/Excel/IO/WorksheetElementContext.cs` — an `in`-passed context struct and a `ref`-passed state struct, mirroring the pattern `WorksheetSheetDataReader` already uses, so both readers in the load path read the same way.
- **`WorksheetElementReader`** — 14 `internal static` entry points become 2. `TryLoad` is the one dispatch entry point; `LoadAutoFilterColumns` stays `internal` because `LoadSingleTable` reads a table's own `<autoFilter>` through it. The reader also absorbed `LoadSheetFormatProperties` and `LoadMergeCellsStreaming`, the last two element handlers still living on the loader.
- **`XLWorkbook_Load.cs`** — 104 lines lighter. `LoadWorksheetElement`, `LoadStructureElement` and `LoadPrintAndExtensionElement` are gone. It now names no worksheet element type at all: `CustomSheetViews` and `SheetData` appear only in the pass-1 skip loop, which is sequencing rather than element knowledge.
- `pageSetupProperties` is no longer a local threaded through four signatures — `sheetPr` writes it into `WorksheetElementState` and `pageSetup` reads it back.
- `XLWorkbook.CalculateColumnWidth` widened from `private static` to `internal static`; it already took the workbook as a parameter.

Behaviour-preserving throughout. The two-pass load is untouched: `<sheetData>` is still skipped in pass 1 and read in pass 2 with a raw `XmlReader`.

## Tests

New `WorksheetElementRoundTripTests.Every_worksheet_element_survives_a_round_trip` — one workbook carrying all 17 elements the loader dispatches on, saved and read back. This is the gate for the refactor, so it was proven able to fail first: deleting the `RowBreaks` branch failed the test on that assertion alone, and only that one.

One assertion differs from the spec's draft, without weakening. Header text is read back with `GetText(XLHFOccurrence.OddPages)` rather than `AllPages`: `XLHFItem.AddText` fans `AllPages` out into the three concrete occurrences and never stores `AllPages` as a key, so `GetText(AllPages)` returns `""` for any header. That is how the accessor has always behaved, not a round-trip gap.

Full suite green on net8.0 and net10.0 — 23,738 tests, 0 failed, 8 pre-existing skips. No `PublicAPI.*.txt` change.

## Per-sheet load cost

`LoadWorksheetElements` is 23.7% of the template round-trip trace, so the cost had to be shown not to have moved. `profile template`, net10.0, header-only sheet sweep, base and branch **interleaved** across four pairs:

| Sheets | base median ms | branch median ms | base alloc | branch alloc |
|---|---|---|---|---|
| 1 | 6.5 | 6.2 | 1.0 MB | 1.0 MB |
| 10 | 12.8 | 13.0 | 2.6 MB | 2.6 MB |
| 40 | 40.1 | 38.4 | 8.4 MB | 8.4 MB |

Per-sheet slope: base 0.86 ms / 0.19 MB, branch 0.83 ms / 0.19 MB. Unchanged — the branch is marginally *below* the base, well inside spec 18's ~1.2 ms probe noise floor. Allocation is byte-identical at every sheet count, which is the measurement that would have caught a copied context struct.

**Worth knowing for spec 18 task 5, which measures this same method.** A first attempt ran six branch runs then six base runs and produced an apparent +10% per-sheet regression that did not survive interleaving. Two causes: `... | Select-Object -First N` stops the upstream pipeline and leaves the benchmark process orphaned and still running, so later runs in the block compete with earlier ones; and the machine drifts enough across a multi-minute block to swamp a 3 ms difference on a 38 ms probe. What flagged it as suspect before the interleaved run confirmed it was the mechanism check — 0.1 ms per sheet over ~10 elements is 10 µs per element, orders of magnitude more than a static call and a 40-byte `in` struct can cost. The Results section records this.

## Notes for the reviewer

- `TryLoad` carries a `#pragma warning disable S3776` with a reason. Sonar's cognitive-complexity rule is what split the chain in two in the first place; a flat dispatch over element types is the clearest form it can take, and splitting it by an arbitrary cut is what put the element names in a different module from the element bodies.
- Spec 24's own file is added under `docs/specs/`, with its Results section filled in, matching how specs 01–19 and 21 are tracked. The shared `TASKLIST-architecture-deepening.md` and `docs/specs/README.md` rows are **not** updated here — they are still untracked in the repo, and every spec in that wave edits the same two files.
- **Conflicts with spec 18 task 5**, which owns the per-sheet cost of this exact method. This one lands first by design: it is mechanical and behaviour-preserving, and it leaves 18 task 5 a single method to optimise instead of four across two modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading and re-saving workbooks, preserving worksheet formatting, data, views, filters, protection, validations, hyperlinks, conditional formatting, print settings, headers, breaks, and tab colors.

- **Tests**
  - Added comprehensive round-trip coverage to verify worksheet elements remain intact after a workbook is saved and reopened.

- **Documentation**
  - Documented worksheet element processing behavior, compatibility expectations, performance characteristics, and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->