### PR TITLE
test(fidelity): compare every part-byte assertion in order, not as a multiset

### DIFF
--- a/XLibur.Tests/Excel/Slicers/SlicerPositionTests.cs
+++ b/XLibur.Tests/Excel/Slicers/SlicerPositionTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
+using TUnit.Assertions.Enums;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
@@ -53,7 +54,7 @@ public class SlicerPositionTests
 
         using var original = Resource();
         await Assert.That(PartBytes(saved, "xl/slicers/slicer2.xml"))
-            .IsEquivalentTo(PartBytes(original, "xl/slicers/slicer2.xml"));
+            .IsEquivalentTo(PartBytes(original, "xl/slicers/slicer2.xml"), CollectionOrdering.Matching);
     }
 
     // ── Placing a created slicer ────────────────────────────────────────
@@ -182,7 +183,7 @@ public class SlicerPositionTests
 
         // Position lives in the drawing, so moving a slicer must leave the slicers part closed —
         // the two halves of an edit are gated separately.
-        await Assert.That(PartBytes(saved, "xl/slicers/slicer2.xml")).IsEquivalentTo(before);
+        await Assert.That(PartBytes(saved, "xl/slicers/slicer2.xml")).IsEquivalentTo(before, CollectionOrdering.Matching);
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Slicers/SlicerReadModelTests.cs
+++ b/XLibur.Tests/Excel/Slicers/SlicerReadModelTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
+using TUnit.Assertions.Enums;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
@@ -208,8 +209,8 @@ public class SlicerReadModelTests
 
         using var saved = LoadAndSave();
 
-        await Assert.That(PartBytes(saved, "xl/slicers/slicer2.xml")).IsEquivalentTo(before);
-        await Assert.That(PartBytes(saved, "xl/slicerCaches/slicerCache1.xml")).IsEquivalentTo(beforeCache);
+        await Assert.That(PartBytes(saved, "xl/slicers/slicer2.xml")).IsEquivalentTo(before, CollectionOrdering.Matching);
+        await Assert.That(PartBytes(saved, "xl/slicerCaches/slicerCache1.xml")).IsEquivalentTo(beforeCache, CollectionOrdering.Matching);
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Slicers/SlicerWriteTests.cs
+++ b/XLibur.Tests/Excel/Slicers/SlicerWriteTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
+using TUnit.Assertions.Enums;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
@@ -96,7 +97,7 @@ public class SlicerWriteTests
 
         // slicer1 is the table slicer on the other sheet. Nobody assigned to it, so its part is not
         // even opened — the byte comparison is what proves the patcher's gate actually gates.
-        await Assert.That(PartBytes(saved, "xl/slicers/slicer1.xml")).IsEquivalentTo(before);
+        await Assert.That(PartBytes(saved, "xl/slicers/slicer1.xml")).IsEquivalentTo(before, CollectionOrdering.Matching);
     }
 
     [Test]
@@ -143,7 +144,7 @@ public class SlicerWriteTests
             wb.SaveAs(saved);
         }
 
-        await Assert.That(PartBytes(saved, "xl/slicers/slicer2.xml")).IsEquivalentTo(before)
+        await Assert.That(PartBytes(saved, "xl/slicers/slicer2.xml")).IsEquivalentTo(before, CollectionOrdering.Matching)
             .Because("Excel's own slicer part must pass through untouched; the new slicer belongs in a part of its own.");
     }
 

--- a/XLibur.Tests/Excel/Timelines/TimelinePositionTests.cs
+++ b/XLibur.Tests/Excel/Timelines/TimelinePositionTests.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TUnit.Assertions.Enums;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.Timelines;
@@ -72,7 +73,7 @@ public class TimelinePositionTests
         // A position-only edit must not open the timelines part at all — PatchTimeline's early
         // return on (assigned & ~Position) == None is what this pins. Without it, a part Excel
         // authored would be re-serialised on every move, and nothing above this line would notice.
-        await Assert.That(PartBytes(saved, "xl/timelines/timeline1.xml")).IsEquivalentTo(timelinePartBefore);
+        await Assert.That(PartBytes(saved, "xl/timelines/timeline1.xml")).IsEquivalentTo(timelinePartBefore, CollectionOrdering.Matching);
 
         saved.Position = 0;
         using var reloaded = new XLWorkbook(saved);

--- a/XLibur.Tests/Excel/Timelines/TimelineReadModelTests.cs
+++ b/XLibur.Tests/Excel/Timelines/TimelineReadModelTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
+using TUnit.Assertions.Enums;
 using XLibur.Excel;
 
 namespace XLibur.Tests.Excel.Timelines;
