### PR TITLE
refactor(drawingml): shared anchor factory and shape-properties writer (spec 16 tasks 2 and 3)

### DIFF
--- a/XLibur/Excel/IO/Charts/ChartSeriesFormatXml.cs
+++ b/XLibur/Excel/IO/Charts/ChartSeriesFormatXml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using DocumentFormat.OpenXml;
+using XLibur.Excel.IO.DrawingML;
 using XLibur.Extensions;
 using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
@@ -26,9 +27,6 @@ namespace XLibur.Excel.IO.Charts;
 /// </remarks>
 internal static class ChartSeriesFormatXml
 {
-    /// <summary>EMU per point, the unit DrawingML uses for line widths.</summary>
-    private const double EmuPerPoint = 12700;
-
     /// <summary>
     /// Seeds the model from one <c>c:ser</c> element.
     /// </summary>
@@ -44,7 +42,7 @@ internal static class ChartSeriesFormatXml
         series.SeedLoadedFormat(
             fillColor: ReadSolidFillColor(shapeProperties),
             lineColor: ReadSolidFillColor(outline),
-            lineWidthPt: outline?.Width?.Value is { } width ? width / EmuPerPoint : null,
+            lineWidthPt: outline?.Width?.Value is { } width ? width / DrawingUnits.EmuPerPoint : null,
             markerStyle: ReadMarkerStyle(marker),
             markerSize: marker?.Elements<C.Size>().FirstOrDefault()?.Val?.Value,
             markerFillColor: ReadSolidFillColor(markerFill),
@@ -213,7 +211,7 @@ internal static class ChartSeriesFormatXml
         var shapeProperties = existing ?? NewShapeProperties(seriesElement);
 
         if ((assigned & XLChartSeriesFormat.Fill) != 0)
-            SetFill(shapeProperties, series.FillColor);
+            ShapePropertiesWriter.SetFill(shapeProperties, series.FillColor);
 
         if ((assigned & (XLChartSeriesFormat.Line | XLChartSeriesFormat.LineWidth)) != 0)
             SetOutline(shapeProperties, series, assigned);
@@ -288,7 +286,7 @@ internal static class ChartSeriesFormatXml
             InsertAfterLastOf(marker, markerShapeProperties, typeof(C.Size), typeof(C.Symbol));
         }
 
-        SetFill(markerShapeProperties, series.MarkerFillColor);
+        ShapePropertiesWriter.SetFill(markerShapeProperties, series.MarkerFillColor);
     }
 
     private static void ApplySmooth(OpenXmlCompositeElement seriesElement, XLChartSeries series)
@@ -317,72 +315,30 @@ internal static class ChartSeriesFormatXml
             existing[i].Remove();
     }
 
-    private static void SetFill(C.ChartShapeProperties shapeProperties, XLColor? color)
-    {
-        foreach (var existing in shapeProperties.ChildElements
-                     .Where(IsFillElement).ToList())
-            existing.Remove();
-
-        if (color == null || !color.HasValue)
-            return;
-
-        // The fill precedes the outline and every effect in CT_ShapeProperties.
-        var anchor = shapeProperties.ChildElements.FirstOrDefault(IsAfterFill);
-        var fill = new A.SolidFill(BuildColor(color));
-        if (anchor != null)
-            shapeProperties.InsertBefore(fill, anchor);
-        else
-            shapeProperties.Append(fill);
-    }
-
-#pragma warning disable S3776 // Create-or-update outline, then one flat block per assigned property
+    /// <summary>
+    /// Translates what the caller assigned into the outline operations that says.
+    /// </summary>
+    /// <remarks>
+    /// The mask stops here. <see cref="ShapePropertiesWriter"/> is told to set a width or set a
+    /// colour and works out what the schema requires; which of those to ask for is a question about
+    /// <see cref="XLChartSeries.AssignedFormat"/>, which is chart knowledge and belongs on this side.
+    /// </remarks>
     private static void SetOutline(
         C.ChartShapeProperties shapeProperties, XLChartSeries series, XLChartSeriesFormat assigned)
     {
-        var outline = shapeProperties.Elements<A.Outline>().FirstOrDefault();
-        if (outline == null)
-        {
-            // Nothing to clear and nothing to set: leave the element out entirely.
-            if (series.LineColor == null && series.LineWidthPt == null)
-                return;
+        // Nothing to clear and nothing to set: leave the element out entirely.
+        if (!shapeProperties.Elements<A.Outline>().Any()
+            && series.LineColor == null && series.LineWidthPt == null)
+            return;
 
-            outline = new A.Outline();
-            var anchor = shapeProperties.ChildElements.FirstOrDefault(IsAfterOutline);
-            if (anchor != null)
-                shapeProperties.InsertBefore(outline, anchor);
-            else
-                shapeProperties.Append(outline);
-        }
+        var outline = ShapePropertiesWriter.EnsureOutline(shapeProperties);
 
         if ((assigned & XLChartSeriesFormat.LineWidth) != 0)
-        {
-            if (series.LineWidthPt == null)
-                outline.Width = null;
-            else
-                outline.Width = (int)Math.Round(series.LineWidthPt.Value * EmuPerPoint);
-        }
+            ShapePropertiesWriter.SetOutlineWidth(outline, series.LineWidthPt);
 
         if ((assigned & XLChartSeriesFormat.Line) != 0)
-        {
-            foreach (var existing in outline.ChildElements.Where(IsFillElement).ToList())
-                existing.Remove();
-
-            if (series.LineColor is { HasValue: true })
-                outline.InsertAt(new A.SolidFill(BuildColor(series.LineColor)), 0);
-        }
+            ShapePropertiesWriter.SetOutlineColor(outline, series.LineColor);
     }
-#pragma warning restore S3776
-
-    private static bool IsFillElement(OpenXmlElement element) =>
-        element is A.NoFill or A.SolidFill or A.GradientFill or A.BlipFill or A.PatternFill or A.GroupFill;
-
-    private static bool IsAfterFill(OpenXmlElement element) =>
-        element is A.Outline || IsEffectOrLater(element);
-
-    private static bool IsAfterOutline(OpenXmlElement element) => IsEffectOrLater(element);
-
-    private static bool IsEffectOrLater(OpenXmlElement element) =>
-        element is A.EffectList or A.EffectDag or A.Scene3DType or A.Shape3DType or A.ExtensionList;
 
     /// <summary>
     /// Inserts <paramref name="element"/> directly after the last present element of the given types,
@@ -411,14 +367,6 @@ internal static class ChartSeriesFormatXml
             parent.InsertBefore(element, extensionList);
         else
             parent.Append(element);
