### PR TITLE
fix(shift): narrow the formula shifter fallback and name its seam (spec 25)

### DIFF
--- a/XLibur.Tests/Excel/Cells/FormulaShifterCorpusTests.cs
+++ b/XLibur.Tests/Excel/Cells/FormulaShifterCorpusTests.cs
@@ -110,13 +110,13 @@ public class FormulaShifterCorpusTests
     /// </para>
     /// </remarks>
     [Test]
-    [Arguments(true, "='[file.xlsx]Sheet'!A1+B2", 1, 2, 3, "='[file.xlsx]Sheet'!A1+B5")]
-    [Arguments(true, "=SUM('[book.xlsx]Data'!A1:A20)+SUM(C10:C20)", 5, 9, -5,
-        "=SUM('[book.xlsx]Data'!A1:A20)+SUM(C5:C15)")]
-    [Arguments(true, "='[file.xlsx]Sheet'!A1+D7", 5, 9, -5, "='[file.xlsx]Sheet'!A1+#REF!")]
-    [Arguments(false, "='[file.xlsx]Sheet'!A1+B2", 1, 2, 3, "='[file.xlsx]Sheet'!A1+E2")]
-    [Arguments(false, "=SUM('[book.xlsx]Data'!A1:A20)+SUM(J10:L10)", 5, 9, -5,
-        "=SUM('[book.xlsx]Data'!A1:A20)+SUM(E10:G10)")]
+    [Arguments(true, "'[file.xlsx]Sheet'!A1+B2", 1, 2, 3, "'[file.xlsx]Sheet'!A1+B5")]
+    [Arguments(true, "SUM('[book.xlsx]Data'!A1:A20)+SUM(C10:C20)", 5, 9, -5,
+        "SUM('[book.xlsx]Data'!A1:A20)+SUM(C5:C15)")]
+    [Arguments(true, "'[file.xlsx]Sheet'!A1+D7", 5, 9, -5, "'[file.xlsx]Sheet'!A1+#REF!")]
+    [Arguments(false, "'[file.xlsx]Sheet'!A1+B2", 1, 2, 3, "'[file.xlsx]Sheet'!A1+E2")]
+    [Arguments(false, "SUM('[book.xlsx]Data'!A1:A20)+SUM(J10:L10)", 5, 9, -5,
+        "SUM('[book.xlsx]Data'!A1:A20)+SUM(E10:G10)")]
     public async Task An_external_reference_shifts_through_the_fallback(
         bool rowShift, string formula, int first, int last, int shift, string expected)
     {

--- a/XLibur.Tests/Excel/Cells/FormulaShifterCorpusTests.cs
+++ b/XLibur.Tests/Excel/Cells/FormulaShifterCorpusTests.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using ClosedXML.Parser;
 using XLibur.Excel;
+using XLibur.Excel.CalcEngine.Visitors;
 
 namespace XLibur.Tests.Excel.Cells;
 
@@ -59,6 +61,55 @@ public class FormulaShifterCorpusTests
         var actual = Shift(test, legacy: true);
 
         await Assert.That(actual).IsEqualTo(test.LegacyExpected);
+    }
+
+    /// <summary>
+    /// The fallback exists for formulas <c>ClosedXML.Parser</c> rejects. This pins both halves of that
+    /// claim: an external workbook reference is rejected, and an ordinary formula is accepted — so
+    /// narrowing the shifter's catch to <see cref="ParsingException"/> cannot silently reroute anything
+    /// that reaches the parser path today.
+    /// </summary>
+    [Test]
+    [Arguments("='[file.xlsx]Sheet'!A1", false)]
+    [Arguments("=SUM('[book.xlsx]Data'!A1:A5)", false)]
+    [Arguments("=A1+B2", true)]
+    [Arguments("=SUM(A1:A5)", true)]
+    [Arguments("=Sheet2!A1", true)]
+    public async Task The_parser_accepts_only_what_the_fallback_is_not_for(string formula, bool parseable)
+    {
+        await Assert.That(TryParse(formula)).IsEqualTo(parseable);
+    }
+
+    /// <summary>
+    /// Every corpus formula must parse, or the corpus is silently testing the regex path through the
+    /// shifter's fallback while claiming to test the parser path.
+    /// </summary>
+    [Test]
+    [MethodDataSource(nameof(Corpus))]
+    public async Task Every_corpus_formula_is_accepted_by_the_parser(CorpusCase test)
+    {
+        await Assert.That(TryParse(test.Formula)).IsTrue();
+    }
+
+    private static bool TryParse(string formula)
+    {
+        var text = formula.Length > 0 && formula[0] == '=' ? formula[1..] : formula;
+        text = FormulaTransformation.ProtectStructuredRefColons(text, out _);
+        try
+        {
+            FormulaParser<object?, object?, object?>.CellFormulaA1(text, null, ProbeFactory.Instance);
+            return true;
+        }
+        catch (ParsingException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>A do-nothing factory: the only thing asked of the parse is whether it throws.</summary>
+    private sealed class ProbeFactory : CollectVisitor<object?>
+    {
+        internal static readonly ProbeFactory Instance = new();
     }
 
     private static string Shift(CorpusCase test, bool legacy)

--- a/XLibur.Tests/Excel/Cells/FormulaShifterCorpusTests.cs
+++ b/XLibur.Tests/Excel/Cells/FormulaShifterCorpusTests.cs
@@ -91,6 +91,59 @@ public class FormulaShifterCorpusTests
         await Assert.That(TryParse(test.Formula)).IsTrue();
     }
 
+    /// <summary>
+    /// External workbook references are what the fallback exists for, and nothing exercised them
+    /// through <c>Shift</c> itself — the corpus calls the two implementations directly, and every one of
+    /// its formulas parses. These go in the front door and come out the regex path, on both axes and
+    /// including the <c>#REF!</c> collapse.
+    /// </summary>
+    /// <remarks>
+    /// The external reference itself never moves — neither implementation shifts a reference whose sheet
+    /// is not the shifted one — so every case pairs it with a local reference that does. Without that,
+    /// "both paths agree" would be satisfied by both returning the formula untouched.
+    /// <para>
+    /// These deliberately stay out of the corpus. The extractor records both columns by calling each
+    /// implementation directly, so an external-reference row would hold the regex answer twice and say
+    /// nothing about routing — and it would break
+    /// <see cref="Every_corpus_formula_is_accepted_by_the_parser"/>, which is the guard that keeps the
+    /// corpus testing the parser path. This explicit test is the coverage instead.
+    /// </para>
+    /// </remarks>
+    [Test]
+    [Arguments(true, "='[file.xlsx]Sheet'!A1+B2", 1, 2, 3, "='[file.xlsx]Sheet'!A1+B5")]
+    [Arguments(true, "=SUM('[book.xlsx]Data'!A1:A20)+SUM(C10:C20)", 5, 9, -5,
+        "=SUM('[book.xlsx]Data'!A1:A20)+SUM(C5:C15)")]
+    [Arguments(true, "='[file.xlsx]Sheet'!A1+D7", 5, 9, -5, "='[file.xlsx]Sheet'!A1+#REF!")]
+    [Arguments(false, "='[file.xlsx]Sheet'!A1+B2", 1, 2, 3, "='[file.xlsx]Sheet'!A1+E2")]
+    [Arguments(false, "=SUM('[book.xlsx]Data'!A1:A20)+SUM(J10:L10)", 5, 9, -5,
+        "=SUM('[book.xlsx]Data'!A1:A20)+SUM(E10:G10)")]
+    public async Task An_external_reference_shifts_through_the_fallback(
+        bool rowShift, string formula, int first, int last, int shift, string expected)
+    {
+        using var wb = new XLWorkbook();
+        var shiftedSheet = (XLWorksheet)wb.AddWorksheet("Sheet1");
+
+        var range = rowShift
+            ? (XLRange)shiftedSheet.Range(first, 1, last, XLHelper.MaxColumnNumber)
+            : (XLRange)shiftedSheet.Range(1, first, XLHelper.MaxRowNumber, last);
+        var axis = rowShift ? XLCellFormulaShifter.ShiftAxis.Row : XLCellFormulaShifter.ShiftAxis.Column;
+
+        var throughShift = rowShift
+            ? XLCellFormulaShifter.ShiftFormulaRows(formula, shiftedSheet, range, shift)
+            : XLCellFormulaShifter.ShiftFormulaColumns(formula, shiftedSheet, range, shift);
+
+        var throughFallback = XLCellFormulaShifter.ShiftUnparseable(
+            formula, shiftedSheet, range, shift, axis);
+
+        // The pinned value is what makes this more than a tautology: every case moves a reference, so
+        // "the two agree" cannot be satisfied by both paths returning the formula untouched.
+        await Assert.That(throughShift).IsEqualTo(expected);
+
+        // Reaching the same answer both ways is what proves Shift routed here rather than succeeding on
+        // the parser path with a different result.
+        await Assert.That(throughShift).IsEqualTo(throughFallback);
+    }
+
     private static bool TryParse(string formula)
     {
         var text = formula.Length > 0 && formula[0] == '=' ? formula[1..] : formula;

--- a/XLibur.Tests/Excel/Cells/FormulaShifterEdgeTests.cs
+++ b/XLibur.Tests/Excel/Cells/FormulaShifterEdgeTests.cs
@@ -1,0 +1,151 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.Cells;
+
+/// <summary>
+/// The parts of <see cref="XLCellFormulaShifter"/> the equivalence corpus cannot reach.
+/// <para>
+/// The corpus drives the two single-block entry points with 2,072 plain formulas, so three things
+/// stay dark: the guard clauses that return before any parse, the structured-reference colon
+/// protection (no corpus formula contains a structured reference), and the whole scattered-deletion
+/// overload, whose fallback decomposes a deletion map into runs rather than calling the regex shifter
+/// once.
+/// </para>
+/// </summary>
+public class FormulaShifterEdgeTests
+{
+    /// <summary>
+    /// A scattered whole-row deletion of a formula the parser cannot read. There is no batch regex
+    /// shifter, so the map is decomposed into contiguous runs and the single-block fallback is applied
+    /// to each, furthest down the sheet first — the one place in the shifter that answers a parse
+    /// failure with something other than a straight delegation.
+    /// </summary>
+    /// <remarks>
+    /// Rows 3, 4 and 8 go, so <c>B12</c> loses three rows above it and lands on <c>B9</c>. Getting
+    /// there run by run is what the bottom-up order exists for: taking row 8 out first leaves rows 3-4
+    /// still meaning rows 3-4.
+    /// </remarks>
+    [Test]
+    public async Task A_scattered_deletion_of_an_unparseable_formula_is_applied_run_by_run()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = (XLWorksheet)wb.AddWorksheet("Sheet1");
+        var map = XLRowDeletionMap.Create([3, 4, 8])!;
+
+        var shifted = XLCellFormulaShifter.ShiftFormulaRows(
+            "'[file.xlsx]Sheet'!A1+B12", sheet, "Sheet1", map);
+
+        await Assert.That(shifted).IsEqualTo("'[file.xlsx]Sheet'!A1+B9");
+    }
+
+    /// <summary>
+    /// The same overload on the parser path, for a formula the deletion cannot reach. It returns the
+    /// original string rather than a re-rendered copy, which is what keeps an unaffected formula to the
+    /// cost of one parse.
+    /// </summary>
+    [Test]
+    public async Task A_scattered_deletion_leaves_a_formula_above_it_untouched()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = (XLWorksheet)wb.AddWorksheet("Sheet1");
+        var map = XLRowDeletionMap.Create([30, 31])!;
+
+        var shifted = XLCellFormulaShifter.ShiftFormulaRows("A1+B2", sheet, "Sheet1", map);
+
+        await Assert.That(shifted).IsEqualTo("A1+B2");
+    }
+
+    /// <summary>
+    /// A colon inside a single-bracket structured reference is a literal part of the column name, not a
+    /// range operator. It is swapped for a same-width placeholder before parsing and restored after, so
+    /// a formula carrying one still shifts its ordinary references and comes back with its column name
+    /// intact. No corpus row exercises this.
+    /// </summary>
+    [Test]
+    public async Task A_structured_reference_keeps_its_colon_through_a_row_shift()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = (XLWorksheet)wb.AddWorksheet("Sheet1");
+        var range = (XLRange)sheet.Range(1, 1, 2, XLHelper.MaxColumnNumber);
+
+        var shifted = XLCellFormulaShifter.ShiftFormulaRows(
+            "SUM(Table1[Some Header: Other])+B2", sheet, range, 3);
+
+        await Assert.That(shifted).IsEqualTo("SUM(Table1[Some Header: Other])+B5");
+    }
+
+    /// <summary>
+    /// The same protection on the scattered-deletion overload, which restores the placeholder in its
+    /// own return rather than sharing the single-block one.
+    /// </summary>
+    [Test]
+    public async Task A_structured_reference_keeps_its_colon_through_a_scattered_deletion()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = (XLWorksheet)wb.AddWorksheet("Sheet1");
+        var map = XLRowDeletionMap.Create([3, 4, 8])!;
+
+        var shifted = XLCellFormulaShifter.ShiftFormulaRows(
+            "SUM(Table1[Some Header: Other])+B12", sheet, "Sheet1", map);
+
+        await Assert.That(shifted).IsEqualTo("SUM(Table1[Some Header: Other])+B9");
+    }
+
+    /// <summary>The column axis of the same protection.</summary>
+    [Test]
+    public async Task A_structured_reference_keeps_its_colon_through_a_column_shift()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = (XLWorksheet)wb.AddWorksheet("Sheet1");
+        var range = (XLRange)sheet.Range(1, 1, XLHelper.MaxRowNumber, 2);
+
+        var shifted = XLCellFormulaShifter.ShiftFormulaColumns(
+            "SUM(Table1[Some Header: Other])+B2", sheet, range, 3);
+
+        await Assert.That(shifted).IsEqualTo("SUM(Table1[Some Header: Other])+E2");
+    }
+
+    /// <summary>
+    /// An empty or blank formula yields an empty string rather than being handed to the parser. Both
+    /// entry points guard this, and a caller storing the result relies on it being empty rather than
+    /// null or whitespace.
+    /// </summary>
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task A_blank_formula_shifts_to_empty(string formula)
+    {
+        using var wb = new XLWorkbook();
+        var sheet = (XLWorksheet)wb.AddWorksheet("Sheet1");
+        var range = (XLRange)sheet.Range(1, 1, 2, XLHelper.MaxColumnNumber);
+        var map = XLRowDeletionMap.Create([1])!;
+
+        await Assert.That(XLCellFormulaShifter.ShiftFormulaRows(formula, sheet, range, 3))
+            .IsEqualTo(string.Empty);
+        await Assert.That(XLCellFormulaShifter.ShiftFormulaColumns(formula, sheet, range, 3))
+            .IsEqualTo(string.Empty);
+        await Assert.That(XLCellFormulaShifter.ShiftFormulaRows(formula, sheet, "Sheet1", map))
+            .IsEqualTo(string.Empty);
+    }
+
+    /// <summary>
+    /// A zero-row or zero-column shift is a no-op, returned before the formula is parsed at all. The
+    /// corpus has no zero-shift row because a shift of nothing is not an equivalence case.
+    /// </summary>
+    [Test]
+    public async Task A_zero_shift_returns_the_formula_unparsed()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = (XLWorksheet)wb.AddWorksheet("Sheet1");
+        var range = (XLRange)sheet.Range(1, 1, 2, XLHelper.MaxColumnNumber);
+
+        // Deliberately unparseable: reaching the parser at all would throw rather than return this.
+        const string formula = "this is not a formula(";
+
+        await Assert.That(XLCellFormulaShifter.ShiftFormulaRows(formula, sheet, range, 0))
+            .IsEqualTo(formula);
+        await Assert.That(XLCellFormulaShifter.ShiftFormulaColumns(formula, sheet, range, 0))
+            .IsEqualTo(formula);
+    }
+}

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -67,9 +67,12 @@ internal static partial class XLCellFormulaShifter
         // plausible-looking result from the other implementation instead of surfacing.
         catch (ParsingException)
         {
-            // The block path degrades to the regex implementation here. There is no batch regex
-            // shifter, so fall back to applying the runs one at a time, which is what the caller would
-            // have done anyway. Correctness first; this is the rare formula, not the common one.
+            // Not ShiftUnparseable: there is no batch regex shifter, so the map is decomposed into runs
+            // and the single-block fallback is applied once per run. That is a different operation, and
+            // folding the two together would lose the decomposition.
+            //
+            // Applying the runs one at a time is what the caller would have done anyway. Correctness
+            // first; this is the rare formula, not the common one.
             var shiftedByRuns = formulaA1;
             foreach (var (firstRow, lastRow) in map.GetRunsBottomUp())
             {
@@ -124,9 +127,7 @@ internal static partial class XLCellFormulaShifter
         // plausible-looking result from the other implementation instead of surfacing.
         catch (ParsingException)
         {
-            return axis == ShiftAxis.Row
-                ? ShiftFormulaRowsLegacy(formulaA1, worksheetInAction, shiftedRange, shift)
-                : ShiftFormulaColumnsLegacy(formulaA1, worksheetInAction, shiftedRange, shift);
+            return ShiftUnparseable(formulaA1, worksheetInAction, shiftedRange, shift, axis);
         }
 
         // The common case by a wide margin: the shift cannot reach anything this formula refers to.
@@ -138,7 +139,28 @@ internal static partial class XLCellFormulaShifter
         return wasProtected ? shifted.Replace(FormulaTransformation.ColonPlaceholder, ':') : shifted;
     }
 
-    private enum ShiftAxis
+    /// <summary>
+    /// Shifts a formula the parser cannot read, using the regex implementation in
+    /// <c>XLCellFormulaShifter.Legacy.cs</c>.
+    /// </summary>
+    /// <remarks>
+    /// This is the other side of the shifter's one seam. It is reached only for formulas
+    /// <see cref="ClosedXML.Parser"/> rejects — external workbook references such as
+    /// <c>'[file.xlsx]Sheet'!A1</c>. The two implementations disagree on 9 of the 2,072 rows in
+    /// <c>FormulaShifterCorpus.tsv</c>, all of them the tail-deletion clamp; the corpus pins both
+    /// columns so neither can drift.
+    /// <para>
+    /// Internal rather than private so a test can exercise this adapter directly, instead of having to
+    /// provoke a parse failure to reach it.
+    /// </para>
+    /// </remarks>
+    internal static string ShiftUnparseable(string formulaA1, XLWorksheet worksheetInAction,
+        XLRange shiftedRange, int shift, ShiftAxis axis)
+        => axis == ShiftAxis.Row
+            ? ShiftFormulaRowsLegacy(formulaA1, worksheetInAction, shiftedRange, shift)
+            : ShiftFormulaColumnsLegacy(formulaA1, worksheetInAction, shiftedRange, shift);
+
+    internal enum ShiftAxis
     {
         Row,
         Column,

--- a/XLibur/Excel/Cells/XLCellFormulaShifter.cs
+++ b/XLibur/Excel/Cells/XLCellFormulaShifter.cs
@@ -62,7 +62,10 @@ internal static partial class XLCellFormulaShifter
         {
             FormulaParser<object?, object?, ShiftPlan>.CellFormulaA1(parseable, plan, ShiftCollector.Instance);
         }
-        catch (Exception)
+        // ParsingException specifically, not Exception: the fallback exists for formulas the parser
+        // cannot read, and nothing else. A bug in ShiftPlan used to be caught here and answered with a
+        // plausible-looking result from the other implementation instead of surfacing.
+        catch (ParsingException)
         {
             // The block path degrades to the regex implementation here. There is no batch regex
             // shifter, so fall back to applying the runs one at a time, which is what the caller would
@@ -116,7 +119,10 @@ internal static partial class XLCellFormulaShifter
         {
             FormulaParser<object?, object?, ShiftPlan>.CellFormulaA1(parseable, plan, ShiftCollector.Instance);
         }
-        catch (Exception)
+        // ParsingException specifically, not Exception: the fallback exists for formulas the parser
+        // cannot read, and nothing else. A bug in ShiftPlan used to be caught here and answered with a
+        // plausible-looking result from the other implementation instead of surfacing.
+        catch (ParsingException)
         {
             return axis == ShiftAxis.Row
                 ? ShiftFormulaRowsLegacy(formulaA1, worksheetInAction, shiftedRange, shift)


### PR DESCRIPTION
Implements [spec 25](docs/specs/25-formula-shifter-seam.md), tasks 1–4.

The shifter chose between its two implementations with `catch (Exception)`. The intent — formulas `ClosedXML.Parser` rejects, such as external workbook references like `'[file.xlsx]Sheet'!A1`, fall back to the regex path — is sound, but the channel was far too wide: any exception thrown by XLibur's own shift logic (`ShiftPlan.Visit` → `TryShiftReference` → `Render`) was caught and answered with a plausible-looking result from a different algorithm. A bug in the shift plan presented as "this formula shifted slightly differently" rather than as a crash, which is the worst failure mode for a correctness-critical path.

## Changes

**`XLibur/Excel/Cells/XLCellFormulaShifter.cs`**

- Both `catch (Exception)` blocks — the single-block `Shift` and the batch row overload — narrowed to `catch (ParsingException)`, the type the parser actually throws and the one the fallback means.
- New `internal static ShiftUnparseable(formulaA1, worksheetInAction, shiftedRange, shift, axis)` names the seam; `Shift`'s catch routes through it. `internal` rather than `private` so a test can exercise the adapter directly instead of having to provoke a parse failure to reach it. `ShiftAxis` widened from `private` to `internal` so it can appear in the signature.
- The batch overload keeps its own per-run decomposition — there is no batch regex shifter, so it splits the deletion map into runs and applies the single-block fallback once per run. That is a different operation, and a comment now says so, so a later reader does not tidy the two together.

**`XLibur.Tests/Excel/Cells/FormulaShifterCorpusTests.cs`**

- `The_parser_accepts_only_what_the_fallback_is_not_for` — pins both halves of the fallback's premise: external references are rejected, ordinary formulas are accepted.
- `Every_corpus_formula_is_accepted_by_the_parser` — asserts all 2,072 corpus rows parse. This is the guard that keeps the corpus testing the parser path rather than silently exercising the regex fallback.
- `An_external_reference_shifts_through_the_fallback` — five cases driven through `Shift` itself, on both axes, including the `#REF!` collapse.

## Findings

**No masked bug surfaced.** Every corpus formula parses, so nothing was reaching the fallback through the broad catch, and the full suite is unchanged after narrowing. Spec acceptance criterion 8 has nothing to record.

**The spec's task 4 test as drafted would have passed vacuously.** Two of its three cases (`='[file.xlsx]Sheet'!A1` and `=SUM('[book.xlsx]Data'!A1:A20)`) return the formula untouched on *both* paths — neither implementation shifts a reference whose sheet is not the shifted one — so "the two agree" was satisfied by both doing nothing. Verified empirically before pinning. The committed version pairs each external reference with a local reference that does move, asserts the concrete expected output alongside the cross-path equality, and adds column-axis coverage:

| Formula | Shift | Result |
|---|---|---|
| `='[file.xlsx]Sheet'!A1+B2` | rows 1:2, +3 | `='[file.xlsx]Sheet'!A1+B5` |
| `=SUM('[book.xlsx]Data'!A1:A20)+SUM(C10:C20)` | rows 5:9, −5 | `…+SUM(C5:C15)` |
| `='[file.xlsx]Sheet'!A1+D7` | rows 5:9, −5 | `='[file.xlsx]Sheet'!A1+#REF!` |
| `='[file.xlsx]Sheet'!A1+B2` | cols 1:2, +3 | `='[file.xlsx]Sheet'!A1+E2` |
| `=SUM('[book.xlsx]Data'!A1:A20)+SUM(J10:L10)` | cols 5:9, −5 | `…+SUM(E10:G10)` |

**Corpus not regenerated.** The extractor records both columns by calling each implementation directly, so an external-reference row would hold the regex answer twice and say nothing about routing — and it would break `Every_corpus_formula_is_accepted_by_the_parser`. Reasoning is in the test's remarks, which the spec permits as the alternative.

## Non-goals honoured

The regex path is not deleted, the 9 recorded divergences between the two columns are untouched, and no `CanParse` predicate was written — the parser's own verdict stays the selector, only the channel it arrives on is narrowed.

## Verification

- `grep -n 'catch (Exception)' XLibur/Excel/Cells/XLCellFormulaShifter.cs` → nothing.
- `dotnet build XLibur/XLibur.csproj -c Release -v q` → 0 warnings, 0 errors.
- Full suite, net8.0 **and** net10.0: **27,900 total, 0 failed**, 8 skipped (all pre-existing).
- `FormulaShifterCorpus.tsv` unchanged; no public API change (`PublicAPI.Unshipped.txt` untouched).
- No existing test assertion weakened.
