### PR TITLE
refactor(pivot): drop a dead guard that claimed pivot caches are shared

### DIFF
--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheTests.cs
@@ -15,6 +15,37 @@ public class XLPivotCacheTests
     private static readonly string[] PivotCacheFieldNameOnly = ["Name"];
     private static readonly string[] PivotCacheFieldPastry = ["Pastry"];
 
+    /// <summary>
+    /// Each <c>pivotCacheDefinition</c> part loads as its own cache, even when several of them name
+    /// the same source.
+    /// </summary>
+    /// <remarks>
+    /// Stated as a test because a comment claiming the opposite stood in the reader for years and
+    /// was read, reasonably, as meaning the caches were shared. They are not:
+    /// <c>XLPivotCaches.Add(IXLPivotSource)</c> constructs one every time it is called. The fixture
+    /// carries five parts all sourced from the <c>PastrySalesData</c> table, which is the shape that
+    /// would show the difference if there were one.
+    /// </remarks>
+    [Test]
+    public async Task Each_cache_part_loads_as_its_own_cache_even_on_a_shared_source()
+    {
+        using var stream = TestHelper.GetStreamFromResource(
+            TestHelper.GetResourcePath(@"Other\PivotTableReferenceFiles\PivotMixedDataTypesInTableColumn\input.xlsx"));
+        using var wb = new XLWorkbook(stream);
+
+        var caches = wb.PivotCaches.ToList();
+
+        await Assert.That(caches.Count).IsEqualTo(5);
+        await Assert.That(caches.Select(c => c.SourceName).Distinct().Single()).IsEqualTo("PastrySalesData");
+
+        // Each cache holds the relationship of the part it was read from, which is how the save
+        // path finds that part again. Sharing one cache between parts would leave four of the five
+        // relationships unrecorded.
+        var relIds = caches.Cast<XLPivotCache>().Select(c => c.WorkbookCacheRelId).ToList();
+        await Assert.That(relIds.Any(string.IsNullOrEmpty)).IsFalse();
+        await Assert.That(relIds.Distinct().Count()).IsEqualTo(5);
+    }
+
     [Test]
     public async Task FieldNames_KeepNamesEvenWhenSourceChange()
     {

--- a/XLibur/Excel/IO/PivotTableCacheDefinitionPartReader.cs
+++ b/XLibur/Excel/IO/PivotTableCacheDefinitionPartReader.cs
@@ -21,13 +21,12 @@ internal static class PivotTableCacheDefinitionPartReader
                 throw PartStructureException.RequiredElementIsMissing();
 
             var pivotSourceReference = ParsePivotSourceReference(cacheSource);
-            var pivotCache = workbook.PivotCachesInternal.Add(pivotSourceReference);
 
-            // If WorkbookCacheRelId already has a value, it means the pivot source is being reused
-            if (string.IsNullOrWhiteSpace(pivotCache.WorkbookCacheRelId))
-            {
-                pivotCache.WorkbookCacheRelId = workbookPart.GetIdOfPart(pivotTableCacheDefinitionPart);
-            }
+            // One cache per part, even where several parts name the same source. Excel writes a
+            // part per cache and the save path reads the relationship back off each cache to find
+            // it again, so folding them together here would write out fewer parts than came in.
+            var pivotCache = workbook.PivotCachesInternal.Add(pivotSourceReference);
+            pivotCache.WorkbookCacheRelId = workbookPart.GetIdOfPart(pivotTableCacheDefinitionPart);
 
             if (cacheDefinition.MissingItemsLimit?.Value is { } missingItemsLimit)
             {


### PR DESCRIPTION
`PivotTableCacheDefinitionPartReader.Load` guarded its assignment of `WorkbookCacheRelId`:

```csharp
var pivotCache = workbook.PivotCachesInternal.Add(pivotSourceReference);

// If WorkbookCacheRelId already has a value, it means the pivot source is being reused
if (string.IsNullOrWhiteSpace(pivotCache.WorkbookCacheRelId))
{
    pivotCache.WorkbookCacheRelId = workbookPart.GetIdOfPart(pivotTableCacheDefinitionPart);
}
```

**Nothing is reused, and the guard is always true.** No behaviour change here — this is a clarity fix and a test.

One commit off `62b41f79`.

## Why the guard cannot fire

- `XLPivotCaches.Add(IXLPivotSource)` constructs a new `XLPivotCache` on every call. It never looks for an existing one — unlike `Add(SheetArea)` and `Find(SheetArea)`, which do dedupe, and which are used by the *creation* path rather than the load path.
- `WorkbookCacheRelId` is a plain auto-property that `XLPivotCache`'s constructor does not set, so it is null on the object `Add` just returned.
- The only other writer is `ResetAllRelIds`, which runs *after* `LoadSpreadsheetDocument`, not during it.
- `PivotTableCacheDefinitionPartReader.Load` has exactly one caller.

So the condition is `string.IsNullOrWhiteSpace(null)` every time.

## Why it is worth removing rather than leaving

The comment outlived whatever it once described, and it is not inert. A review of a different pull request read it as evidence that several `pivotCacheDefinition` parts sharing a source fold onto one `XLPivotCache`, and on that basis raised a defect against a nearby unconditional assignment — arguing it would clobber a value a sibling part had supplied. That cannot happen, because there is no shared object to clobber. The comment was the whole basis of the finding.

The replacement says what the loop actually does, and why one-cache-per-part is load-bearing rather than incidental: the save path reads the relationship back off each cache to find its part again, so folding caches together at load would write out fewer parts than came in.

## The test

`Each_cache_part_loads_as_its_own_cache_even_on_a_shared_source`, in `XLPivotCacheTests`.

`Other/PivotTableReferenceFiles/PivotMixedDataTypesInTableColumn/input.xlsx` already carries **five** `pivotCacheDefinition` parts, all sourced from the same `PastrySalesData` table. That is exactly the shape that would show a difference if caches were ever folded together. It loads as **five caches**, each holding a distinct, non-empty relationship id.

Putting it in a test rather than trusting the corrected comment is the point: the previous comment misled a reader for as long as it stood, and a comment cannot fail a build.

## Scope

Deliberately not changed: whether one-cache-per-part is the *right* model. It matches what the file contains and what the writer expects, and changing it would alter `IXLWorkbook.PivotCaches.Count` and the number of parts written. That is a design question, not this PR.

## Tests

Full solution, both frameworks, 8 assemblies:

```
total: 29156   passed: 29148   failed: 0   skipped: 8
```

The 8 skips are pre-existing and unrelated. Release build across all target frameworks: 0 warnings, 0 errors. The unchanged suite is the evidence that removing the guard changed nothing — the assignment it wrapped now runs unconditionally, which is what it already did.