-    }
-
-    private static OpenXmlElement BuildColor(XLColor color)
-    {
-        if (color.ColorType == XLColorType.Theme)
-            return new A.SchemeColor { Val = MapSchemeColor(color.ThemeColor) };
-
-        return new A.RgbColorModelHex { Val = color.Color.ToHex().Substring(2) };
     }
 
     private static XLColor? ReadSolidFillColor(OpenXmlCompositeElement? parent)
@@ -491,23 +439,6 @@ internal static class ChartSeriesFormatXml
         XLMarkerStyle.Triangle => C.MarkerStyleValues.Triangle,
         XLMarkerStyle.X => C.MarkerStyleValues.X,
         _ => throw new ArgumentOutOfRangeException(nameof(style), style, "Unknown marker style.")
-    };
-
-    private static A.SchemeColorValues MapSchemeColor(XLThemeColor themeColor) => themeColor switch
-    {
-        XLThemeColor.Background1 => A.SchemeColorValues.Background1,
-        XLThemeColor.Text1 => A.SchemeColorValues.Text1,
-        XLThemeColor.Background2 => A.SchemeColorValues.Background2,
-        XLThemeColor.Text2 => A.SchemeColorValues.Text2,
-        XLThemeColor.Accent1 => A.SchemeColorValues.Accent1,
-        XLThemeColor.Accent2 => A.SchemeColorValues.Accent2,
-        XLThemeColor.Accent3 => A.SchemeColorValues.Accent3,
-        XLThemeColor.Accent4 => A.SchemeColorValues.Accent4,
-        XLThemeColor.Accent5 => A.SchemeColorValues.Accent5,
-        XLThemeColor.Accent6 => A.SchemeColorValues.Accent6,
-        XLThemeColor.Hyperlink => A.SchemeColorValues.Hyperlink,
-        XLThemeColor.FollowedHyperlink => A.SchemeColorValues.FollowedHyperlink,
-        _ => throw new ArgumentOutOfRangeException(nameof(themeColor), themeColor, "Unknown theme colour.")
     };
 
     /// <summary>

--- a/XLibur/Excel/IO/DrawingML/DrawingAnchorFactory.cs
+++ b/XLibur/Excel/IO/DrawingML/DrawingAnchorFactory.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Drawing;
+using DocumentFormat.OpenXml;
+using XLibur.Excel.Drawings;
+using XLibur.Extensions;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
+
+namespace XLibur.Excel.IO.DrawingML;
+
+/// <summary>
+/// Builds the spreadsheet-drawing anchor that fixes a drawing to a sheet, in whichever of the three
+/// forms the placement calls for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The anchor is the same regardless of what it holds — a picture, a shape, a text box, a chart
+/// frame — so the content is handed in rather than built here. What varies between the forms is
+/// only which of the geometry's parts is used: <see cref="XLPicturePlacement.FreeFloating"/> takes
+/// the pixel position and size, <see cref="XLPicturePlacement.Move"/> takes the top-left marker and
+/// the size, and <see cref="XLPicturePlacement.MoveAndSize"/> takes both markers and no size at all.
+/// </para>
+/// <para>
+/// <b>The A1 fallbacks are part of the contract, not an implementation detail.</b> A caller that
+/// leaves a marker unset does not get an exception and does not get a missing element — it gets a
+/// marker at A1:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// A missing <see cref="DrawingAnchorGeometry.FromMarker"/> becomes A1 at offset zero, for both
+/// anchored forms.
+/// </item>
+/// <item>
+/// A missing <see cref="DrawingAnchorGeometry.ToMarker"/> becomes A1 offset by the drawing's own
+/// pixel width and height, so a <see cref="XLPicturePlacement.MoveAndSize"/> drawing nobody
+/// positioned still comes out its intended size rather than collapsed to nothing.
+/// </item>
+/// </list>
+/// <para>
+/// This is reachable through ordinary use, not just by misuse: a picture is created
+/// <see cref="XLPicturePlacement.MoveAndSize"/> with neither marker set, so a picture nobody moved
+/// takes both fallbacks at once.
+/// </para>
+/// <para>
+/// <see cref="XLPicturePlacement"/> is named for pictures because pictures were the first drawings
+/// XLibur wrote, but what it describes — how a drawing reacts when the rows and columns underneath
+/// it are resized — belongs to every kind of drawing. A second enum saying the same three things
+/// would be exactly the duplication this layer exists to prevent, so other drawing kinds should
+/// reuse this one rather than declare their own.
+/// </para>
+/// </remarks>
+internal static class DrawingAnchorFactory
+{
+    /// <summary>
+    /// Creates the anchor for the given placement, wrapping <paramref name="content"/> and closing
+    /// with the <c>xdr:clientData</c> the schema requires.
+    /// </summary>
+    /// <param name="placement">Which of the three anchor forms to build.</param>
+    /// <param name="geometry">Where the drawing sits and how big it is. See the A1 fallbacks above.</param>
+    /// <param name="content">
+    /// The drawing itself — an <c>xdr:pic</c>, <c>xdr:sp</c> or any other member of the anchor's
+    /// content choice group. It is placed into the anchor as-is, so it must not already have a
+    /// parent.
+    /// </param>
+    internal static OpenXmlCompositeElement Create(
+        XLPicturePlacement placement,
+        DrawingAnchorGeometry geometry,
+        OpenXmlElement content)
+    {
+        var workbook = geometry.Worksheet.Workbook;
+        var dpiX = workbook.DpiX;
+        var dpiY = workbook.DpiY;
+
+        switch (placement)
+        {
+            case XLPicturePlacement.FreeFloating:
+                return new Xdr.AbsoluteAnchor(
+                    new Xdr.Position
+                    {
+                        X = DrawingUnits.PixelsToEmu(geometry.LeftPx, dpiX),
+                        Y = DrawingUnits.PixelsToEmu(geometry.TopPx, dpiY)
+                    },
+                    Extent(geometry, dpiX, dpiY),
+                    content,
+                    new Xdr.ClientData()
+                );
+
+            case XLPicturePlacement.MoveAndSize:
+            {
+                // Resolved in this order because building a fallback marker registers a range with
+                // the workbook, and the inline code this replaced registered the from marker first.
+                var from = CreateMarker<Xdr.FromMarker>(FromMarkerOf(geometry), dpiX, dpiY);
+                var to = CreateMarker<Xdr.ToMarker>(ToMarkerOf(geometry), dpiX, dpiY);
+
+                return new Xdr.TwoCellAnchor(from, to, content, new Xdr.ClientData());
+            }
+
+            case XLPicturePlacement.Move:
+                return new Xdr.OneCellAnchor(
+                    CreateMarker<Xdr.FromMarker>(FromMarkerOf(geometry), dpiX, dpiY),
+                    Extent(geometry, dpiX, dpiY),
+                    content,
+                    new Xdr.ClientData()
+                );
+
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(placement), placement, "Unsupported picture placement.");
+        }
+    }
+
+    private static Xdr.Extent Extent(DrawingAnchorGeometry geometry, double dpiX, double dpiY) => new()
+    {
+        Cx = DrawingUnits.PixelsToEmu(geometry.WidthPx, dpiX),
+        Cy = DrawingUnits.PixelsToEmu(geometry.HeightPx, dpiY)
+    };
+
+    /// <summary>The top-left anchor point, falling back to A1 at offset zero.</summary>
+    private static XLMarker FromMarkerOf(DrawingAnchorGeometry geometry) =>
+        geometry.FromMarker ?? new XLMarker(geometry.Worksheet.Cell("A1"));
+
+    /// <summary>
+    /// The bottom-right anchor point, falling back to A1 offset by the drawing's own size — which is
+    /// what keeps an unpositioned <see cref="XLPicturePlacement.MoveAndSize"/> drawing its right
+    /// size rather than collapsing it onto its own top-left corner.
+    /// </summary>
+    private static XLMarker ToMarkerOf(DrawingAnchorGeometry geometry) =>
+        geometry.ToMarker ?? new XLMarker(
+            geometry.Worksheet.Cell("A1"), new Point(geometry.WidthPx, geometry.HeightPx));
+
+    /// <summary>
+    /// Fills in one marker. <c>xdr:from</c> and <c>xdr:to</c> are the same schema type differing only
+    /// in name, so they are built once: a second copy of the off-by-one and the two unit conversions
+    /// is exactly the drift this layer exists to prevent.
+    /// </summary>
+    /// <remarks>
+    /// The column and row are written zero-based, while the model counts from one.
+    /// </remarks>
+    private static TMarker CreateMarker<TMarker>(XLMarker marker, double dpiX, double dpiY)
+        where TMarker : Xdr.MarkerType, new() => new()
+    {
+        ColumnId = new Xdr.ColumnId((marker.ColumnNumber - 1).ToInvariantString()),
+        RowId = new Xdr.RowId((marker.RowNumber - 1).ToInvariantString()),
+        ColumnOffset = new Xdr.ColumnOffset(DrawingUnits.PixelsToEmu(marker.Offset.X, dpiX).ToInvariantString()),
+        RowOffset = new Xdr.RowOffset(DrawingUnits.PixelsToEmu(marker.Offset.Y, dpiY).ToInvariantString())
+    };
+}