@@ -126,8 +127,8 @@ public class TimelineReadModelTests
 
         using var saved = LoadAndSave();
 
-        await Assert.That(PartBytes(saved, "xl/timelines/timeline1.xml")).IsEquivalentTo(before);
-        await Assert.That(PartBytes(saved, "xl/timelineCaches/timelineCache1.xml")).IsEquivalentTo(beforeCache);
+        await Assert.That(PartBytes(saved, "xl/timelines/timeline1.xml")).IsEquivalentTo(before, CollectionOrdering.Matching);
+        await Assert.That(PartBytes(saved, "xl/timelineCaches/timelineCache1.xml")).IsEquivalentTo(beforeCache, CollectionOrdering.Matching);
     }
 
     [Test]

--- a/XLibur.Tests/Excel/Timelines/TimelineWriteTests.cs
+++ b/XLibur.Tests/Excel/Timelines/TimelineWriteTests.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TUnit.Assertions.Enums;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
@@ -145,7 +146,7 @@ public class TimelineWriteTests
             wb.SaveAs(saved);
         }
 
-        await Assert.That(PartBytes(saved, "xl/timelines/timeline1.xml")).IsEquivalentTo(before);
+        await Assert.That(PartBytes(saved, "xl/timelines/timeline1.xml")).IsEquivalentTo(before, CollectionOrdering.Matching);
     }
 
     [Test]
@@ -231,7 +232,7 @@ public class TimelineWriteTests
             wb.SaveAs(saved);
         }
 
-        await Assert.That(PartBytes(saved, "xl/drawings/drawing1.xml")).IsEquivalentTo(drawingBaseline);
+        await Assert.That(PartBytes(saved, "xl/drawings/drawing1.xml")).IsEquivalentTo(drawingBaseline, CollectionOrdering.Matching);
     }
 
     [Test]
@@ -248,7 +249,7 @@ public class TimelineWriteTests
             wb.SaveAs(saved);
         }
 
-        await Assert.That(PartBytes(saved, "xl/timelines/timeline1.xml")).IsEquivalentTo(before);
+        await Assert.That(PartBytes(saved, "xl/timelines/timeline1.xml")).IsEquivalentTo(before, CollectionOrdering.Matching);
     }
 
     // ── Schema ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #407, where CodeRabbit raised this against the two assertions that PR happened to add. The same weakness was in twelve more, across the slicer and timeline suites.

## The problem

**TUnit's `IsEquivalentTo` ignores order by default.** Verified directly rather than inferred — a throwaway test confirms it holds `{1, 2, 3}` equivalent to `{3, 2, 1}`.

So twelve assertions of the form

```csharp
await Assert.That(PartBytes(saved, "xl/slicers/slicer2.xml")).IsEquivalentTo(before);
```

were claiming a part survived **byte for byte** while actually asserting only that the same bytes were present in some order — the multiset, not the sequence.

## Why it matters more here than usual

These are not incidental assertions. They are the gates the round-trip fidelity guarantee rests on: that a slicer part, a timeline part, a cache part or a drawing is **passed through untouched** rather than re-serialised by the SDK. `docs/round-trip-fidelity.md` cites them by name as the evidence for that claim.

An assertion that does not say what it claims is worse than one that is merely weak, because it reads as stronger evidence than it is. #407 exists precisely because a part *was* being re-serialised for months and no assertion could see it.

## What changed

`CollectionOrdering.Matching` on all twelve, plus the `TUnit.Assertions.Enums` import where it was missing:

| File | Assertions |
|---|---|
| `Slicers/SlicerPositionTests.cs` | 2 |
| `Slicers/SlicerReadModelTests.cs` | 2 |
| `Slicers/SlicerWriteTests.cs` | 2 |
| `Timelines/TimelinePositionTests.cs` | 1 |
| `Timelines/TimelineReadModelTests.cs` | 2 |
| `Timelines/TimelineWriteTests.cs` | 3 |

Two needed care and are worth a look in the diff: `SlicerPositionTests:56` passes a nested `PartBytes(...)` call as the expected value, and `SlicerWriteTests:146` chains `.Because(...)` on the next line. Both were edited by locating the matching close-paren rather than by pattern substitution.

## Verification

No production change. No test changes behaviour — every one of the twelve already passed and still does. Full suite **14,116 tests, 0 failing**.

That last point is worth stating plainly: this PR does **not** fix a bug, and it does not prove one was absent. It makes twelve assertions actually test what they have always claimed to test, so that a future regression of the kind #407 fixed cannot slip past them on a technicality.