--- a/XLibur/Excel/IO/DrawingML/DrawingAnchorGeometry.cs
+++ b/XLibur/Excel/IO/DrawingML/DrawingAnchorGeometry.cs
@@ -1,0 +1,48 @@
+using XLibur.Excel.Drawings;
+
+namespace XLibur.Excel.IO.DrawingML;
+
+/// <summary>
+/// Where a drawing sits on a sheet and how big it is, in the units the model holds it in: pixels for
+/// the free-floating geometry, cell markers for the two anchored forms.
+/// <see cref="DrawingAnchorFactory"/> converts to EMU and picks whichever of these the placement
+/// actually uses.
+/// </summary>
+/// <remarks>
+/// Every value is supplied whatever the placement, because the geometry describes the drawing rather
+/// than the anchor. A free-floating drawing still has a size; an anchored one still has a pixel
+/// width and height, which is what the <see cref="ToMarker"/> fallback is derived from.
+/// </remarks>
+internal sealed class DrawingAnchorGeometry
+{
+    /// <summary>
+    /// The sheet the drawing sits on. It is here for two things the factory cannot work out on its
+    /// own: the workbook resolution the pixel values were measured at, and the cell a missing marker
+    /// falls back to.
+    /// </summary>
+    internal required IXLWorksheet Worksheet { get; init; }
+
+    /// <summary>Distance from the left edge of the sheet, in pixels. Used by free-floating only.</summary>
+    internal required int LeftPx { get; init; }
+
+    /// <summary>Distance from the top edge of the sheet, in pixels. Used by free-floating only.</summary>
+    internal required int TopPx { get; init; }
+
+    /// <summary>The drawing's width in pixels.</summary>
+    internal required int WidthPx { get; init; }
+
+    /// <summary>The drawing's height in pixels.</summary>
+    internal required int HeightPx { get; init; }
+
+    /// <summary>
+    /// The top-left anchor point, or <c>null</c> to take the factory's A1 fallback. Used by the
+    /// <see cref="XLPicturePlacement.Move"/> and <see cref="XLPicturePlacement.MoveAndSize"/> forms.
+    /// </summary>
+    internal XLMarker? FromMarker { get; init; }
+
+    /// <summary>
+    /// The bottom-right anchor point, or <c>null</c> to take the factory's A1 fallback. Used by the
+    /// <see cref="XLPicturePlacement.MoveAndSize"/> form only.
+    /// </summary>
+    internal XLMarker? ToMarker { get; init; }
+}

--- a/XLibur/Excel/IO/DrawingML/DrawingUnits.cs
+++ b/XLibur/Excel/IO/DrawingML/DrawingUnits.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace XLibur.Excel.IO.DrawingML;
+
+/// <summary>
+/// Converts the screen-pixel lengths the drawing model holds into the English Metric Units
+/// DrawingML writes. There are 914400 EMU to the inch, which is why the conversion needs the
+/// resolution the pixel count was measured at.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Not to be confused with <see cref="Coordinates.Emu"/>, which is a length <em>value</em> — a
+/// number with a preferred unit — and converts between inches, points, picas and the rest. It has
+/// no notion of pixels or of a resolution, and it rounds away from zero rather than to even, so the
+/// two are not interchangeable and neither can be expressed in terms of the other.
+/// </para>
+/// <para>
+/// See http://polymathprogrammer.com/2009/10/22/english-metric-units-and-open-xml/,
+/// http://archive.oreilly.com/pub/post/what_is_an_emu.html and
+/// https://en.wikipedia.org/wiki/Office_Open_XML_file_formats#DrawingML.
+/// </para>
+/// </remarks>
+internal static class DrawingUnits
+{
+    private const long EmuPerInch = 914400L;
+
+    /// <summary>Converts a pixel length, measured at the given resolution, to EMU.</summary>
+    /// <remarks>
+    /// The rounding is <see cref="Convert.ToInt64(double)"/>'s — to even — and not a cast, which
+    /// would truncate. Every extent and offset XLibur has ever written came out of this exact
+    /// expression, so the two are not interchangeable.
+    /// </remarks>
+    internal static long PixelsToEmu(int pixels, double resolution) =>
+        Convert.ToInt64(EmuPerInch * pixels / resolution);
+}

--- a/XLibur/Excel/IO/DrawingML/DrawingUnits.cs
+++ b/XLibur/Excel/IO/DrawingML/DrawingUnits.cs
@@ -24,6 +24,11 @@ internal static class DrawingUnits
 {
     private const long EmuPerInch = 914400L;
 
+    /// <summary>
+    /// EMU per point, the unit DrawingML states line widths in. There are 72 points to the inch.
+    /// </summary>
+    internal const double EmuPerPoint = 12700;
+
     /// <summary>Converts a pixel length, measured at the given resolution, to EMU.</summary>
     /// <remarks>
     /// The rounding is <see cref="Convert.ToInt64(double)"/>'s — to even — and not a cast, which
@@ -32,4 +37,11 @@ internal static class DrawingUnits
     /// </remarks>
     internal static long PixelsToEmu(int pixels, double resolution) =>
         Convert.ToInt64(EmuPerInch * pixels / resolution);
+
+    /// <summary>Converts a length in points to EMU, for the attributes that are stated that way.</summary>
+    /// <remarks>
+    /// <see cref="Math.Round(double)"/> then a cast, which is what every line width XLibur has
+    /// written came out of. The result is <see cref="int"/> because that is what <c>a:ln/@w</c> is.
+    /// </remarks>
+    internal static int PointsToEmu(double points) => (int)Math.Round(points * EmuPerPoint);
 }

--- a/XLibur/Excel/IO/DrawingML/ShapePropertiesWriter.cs
+++ b/XLibur/Excel/IO/DrawingML/ShapePropertiesWriter.cs
@@ -1,0 +1,170 @@
+using System.Linq;
+using DocumentFormat.OpenXml;
+using XLibur.Extensions;
+using A = DocumentFormat.OpenXml.Drawing;
+
+namespace XLibur.Excel.IO.DrawingML;
+
+/// <summary>
+/// Writes into <c>a:CT_ShapeProperties</c> — the fill, the outline and the colours they carry.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A chart series' <c>c:spPr</c> and a shape's <c>xdr:sp/spPr</c> are the same schema type, so the
+/// rules for writing into one are the rules for writing into the other. They are subtle enough that
+/// a second implementation would be a second set of bugs, which is why this takes an
+/// <see cref="OpenXmlCompositeElement"/> rather than any one host's element type.
+/// </para>
+/// <para>Three facts about the schema shape everything here:</para>
+/// <list type="number">
+/// <item>
+/// The fills are a <b>choice</b> group. Setting a colour over an <c>a:gradFill</c> means removing
+/// the whole group first, not appending a second fill beside it.
+/// </item>
+/// <item>
+/// The type is a <b>sequence</b> — <c>a:xfrm</c>, geometry, fill, <c>a:ln</c>, <c>a:effectLst</c>,
+/// 3-D, <c>a:extLst</c> — and the SDK does not order the children of an element built by hand. Every
+/// insertion here goes in front of the first child that must follow it.
+/// </item>
+/// <item>
+/// Existing elements are <b>mutated in place, never rebuilt</b>, so children XLibur does not model —
+/// an <c>a:round</c> join, a <c>cap</c>, arrowheads — survive an edit that never mentions them.
+/// </item>
+/// </list>
+/// <para>
+/// Every operation takes plain values. Whether to write at all is the caller's decision and stays
+/// with the caller; what the schema then requires is this layer's. A <c>null</c> colour means "no
+/// explicit colour", which removes the element rather than writing black — the model convention
+/// throughout XLibur.
+/// </para>
+/// </remarks>
+internal static class ShapePropertiesWriter
+{
+    /// <summary>
+    /// Sets the fill to a solid <paramref name="color"/>, or removes the fill entirely when the
+    /// colour is <c>null</c> or has no value.
+    /// </summary>
+    /// <remarks>
+    /// Whatever fill was there goes first either way, because the fills are one choice group: a
+    /// solid fill appended beside a surviving gradient would be schema-invalid and would render as
+    /// the gradient.
+    /// </remarks>
+    internal static void SetFill(OpenXmlCompositeElement shapeProperties, XLColor? color)
+    {
+        foreach (var existing in shapeProperties.ChildElements.Where(IsFillElement).ToList())
+            existing.Remove();
+
+        if (color == null || !color.HasValue)
+            return;
+
+        // The fill precedes the outline and every effect in CT_ShapeProperties.
+        var anchor = shapeProperties.ChildElements.FirstOrDefault(IsAfterFill);
+        var fill = new A.SolidFill(BuildColor(color));
+        if (anchor != null)
+            shapeProperties.InsertBefore(fill, anchor);
+        else
+            shapeProperties.Append(fill);
+    }
+
+    /// <summary>
+    /// Returns the <c>a:ln</c>, adding an empty one in its schema position if there is none.
+    /// </summary>
+    /// <remarks>
+    /// Deciding whether an outline is wanted at all belongs to the caller: an element added here for
+    /// properties that all turn out to be absent would read back as "this shape has an explicit
+    /// outline". Callers that may have nothing to write check first and do not call.
+    /// </remarks>
+    internal static A.Outline EnsureOutline(OpenXmlCompositeElement shapeProperties)
+    {
+        var existing = shapeProperties.Elements<A.Outline>().FirstOrDefault();
+        if (existing != null)
+            return existing;
+
+        var outline = new A.Outline();
+        var anchor = shapeProperties.ChildElements.FirstOrDefault(IsAfterOutline);
+        if (anchor != null)
+            shapeProperties.InsertBefore(outline, anchor);
+        else
+            shapeProperties.Append(outline);
+
+        return outline;
+    }
+
+    /// <summary>
+    /// Sets the outline width in points, or removes the width when <paramref name="widthPoints"/> is
+    /// <c>null</c>, leaving everything else about the outline alone.
+    /// </summary>
+    internal static void SetOutlineWidth(A.Outline outline, double? widthPoints)
+    {
+        if (widthPoints == null)
+            outline.Width = null;
+        else
+            outline.Width = DrawingUnits.PointsToEmu(widthPoints.Value);
+    }
+
+    /// <summary>
+    /// Sets the outline's fill to a solid <paramref name="color"/>, or removes it when the colour is
+    /// <c>null</c> or has no value. The outline's width, cap, join and ends are untouched.
+    /// </summary>
+    /// <remarks>
+    /// The fill goes first in <c>a:ln</c>, ahead of the dash, the join and the line ends — which is
+    /// why this inserts at the front rather than in front of a computed successor the way
+    /// <see cref="SetFill"/> has to.
+    /// </remarks>
+    internal static void SetOutlineColor(A.Outline outline, XLColor? color)
+    {
+        foreach (var existing in outline.ChildElements.Where(IsFillElement).ToList())
+            existing.Remove();
+
+        if (color is { HasValue: true })
+            outline.InsertAt(new A.SolidFill(BuildColor(color)), 0);
+    }
+
+    // ── The CT_ShapeProperties sequence ─────────────────────────────────
+
+    /// <summary>The members of the fill choice group, exactly one of which may be present.</summary>
+    private static bool IsFillElement(OpenXmlElement element) =>
+        element is A.NoFill or A.SolidFill or A.GradientFill or A.BlipFill or A.PatternFill or A.GroupFill;
+
+    /// <summary>The children that must follow the fill.</summary>
+    private static bool IsAfterFill(OpenXmlElement element) =>
+        element is A.Outline || IsEffectOrLater(element);
+
+    /// <summary>The children that must follow the outline.</summary>
+    private static bool IsAfterOutline(OpenXmlElement element) => IsEffectOrLater(element);
+
+    private static bool IsEffectOrLater(OpenXmlElement element) =>
+        element is A.EffectList or A.EffectDag or A.Scene3DType or A.Shape3DType or A.ExtensionList;
+
+    // ── Colours ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The colour element for a fill: a theme colour becomes <c>a:schemeClr</c> so that it keeps
+    /// following the theme, and anything else becomes a literal <c>a:srgbClr</c>.
+    /// </summary>
+    private static OpenXmlElement BuildColor(XLColor color)
+    {
+        if (color.ColorType == XLColorType.Theme)
+            return new A.SchemeColor { Val = MapSchemeColor(color.ThemeColor) };
+
+        return new A.RgbColorModelHex { Val = color.Color.ToHex().Substring(2) };
+    }
+
+    private static A.SchemeColorValues MapSchemeColor(XLThemeColor themeColor) => themeColor switch
+    {
+        XLThemeColor.Background1 => A.SchemeColorValues.Background1,
+        XLThemeColor.Text1 => A.SchemeColorValues.Text1,
+        XLThemeColor.Background2 => A.SchemeColorValues.Background2,
+        XLThemeColor.Text2 => A.SchemeColorValues.Text2,
+        XLThemeColor.Accent1 => A.SchemeColorValues.Accent1,
+        XLThemeColor.Accent2 => A.SchemeColorValues.Accent2,
+        XLThemeColor.Accent3 => A.SchemeColorValues.Accent3,
+        XLThemeColor.Accent4 => A.SchemeColorValues.Accent4,
+        XLThemeColor.Accent5 => A.SchemeColorValues.Accent5,
+        XLThemeColor.Accent6 => A.SchemeColorValues.Accent6,
+        XLThemeColor.Hyperlink => A.SchemeColorValues.Hyperlink,
+        XLThemeColor.FollowedHyperlink => A.SchemeColorValues.FollowedHyperlink,
+        _ => throw new System.ArgumentOutOfRangeException(
+            nameof(themeColor), themeColor, "Unknown theme colour.")
+    };
+}

--- a/XLibur/Excel/IO/PictureWriter.cs
+++ b/XLibur/Excel/IO/PictureWriter.cs
@@ -7,11 +7,11 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel.ContentManagers;
 using XLibur.Excel.Drawings;
+using XLibur.Excel.IO.DrawingML;
 using XLibur.Extensions;
 using static XLibur.Excel.IO.OpenXmlConst;
 using static XLibur.Excel.XLWorkbook;
 using Drawing = DocumentFormat.OpenXml.Spreadsheet.Drawing;
-using Point = System.Drawing.Point;
 using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
 
 namespace XLibur.Excel.IO;
@@ -169,14 +169,6 @@ internal static class PictureWriter
         }
     }
 
-    // http://polymathprogrammer.com/2009/10/22/english-metric-units-and-open-xml/
-    // http://archive.oreilly.com/pub/post/what_is_an_emu.html
-    // https://en.wikipedia.org/wiki/Office_Open_XML_file_formats#DrawingML
-    private static long ConvertToEnglishMetricUnits(int pixels, double resolution)
-    {
-        return Convert.ToInt64(914400L * pixels / resolution);
-    }
-
     // A group scale at or extremely near zero is degenerate: dividing by it would
     // overflow the EMU long, so callers fall back to the untransformed sheet value.
     private const double DegenerateScaleEpsilon = 1e-9;
@@ -230,179 +222,58 @@ internal static class PictureWriter
             return;
 
         var wb = pic.Worksheet.Workbook;
-        var extentsCx = ConvertToEnglishMetricUnits(pic.Width, wb.DpiX);
-        var extentsCy = ConvertToEnglishMetricUnits(pic.Height, wb.DpiY);
+        var extentsCx = DrawingUnits.PixelsToEmu(pic.Width, wb.DpiX);
+        var extentsCy = DrawingUnits.PixelsToEmu(pic.Height, wb.DpiY);
 
         var nvps = worksheetDrawing.Descendants<Xdr.NonVisualDrawingProperties>();
         var nvpId = nvps.Any()
             ? (UInt32Value)worksheetDrawing.Descendants<Xdr.NonVisualDrawingProperties>().Max(p => p.Id!.Value) + 1
             : 1U;
 
-        Xdr.FromMarker fMark;
-        switch (pic.Placement)
-        {
-            case XLPicturePlacement.FreeFloating:
-                var absoluteAnchor = new Xdr.AbsoluteAnchor(
-                    new Xdr.Position
-                    {
-                        X = ConvertToEnglishMetricUnits(pic.Left, wb.DpiX),
-                        Y = ConvertToEnglishMetricUnits(pic.Top, wb.DpiY)
-                    },
-                    new Xdr.Extent
-                    {
-                        Cx = extentsCx,
-                        Cy = extentsCy
-                    },
-                    new Xdr.Picture(
-                        new Xdr.NonVisualPictureProperties(
-                            new Xdr.NonVisualDrawingProperties { Id = nvpId, Name = pic.Name },
-                            new Xdr.NonVisualPictureDrawingProperties(new PictureLocks { NoChangeAspect = true })
-                        ),
-                        new Xdr.BlipFill(
-                            new Blip
-                            {
-                                Embed = drawingsPart.GetIdOfPart(imagePart),
-                                CompressionState = BlipCompressionValues.Print
-                            },
-                            new Stretch(new FillRectangle())
-                        ),
-                        new Xdr.ShapeProperties(
-                            new Transform2D(
-                                new Offset { X = 0, Y = 0 },
-                                new Extents { Cx = extentsCx, Cy = extentsCy }
-                            ),
-                            new PresetGeometry { Preset = ShapeTypeValues.Rectangle }
-                        )
-                    ),
-                    new Xdr.ClientData()
-                );
-
-                AttachAnchor(absoluteAnchor, existingAnchor);
-                break;
-
-            case XLPicturePlacement.MoveAndSize:
-                var moveAndSizeFromMarker = pic.Markers[XLMarkerPosition.TopLeft];
-                if (moveAndSizeFromMarker == null)
-                    moveAndSizeFromMarker = new XLMarker(picture.Worksheet.Cell("A1"));
-                fMark = new Xdr.FromMarker
+        // The same xdr:pic whichever anchor form ends up holding it: the anchor decides where the
+        // drawing goes, never what it is.
+        var pictureElement = new Xdr.Picture(
+            new Xdr.NonVisualPictureProperties(
+                new Xdr.NonVisualDrawingProperties { Id = nvpId, Name = pic.Name },
+                new Xdr.NonVisualPictureDrawingProperties(new PictureLocks { NoChangeAspect = true })
+            ),
+            new Xdr.BlipFill(
+                new Blip
                 {
-                    ColumnId = new Xdr.ColumnId((moveAndSizeFromMarker.ColumnNumber - 1).ToInvariantString()),
-                    RowId = new Xdr.RowId((moveAndSizeFromMarker.RowNumber - 1).ToInvariantString()),
-                    ColumnOffset =
-                        new Xdr.ColumnOffset(ConvertToEnglishMetricUnits(moveAndSizeFromMarker.Offset.X, wb.DpiX)
-                            .ToInvariantString()),
-                    RowOffset = new Xdr.RowOffset(ConvertToEnglishMetricUnits(moveAndSizeFromMarker.Offset.Y, wb.DpiY)
-                        .ToInvariantString())
-                };
+                    Embed = drawingsPart.GetIdOfPart(imagePart),
+                    CompressionState = BlipCompressionValues.Print
+                },
+                new Stretch(new FillRectangle())
+            ),
+            new Xdr.ShapeProperties(
+                new Transform2D(
+                    new Offset { X = 0, Y = 0 },
+                    new Extents { Cx = extentsCx, Cy = extentsCy }
+                ),
+                new PresetGeometry { Preset = ShapeTypeValues.Rectangle }
+            )
+        );
 
-                var moveAndSizeToMarker = pic.Markers[XLMarkerPosition.BottomRight];
-                if (moveAndSizeToMarker == null)
-                    moveAndSizeToMarker = new XLMarker(picture.Worksheet.Cell("A1"),
-                        new Point(picture.Width, picture.Height));
-                var tMark = new Xdr.ToMarker
-                {
-                    ColumnId = new Xdr.ColumnId((moveAndSizeToMarker.ColumnNumber - 1).ToInvariantString()),
-                    RowId = new Xdr.RowId((moveAndSizeToMarker.RowNumber - 1).ToInvariantString()),
-                    ColumnOffset =
-                        new Xdr.ColumnOffset(ConvertToEnglishMetricUnits(moveAndSizeToMarker.Offset.X, wb.DpiX)
-                            .ToInvariantString()),
-                    RowOffset = new Xdr.RowOffset(ConvertToEnglishMetricUnits(moveAndSizeToMarker.Offset.Y, wb.DpiY)
-                        .ToInvariantString())
-                };
-
-                var twoCellAnchor = new Xdr.TwoCellAnchor(
-                    fMark,
-                    tMark,
-                    new Xdr.Picture(
-                        new Xdr.NonVisualPictureProperties(
-                            new Xdr.NonVisualDrawingProperties { Id = nvpId, Name = pic.Name },
-                            new Xdr.NonVisualPictureDrawingProperties(new PictureLocks { NoChangeAspect = true })
-                        ),
-                        new Xdr.BlipFill(
-                            new Blip
-                            {
-                                Embed = drawingsPart.GetIdOfPart(imagePart),
-                                CompressionState = BlipCompressionValues.Print
-                            },
-                            new Stretch(new FillRectangle())
-                        ),
-                        new Xdr.ShapeProperties(
-                            new Transform2D(
-                                new Offset { X = 0, Y = 0 },
-                                new Extents { Cx = extentsCx, Cy = extentsCy }
-                            ),
-                            new PresetGeometry { Preset = ShapeTypeValues.Rectangle }
-                        )
-                    ),
-                    new Xdr.ClientData()
-                );
-
-                AttachAnchor(twoCellAnchor, existingAnchor);
-                break;
-
-            case XLPicturePlacement.Move:
-                var moveFromMarker = pic.Markers[XLMarkerPosition.TopLeft];
-                if (moveFromMarker == null) moveFromMarker = new XLMarker(picture.Worksheet.Cell("A1"));
-                fMark = new Xdr.FromMarker
-                {
-                    ColumnId = new Xdr.ColumnId((moveFromMarker.ColumnNumber - 1).ToInvariantString()),
-                    RowId = new Xdr.RowId((moveFromMarker.RowNumber - 1).ToInvariantString()),
-                    ColumnOffset = new Xdr.ColumnOffset(ConvertToEnglishMetricUnits(moveFromMarker.Offset.X, wb.DpiX)
-                        .ToInvariantString()),
-                    RowOffset = new Xdr.RowOffset(ConvertToEnglishMetricUnits(moveFromMarker.Offset.Y, wb.DpiY)
-                        .ToInvariantString())
-                };
-
-                var oneCellAnchor = new Xdr.OneCellAnchor(
-                    fMark,
-                    new Xdr.Extent
-                    {
-                        Cx = extentsCx,
-                        Cy = extentsCy
-                    },
-                    new Xdr.Picture(
-                        new Xdr.NonVisualPictureProperties(
-                            new Xdr.NonVisualDrawingProperties { Id = nvpId, Name = pic.Name },
-                            new Xdr.NonVisualPictureDrawingProperties(new PictureLocks { NoChangeAspect = true })
-                        ),
-                        new Xdr.BlipFill(
-                            new Blip
-                            {
-                                Embed = drawingsPart.GetIdOfPart(imagePart),
-                                CompressionState = BlipCompressionValues.Print
-                            },
-                            new Stretch(new FillRectangle())
-                        ),
-                        new Xdr.ShapeProperties(
-                            new Transform2D(
-                                new Offset { X = 0, Y = 0 },
-                                new Extents { Cx = extentsCx, Cy = extentsCy }
-                            ),
-                            new PresetGeometry { Preset = ShapeTypeValues.Rectangle }
-                        )
-                    ),
-                    new Xdr.ClientData()
-                );
-
-                AttachAnchor(oneCellAnchor, existingAnchor);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(picture), pic.Placement, "Unsupported picture placement.");
-        }
-
-        return;
-
-        void AttachAnchor(OpenXmlElement pictureAnchor, OpenXmlElement? existingAnchorX)
-        {
-            if (existingAnchorX is not null)
+        // A marker left null here is not an oversight: DrawingAnchorFactory falls back to A1, and a
+        // picture nobody moved arrives with both of them unset. See its remarks.
+        var anchor = DrawingAnchorFactory.Create(
+            pic.Placement,
+            new DrawingAnchorGeometry
             {
-                worksheetDrawing.ReplaceChild(pictureAnchor, existingAnchorX);
-            }
-            else
-            {
-                worksheetDrawing.Append(pictureAnchor);
-            }
-        }
+                Worksheet = picture.Worksheet,
+                LeftPx = pic.Left,
+                TopPx = pic.Top,
+                WidthPx = pic.Width,
+                HeightPx = pic.Height,
+                FromMarker = pic.Markers[XLMarkerPosition.TopLeft],
+                ToMarker = pic.Markers[XLMarkerPosition.BottomRight]
+            },
+            pictureElement);
+
+        if (existingAnchor is not null)
+            worksheetDrawing.ReplaceChild(anchor, existingAnchor);
+        else
+            worksheetDrawing.Append(anchor);
     }
 
     /// <summary>
@@ -494,11 +365,11 @@ internal static class PictureWriter
             {
                 // Identity child space: child coordinates are the member's absolute sheet EMU.
                 transform.Offset ??= new Offset();
-                transform.Offset.X = ConvertToEnglishMetricUnits(member.Left, wb.DpiX);
-                transform.Offset.Y = ConvertToEnglishMetricUnits(member.Top, wb.DpiY);
+                transform.Offset.X = DrawingUnits.PixelsToEmu(member.Left, wb.DpiX);
+                transform.Offset.Y = DrawingUnits.PixelsToEmu(member.Top, wb.DpiY);
                 transform.Extents ??= new Extents();
-                transform.Extents.Cx = ConvertToEnglishMetricUnits(member.Width, wb.DpiX);
-                transform.Extents.Cy = ConvertToEnglishMetricUnits(member.Height, wb.DpiY);
+                transform.Extents.Cx = DrawingUnits.PixelsToEmu(member.Width, wb.DpiX);
+                transform.Extents.Cy = DrawingUnits.PixelsToEmu(member.Height, wb.DpiY);
             }
 
             picElement.Remove();
@@ -578,10 +449,10 @@ internal static class PictureWriter
         imagePart.FeedData(pic.ImageStream);
 
         var wb = pic.Worksheet.Workbook;
-        var sheetEmuCx = ConvertToEnglishMetricUnits(pic.Width, wb.DpiX);
-        var sheetEmuCy = ConvertToEnglishMetricUnits(pic.Height, wb.DpiY);
-        var sheetEmuX = ConvertToEnglishMetricUnits(pic.Left, wb.DpiX);
-        var sheetEmuY = ConvertToEnglishMetricUnits(pic.Top, wb.DpiY);
+        var sheetEmuCx = DrawingUnits.PixelsToEmu(pic.Width, wb.DpiX);
+        var sheetEmuCy = DrawingUnits.PixelsToEmu(pic.Height, wb.DpiY);
+        var sheetEmuX = DrawingUnits.PixelsToEmu(pic.Left, wb.DpiX);
+        var sheetEmuY = DrawingUnits.PixelsToEmu(pic.Top, wb.DpiY);
 
         var childCx = IsDegenerateScale(group.ScaleX) ? sheetEmuCx : (long)Math.Round(sheetEmuCx / group.ScaleX);
         var childCy = IsDegenerateScale(group.ScaleY) ? sheetEmuCy : (long)Math.Round(sheetEmuCy / group.ScaleY);
@@ -687,8 +558,8 @@ internal static class PictureWriter
 
     private static void ApplyGroupedChildExtents(Transform2D transform, XLPicture pic, XLPictureGroup group, XLWorkbook wb)
     {
-        var sheetEmuCx = ConvertToEnglishMetricUnits(pic.Width, wb.DpiX);
-        var sheetEmuCy = ConvertToEnglishMetricUnits(pic.Height, wb.DpiY);
+        var sheetEmuCx = DrawingUnits.PixelsToEmu(pic.Width, wb.DpiX);
+        var sheetEmuCy = DrawingUnits.PixelsToEmu(pic.Height, wb.DpiY);
 
         // Convert the sheet-space size back to the group's child coordinate space.
         var childCx = IsDegenerateScale(group.ScaleX) ? sheetEmuCx : (long)Math.Round(sheetEmuCx / group.ScaleX);
@@ -701,8 +572,8 @@ internal static class PictureWriter
 
     private static void ApplyGroupedChildOffset(Transform2D transform, XLPicture pic, XLPictureGroup group, XLWorkbook wb)
     {
-        var sheetEmuX = ConvertToEnglishMetricUnits(pic.Left, wb.DpiX);
-        var sheetEmuY = ConvertToEnglishMetricUnits(pic.Top, wb.DpiY);
+        var sheetEmuX = DrawingUnits.PixelsToEmu(pic.Left, wb.DpiX);
+        var sheetEmuY = DrawingUnits.PixelsToEmu(pic.Top, wb.DpiY);
 
         // Invert the composed affine (sheet = offset + child·scale) to get the child a:off.
         var childOffX = IsDegenerateScale(group.ScaleX) ? sheetEmuX : (long)Math.Round((sheetEmuX - group.OffsetX) / group.ScaleX);


### PR DESCRIPTION
Spec 16 tasks 2 and 3, on top of the change-set harness and golden corpus that landed in #401.

Both are behaviour-preserving extractions of shipped code, gated by the suite and by the golden
fixtures #401 captured from the pre-refactor writer. Neither adds a DrawingML capability. **No test
is added, removed or changed by this PR** — the diff is six production files.

`xdr:sp/spPr` and a chart series' `c:spPr` are the same schema type, `a:CT_ShapeProperties`, and all
three anchor forms are the same regardless of what they hold. Both were implemented once, correctly,
in a place only one caller could reach. Spec 15 (shapes and text boxes) needs both, and a second
implementation is how the two copies drift.

## Task 2 — `DrawingAnchorFactory`

`PictureWriter.AddPictureAnchor` built all three anchor forms as three inline blocks, one per
placement.

```csharp
DrawingAnchorFactory.Create(placement, geometry, content) -> OpenXmlCompositeElement
```

returns `xdr:absoluteAnchor`, `xdr:oneCellAnchor` or `xdr:twoCellAnchor`, converting to EMU on the
way. `DrawingAnchorGeometry` carries the drawing's pixel position and size and its two optional
markers. The content is handed in rather than built, which is what lets a caller holding an
`xdr:sp` use the same factory.

The three blocks turned out to be more alike than the spec assumed: it describes them as differing
in "the `xdr:pic` payload and marker sources", but the payloads are byte-for-byte identical. Only
the anchor element and which parts of the geometry it uses actually vary. The picture is therefore
built once.

**The A1 marker fallbacks moved with it and are documented as contract, not implementation detail**,
because a future caller inherits them silently. A missing *from* marker becomes A1 at offset zero; a
missing *to* marker becomes A1 offset by the drawing's own width and height, which is what stops an
unpositioned `MoveAndSize` drawing collapsing onto its own corner. That path is ordinary use, not
misuse — a picture is created `MoveAndSize` with neither marker set, so a picture nobody moved takes
both fallbacks at once.

`PictureWriter` becomes a caller: **net −129 lines**.

## Task 3 — `ShapePropertiesWriter`

```csharp
SetFill(shapeProperties, XLColor?)
EnsureOutline(shapeProperties) -> A.Outline
SetOutlineWidth(outline, double?)
SetOutlineColor(outline, XLColor?)
```

typed over `OpenXmlCompositeElement`, with `BuildColor`, `MapSchemeColor` and the
`CT_ShapeProperties` sequence predicates private to it. `ChartSeriesFormatXml` goes 107 lines
lighter and keeps its thin mask-driven adapters and all its parent-positioning logic.

Three schema facts the original got right and the extraction preserves: fills are a **choice** group,
so setting a colour over an `a:gradFill` removes the whole group rather than appending beside it; the
type is a **sequence** the SDK will not order for you; and existing elements are **mutated in place,
never rebuilt**, so unmodeled children — an `a:round` join, a `cap`, arrowheads — survive an edit
that never mentions them.

## The four redesign rules

1. **Values, never masks.** This was the real work. `SetOutline` used to be
   `SetOutline(C.ChartShapeProperties, XLChartSeries, XLChartSeriesFormat)` and decided for itself,
   from the mask, whether to write the width and whether to write the colour. The mask now stops at
   the chart boundary: `ChartSeriesFormatXml` keeps a twelve-line adapter that reads
   `XLChartSeriesFormat` and asks for the operations it names. Verified by grep — no
   `XLChartSeriesFormat`, no `XLChart*` type and nothing from `DocumentFormat.OpenXml.Drawing.Charts`
   appears anywhere under `DrawingML/`.
2. **Parent positioning stays with the parent.** Where `c:spPr` sits inside `c:ser` is chart
   knowledge; `NewShapeProperties` and its type list are untouched. The shared layer only ever
   operates *within* an `spPr` it is handed.
3. **Colour building moves with the setters.** `BuildColor` and `MapSchemeColor` came across, so
   consumers get theme-colour writing for free.
4. **Behaviour-preserving, proven twice.** Suite green and unmodified, output byte-identical against
   the goldens.

`DrawingUnits` holds the two unit conversions so each has one definition rather than one on each side
of the new boundary. It is deliberately not called `Emu`: `XLibur.Excel.Coordinates.Emu` already
exists, is a length *value* rather than a conversion, and rounds away from zero where this rounds to
even — so the shorter name would have shadowed a type that means something else, and reusing it would
have silently shifted extents at `.5` boundaries.

## What the goldens proved

Every fixture #401 captured from the pre-refactor writer is **byte-identical** after both
extractions. Nothing was re-baselined.

- **`pictures-three-placements`** and **`pictures-default-markers`** cover all three anchor forms and
  both A1 fallbacks, with non-A1 cells and non-zero offsets so the zero-based off-by-one and both
  offset conversions are exercised with values that would fail loudly if wrong.
- **Nine `patch-*` fixtures** cover exactly the paths task 3 rewrote: a fill replaced, cleared and
  themed; an outline widened, recoloured and added; a gradient replaced through the choice group;
  `c:spPr` built from nothing and positioned; the marker's own shape properties.

**29,154 tests green** on net8.0 and net10.0 across all four test projects. Chart 148, picture 75,
drawing 12 — all green and unmodified. `PublicAPI.Unshipped.txt` untouched; every type added is
`internal`.

## Findings reported but deliberately not acted on

Three things surfaced that are out of scope here and are flagged rather than folded in.

**1. Two items on spec 16's task 3 list did not move, on purpose.**

`AppendBeforeExtensionList` names `C.ExtensionList`, a chart-namespace type. Moving it into
`DrawingML/` would have put a chart type into a shared signature — the same category of mistake as
putting a flags enum there.

`InsertAfterLastOf` could have moved, but `ChartElementOrder.InsertOrdered` already exists. Spec 22
introduced it *after* spec 16 was written, and the sibling chart concept modules already use it; it
is a strictly better generalisation of both helpers, and `SeriesChildOrder` already lists
`ChartShapeProperties`, `Marker`, `Smooth` and `ExtensionList` in schema order. Moving the older
helper into `DrawingML/` would have made three ordering implementations where the tree has two. The
right follow-up is folding `ChartSeriesFormatXml`'s two older helpers onto `InsertOrdered` —
chart-side, spec 22's territory. Not free: it needs a `MarkerChildOrder` table and care at eight call
sites, because the two mechanisms differ in their fallback (`InsertAfterLastOf` inserts at index 0,
`InsertOrdered` appends).

**2. A third copy of the pixels-to-EMU conversion exists** at `XLibur/Excel/Drawings/XLPictures.cs`,
logically identical to the one relocated here. Outside `PictureWriter` and outside task 2's scope, so
left alone; a two-line change gated by the same suite whenever wanted.

**3. One branch of the new layer has no test behind it.** `SetOutlineColor(outline, null)` — clearing
a series' line colour. Nothing in the suite sets `LineColor = null`. It was equally untested before
the extraction, since the identical code sat inside the old `SetOutline`, so no path was added; but
it is now a named operation of a shared layer and should not go unmentioned. No test was added
because task 3's gate is the existing suite *unmodified*.

One deliberate behaviour difference, unobservable: the unsupported-placement
`ArgumentOutOfRangeException` now names `placement` rather than `picture`. `XLPicturePlacement` has
exactly three members, so the branch is unreachable without a cast, and nothing asserts the message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved placement and sizing of pictures, including free-floating, one-cell, and two-cell anchors.
  * Added more consistent handling of picture dimensions and positions when spreadsheet markers are incomplete.
  * Improved chart series and shape formatting for fills, outlines, colors, and line widths.

* **Improvements**
  * Enhanced accuracy when converting measurements for drawings and pictures, supporting more consistent rendering across worksheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->