### PR TITLE
fix(calc): a dirty formula no longer stops recalculation from reaching its dependents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
 
   The rest of the library follows the same distinction: an unfrozen split is not moved by row or column edits, is not treated as a frozen band by `FocusCell`, is dropped rather than reinterpreted when `FreezeRows`/`FreezeColumns` freezes the other axis, and anchors its `topLeftCell` at `A1` rather than at split + 1, which is a cell address only for a freeze. The caller-visible half of this — what `SplitRow` and `SplitColumn` now mean, and what to call instead — is under Breaking Changes above.
 
+- **Editing a cell now recalculates every dependent, even when something else already marked one of them dirty first.** Calling `InvalidateFormula`, renaming a sheet, moving a range, or shifting references on a row/column insert could each leave a formula flagged dirty for a reason unrelated to the current edit; the recalculation walk mistook that pre-existing flag for "already visited by this walk," stopped there, and left everything downstream silently stale. `A1=1, B1=A1+1, C1=B1+1, D1=C1+1; C1.InvalidateFormula(); A1.Value = 10` used to leave `D1` at `4` instead of `13`.
+
 ## v0.311.1 - 2026-08-11
 
 A dependency release: `XLibur.Fonts.SkiaSharp` moves to SkiaSharp 4.151.1, a patch bump. No new features, no bug fixes and no breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
 
 - **Editing a cell now recalculates every dependent, even when something else already marked one of them dirty first.** Calling `InvalidateFormula`, renaming a sheet, moving a range, or shifting references on a row/column insert could each leave a formula flagged dirty for a reason unrelated to the current edit; the recalculation walk mistook that pre-existing flag for "already visited by this walk," stopped there, and left everything downstream silently stale. `A1=1, B1=A1+1, C1=B1+1, D1=C1+1; C1.InvalidateFormula(); A1.Value = 10` used to leave `D1` at `4` instead of `13`.
 
+  This costs something on one shape. Treating "already dirty" as "already visited" also stopped the walk early *between* edits, so writing many cells that feed the same model without reading anything in between used to mark that model dirty once and skip it thereafter. Each such write now walks the model again, because there is no longer any sound way to tell "dirty because a walk reached it" from "dirty for some unrelated reason" — the conflation that caused the bug. Writing 20,000 inputs of a 50-formula-deep shared model with no intervening read goes from roughly 50 ms to 190 ms; reading or saving between edits, or writing cells nothing depends on, is unaffected and now allocates less than before.
+
 ## v0.311.1 - 2026-08-11
 
 A dependency release: `XLibur.Fonts.SkiaSharp` moves to SkiaSharp 4.151.1, a patch bump. No new features, no bug fixes and no breaking changes.

--- a/XLibur.Benchmarks/BulkEditDirtyWalkProfile.cs
+++ b/XLibur.Benchmarks/BulkEditDirtyWalkProfile.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Diagnostics;
+using XLibur.Excel;
+using XLibur.Fonts.SixLabors.V1;
+
+namespace XLibur.Benchmarks;
+
+/// <summary>
+/// Cost of the dependency-tree <c>MarkDirty</c> walk on the bulk-edit path: many single-cell
+/// value writes against an already-built dependency tree, once the tree has real dependents to
+/// walk and once it has none. Spec 40 replaces the walk's "already visited" check (which reused
+/// a formula's dirty flag) with its own tracking; this profile is the before/after gate that
+/// change must not regress.
+///
+/// Run with: dotnet run -c Release --framework net10.0 --project XLibur.Benchmarks -- profile bulkedit
+/// </summary>
+public static class BulkEditDirtyWalkProfile
+{
+    private const int Edits = 200_000;
+    private const int Chains = 200;
+    private const int ChainDepth = 10;
+
+    public static void Run()
+    {
+        SixLaborsV1FontBootstrap.Register();
+
+        RunProbe(("warmup", () => EditRootsWithDependents(chains: 10, depth: 5, edits: 1_000)));
+
+        Console.WriteLine();
+        Console.WriteLine($"{Edits:N0} single-cell value writes per probe");
+        Console.WriteLine("| Probe                                             |    Total |    ms |   us/edit |");
+        Console.WriteLine("|---------------------------------------------------|----------|-------|-----------|");
+
+        foreach (var probe in Probes())
+            RunProbe(probe);
+
+        Console.WriteLine();
+        Console.WriteLine("Bytes are exact. Times are single-shot — use BenchmarkDotNet for time claims.");
+    }
+
+    private static (string Name, Action Action)[] Probes() =>
+    [
+        ($"{Edits:N0} edits, {Chains}x{ChainDepth} chains (real walk)", () => EditRootsWithDependents(Chains, ChainDepth, Edits)),
+        ($"{Edits:N0} edits, no dependents (walk finds nothing)", () => EditCellsWithNoDependents(Edits)),
+    ];
+
+    /// <summary>
+    /// Every root feeds a chain of <paramref name="depth"/> formulas, so each edit's walk has real
+    /// work: it must traverse the whole chain and mark every link dirty.
+    /// </summary>
+    /// <remarks>
+    /// Each edit is immediately followed by reading every cell of the edited chain, top to
+    /// bottom, which cleans every link before the next edit without ever needing the chain's
+    /// exception-driven <c>GettingDataException</c>/full-recalculate fallback (each read's own
+    /// precedent was just cleaned by the read before it). Two things this deliberately avoids:
+    /// <list type="bullet">
+    /// <item>
+    /// Not settling at all would let a column sampled twice in a row hit the pre-fix code's
+    /// dirty-as-visited shortcut on the second edit (its first dependent is already dirty from
+    /// the first edit and nothing ever cleaned it) and end the walk after one hop — understating
+    /// the pre-fix baseline by skipping exactly the work spec 40 restores, rather than measuring
+    /// the walk's genuine per-edit cost.
+    /// </item>
+    /// <item>
+    /// Settling with a single read of the chain's tail instead of level-by-level makes every edit
+    /// pay for one <c>GettingDataException</c> cascade back to the root through
+    /// <c>XLCalculationChain</c>'s reordering, which dominates the measurement by roughly three
+    /// orders of magnitude and buries the walk's own cost — identically before and after this
+    /// spec's fix, since neither touches the calculation chain.
+    /// </item>
+    /// </list>
+    /// </remarks>
+    private static void EditRootsWithDependents(int chains, int depth, int edits)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        for (var c = 1; c <= chains; c++)
+        {
+            ws.Cell(1, c).Value = 1;
+            for (var r = 2; r <= depth + 1; r++)
+                ws.Cell(r, c).FormulaA1 = $"{ws.Cell(r - 1, c).Address.ColumnLetter}{r - 1}+1";
+        }
+
+        // Force evaluation so the dependency tree exists and every formula starts clean.
+        foreach (var cell in ws.CellsUsed(x => x.HasFormula))
+            _ = cell.Value;
+
+        var rnd = new Random(42);
+        for (var i = 0; i < edits; i++)
+        {
+            var column = rnd.Next(1, chains + 1);
+            ws.Cell(1, column).Value = i;
+            for (var r = 2; r <= depth + 1; r++)
+                _ = ws.Cell(r, column).Value;
+        }
+    }
+
+    /// <summary>
+    /// A dependency tree exists (seeded by one unrelated formula), but the edited cells have no
+    /// dependents at all, so every walk this triggers finds nothing — isolating the walk's
+    /// per-call overhead from any work it does when it finds dependents.
+    /// </summary>
+    private static void EditCellsWithNoDependents(int edits)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell(1, 1).Value = 1;
+        ws.Cell(2, 1).FormulaA1 = "A1+1";
+        _ = ws.Cell(2, 1).Value;
+
+        for (var i = 0; i < edits; i++)
+            ws.Cell(100 + i % 1000, 50).Value = i;
+    }
+
+    private static void RunProbe((string Name, Action Action) probe)
+    {
+        ForceGC();
+
+        var before = GC.GetTotalAllocatedBytes(precise: true);
+        var watch = Stopwatch.StartNew();
+        probe.Action();
+        watch.Stop();
+        var bytes = GC.GetTotalAllocatedBytes(precise: true) - before;
+
+        if (probe.Name == "warmup")
+            return;
+
+        Console.WriteLine(
+            $"| {probe.Name,-49} | {bytes / 1048576.0,5:F1} MB | {watch.Elapsed.TotalMilliseconds,5:F0} | {watch.Elapsed.TotalMicroseconds / Edits,9:F2} |");
+    }
+
+    private static void ForceGC()
+    {
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+    }
+}

--- a/XLibur.Benchmarks/BulkEditDirtyWalkProfile.cs
+++ b/XLibur.Benchmarks/BulkEditDirtyWalkProfile.cs
@@ -19,15 +19,17 @@ public static class BulkEditDirtyWalkProfile
     private const int Edits = 200_000;
     private const int Chains = 200;
     private const int ChainDepth = 10;
+    private const int UnsettledInputs = 20_000;
+    private const int UnsettledDepth = 50;
 
     public static void Run()
     {
         SixLaborsV1FontBootstrap.Register();
 
-        RunProbe(("warmup", () => EditRootsWithDependents(chains: 10, depth: 5, edits: 1_000)));
+        RunProbe(("warmup", () => EditRootsWithDependents(chains: 10, depth: 5, edits: 1_000), 1));
 
         Console.WriteLine();
-        Console.WriteLine($"{Edits:N0} single-cell value writes per probe");
+        Console.WriteLine("Single-cell value writes; edit count is named per probe.");
         Console.WriteLine("| Probe                                             |    Total |    ms |   us/edit |");
         Console.WriteLine("|---------------------------------------------------|----------|-------|-----------|");
 
@@ -38,11 +40,51 @@ public static class BulkEditDirtyWalkProfile
         Console.WriteLine("Bytes are exact. Times are single-shot — use BenchmarkDotNet for time claims.");
     }
 
-    private static (string Name, Action Action)[] Probes() =>
+    private static (string Name, Action Action, int Edits)[] Probes() =>
     [
-        ($"{Edits:N0} edits, {Chains}x{ChainDepth} chains (real walk)", () => EditRootsWithDependents(Chains, ChainDepth, Edits)),
-        ($"{Edits:N0} edits, no dependents (walk finds nothing)", () => EditCellsWithNoDependents(Edits)),
+        ($"{Edits:N0} edits, {Chains}x{ChainDepth} chains (real walk)", () => EditRootsWithDependents(Chains, ChainDepth, Edits), Edits),
+        ($"{Edits:N0} edits, no dependents (walk finds nothing)", () => EditCellsWithNoDependents(Edits), Edits),
+        ($"{UnsettledInputs:N0} unsettled edits, {UnsettledDepth}-deep shared model", () => EditSharedModelWithoutSettling(UnsettledInputs, UnsettledDepth), UnsettledInputs),
     ];
+
+    /// <summary>
+    /// The worst case for a walk that tracks visits per call rather than reusing the dirty flag:
+    /// every input of a shared model is written with no read in between, so nothing ever cleans
+    /// the model and every edit re-walks the same dependent closure.
+    /// </summary>
+    /// <remarks>
+    /// This is the one workload spec 40's fix genuinely makes more expensive, and it is measured
+    /// here rather than assumed away. Reusing the dirty flag as the visited marker also
+    /// short-circuited <i>across</i> calls: once the model was dirty from the first edit, every
+    /// later edit stopped at the first hop, making the sequence roughly O(N + M) instead of
+    /// O(N x M). That saving was never sound — it is the same shortcut that pruned legitimate
+    /// walks and produced stale values, which is why it is gone — so the numbers below are the
+    /// price of correctness on this shape, not a regression to be optimised away by restoring it.
+    /// Anyone tempted to reintroduce a cross-call skip needs a marker that distinguishes "this
+    /// subtree is dirty because a walk reached it" from "dirty for some unrelated reason";
+    /// the dirty flag alone cannot.
+    /// </remarks>
+    private static void EditSharedModelWithoutSettling(int inputs, int depth)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        for (var r = 1; r <= inputs; r++)
+            ws.Cell(r, 1).Value = r;
+
+        // Every input feeds the head of the model, and each link feeds the next, so a walk from
+        // any single input has the whole depth-deep chain downstream of it.
+        ws.Cell(1, 2).FormulaA1 = $"SUM(A1:A{inputs})";
+        for (var r = 2; r <= depth; r++)
+            ws.Cell(r, 2).FormulaA1 = $"B{r - 1}+1";
+
+        foreach (var cell in ws.CellsUsed(x => x.HasFormula))
+            _ = cell.Value;
+
+        // No read between edits: the model stays dirty throughout.
+        for (var r = 1; r <= inputs; r++)
+            ws.Cell(r, 1).Value = r + 1;
+    }
 
     /// <summary>
     /// Every root feeds a chain of <paramref name="depth"/> formulas, so each edit's walk has real
@@ -113,7 +155,7 @@ public static class BulkEditDirtyWalkProfile
             ws.Cell(100 + i % 1000, 50).Value = i;
     }
 
-    private static void RunProbe((string Name, Action Action) probe)
+    private static void RunProbe((string Name, Action Action, int Edits) probe)
     {
         ForceGC();
 
@@ -127,7 +169,7 @@ public static class BulkEditDirtyWalkProfile
             return;
 
         Console.WriteLine(
-            $"| {probe.Name,-49} | {bytes / 1048576.0,5:F1} MB | {watch.Elapsed.TotalMilliseconds,5:F0} | {watch.Elapsed.TotalMicroseconds / Edits,9:F2} |");
+            $"| {probe.Name,-49} | {bytes / 1048576.0,5:F1} MB | {watch.Elapsed.TotalMilliseconds,5:F0} | {watch.Elapsed.TotalMicroseconds / probe.Edits,9:F2} |");
     }
 
     private static void ForceGC()

--- a/XLibur.Benchmarks/Program.cs
+++ b/XLibur.Benchmarks/Program.cs
@@ -17,6 +17,8 @@ if (args.Length > 0 && args[0].Equals("profile", StringComparison.OrdinalIgnoreC
     //               model, optionally taking a row count
     //   structural  the cost of repeated row inserts split into its range-shift and
     //               formula-shift halves
+    //   bulkedit    the dependency-tree MarkDirty walk's cost on repeated single-cell value
+    //               writes, with and without dependents to walk
     //   template    the open->edit->save round trip of an existing workbook, split into parse
     //               and serialise; optionally takes a path to a real .xlsx template
     // Every other mode attaches dotMemory and targets the load path.
@@ -40,6 +42,8 @@ if (args.Length > 0 && args[0].Equals("profile", StringComparison.OrdinalIgnoreC
         DirtyFormulaReadProfile.Run();
     else if (args.Length > 1 && args[1].Equals("hyperlinks", StringComparison.OrdinalIgnoreCase))
         HyperlinkScalingProfile.Run();
+    else if (args.Length > 1 && args[1].Equals("bulkedit", StringComparison.OrdinalIgnoreCase))
+        BulkEditDirtyWalkProfile.Run();
     else
         MemoryProfile.Run(args);
 

--- a/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -377,11 +377,10 @@ internal class DependencyTreeTests
         // Set directly, so the cell is not marked as a dirty.
         var cell = (XLCell)sheet.Cell(address);
         cell.Formula = XLCellFormula.NormalA1(formula);
-        // Pre-mark the formula as clean against the current workbook epoch so that the
-        // dependency-tree MarkDirty walk has a meaningful "started clean → became dirty"
-        // transition to assert against. A freshly-constructed XLCellFormula defaults to
-        // _evalEpoch=0 (explicitly dirty / never evaluated).
-        cell.Formula.MarkClean(((XLWorksheet)sheet).Workbook);
+        // Pre-mark the formula as clean so that the dependency-tree MarkDirty walk has a
+        // meaningful "started clean -> became dirty" transition to assert against. A
+        // freshly-constructed XLCellFormula defaults to dirty (never evaluated).
+        cell.Formula.MarkClean();
         var cellArea = new SheetArea(sheet.Name, new Area(cell.SheetPoint, cell.SheetPoint));
         tree.AddFormula(cellArea, cell.Formula, sheet.Workbook);
         return cell.Formula;
@@ -405,12 +404,11 @@ internal class DependencyTreeTests
     private static async Task AssertDirtyFlag(bool expectedDirtyFlag, IXLWorksheet sheet, params string[] dirtyRanges)
     {
         var ws = (XLWorksheet)sheet;
-        var wb = ws.Workbook;
         foreach (var dirtyRange in dirtyRanges)
         {
             foreach (var dirtyCell in ws.Cells(dirtyRange))
             {
-                await Assert.That(dirtyCell.Formula?.IsDirty(wb)).IsEqualTo(expectedDirtyFlag);
+                await Assert.That(dirtyCell.Formula?.IsDirty()).IsEqualTo(expectedDirtyFlag);
             }
         }
     }

--- a/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -227,8 +227,14 @@ internal class DependencyTreeTests
         await AssertNotDirty(ws2, "B1", "D1");
     }
 
+    /// <summary>
+    /// Spec 40: a formula already dirty for a reason unrelated to this walk (the same primitive
+    /// <c>InvalidateFormula</c>, a sheet rename or a reference shift use) must still be traversed,
+    /// so anything downstream of it is reached. Before that fix, the walk used "already dirty" as
+    /// its own "already visited" marker and stopped at A3, leaving A4 stale.
+    /// </summary>
     [Test]
-    public async Task Mark_dirty_stops_at_dirty_cell()
+    public async Task Mark_dirty_continues_through_a_cell_already_dirty_for_an_unrelated_reason()
     {
         using var wb = new XLWorkbook();
         var tree = new DependencyTree();
@@ -238,12 +244,12 @@ internal class DependencyTreeTests
         AddFormula(tree, ws, "A3", "=A2");
         AddFormula(tree, ws, "A4", "=A3");
 
-        // Mark the middle one dirty, but A4 is still clear
+        // Simulate an external dirtier (e.g. InvalidateFormula) marking the middle cell dirty
+        // before this walk starts.
         ((XLCell)ws.Cell("A3")).Formula!.MarkExplicitlyDirty();
 
         MarkDirty(tree, ws, "A1");
-        await AssertDirty(ws, "A2", "A3");
-        await AssertNotDirty(ws, "A4"); // Propagation stopped at the dirty cell A3.
+        await AssertDirty(ws, "A2", "A3", "A4");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/DirtyPropagationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DirtyPropagationTests.cs
@@ -247,6 +247,102 @@ internal class DirtyPropagationTests
 
     #endregion
 
+    #region Graph-shape tests (chain covered above; diamond, cross-sheet, cycle here)
+
+    /// <summary>
+    /// The interfered-with cell (B1) sits mid-arm, one hop before the join (D1). D1 is reachable
+    /// through the OTHER arm (C1) regardless of what happens to B1's arm, so a naive diamond test
+    /// that only checks the join can pass even with the defect present — the join gets lucky via
+    /// its unaffected route. B2, which is downstream of B1 on the SAME arm and has no other route
+    /// to the root, is where the defect actually shows: nothing else can reach it if the walk
+    /// stops at B1.
+    /// </summary>
+    [Test]
+    public async Task Diamond_shaped_graph_recalculates_every_path_despite_interference()
+    {
+        using var wb = new XLWorkbook();
+        var ws = BuildDiamond(wb);
+
+        ws.Cell("B1").InvalidateFormula(); // mid-arm, one hop before the join
+        ws.Cell("A1").Value = 10;
+
+        await AssertDiamond(ws, a1: 10, b1: 11, b2: 12, c1: 12, d1: 24);
+    }
+
+    [Test]
+    public async Task Diamond_shaped_graph_control_without_interference()
+    {
+        using var wb = new XLWorkbook();
+        var ws = BuildDiamond(wb);
+
+        ws.Cell("A1").Value = 10;
+
+        await AssertDiamond(ws, a1: 10, b1: 11, b2: 12, c1: 12, d1: 24);
+    }
+
+    [Test]
+    public async Task Cross_sheet_chain_recalculates_despite_interference()
+    {
+        using var wb = new XLWorkbook();
+        var (sheet1, sheet2) = BuildCrossSheetChain(wb);
+
+        sheet2.Cell("B1").InvalidateFormula(); // intermediate node, lives on Sheet2
+        sheet1.Cell("A1").Value = 10;
+
+        await AssertCrossSheetChain(sheet1, sheet2, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
+    [Test]
+    public async Task Cross_sheet_chain_control_without_interference()
+    {
+        using var wb = new XLWorkbook();
+        var (sheet1, sheet2) = BuildCrossSheetChain(wb);
+
+        sheet1.Cell("A1").Value = 10;
+
+        await AssertCrossSheetChain(sheet1, sheet2, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
+    [Test]
+    public async Task Cycle_with_externally_dirtied_node_still_reaches_tail()
+    {
+        using var wb = new XLWorkbook();
+        var tree = new DependencyTree();
+        var ws = wb.AddWorksheet();
+        tree.AddSheetTree(ws);
+        AddFormula(tree, ws, "B1", "=D1 + A1");
+        AddFormula(tree, ws, "C1", "=B1");
+        AddFormula(tree, ws, "D1", "=C1"); // B1 -> C1 -> D1 -> B1 is a cycle
+        AddFormula(tree, ws, "E1", "=D1"); // tail hanging off the cycle
+
+        // A node inside the cycle is already dirty for a reason unrelated to this walk (as
+        // InvalidateFormula would do) before the walk even starts.
+        ((XLCell)ws.Cell("C1")).Formula!.MarkExplicitlyDirty();
+
+        MarkDirty(tree, ws, "A1");
+
+        await AssertDirty(ws, "B1", "C1", "D1", "E1");
+    }
+
+    [Test]
+    public async Task Cycle_control_without_interference()
+    {
+        using var wb = new XLWorkbook();
+        var tree = new DependencyTree();
+        var ws = wb.AddWorksheet();
+        tree.AddSheetTree(ws);
+        AddFormula(tree, ws, "B1", "=D1 + A1");
+        AddFormula(tree, ws, "C1", "=B1");
+        AddFormula(tree, ws, "D1", "=C1");
+        AddFormula(tree, ws, "E1", "=D1");
+
+        MarkDirty(tree, ws, "A1");
+
+        await AssertDirty(ws, "B1", "C1", "D1", "E1");
+    }
+
+    #endregion
+
     #region Helpers
 
     private static IXLWorksheet BuildChain(XLWorkbook wb, string sheetName = "Sheet1", bool intermediateReferencesOwnSheetByName = false)
@@ -281,6 +377,54 @@ internal class DirtyPropagationTests
         await Assert.That((double)ws.Cell("B1").Value).IsEqualTo(b1);
         await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(c1);
         await Assert.That((double)ws.Cell("D1").Value).IsEqualTo(d1);
+    }
+
+    /// <summary>
+    /// A1 feeds two arms that join at D1: a two-hop arm A1 -> B1 -> B2 -> D1, and a one-hop arm
+    /// A1 -> C1 -> D1.
+    /// </summary>
+    private static IXLWorksheet BuildDiamond(XLWorkbook wb)
+    {
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").FormulaA1 = "A1+1";
+        ws.Cell("B2").FormulaA1 = "B1+1";
+        ws.Cell("C1").FormulaA1 = "A1+2";
+        ws.Cell("D1").FormulaA1 = "B2+C1";
+
+        ForceEvaluation(ws).GetAwaiter().GetResult();
+        return ws;
+    }
+
+    private static (IXLWorksheet Sheet1, IXLWorksheet Sheet2) BuildCrossSheetChain(XLWorkbook wb)
+    {
+        var sheet1 = wb.AddWorksheet("Sheet1");
+        var sheet2 = wb.AddWorksheet("Sheet2");
+        sheet1.Cell("A1").Value = 1;
+        sheet2.Cell("B1").FormulaA1 = "Sheet1!A1+1";
+        sheet1.Cell("C1").FormulaA1 = "Sheet2!B1+1";
+        sheet2.Cell("D1").FormulaA1 = "Sheet1!C1+1";
+
+        ForceEvaluation(sheet1).GetAwaiter().GetResult();
+        ForceEvaluation(sheet2).GetAwaiter().GetResult();
+        return (sheet1, sheet2);
+    }
+
+    private static async Task AssertDiamond(IXLWorksheet ws, double a1, double b1, double b2, double c1, double d1)
+    {
+        await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(a1);
+        await Assert.That((double)ws.Cell("B1").Value).IsEqualTo(b1);
+        await Assert.That((double)ws.Cell("B2").Value).IsEqualTo(b2);
+        await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(c1);
+        await Assert.That((double)ws.Cell("D1").Value).IsEqualTo(d1);
+    }
+
+    private static async Task AssertCrossSheetChain(IXLWorksheet sheet1, IXLWorksheet sheet2, double a1, double b1, double c1, double d1)
+    {
+        await Assert.That((double)sheet1.Cell("A1").Value).IsEqualTo(a1);
+        await Assert.That((double)sheet2.Cell("B1").Value).IsEqualTo(b1);
+        await Assert.That((double)sheet1.Cell("C1").Value).IsEqualTo(c1);
+        await Assert.That((double)sheet2.Cell("D1").Value).IsEqualTo(d1);
     }
 
     private static XLCellFormula AddFormula(DependencyTree tree, IXLWorksheet sheet, string address, string formula)

--- a/XLibur.Tests/Excel/CalcEngine/DirtyPropagationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DirtyPropagationTests.cs
@@ -245,6 +245,34 @@ internal class DirtyPropagationTests
         await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(12);
     }
 
+    /// <summary>
+    /// The dependency tree is thrown away and rebuilt from scratch by <c>XLCalcEngine.Purge</c>,
+    /// which any row/column insert or delete and any sheet add or rename triggers, but the
+    /// <c>XLCellFormula</c> objects carrying the walk stamp survive that rebuild. A walk id that
+    /// restarted per tree would therefore be handed out a second time to formulas still stamped
+    /// with it from the previous tree, and the first walk after every purge would prune at its
+    /// first hop — the very defect this spec removes, reinstated in a narrower window.
+    /// </summary>
+    [Test]
+    public async Task Walk_ids_are_not_reused_after_the_dependency_tree_is_rebuilt()
+    {
+        using var wb = new XLWorkbook();
+        var ws = BuildChain(wb);
+
+        // First walk on the original tree; stamps B1, C1 and D1.
+        ws.Cell("A1").Value = 5;
+        await AssertChain(ws, a1: 5, b1: 6, c1: 7, d1: 8);
+
+        // Discards the dependency tree. A row far below the chain keeps the addresses stable.
+        ws.Row(50).InsertRowsAbove(1);
+        await ForceEvaluation(ws);
+
+        // First walk on the rebuilt tree.
+        ws.Cell("A1").Value = 10;
+
+        await AssertChain(ws, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
     #endregion
 
     #region Graph-shape tests (chain covered above; diamond, cross-sheet, cycle here)

--- a/XLibur.Tests/Excel/CalcEngine/DirtyPropagationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DirtyPropagationTests.cs
@@ -53,7 +53,235 @@ internal class DirtyPropagationTests
 
     #endregion
 
+    #region Interference matrix (centrepiece; red before the fix)
+
+    // Chain used by every case below: A1 = 1, B1 = A1 + 1, C1 = B1 + 1, D1 = C1 + 1.
+    // Each case dirties C1 (the intermediate node) through something other than the walk, then
+    // edits A1 (the root), and asserts the whole chain recalculates.
+
+    [Test]
+    public async Task InvalidateFormula_on_an_intermediate_cell_does_not_prune_a_later_edit()
+    {
+        using var wb = new XLWorkbook();
+        var ws = BuildChain(wb);
+
+        ws.Cell("C1").InvalidateFormula();
+        ws.Cell("A1").Value = 10;
+
+        await AssertChain(ws, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
+    [Test]
+    public async Task InvalidateFormula_control_without_interference()
+    {
+        using var wb = new XLWorkbook();
+        var ws = BuildChain(wb);
+
+        ws.Cell("A1").Value = 10;
+
+        await AssertChain(ws, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
+    /// <summary>
+    /// A live rename goes through <c>XLWorksheets.Rename</c>, which re-keys the sheet by removing
+    /// and re-adding it — the same path a newly added sheet takes — so it also fires
+    /// <c>XLCalcEngine.OnAddedSheet</c>, which purges the whole dependency tree and marks every
+    /// formula in the workbook dirty. That blanket invalidation is a separate, coarser mechanism
+    /// than the one this spec fixes, and it happens to make every formula on the sheet dirty
+    /// regardless of whether the rename actually touched its text — so this test is expected to
+    /// pass both before and after the fix. <see cref="Formula_marked_dirty_by_a_text_rewrite_does_not_prune_a_later_edit"/>
+    /// isolates the walk from that purge and is the test that actually goes red beforehand.
+    /// </summary>
+    [Test]
+    public async Task Sheet_rename_does_not_prune_a_later_edit()
+    {
+        using var wb = new XLWorkbook();
+        var ws = BuildChain(wb, "Data", intermediateReferencesOwnSheetByName: true);
+
+        ws.Name = "Renamed";
+        ws.Cell("A1").Value = 10;
+
+        await AssertChain(ws, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
+    [Test]
+    public async Task Sheet_rename_control_without_interference()
+    {
+        using var wb = new XLWorkbook();
+        var ws = BuildChain(wb, "Data", intermediateReferencesOwnSheetByName: true);
+
+        ws.Cell("A1").Value = 10;
+
+        await AssertChain(ws, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
+    /// <summary>
+    /// A row/column insert always goes through <c>XLCalcEngine.OnInsertAreaAndShiftDown</c> /
+    /// <c>OnInsertAreaAndShiftRight</c>, which purges the whole dependency tree and marks every
+    /// formula in the workbook dirty — the same blanket mechanism <see cref="Sheet_rename_does_not_prune_a_later_edit"/>
+    /// documents. It happens to dirty C1 (and B1 and D1) regardless of whether the shift touched
+    /// their text, so this test is expected to pass both before and after the fix.
+    /// <see cref="Formula_marked_dirty_by_a_text_rewrite_does_not_prune_a_later_edit"/> isolates
+    /// the walk from that purge and is the test that actually goes red beforehand.
+    /// </summary>
+    [Test]
+    public async Task Row_insert_shifting_an_intermediate_reference_does_not_prune_a_later_edit()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        // C1 references a far-away helper cell so a row insert well below the chain shifts only
+        // that reference, forcing C1's formula text to be rewritten (and the formula marked
+        // dirty) without touching A1/B1/D1's text.
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").FormulaA1 = "A1+1";
+        ws.Cell("C1").FormulaA1 = "B1+1+Z100";
+        ws.Cell("D1").FormulaA1 = "C1+1";
+        ws.Cell("Z100").Value = 0;
+        await ForceEvaluation(ws);
+
+        ws.Row(50).InsertRowsAbove(1); // shifts Z100 -> Z101, rewrites C1's formula text
+        ws.Cell("A1").Value = 10;
+
+        await AssertChain(ws, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
+    [Test]
+    public async Task Row_insert_control_without_interference()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").FormulaA1 = "A1+1";
+        ws.Cell("C1").FormulaA1 = "B1+1+Z100";
+        ws.Cell("D1").FormulaA1 = "C1+1";
+        ws.Cell("Z100").Value = 0;
+        await ForceEvaluation(ws);
+
+        ws.Cell("A1").Value = 10;
+
+        await AssertChain(ws, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
+    /// <summary>
+    /// The primitive both a sheet rename (<see cref="XLCellFormula.RenameSheet"/>) and a
+    /// row/column insert's reference shift (<see cref="XLCellFormula.UpdateShiftedA1"/>) use to
+    /// dirty a formula whose text changed: <see cref="XLCellFormula.MarkExplicitlyDirty"/>,
+    /// called directly on the formula, independent of the walk. Exercising it directly, without
+    /// going through the live operations, isolates it from the whole-workbook purge those two
+    /// operations also happen to trigger today (see <see cref="Sheet_rename_does_not_prune_a_later_edit"/>
+    /// and <see cref="Row_insert_shifting_an_intermediate_reference_does_not_prune_a_later_edit"/>),
+    /// which would otherwise mask this defect for both of them.
+    /// </summary>
+    [Test]
+    public async Task Formula_marked_dirty_by_a_text_rewrite_does_not_prune_a_later_edit()
+    {
+        using var wb = new XLWorkbook();
+        var ws = BuildChain(wb);
+
+        ((XLCell)ws.Cell("C1")).Formula!.MarkExplicitlyDirty();
+        ws.Cell("A1").Value = 10;
+
+        await AssertChain(ws, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
+    [Test]
+    public async Task Formula_marked_dirty_by_a_text_rewrite_control_without_interference()
+    {
+        using var wb = new XLWorkbook();
+        var ws = BuildChain(wb);
+
+        ws.Cell("A1").Value = 10;
+
+        await AssertChain(ws, a1: 10, b1: 11, c1: 12, d1: 13);
+    }
+
+    [Test]
+    public async Task Range_move_of_an_intermediate_formula_does_not_prune_a_later_edit()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        ws.Cell("A1").Value = 1;
+        // D3 is the intermediate node; a transpose of the square range C3:D4 swaps it with its
+        // off-diagonal partner C4. E1 is written against that destination address up front, so
+        // the chain flows through wherever D3 lands.
+        ws.Cell("D3").FormulaA1 = "$A$1+1";
+        ws.Cell("E1").FormulaA1 = "C4+1";
+        await ForceEvaluation(ws);
+
+        // A square range whose first row number equals its first column number (3 and 3) is
+        // used deliberately: XLRange.TransposeRange computes a swapped-off-diagonal cell's new
+        // address as Point(col + colOffset, row + rowOffset) instead of the axis-correct
+        // Point(col + rowOffset, row + colOffset), so a range whose row/column start numbers
+        // differ (e.g. B1:C2) transposes to the wrong cell. That is a pre-existing defect in
+        // Transpose, outside spec 40's scope, reported separately; picking equal offsets here
+        // keeps this test from depending on it.
+        ws.Range("C3:D4").Transpose(XLTransposeOptions.MoveCells);
+
+        ws.Cell("A1").Value = 10;
+
+        await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(10);
+        await Assert.That((double)ws.Cell("C4").Value).IsEqualTo(11);
+        await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(12);
+    }
+
+    [Test]
+    public async Task Range_move_control_without_interference()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+
+        ws.Cell("A1").Value = 1;
+        ws.Cell("C4").FormulaA1 = "$A$1+1";
+        ws.Cell("E1").FormulaA1 = "C4+1";
+        await ForceEvaluation(ws);
+
+        ws.Cell("A1").Value = 10;
+
+        await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(10);
+        await Assert.That((double)ws.Cell("C4").Value).IsEqualTo(11);
+        await Assert.That((double)ws.Cell("E1").Value).IsEqualTo(12);
+    }
+
+    #endregion
+
     #region Helpers
+
+    private static IXLWorksheet BuildChain(XLWorkbook wb, string sheetName = "Sheet1", bool intermediateReferencesOwnSheetByName = false)
+    {
+        var ws = wb.AddWorksheet(sheetName);
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").FormulaA1 = "A1+1";
+        ws.Cell("C1").FormulaA1 = intermediateReferencesOwnSheetByName ? $"{sheetName}!B1+1" : "B1+1";
+        ws.Cell("D1").FormulaA1 = "C1+1";
+
+        ForceEvaluation(ws).GetAwaiter().GetResult();
+        return ws;
+    }
+
+    /// <summary>
+    /// Reads every used formula cell's value once, so the calc chain and dependency tree exist
+    /// and every formula starts clean before a test applies its interference.
+    /// </summary>
+    private static async Task ForceEvaluation(IXLWorksheet ws)
+    {
+        foreach (var cell in ws.CellsUsed(c => c.HasFormula))
+        {
+            _ = cell.Value;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    private static async Task AssertChain(IXLWorksheet ws, double a1, double b1, double c1, double d1)
+    {
+        await Assert.That((double)ws.Cell("A1").Value).IsEqualTo(a1);
+        await Assert.That((double)ws.Cell("B1").Value).IsEqualTo(b1);
+        await Assert.That((double)ws.Cell("C1").Value).IsEqualTo(c1);
+        await Assert.That((double)ws.Cell("D1").Value).IsEqualTo(d1);
+    }
 
     private static XLCellFormula AddFormula(DependencyTree tree, IXLWorksheet sheet, string address, string formula)
     {

--- a/XLibur.Tests/Excel/CalcEngine/DirtyPropagationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DirtyPropagationTests.cs
@@ -1,0 +1,89 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+using XLibur.Excel.CalcEngine;
+using XLibur.Excel.Coordinates;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// Spec 40 — the dependency-tree walk uses a formula's dirty flag both to mean "needs
+/// recalculation" and, internally, "already visited by this walk". Anything other than the walk
+/// itself that dirties a formula (<see cref="IXLCell.InvalidateFormula"/>, a sheet rename, a
+/// row/column insert, a range move) makes the walk mistake "already dirty for an unrelated
+/// reason" for "already visited", stop, and prune everything downstream of that node.
+/// </summary>
+/// <remarks>
+/// Every interference test is paired with a control: the same graph and the same edit, without
+/// the interfering operation. The control proves the graph and edit are capable of producing the
+/// right answer on their own, so a failure in the interference test can only be attributed to the
+/// interference.
+/// </remarks>
+internal class DirtyPropagationTests
+{
+    #region Cycle termination (safety net, written and seen green before the fix)
+
+    /// <summary>
+    /// The dirty flag used to double as the walk's cycle guard: a node already marked dirty by
+    /// the walk itself was not re-enqueued, which is also what stopped the walk looping forever
+    /// around a cycle. Separating "visited" from "dirty" must not reopen the cycle as an infinite
+    /// loop, and a formula strictly downstream of the cycle must still be reached.
+    /// </summary>
+    /// <remarks>
+    /// A genuine cycle cannot be evaluated to a value through the public API without throwing
+    /// (<c>XLCalculationChain</c> detects it and throws once evaluation is attempted), so this
+    /// exercises <see cref="DependencyTree.MarkDirty"/> directly, the same seam
+    /// <c>DependencyTreeTests</c> already uses for its cycle coverage.
+    /// </remarks>
+    [Test]
+    public async Task Mark_dirty_terminates_on_cycle_and_reaches_tail_without_interference()
+    {
+        using var wb = new XLWorkbook();
+        var tree = new DependencyTree();
+        var ws = wb.AddWorksheet();
+        tree.AddSheetTree(ws);
+        AddFormula(tree, ws, "B1", "=D1 + A1");
+        AddFormula(tree, ws, "C1", "=B1");
+        AddFormula(tree, ws, "D1", "=C1"); // B1 -> C1 -> D1 -> B1 is a cycle
+        AddFormula(tree, ws, "E1", "=D1"); // tail hanging off the cycle
+
+        MarkDirty(tree, ws, "A1");
+
+        await AssertDirty(ws, "B1", "C1", "D1", "E1");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static XLCellFormula AddFormula(DependencyTree tree, IXLWorksheet sheet, string address, string formula)
+    {
+        var cell = (XLCell)sheet.Cell(address);
+        cell.Formula = XLCellFormula.NormalA1(formula);
+        cell.Formula.MarkClean(((XLWorksheet)sheet).Workbook);
+        var cellArea = new SheetArea(sheet.Name, new Area(cell.SheetPoint, cell.SheetPoint));
+        tree.AddFormula(cellArea, cell.Formula, sheet.Workbook);
+        return cell.Formula;
+    }
+
+    private static void MarkDirty(DependencyTree tree, IXLWorksheet sheet, string range)
+    {
+        var area = new SheetArea(sheet.Name, Area.Parse(range));
+        tree.MarkDirty(area);
+    }
+
+    private static async Task AssertDirty(IXLWorksheet sheet, params string[] dirtyRanges)
+    {
+        var ws = (XLWorksheet)sheet;
+        var wb = ws.Workbook;
+        foreach (var dirtyRange in dirtyRanges)
+        {
+            foreach (var dirtyCell in ws.Cells(dirtyRange))
+            {
+                await Assert.That(dirtyCell.Formula).IsNotNull();
+                await Assert.That(dirtyCell.Formula!.IsDirty(wb)).IsTrue();
+            }
+        }
+    }
+
+    #endregion
+}

--- a/XLibur.Tests/Excel/CalcEngine/DirtyPropagationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DirtyPropagationTests.cs
@@ -431,7 +431,7 @@ internal class DirtyPropagationTests
     {
         var cell = (XLCell)sheet.Cell(address);
         cell.Formula = XLCellFormula.NormalA1(formula);
-        cell.Formula.MarkClean(((XLWorksheet)sheet).Workbook);
+        cell.Formula.MarkClean();
         var cellArea = new SheetArea(sheet.Name, new Area(cell.SheetPoint, cell.SheetPoint));
         tree.AddFormula(cellArea, cell.Formula, sheet.Workbook);
         return cell.Formula;
@@ -446,13 +446,12 @@ internal class DirtyPropagationTests
     private static async Task AssertDirty(IXLWorksheet sheet, params string[] dirtyRanges)
     {
         var ws = (XLWorksheet)sheet;
-        var wb = ws.Workbook;
         foreach (var dirtyRange in dirtyRanges)
         {
             foreach (var dirtyCell in ws.Cells(dirtyRange))
             {
                 await Assert.That(dirtyCell.Formula).IsNotNull();
-                await Assert.That(dirtyCell.Formula!.IsDirty(wb)).IsTrue();
+                await Assert.That(dirtyCell.Formula!.IsDirty()).IsTrue();
             }
         }
     }

--- a/XLibur/Excel/CalcEngine/CalcContext.cs
+++ b/XLibur/Excel/CalcEngine/CalcContext.cs
@@ -129,7 +129,7 @@ internal sealed class CalcContext : IStructuredReferenceScope
             // A formula-less cell may still be a spilled cell of a dynamic array. If its owning
             // anchor is dirty, the stored value is stale — force the anchor to evaluate first.
             if (CalcEngine.HasSpillOwners &&
-                CalcEngine.TryGetDirtySpillOwner(sheet.SheetId, point, Workbook, out var spillAnchor))
+                CalcEngine.TryGetDirtySpillOwner(sheet.SheetId, point, out var spillAnchor))
             {
                 if (RecalculateSheetId is not null && sheet.SheetId != RecalculateSheetId.Value)
                     return valueSlice.GetCellValue(point);
@@ -147,7 +147,7 @@ internal sealed class CalcContext : IStructuredReferenceScope
             return valueSlice.GetCellValue(point);
         }
 
-        if (formula.IsClean(Workbook))
+        if (formula.IsClean())
             return valueSlice.GetCellValue(point);
 
         // Used when only one sheet should be recalculated, leaving other sheets with their data.

--- a/XLibur/Excel/CalcEngine/DependencyTree.cs
+++ b/XLibur/Excel/CalcEngine/DependencyTree.cs
@@ -191,10 +191,32 @@ internal sealed class DependencyTree
     }
 
     /// <summary>
+    /// Monotonically increasing walk id, handed out one per <see cref="MarkDirty"/> call and
+    /// stamped onto each formula the walk enqueues (see <see cref="XLCellFormula.TryVisit"/>).
+    /// Distinguishing "enqueued by walk N" from "dirty for any other reason" this way costs one
+    /// field compare-and-set per node instead of a collection allocated per call; a HashSet-based
+    /// visited set was measured first and cost roughly 7x the allocation and 3x the wall time on
+    /// a bulk-edit workload with real dependents (see XLibur.Benchmarks.BulkEditDirtyWalkProfile,
+    /// "bulkedit" profile mode) before this replaced it.
+    /// </summary>
+    private long _walkGeneration;
+
+    /// <summary>
     /// Mark all formulas that depend (directly or transitively) on the area as dirty.
     /// </summary>
+    /// <remarks>
+    /// The walk tracks which formulas it has already enqueued itself, instead of asking whether a
+    /// formula is already dirty. A formula can be dirty for reasons that have nothing to do with
+    /// this walk — <see cref="XLCellFormula.MarkExplicitlyDirty"/> is also called by the public
+    /// <c>InvalidateFormula</c>, a sheet rename, a reference shift and a range move — and treating
+    /// "already dirty" as "already visited" stopped the walk at such a node and pruned everything
+    /// downstream of it. Marking stays idempotent only for a node this same walk has already
+    /// enqueued; a node dirtied by anything else is still traversed.
+    /// </remarks>
     internal void MarkDirty(SheetArea dirtyArea)
     {
+        var walkId = ++_walkGeneration;
+
         // BFS vs DFS: Although the longest chain found in the wild is 1000
         // formulas long, attacker could supply malicious excel with recursion
         // leading to stack overflow => use queue even with extra allocation cost.
@@ -208,8 +230,9 @@ internal sealed class DependencyTree
             {
                 foreach (var dependent in area.Dependents)
                 {
-                    // Ensure we don't end up in an infinite cycle
-                    if (dependent.IsExplicitlyDirty)
+                    // Ensure we don't end up in an infinite cycle: a formula already enqueued by
+                    // this walk is not enqueued again, regardless of its dirty state.
+                    if (!dependent.Formula.TryVisit(walkId))
                         continue;
 
                     dependent.MarkDirty();
@@ -328,8 +351,6 @@ internal sealed class DependencyTree
         /// The formula that is affected by changes in precedent area.
         /// </summary>
         internal XLCellFormula Formula { get; }
-
-        internal bool IsExplicitlyDirty => Formula.IsExplicitlyDirty;
 
         internal void MarkDirty() => Formula.MarkExplicitlyDirty();
     }

--- a/XLibur/Excel/CalcEngine/DependencyTree.cs
+++ b/XLibur/Excel/CalcEngine/DependencyTree.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using RBush;
@@ -222,6 +223,23 @@ internal sealed class DependencyTree
     private readonly Queue<SheetArea> _walkQueue = new();
 
     /// <summary>
+    /// Capacity above which <see cref="MarkDirty"/> releases the reused queue's backing array
+    /// instead of holding it for the tree's lifetime. One unusually wide walk on a long-lived
+    /// workbook would otherwise retain a slot per node it visited, along with a sheet-name
+    /// reference each, long after the small walks that follow could use them. The threshold is
+    /// well above any ordinary closure, so the common path never trims.
+    /// </summary>
+    private const int WalkQueueRetainedCapacity = 4096;
+
+    /// <summary>
+    /// Guards the assumption that <see cref="MarkDirty"/> is never re-entered, which is what makes
+    /// a single reused <see cref="_walkQueue"/> safe. Nothing the walk calls evaluates a formula or
+    /// re-enters the tree today; a future change that did would silently corrupt the outer walk's
+    /// queue rather than fail, so it is asserted in debug builds instead of left to comments.
+    /// </summary>
+    private bool _walkInProgress;
+
+    /// <summary>
     /// Mark all formulas that depend (directly or transitively) on the area as dirty.
     /// </summary>
     /// <remarks>
@@ -235,31 +253,49 @@ internal sealed class DependencyTree
     /// </remarks>
     internal void MarkDirty(SheetArea dirtyArea)
     {
+        Debug.Assert(!_walkInProgress, "MarkDirty is not re-entrant: it reuses a single walk queue.");
+        _walkInProgress = true;
+
         var walkId = Interlocked.Increment(ref _walkGeneration);
 
         // BFS vs DFS: Although the longest chain found in the wild is 1000
         // formulas long, attacker could supply malicious excel with recursion
         // leading to stack overflow => use queue even with extra allocation cost.
         var queue = _walkQueue;
-        queue.Clear();
-        queue.Enqueue(dirtyArea);
-        while (queue.Count > 0)
+        try
         {
-            var affectedArea = queue.Dequeue();
-            var sheetTree = _sheetTrees[affectedArea.Name];
-            foreach (var area in sheetTree.FindDependentsAreas(affectedArea.Area))
+            queue.Enqueue(dirtyArea);
+            while (queue.Count > 0)
             {
-                foreach (var dependent in area.Dependents)
+                var affectedArea = queue.Dequeue();
+                var sheetTree = _sheetTrees[affectedArea.Name];
+                foreach (var area in sheetTree.FindDependentsAreas(affectedArea.Area))
                 {
-                    // Ensure we don't end up in an infinite cycle: a formula already enqueued by
-                    // this walk is not enqueued again, regardless of its dirty state.
-                    if (!dependent.Formula.TryVisit(walkId))
-                        continue;
+                    foreach (var dependent in area.Dependents)
+                    {
+                        // Ensure we don't end up in an infinite cycle: a formula already enqueued
+                        // by this walk is not enqueued again, regardless of its dirty state.
+                        if (!dependent.Formula.TryVisit(walkId))
+                            continue;
 
-                    dependent.MarkDirty();
-                    queue.Enqueue(dependent.FormulaArea);
+                        dependent.MarkDirty();
+                        queue.Enqueue(dependent.FormulaArea);
+                    }
                 }
             }
+        }
+        finally
+        {
+            // Clear on the way out, not on the way in, so a walk that threw does not leave its
+            // entries — and their sheet-name references — reachable until the next MarkDirty.
+            queue.Clear();
+
+            // EnsureCapacity(0) grows nothing and returns the capacity, which Queue<T> does not
+            // otherwise expose on every target framework.
+            if (queue.EnsureCapacity(0) > WalkQueueRetainedCapacity)
+                queue.TrimExcess();
+
+            _walkInProgress = false;
         }
     }
 

--- a/XLibur/Excel/CalcEngine/DependencyTree.cs
+++ b/XLibur/Excel/CalcEngine/DependencyTree.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using RBush;
 using XLibur.Excel.Coordinates;
 
@@ -191,6 +192,7 @@ internal sealed class DependencyTree
     }
 
     /// <summary>
+    /// <para>
     /// Monotonically increasing walk id, handed out one per <see cref="MarkDirty"/> call and
     /// stamped onto each formula the walk enqueues (see <see cref="XLCellFormula.TryVisit"/>).
     /// Distinguishing "enqueued by walk N" from "dirty for any other reason" this way costs one
@@ -198,8 +200,18 @@ internal sealed class DependencyTree
     /// visited set was measured first and cost roughly 7x the allocation and 3x the wall time on
     /// a bulk-edit workload with real dependents (see XLibur.Benchmarks.BulkEditDirtyWalkProfile,
     /// "bulkedit" profile mode) before this replaced it.
+    /// </para>
+    /// <para>
+    /// The counter is process-wide rather than per-tree because the stamps outlive any single
+    /// tree: <c>XLCalcEngine.Purge</c> discards and rebuilds the whole dependency tree on a sheet
+    /// add or rename and on every row/column insert or delete, but the <see cref="XLCellFormula"/>
+    /// objects holding the stamps are not recreated. A per-tree counter would restart at zero and
+    /// hand a surviving formula an id it is already stamped with, so the first walk after each
+    /// rebuild would prune at its first hop. One interlocked increment per walk — not per node —
+    /// buys ids that are never reused for the life of the process.
+    /// </para>
     /// </summary>
-    private long _walkGeneration;
+    private static long _walkGeneration;
 
     /// <summary>
     /// Mark all formulas that depend (directly or transitively) on the area as dirty.
@@ -215,7 +227,7 @@ internal sealed class DependencyTree
     /// </remarks>
     internal void MarkDirty(SheetArea dirtyArea)
     {
-        var walkId = ++_walkGeneration;
+        var walkId = Interlocked.Increment(ref _walkGeneration);
 
         // BFS vs DFS: Although the longest chain found in the wild is 1000
         // formulas long, attacker could supply malicious excel with recursion

--- a/XLibur/Excel/CalcEngine/DependencyTree.cs
+++ b/XLibur/Excel/CalcEngine/DependencyTree.cs
@@ -214,6 +214,14 @@ internal sealed class DependencyTree
     private static long _walkGeneration;
 
     /// <summary>
+    /// Queue reused across <see cref="MarkDirty"/> calls. The walk never re-enters itself (it only
+    /// reads the sheet trees and sets a flag per formula), so one queue per tree is enough, and it
+    /// keeps a bulk edit from allocating and regrowing a queue per written cell. Like the rest of
+    /// the tree — and the workbook it belongs to — this assumes a single thread at a time.
+    /// </summary>
+    private readonly Queue<SheetArea> _walkQueue = new();
+
+    /// <summary>
     /// Mark all formulas that depend (directly or transitively) on the area as dirty.
     /// </summary>
     /// <remarks>
@@ -232,7 +240,8 @@ internal sealed class DependencyTree
         // BFS vs DFS: Although the longest chain found in the wild is 1000
         // formulas long, attacker could supply malicious excel with recursion
         // leading to stack overflow => use queue even with extra allocation cost.
-        var queue = new Queue<SheetArea>();
+        var queue = _walkQueue;
+        queue.Clear();
         queue.Enqueue(dirtyArea);
         while (queue.Count > 0)
         {

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -298,7 +298,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
                 }
             }
 
-            formula.MarkClean(sheet.Workbook);
+            formula.MarkClean();
             _needsDependencyTree = true;
             return true;
         }
@@ -364,13 +364,13 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
             if (cellFormula is null)
                 throw new InvalidOperationException($"Calculation chain contains a '${sheetInfo.Sheet.Name}'!${current.Point}, but the cell doesn't contain formula.");
 
-            if (cellFormula.IsClean(sheetInfo.Sheet.Workbook))
+            if (cellFormula.IsClean())
                 break;
 
             try
             {
                 ApplyFormula(cellFormula, current.Point, sheetInfo.Sheet, sheetInfo.ValueSlice, recalculateSheetId);
-                cellFormula.MarkClean(sheetInfo.Sheet.Workbook);
+                cellFormula.MarkClean();
                 break;
             }
             catch (GettingDataException ex)
@@ -599,11 +599,11 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
     /// is dirty, returns the anchor point so the caller can force the anchor to evaluate first.
     /// The anchor cell itself holds a formula, so it never reaches this lookup.
     /// </summary>
-    internal bool TryGetDirtySpillOwner(uint sheetId, Point point, XLWorkbook wb, out Point anchor)
+    internal bool TryGetDirtySpillOwner(uint sheetId, Point point, out Point anchor)
     {
         foreach (var footprint in _spillOwners)
         {
-            if (footprint.SheetId == sheetId && footprint.Range.Contains(point) && footprint.Owner.IsDirty(wb))
+            if (footprint.SheetId == sheetId && footprint.Range.Contains(point) && footprint.Owner.IsDirty())
             {
                 anchor = footprint.Range.FirstPoint;
                 return true;

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -718,7 +718,7 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
     /// <summary>
     /// Flag indicating that previously calculated cell value may be not valid anymore and has to be re-evaluated.
     /// </summary>
-    public bool NeedsRecalculation => Formula is not null && Formula.IsDirty(Worksheet.Workbook);
+    public bool NeedsRecalculation => Formula is not null && Formula.IsDirty();
 
     public XLCellValue CachedValue => SliceCellValue;
 

--- a/XLibur/Excel/Cells/XLCellFormula.cs
+++ b/XLibur/Excel/Cells/XLCellFormula.cs
@@ -45,6 +45,14 @@ internal sealed class XLCellFormula
     private long _evalEpoch;
 
     /// <summary>
+    /// The id of the last <see cref="DependencyTree.MarkDirty"/> walk that enqueued this formula,
+    /// or <c>0</c> if none has. Distinct from <see cref="_evalEpoch"/>: this tracks whether the
+    /// current walk has already visited the formula, regardless of whether it is dirty for some
+    /// other reason (see <see cref="TryVisit"/>).
+    /// </summary>
+    private long _visitedByWalk;
+
+    /// <summary>
     /// Lazily allocated holder for fields used only by Array/DataTable formulas
     /// (Range, Input1, Input2). Null for Normal formulas — saves ~32 bytes per
     /// instance on the dominant case where most cells in a workbook are non-array.
@@ -86,11 +94,19 @@ internal sealed class XLCellFormula
     internal void MarkExplicitlyDirty() => _evalEpoch = 0;
 
     /// <summary>
-    /// True if the formula is in the explicitly-dirty state (epoch <c>0</c>). Used
-    /// by dependency-tree cycle detection to avoid revisiting a formula already
-    /// flagged in the current MarkDirty walk.
+    /// Records that <paramref name="walkId"/>'s <see cref="DependencyTree.MarkDirty"/> walk has
+    /// enqueued this formula, so it can be skipped if the same walk reaches it again (a diamond
+    /// shape, or a cycle). Returns <c>false</c> when this walk already visited it; <c>true</c> the
+    /// first time, including when the formula is already dirty for an unrelated reason.
     /// </summary>
-    internal bool IsExplicitlyDirty => _evalEpoch == 0;
+    internal bool TryVisit(long walkId)
+    {
+        if (_visitedByWalk == walkId)
+            return false;
+
+        _visitedByWalk = walkId;
+        return true;
+    }
 
     /// <summary>
     /// Formula in A1 notation. Doesn't start with <c>=</c> sign.

--- a/XLibur/Excel/Cells/XLCellFormula.cs
+++ b/XLibur/Excel/Cells/XLCellFormula.cs
@@ -47,7 +47,8 @@ internal sealed class XLCellFormula
     /// The id of the last <see cref="DependencyTree.MarkDirty"/> walk that enqueued this formula,
     /// or <c>0</c> if none has. Distinct from <see cref="_isClean"/>: this tracks whether the
     /// current walk has already visited the formula, regardless of whether it is dirty for some
-    /// other reason (see <see cref="TryVisit"/>).
+    /// other reason (see <see cref="TryVisit"/>). Walk ids are process-wide and never reused, so
+    /// a stamp stays meaningful across a dependency tree rebuild, which this formula outlives.
     /// </summary>
     private long _visitedByWalk;
 

--- a/XLibur/Excel/Cells/XLCellFormula.cs
+++ b/XLibur/Excel/Cells/XLCellFormula.cs
@@ -38,15 +38,14 @@ internal sealed class XLCellFormula
     private FormulaFlags _flags;
 
     /// <summary>
-    /// Workbook edit epoch at which this formula was last successfully evaluated.
-    /// <c>0</c> means "never evaluated / explicitly dirty"; any positive value is
-    /// compared against <see cref="XLWorkbook.EditEpoch"/> to determine cleanliness.
+    /// Is this formula's cached value up to date? Defaults to <see langword="false"/> (dirty), so
+    /// a freshly constructed formula is dirty until it is evaluated.
     /// </summary>
-    private long _evalEpoch;
+    private bool _isClean;
 
     /// <summary>
     /// The id of the last <see cref="DependencyTree.MarkDirty"/> walk that enqueued this formula,
-    /// or <c>0</c> if none has. Distinct from <see cref="_evalEpoch"/>: this tracks whether the
+    /// or <c>0</c> if none has. Distinct from <see cref="_isClean"/>: this tracks whether the
     /// current walk has already visited the formula, regardless of whether it is dirty for some
     /// other reason (see <see cref="TryVisit"/>).
     /// </summary>
@@ -71,27 +70,25 @@ internal sealed class XLCellFormula
     private int _maxShiftableColumn;
 
     /// <summary>
-    /// Is this formula clean, i.e. evaluated against the workbook's current edit epoch?
+    /// Is this formula clean, i.e. is its cached value up to date?
     /// </summary>
-    internal bool IsClean(XLWorkbook wb) => _evalEpoch == wb.EditEpoch;
+    internal bool IsClean() => _isClean;
 
     /// <summary>
     /// Is this formula dirty, i.e. potentially out of date due to changes to precedent cells?
     /// </summary>
-    internal bool IsDirty(XLWorkbook wb) => _evalEpoch != wb.EditEpoch;
+    internal bool IsDirty() => !_isClean;
 
     /// <summary>
-    /// Mark this formula as freshly evaluated against the workbook's current edit epoch.
+    /// Mark this formula as freshly evaluated.
     /// </summary>
-    internal void MarkClean(XLWorkbook wb) => _evalEpoch = wb.EditEpoch;
+    internal void MarkClean() => _isClean = true;
 
     /// <summary>
-    /// Mark this formula as explicitly dirty regardless of the workbook epoch. Used
-    /// when the formula text itself changed (rename, shift) and dependency-tree based
-    /// dirty propagation needs to flag a single formula without bumping the workbook
-    /// epoch.
+    /// Mark this formula as dirty. Used when the formula text itself changed (rename, shift, a
+    /// range move) and dependency-tree based dirty propagation needs to flag a single formula.
     /// </summary>
-    internal void MarkExplicitlyDirty() => _evalEpoch = 0;
+    internal void MarkExplicitlyDirty() => _isClean = false;
 
     /// <summary>
     /// Records that <paramref name="walkId"/>'s <see cref="DependencyTree.MarkDirty"/> walk has

--- a/XLibur/Excel/IO/SheetDataWriter.cs
+++ b/XLibur/Excel/IO/SheetDataWriter.cs
@@ -120,15 +120,13 @@ internal static class SheetDataWriter
     /// </remarks>
     private static void EvaluateDirtyFormulas(XLWorksheet xlWorksheet)
     {
-        var workbook = xlWorksheet.Workbook;
-
         List<(Point Point, XLCellFormula Formula)>? dirty = null;
         using (var enumerator = xlWorksheet.Internals.CellsCollection.FormulaSlice.GetForwardEnumerator(Area.Full))
         {
             while (enumerator.MoveNext())
             {
                 var formula = enumerator.Current;
-                if (formula.IsDirty(workbook))
+                if (formula.IsDirty())
                     (dirty ??= []).Add((enumerator.Point, formula));
             }
         }
@@ -138,7 +136,7 @@ internal static class SheetDataWriter
 
         foreach (var (point, formula) in dirty)
         {
-            if (formula.IsDirty(workbook))
+            if (formula.IsDirty())
                 EvaluateFormulaForSave(xlWorksheet, formula, point);
         }
     }
@@ -315,7 +313,7 @@ internal static class SheetDataWriter
         var xlWorksheet = cellsCollection.Worksheet;
         var saveContext = ctx.SaveContext;
 
-        if (ctx.SaveOptions.EvaluateFormulasBeforeSaving && formula.IsDirty(xlWorksheet.Workbook))
+        if (ctx.SaveOptions.EvaluateFormulasBeforeSaving && formula.IsDirty())
             EvaluateFormulaForSave(xlWorksheet, formula, point);
 
         // Determine cell type from cached value (preserves type round-trip for formulas
@@ -377,7 +375,7 @@ internal static class SheetDataWriter
 
         // Write cached value if present and the formula isn't dirty. Spilled (non-master)
         // array-formula cells also fall through here so their cached values round-trip.
-        if (cachedValueType != XLDataType.Blank && formula.IsClean(xlWorksheet.Workbook))
+        if (cachedValueType != XLDataType.Blank && formula.IsClean())
         {
             WriteCachedFormulaValue(xml, cachedValue, ctx.Use1904DateSystem);
         }

--- a/XLibur/Excel/IO/WorksheetSheetDataReader.cs
+++ b/XLibur/Excel/IO/WorksheetSheetDataReader.cs
@@ -453,7 +453,7 @@ internal static class WorksheetSheetDataReader
         }
 
         if (formula is not null && (cellHasValue || cellWasSetWithEmptyValue))
-            formula.MarkClean(ws.Workbook);
+            formula.MarkClean();
 
         if (IsMainElement(reader, "is"))
             LoadInlineStringXml(reader, dataType, cellsCollection, cellAddress, ws);

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -1169,17 +1169,6 @@ public partial class XLWorkbook : IXLWorkbook
         get { return _calcEngine ??= new XLCalcEngine(CultureInfo.CurrentCulture); }
     }
 
-    /// <summary>
-    /// Monotonic counter incremented on every workbook edit (cell value change, formula
-    /// change, structural change). Formulas record the epoch at which they were last
-    /// evaluated; a formula is dirty when its recorded epoch differs from this one.
-    /// </summary>
-    /// <remarks>Starts at 1 so that the default <c>0</c> on <see cref="XLCellFormula"/>
-    /// always reads as "never evaluated".</remarks>
-    internal long EditEpoch { get; private set; } = 1;
-
-    internal void BumpEditEpoch() => EditEpoch++;
-
     public XLCellValue Evaluate(string expression)
     {
         return CalcEngine.EvaluateFormula(expression, this).ToCellValue();

--- a/docs/dirty-walk-bulk-edit.md
+++ b/docs/dirty-walk-bulk-edit.md
@@ -1,0 +1,176 @@
+# The dirty walk and the bulk-edit cost
+
+Notes on the performance side of spec 40 ("the dirty flag stops doubling as a visited
+marker"), written for review. The correctness story is in the CHANGELOG entry and the spec;
+this document covers only what the change did to bulk-edit cost, and why the expensive shape
+is expensive on purpose.
+
+Branch: `task/40`. Profile: `XLibur.Benchmarks`, `profile bulkedit`
+(`XLibur.Benchmarks/BulkEditDirtyWalkProfile.cs`).
+
+## The mechanism that changed
+
+`DependencyTree.MarkDirty` walks the dependency graph breadth-first from an edited area and
+marks every dependent formula dirty. It needs some "already visited" marker, or a cyclic
+graph loops forever.
+
+It used to use the formula's own dirty flag as that marker: if a dependent was already dirty,
+the walk skipped it and everything beneath it. Spec 40 replaced that with a walk id stamped
+on each formula it enqueues, so the walk tracks its own visits and a formula's dirty state no
+longer influences traversal.
+
+That fixed the correctness bug, and it also removed a saving that nobody had written down.
+
+## Before: the walk short-circuited *between* edits, not just within one
+
+The dirty flag is not reset until a formula is evaluated. So a formula left dirty by one
+`MarkDirty` call was still dirty when the next call arrived, and the next walk skipped it —
+along with everything downstream.
+
+For a sequence of edits with no read in between, that meant:
+
+```
+edit 1  ->  walk marks the whole downstream model dirty
+edit 2  ->  first dependent is already dirty -> stop after one hop
+edit 3  ->  stop after one hop
+...
+```
+
+Roughly `O(edits + model)` for the whole sequence, because only the first edit paid for the
+traversal.
+
+This was never sound. It is the same shortcut that produced the bug spec 40 exists to fix: a
+formula dirty for an unrelated reason (a prior `InvalidateFormula`, a rename's reference
+rewrite, a shift, a range move) was indistinguishable from one this walk had already visited,
+so a legitimate walk stopped at it and left real dependents stale. The cheapness and the bug
+were the same behaviour seen from two sides.
+
+## After: every edit walks the closure it actually affects
+
+Each `MarkDirty` gets a fresh walk id, so nothing carries over between calls. The same
+sequence is now `O(edits × closure)`.
+
+There is no cheap way to get the saving back correctly. A cross-call skip needs a marker that
+distinguishes *"this subtree is dirty because a walk reached it"* from *"dirty for some
+unrelated reason"* — a third state, e.g. a `_dirtiedByWalk` bit separate from `_isClean` and
+cleared by `MarkClean()`. The dirty flag alone cannot carry that distinction, which is the
+whole finding of the spec. Reintroducing a skip on the dirty flag would reintroduce the bug.
+
+## Measurements
+
+Three probes, same machine, back to back. **Allocation figures are exact and were
+byte-identical across repeated runs.** Times are single-shot Stopwatch numbers on a machine
+with roughly 40% run-to-run variance — treat them as order-of-magnitude, not as a benchmark
+result. Times below are medians of three runs.
+
+| Probe | `main` | fix, queue per walk | fix + pooled queue (HEAD) |
+|---|---|---|---|
+| 200k edits, 200×10 chains (real walk) | 821.5 MB / 1588 ms | 821.5 MB / 1531 ms | **791.0 MB** / 1848 ms |
+| 200k edits, no dependents (walk finds nothing) | 46.5 MB / 41 ms | 46.5 MB / 37 ms | **16.0 MB** / 46 ms |
+| 20k unsettled edits, 50-deep shared model | 12.6 MB / 48 ms | 224.4 MB / 184 ms | **221.3 MB** / 216 ms |
+
+Independently reproduced during code review on a throwaway worktree of `upstream/main` with
+the benchmark file copied across: 49 ms / 12.6 MB on `main` versus 191 ms / 221.3 MB on HEAD
+for the third probe. That agreement is the main reason to trust these numbers despite the
+timing noise.
+
+### Reading the table
+
+- **Row 1 and row 2 are the normal cases and did not regress.** Anything that reads or saves
+  between edits, and any edit to a cell nothing depends on, settles the graph and never hits
+  the cross-call skip. Row 2 actually improves by ~3x on allocation versus `main` — see
+  pooling below.
+- **Row 3 is the whole cost.** 17.6x allocation, ~4x time. This is the shape that used to be
+  free and now is not.
+- The row 3 allocation is **not** the walk queue. It is one RBush `FindDependentsAreas` search
+  list per hop: 20,000 edits × 50 hops = 1M searches instead of 20k. It scales linearly with
+  model depth, so a model deeper than 50 costs proportionally more.
+
+### The pooled queue
+
+`MarkDirty` allocated a fresh `Queue<SheetArea>` per call and regrew it as the walk went.
+Reusing one queue per tree (the walk is not re-entrant) removes that. It is a small win where
+the walk has real work to do and a large one where it does not — row 2 is the common case
+when bulk-writing plain data, and it drops to about a third of what `main` allocated.
+
+The queue is cleared on the way out rather than the way in, so a walk that threw does not
+leave its entries reachable, and its backing array is released when it grows past
+`WalkQueueRetainedCapacity` (4096) so one unusually wide walk does not retain a slot per
+visited node for the tree's lifetime.
+
+## The open question
+
+**Is row 3 acceptable to ship?** "Fill an input range beneath a model, then read or save once"
+is a real and common pattern, and 17.6x allocation on it is not nothing. The judgement made
+on the branch was: take correctness now, measure and document the cost rather than gamble on
+a soundness argument for a cross-call skip under time pressure. That is a product call, made
+autonomously, and it is the one most worth a second opinion.
+
+If it needs to be recovered, the `_dirtiedByWalk` third state described above is the shape of
+the answer, and the third probe in `BulkEditDirtyWalkProfile` is the guard that any such
+change has to move.
+
+---
+
+# Follow-ups
+
+Two items from the branch's "least sure of" list, recorded here so they are not lost.
+
+## 1. The interference matrix was organised by the wrong axis
+
+**What happened.** Spec 40's test plan is a matrix over *dirtiers* — `InvalidateFormula`,
+sheet rename, row/column insert, range move — each with a control. That matrix was built,
+went red before the fix and green after, and missed a regression the fix itself introduced.
+
+The regression: the walk-id counter initially lived on `DependencyTree`. But
+`XLCalcEngine.Purge` discards and rebuilds the whole tree on a sheet add or rename and on
+every row/column insert or delete, while the `XLCellFormula` objects carrying the walk stamps
+survive. A per-tree counter restarted at zero and handed surviving formulas an id they were
+already stamped with, so the first walk after every rebuild pruned at its first hop — the
+original defect, in a narrower window. Code review caught it; the matrix could not, because
+**every test in it builds its graph after the last purge**.
+
+Fixed in `b08faf00` (process-wide counter) with
+`Walk_ids_are_not_reused_after_the_dependency_tree_is_rebuilt` as cover.
+
+**Why it matters beyond this one bug.** The matrix enumerates *what dirties a formula*. The
+defect lived in *the lifetime of the structure doing the walking*. Those are different axes,
+and only one was enumerated. Worth asking, before the next spec in this area:
+
+- What else in the calc engine has state that outlives the object that issues it? The walk
+  stamp on `XLCellFormula` versus the tree is one instance; the calculation chain and the
+  spill footprints are worth the same question.
+- Which tests would survive a `Purge` in the middle of them? Almost none currently exercise
+  the rebuild boundary at all.
+- `Purge` is blunt enough to mask narrow bugs (it already masks two of the four dirtiers in
+  the matrix — see the note in `DirtyPropagationTests.cs`). Anything it masks is invisible to
+  public-API tests and needs a white-box test against the primitive.
+
+**Suggested action.** A small second matrix over *lifecycle events* (purge/rebuild, sheet
+add, sheet delete, workbook load) crossed with "does a stale marker survive this?", rather
+than more dirtiers.
+
+## 2. `WalkQueueRetainedCapacity` is a guess, not a measurement
+
+**What it is.** `DependencyTree.WalkQueueRetainedCapacity = 4096`. Above this, `MarkDirty`
+trims the pooled queue's backing array on exit instead of retaining it.
+
+**What is actually known.** Only that it is high enough not to fire on any of the three
+profile probes — verified, since allocations are byte-identical with and without the trim. So
+it is not currently costing anything.
+
+**What is not known.** Where real workbooks' dependency closures actually sit. The constant
+was chosen to sit "above any ordinary closure" on the strength of the existing comment in
+`MarkDirty` that the longest chain seen in the wild is ~1000 formulas — but a *closure* is not
+a *chain*, and a wide fan-out (one input feeding thousands of formulas) reaches 4096 far more
+easily than a deep one does. Both failure modes are mild:
+
+- Too high: a wide walk retains up to 4096 `SheetArea` slots plus a sheet-name reference each
+  for the tree's lifetime. Bounded and small.
+- Too low: frequent trims on a workload that repeatedly walks a large closure, giving back
+  the pooling win.
+
+**Suggested action.** Cheap to resolve — instrument peak queue depth across the existing
+benchmark corpus and the round-trip fidelity fixtures, then set the constant from the
+distribution rather than from a comment about chain length. Low priority; it is a tuning
+constant with no correctness role.

--- a/docs/specs/31-worksheet-element-writers.md
+++ b/docs/specs/31-worksheet-element-writers.md
@@ -3,8 +3,35 @@
 **Area:** Architecture · Refactor
 **Effort:** M–L (~1–1.5 weeks)
 **Dependencies:** **Spec 29 must land first** — it touches `SheetViewWriter.cs` and `ColumnWriter.cs`,
-which this spec rewrites wholesale. See Conflicts.
-**Status:** Proposed.
+which this spec rewrites wholesale. See Conflicts. **Spec 29 landed as #413 (`8d2acfc7`) on
+2026-08-27, so this is unblocked.**
+**Status:** Proposed — unblocked.
+
+> ## ⚠️ Read this before touching `SheetViewWriter`
+>
+> **`SplitRow` and `SplitColumn` carry two different units, and the unit lives in a sibling boolean
+> rather than in the type.** After D18 (PR #416, `37c986bb`) a pane is a freeze or an unfrozen split:
+> for a freeze the two numbers count frozen lines, for a split they are the split bar's position in
+> twentieths of a point. `FreezePanes` is what says which. `int SplitRow` carries no unit and its
+> public setter validates nothing.
+>
+> **This spec is the next set of hands on exactly that code**, and the agent that fixed D18 named it
+> as the most likely place the distinction gets broken next. Its guidance, carried here verbatim
+> because it will not be obvious from the code:
+>
+> - **Never read `SplitRow`/`SplitColumn` without `FreezePanes` in the same expression.** When
+>   auditing, grep for the three together.
+> - **Any new copy or clone path that takes the two numbers without the flag flips the units
+>   silently.** `XLSheetView`'s copy constructor is correct only because it happens to copy all three.
+> - **Any expression deriving a cell from `split + 1` is a landmine.** That is a cell address for a
+>   freeze and meaningless for a split; an unfrozen split anchors its `topLeftCell` at `A1`.
+>   `ScrollIntoView` was one instance of a pattern, not a one-off.
+> - **No round-trip test can catch a unit error here**, because the reader normalises both spellings
+>   into the same ints. Only byte-level assertions can — the same blindness spec 29 was written about.
+>
+> **The durable fix, deliberately not done by D18:** make the numbers and the mode inseparable — one
+> struct holding both values and the unit, so the values cannot be obtained without the unit. If this
+> spec is rewriting these writers anyway, that is the moment to do it.
 
 ## Goal
 

--- a/docs/specs/33-sheet-listener-seam.md
+++ b/docs/specs/33-sheet-listener-seam.md
@@ -1333,19 +1333,17 @@ task 7 is for**, and caching the listener list would have hidden it rather than 
   because making the shifter's area agree with `XLRangeInsertHelper`'s `insertedRange` changes output
   for existing documents. This spec pinned the defect instead, in
   `SheetEditAreaTests.The_listener_area_is_the_whole_range_extended_by_shift_minus_one`, so that
-  whoever fixed it had to change that test deliberately. **It has since been fixed on `fix/D15`**,
-  which re-pointed both pins rather than deleting them; `XLWorksheetRangeShifter` now trims the area
-  to the edited range's leading edge before extending it, and the delete branch turned out to need no
-  change at all.
+  whoever fixed it had to change that test deliberately. **It has since been fixed and merged as
+  PR #415** (`199b3e2b`), which re-pointed both pins rather than deleting them; `XLWorksheetRangeShifter` now trims
+  the area to the edited range's leading edge before extending it, and the delete branch turned out to
+  need no change at all.
 - **`XLRangeShiftHelper`'s `destroyedByShift` branch is untouched.** D16 is fixed for drawing anchors
   by moving them onto `GridShift`; an ordinary stored range still behaves the old way, because
   "destroyed" may well be the right answer for a range and that is a separate question.
-- **D17 is recorded, not decided.** It needs Excel.
-  *Update, 2026-08-27: since decided, on `fix/D17-D18`, and without Excel — the two fields were
-  collapsed onto one storage location, so the question of which of them should drive the file no
-  longer arises. The surviving value means move-and-size-with-cells, which is what `Anchor` had
-  always said. The sentence above records what spec 33 decided at the time and is left standing.
-  See `CHANGELOG.md`.*
+- **D17 is recorded, not decided.** It needs Excel. *(Decided on 2026-08-27 on [#416](https://github.com/XLibur/XLibur/pull/416) (`37c986bb`), and
+  without Excel: the two fields were collapsed onto one storage location, so the question of which
+  of them should drive the file no longer arises. The surviving value means move-and-size-with-cells,
+  which is what `Anchor` had always said. See `CHANGELOG.md`.)*
 - **No public API change.** `PublicAPI.Unshipped.txt` untouched.
 - **`briefs/` was not copied into the repo's `docs/specs`, and never should be.** The sync that keeps
   `docs/specs` in step with this folder copies the specs and the tasklists only. The `briefs/`
@@ -1369,16 +1367,23 @@ task 7 is for**, and caching the listener list would have hidden it rather than 
   the other was a defect.** The difference was documented on the type and repeated at both call
   sites. This is the trap task 3 step 2 warned about; the arithmetic was checked rather than assumed,
   and they differed whenever the edited range was more than one line tall on the shift axis — because
-  `Area` carried D15 and `CoverageArea` did not. **The D15 fix on `fix/D15` makes the two agree for
-  every reachable call**, so the two are now redundant rather than distinct; collapsing them was left
-  out of that fix to keep it minimal, and is the follow-on this bullet now points at.
+  `Area` carried D15 and `CoverageArea` did not. **The D15 fix on [#415](https://github.com/XLibur/XLibur/pull/415) (`199b3e2b`) makes the two
+  agree for every reachable call**, so the two are now redundant rather than distinct; collapsing them
+  was left out of that fix to keep it minimal, and is the follow-on this bullet now points at.
+- **⚠️ `SheetEdit.Shift`'s justification is gone, and the remark on it is now stale.** Task 3 step 1's
+  probe concluded that `Shift` is not recoverable from `Area`, and that premise is why the field
+  exists. **After the D15 fix it is recoverable, in both directions** — the areas now differ by the
+  shift on the shift axis and by nothing else. `Range` still earns its place; `Shift` does not, on
+  the old argument. Whoever collapses `Area` and `CoverageArea` should re-examine `Shift` in the same
+  pass rather than wave it through on a remark that no longer holds. Raised by the D15 agent's
+  retrospective, 2026-08-28.
 - **`GridShift` is the transform for anything holding a raw position.** A line index, a line count,
   or an area. It is `XLRangeShiftHelper` reduced to the integers, so a feature that adopts it moves
   the way a feature in the range repository already moves — by construction, not by coincidence.
 - **Three new defects to pick up:** D15 (hyperlink detaches from its cell for a multi-line edited
   range), D16 (a delete starting on a range's leading edge leaves its first address invalid), D17
   (a note's anchoring mode is stated twice and the two disagree). **D15 and D17 have since been
-  fixed**, on `fix/D15` and `fix/D17-D18`; D16 stands.
+  fixed**, on [#415](https://github.com/XLibur/XLibur/pull/415) (`199b3e2b`) and [#416](https://github.com/XLibur/XLibur/pull/416) (`37c986bb`); D16 stands.
 
 ### The code review found three defects in this spec's own new work
 

--- a/docs/specs/36-one-normalised-rectangle.md
+++ b/docs/specs/36-one-normalised-rectangle.md
@@ -1,0 +1,234 @@
+# Spec 36 — One rectangle, normalised once
+
+**Area:** Architecture · **Defect (5 shipped, 1 fatal)**
+**Effort:** M (~5–6 days)
+**Dependencies:** None hard. **Should land before spec 51** — the consolidation engines' only live
+divergence is the one this spec removes.
+**Status:** 🟩 Implemented on `task/36` (2026-08-30), unmerged — see Results. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+A user can name a range by its corners in either order. `ws.Range("B5:E2")` and
+`ws.Range(ws.Cell("C3"), ws.Cell("A1"))` are both accepted, and Excel accepts the same thing. What
+XLibur does with such a range then depends on which part of the library it reaches.
+
+Five failures, all shipped, all reachable from ordinary public API:
+
+1. **The workbook cannot be saved.** Adding a conditional format to a range whose rows are reversed
+   but whose columns are not makes `SaveAs` throw. Not a wrong result — a hard failure, on every
+   save, for the life of the workbook.
+2. **Data validation is silently lost.** A validation created on such a range survives in memory,
+   writes an invalid reference on save, and comes back as nothing after reload.
+3. **Styling silently does nothing.** Applying a style to such a range writes no cells, while
+   assigning a value to the *same* range writes all of them.
+4. **Counts go negative.** `RowCount()` and `ColumnCount()` return negative numbers while the range
+   address's spans and `Cells().Count()` are correct. A table built over such a range reports zero
+   fields, because it derives its field count from the negative one.
+5. **Consolidation drops the range.** `Consolidate()` returns an empty collection where it should
+   return the equivalent forward range.
+
+The user wrote nothing invalid. They wrote corners in an order the library accepts.
+
+## Solution
+
+The rectangle a range occupies is decided in exactly one place, and every part of the library that
+needs geometry asks that one place rather than working it out from the address.
+
+The range address keeps its current observable behaviour — it may still be reversed, and
+`IsNormalized` still reports so, because callers depend on that and tests pin it. What changes is
+that nothing downstream computes geometry from the address any more. Everything goes through the
+value-typed rectangle, and that rectangle is normalised per axis at the single point where an
+address becomes one.
+
+After this spec, a reversed range behaves exactly like the forward range with the same corners:
+it saves, it styles, it validates, it counts, it consolidates.
+
+## User Stories
+
+1. As a library consumer, I want a range written with its corners in either order to save without
+   throwing, so that my application does not fail on input a user could reasonably produce.
+2. As a library consumer, I want a conditional format on a reversed range to be written to the file,
+   so that the format I asked for reaches Excel.
+3. As a library consumer, I want a data validation on a reversed range to survive a save and reload,
+   so that reopening my own output does not lose rules.
+4. As a library consumer, I want applying a style to a reversed range to style its cells, so that
+   styling and value assignment agree about which cells a range contains.
+5. As a library consumer, I want `RowCount()` and `ColumnCount()` to return the same magnitudes as
+   the address's row and column spans, so that I can size a loop without checking the sign.
+6. As a library consumer, I want a table created over a reversed range to have the same fields as one
+   created over the equivalent forward range, so that table features work regardless of corner order.
+7. As a library consumer, I want `Consolidate()` to include a reversed range in its output, so that
+   merging ranges does not silently discard some of them.
+8. As a library consumer, I want a range's merged, sorted and cleared behaviour to be identical for
+   both corner orders, so that corner order is never load-bearing.
+9. As a library consumer, I want a reversed range used as a formula reference to evaluate rather than
+   throw, so that the calc engine accepts everything the object model accepts.
+10. As a library consumer, I want the quad-tree range index to find a reversed range, so that
+    intersection queries do not depend on how the range was constructed.
+11. As a library consumer, I want `IsNormalized` to keep reporting whether the address I built was
+    normalised, so that existing code that inspects it keeps working.
+12. As an XLibur maintainer, I want one place that decides what "reversed" means, so that fixing a
+    geometry bug fixes it everywhere at once.
+13. As an XLibur maintainer, I want new geometry consumers to be unable to receive a reversed
+    rectangle, so that the next consumer cannot reintroduce this defect class.
+14. As an XLibur maintainer, I want the defensive normalisation currently scattered through the cell
+    enumerator to become unnecessary, so that the code stops paying for an invariant twice.
+15. As an XLibur maintainer, I want the calc engine's reference type to stop throwing defensively on
+    un-normalised input, so that the exception it currently needs can be deleted.
+16. As an XLibur maintainer, I want a single property test that exercises every geometry consumer
+    against all four corner orders, so that a regression in any one of them fails a test.
+17. As a contributing agent, I want the geometry seam to be obvious from the type signatures, so that
+    I can tell where a rectangle is guaranteed normalised without reading every consumer.
+
+## Implementation Decisions
+
+**The seam is the value-typed rectangle.** The area type is the single conversion point from a range
+address to geometry, and it normalises per axis. This was chosen over normalising at range-address
+construction, which would be a higher seam but would change public behaviour and break the tests that
+deliberately pin an un-normalised address.
+
+**Normalisation is per axis, not per corner.** The current conversion tests whether *either* the row
+or the column is inverted and, if so, swaps *both* corners together. That is correct when both axes
+are inverted and wrong when only one is — it produces a rectangle with a negative width, which is the
+root of every defect above. The range address type already implements the correct per-axis rule,
+including the fixed-row and fixed-column bookkeeping that goes with it; that behaviour is the
+reference, and the conversion adopts it.
+
+**Consumers read the rectangle, not the address.** The row and column count methods on the range base
+derive from the rectangle rather than subtracting address corners. Style application, cell
+enumeration, consolidation, the quad-tree's coverage test, and reference writing all take the
+rectangle. No consumer computes a span from two addresses.
+
+**No public behaviour changes.** The range address remains constructible in reversed form and
+`IsNormalized` continues to report it. The counts change sign, which is a bug fix, not an API change:
+they become the magnitudes the spans already report.
+
+**The calc engine's reference precondition becomes redundant.** The reference type currently rejects
+un-normalised input with an exception. Once the rectangle is the only way geometry arrives, that
+precondition cannot fire; it is removed rather than left as unreachable code.
+
+**Ordering.** The conversion fix lands first, with the tests that would have caught each defect. The
+consumer migration follows, one consumer per commit, so a regression bisects to a single consumer.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test drives the public object model and asserts on observable
+results — a saved file, a reloaded workbook, a cell's style, a count, a collection's contents. It
+does not assert that a particular internal method normalised its argument. The defects are all
+observable from outside; the tests should be too.
+
+**The property test is the centrepiece.** For every rectangle, and for each of its four corner
+orderings, the following must agree: cell count, row and column counts, the address's spans, the set
+of cells returned by enumeration, the set of cells a style reaches, the result of consolidation, the
+ranges a data validation reports after a save and reload, and a table's field count. One test, one
+loop, covering all five defects and any sixth that has not been found yet.
+
+**Each defect also gets a named regression test**, because a property test that fails tells you
+something is wrong but not which thing. Five named tests, each reproducing the user-visible symptom:
+the save that throws, the validation that vanishes, the style that does nothing, the negative count,
+the dropped consolidation.
+
+**Prior art.** The range address tests already pin the per-axis normalisation rule in isolation,
+including the mixed-inversion cases; those assertions are correct and stay. What is missing is any
+test that runs the same cases through a *live* range, which is exactly the gap this spec closes. The
+area tests cover the value type's own behaviour and are the right place for the conversion fix.
+
+**Test seam.** Everything above is reachable through `IXLWorksheet`, `IXLRange`, `IXLRanges` and a
+save/reload round trip. No new test seam is introduced.
+
+## Out of Scope
+
+- Changing whether a reversed range address can be constructed, or the meaning of `IsNormalized`.
+- The two consolidation implementations. Collapsing them is spec 51; this spec fixes only the
+  normalisation input that makes them disagree today.
+- The quad-tree's allocation behaviour on whole-row ranges, and the promotion policy between its two
+  adapters. Recorded as backlog notes from the same review.
+- The range index's duplicate-detection asymmetry, which is latent and not reachable today.
+- Performance. The conversion is already on the hot path; the fix must not regress it, but this spec
+  claims no improvement.
+
+## Further Notes
+
+The suite currently pins the *existence* of un-normalised addresses without ever pinning what a live
+range built from one should do. That is the shape this review round found repeatedly: the fact has
+two implementations, and the test sits on one side of the seam rather than across it.
+
+The fatal case — the save that throws — is worth treating as the lead symptom when writing the
+commit history, because it is the one a user cannot work around. The other four are silent, which is
+worse in principle but easier to live with in practice.
+
+The five defects were reproduced against a scratch build before this spec was written; the observed
+values are recorded in the round-3 architecture review report.
+
+## Results
+
+**Implemented 2026-08-30 on `task/36` (worktree `xl-wt-36`), head `80a5b77a`, 15 commits, cut from
+`upstream/main` `37c986bb`. Not yet pushed or merged.** Full suite green on both TFMs: XLibur.Tests
+28,524 / 0 failed / 10 pre-existing skips; Report 962, Fonts.SixLabors 62, Fonts.SkiaSharp 74, all
+green. Cell-enumeration benchmark (`L6_CellsUsed`, 50K×10) 19.45 ms → 19.49 ms median-of-three, noise.
+
+**The mechanism was exactly as predicted.** `Area.FromRangeAddress` swapped both corners when either
+axis was inverted; per-axis `Min`/`Max` fixed it (`ef849725`). **What the spec did not anticipate:**
+three of the five defects (the `SaveAs` throw, the lost validation, the styling no-op) were fixed by
+that one commit alone, because those consumers already read `Area` and only inherited its bug. Only
+`RowCount`/`ColumnCount` and `Consolidate` computed from `FirstAddress`/`LastAddress` directly and
+needed their own migration. "Reference writing" needed **no** change — an attempt to write
+`Area.ToString()` directly changed a 1×1 array formula's `ref` from `B6:B6` to `B6` and broke two
+golden files; reverted.
+
+**Named regression tests** (`ReversedRangeGeometryTests.cs`, all seen red in `65acc1b4`):
+`SavingConditionalFormatOnRangeWithReversedRowsDoesNotThrow`,
+`DataValidationOnReversedRangeSurvivesSaveAndReload`, `StyleAppliedToReversedRangeStylesItsCells`,
+`RowCountAndColumnCountOnReversedRangeReturnPositiveMagnitudes`, `ConsolidateIncludesReversedRange`,
+plus `QuadTreeFindsReversedRangeThatSpansAQuadrantBoundary` and
+`FormulaReferencingReversedRangeEvaluates`. Property test
+`AllCornerOrdersAgreeAcrossEveryGeometryConsumer` (`ReversedRangePropertyTests.cs`) covers four
+shapes × four corner orders across count, enumeration, style, consolidation, validation, table
+fields, merge, table save and index intersection.
+
+**The in-branch review widened the scope, correctly.** `/code-review` plus the agent's own quad-tree
+probe found three more sites in the same class, all inside this spec's user stories 8 and 10, and
+they were fixed in a second pass with the seam decision unchanged (consumers read `Area`;
+`XLRangeAddress.Contains`/`Intersects` stay un-normalised): the range index's flat-list path
+(`16542066`), the quadrant's point-containment path — `ws.Range("B5:E2").Merge()` then writing B3 did
+not see the merge (`1d7e55ed`), relative `Range(int,int,int,int)`/`GetRange` anchoring plus the table
+part writer — a table over a reversed range threw on save (`73b8e5f0`), and
+`XLRangeColumn`/`XLRangeRow.CellCount` (`c2d085c6`). `Area.FromRangeAddress` gained a non-generic
+`XLRangeAddress` overload to keep the per-cell-write merge check allocation-free; both overloads share
+one `FromCorners`, so there is still one normalisation.
+
+**Deliberately not done — recorded as D24.** A grep of every `.FirstAddress`/`.LastAddress` read in
+`XLibur/` found ~12 further sites that compute geometry from raw corners: `XLTable` structural edits
+(totals/header toggles, `ExpandTableRows`), `XLTableRange` row bounds, `XLCellCopyHelper`
+(`CopyTo`/`AutoFill` origin and counts), `XLBorder` segment indexing, `XLRangeSetOperationsHelper`
+`Grow`/`Shrink`, `XLRangeCellsHelper` clamping, `XLRange` insert/copy/transpose destinations and
+`Row(int)`/`Column(int)`, and — uncertain — `XLAutoFilter`, `XLWorkbook_Load`, and the two formula
+shifters. Plus `XLHelper.IsValidRangeAddress` rejecting a reversed address, which makes a reversed
+data-validation list source get quoted as a literal. Not fixed here: the volume exceeded what could be
+verified red-first on this branch, and one earlier attempt had already regressed a golden file.
+
+**Third pass, 2026-08-30 evening, `80a5b77a` — driven by the owner in the agent's tab from a
+`/code-review` on the branch. Two findings applied, two scoped out.** (1) The first pass moved the
+*counts* onto the rectangle but left every member that addresses a cell *relative* to the range —
+`Cell(in XLAddress)`, `ColumnQuick`, `Row(int)`, `Column(int)`, `FirstCell`/`LastCell`, `Rows()`/
+`Columns()`, and the four `First`/`LastRow`/`ColumnUsed` probes — anchored on `RangeAddress.FirstAddress`.
+With the two disagreeing, `LastCell()` on `B5:E2` returned `E8` and `Rows()` yielded `B5:E5..B8:E8`,
+three rows outside the range, so a style or value written through `Rows()` landed on unrelated
+cells. All now measure from the rectangle. (2) **A regression the branch itself introduced:** routing
+the counts through `SheetRange` made `RowCount()`/`ColumnCount()` throw `InvalidOperationException`
+for a `#REF!` range (both corners `InvalidAddress`, which `XLRangeShiftHelper` produces when a delete
+swallows a range whole) — and the save and copy paths call them on stored ranges. Fixed by
+`SheetRangeUnchecked`, the same per-axis normalisation without the validity guard. Six red-first
+tests in `ReversedRangeGeometryTests.cs`; suite green on net10.0 across all four projects, and on net8.0
+(14,268 / 0 failed, run by the orchestrator). **Lead for D24 / whoever touches `Reference.cs`:** its
+`List<XLRangeAddress>` ctor doc still promises normalised areas and `RangeOp.ExpandBoundingBox`
+still says "Areas are normalized", with no guard behind either now that the precondition is gone.
+
+**Least sure of (agent's own list).** The `CellCount` fix was not independently cycled red — it was
+reasoned by exact analogy to the verified `RowCount` fix. The audit's classification of the formula
+shifters and `XLAutoFilter`/`XLWorkbook_Load` is unverified.
+
+**What the next consumer inherits.** `Area.FromRangeAddress` is the one place normalisation happens;
+any new consumer reads `Area`/`SheetRange` bounds, never `RangeAddress.FirstAddress`/`LastAddress`.
+Spec 51 now receives normalised input to both consolidation engines. Spec 50 (`Intersection`) should
+build on `Area`. D24 is the follow-on spec.

--- a/docs/specs/37-scalar-argument-reduction.md
+++ b/docs/specs/37-scalar-argument-reduction.md
@@ -1,0 +1,221 @@
+# Spec 37 — One way to reduce an argument to a scalar
+
+**Area:** Architecture · **Defect (22 functions unusable with references)**
+**Effort:** M (~4–5 days)
+**Dependencies:** None hard. File-disjoint from spec 30, which owns the function-definition array
+path. **Must land before spec 32** — 32 rewrites 411 registrations across the same function families
+and would collide head-on.
+**Status:** 🟩 Implemented on `task/37` (2026-08-30), unmerged — see Results. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+Every dynamic-array function returns `#VALUE!` when one of its scalar parameters is a cell reference
+instead of a literal. So do the four regression functions.
+
+```
+=SEQUENCE(A1)               ->  #VALUE!     Excel: 1;2;3
+=SEQUENCE(3,B1)             ->  #VALUE!     Excel: a 3x2 grid
+=TAKE(A1:A3,B1)             ->  #VALUE!     Excel: 3;1
+=SORT(A1:A3,B1)             ->  #VALUE!
+=UNIQUE(data,B1)            ->  #VALUE!
+=XLOOKUP(k,a,b,,C1)         ->  #VALUE!
+=LINEST(A1:A4,B1:B4,D1)     ->  #VALUE!     Excel: 2
+=TREND(A1:A4,B1:B4,D2,D1)   ->  #VALUE!     Excel: 10
+```
+
+The same functions work when the argument is written as a literal — `=SEQUENCE(3)`, `=TAKE(A1:A3,2)`,
+`=LINEST(A1:A4,B1:B4,TRUE)`. Putting the count, the index, the sort order or the flag in a cell and
+referring to it is the ordinary way people write these formulas, and it is the way that fails.
+
+Eighteen dynamic-array functions and four regression functions are affected. The feature ships
+unusable for anything but hard-coded arguments.
+
+## Solution
+
+There is one module that answers "give me this argument as a single scalar value, or the error". It
+knows every way an argument can arrive — already a scalar, a one-cell array, a single-cell reference,
+a multi-cell reference that needs implicit intersection, a multi-area reference that cannot be
+reduced — and it returns the same answer for all of them regardless of which function asked.
+
+Every function that needs a scalar argument calls it. None of them re-derives the reduction.
+
+## User Stories
+
+1. As a spreadsheet author, I want `=SEQUENCE(A1)` to produce a sequence of the length held in A1, so
+   that I can change the size of a spill by editing a cell.
+2. As a spreadsheet author, I want `=SEQUENCE(3,B1)` to use B1 as the column count, so that both
+   dimensions can be driven from cells.
+3. As a spreadsheet author, I want `=TAKE(range, B1)` and `=DROP(range, B1)` to take a count from a
+   cell, so that I can build a parameterised extract.
+4. As a spreadsheet author, I want `=SORT(range, C1)` to take its sort index from a cell, so that a
+   user of my sheet can change the sort column without editing a formula.
+5. As a spreadsheet author, I want `=SORTBY`, `=FILTER`, `=UNIQUE`, `=CHOOSECOLS`, `=CHOOSEROWS`,
+   `=EXPAND`, `=TOCOL`, `=TOROW`, `=WRAPCOLS`, `=WRAPROWS`, `=HSTACK` and `=VSTACK` to accept cell
+   references in every scalar slot, so that the whole dynamic-array family behaves consistently.
+6. As a spreadsheet author, I want `=XLOOKUP` and `=XMATCH` to take their match mode and search mode
+   from cells, so that lookup behaviour can be configured on the sheet.
+7. As a spreadsheet author, I want `=TEXTSPLIT` to accept a reference for its delimiter, so that the
+   delimiter can be edited without touching the formula.
+8. As a spreadsheet author, I want `=LINEST`, `=LOGEST`, `=TREND` and `=GROWTH` to accept a reference
+   for their constant and statistics flags, so that regression options can be driven from cells.
+9. As a spreadsheet author, I want a scalar argument that refers to a whole column to resolve by
+   implicit intersection the way Excel does, so that formulas copied from Excel behave the same.
+10. As a spreadsheet author, I want an implicit intersection that finds no cell to give me Excel's
+    error rather than a different one, so that I can diagnose it using what I already know.
+11. As a spreadsheet author, I want a multi-area reference in a scalar slot to give `#VALUE!`, so that
+    a genuinely unreducible argument is reported rather than guessed at.
+12. As a spreadsheet author, I want a blank cell in a scalar slot to behave as Excel treats a blank,
+    so that empty inputs do not need special handling in my formulas.
+13. As a spreadsheet author, I want a text function given an unreducible argument to return an error
+    rather than throw, so that one bad cell does not abort a whole calculation.
+14. As an XLibur maintainer, I want the reduction rule to exist once, so that a change to implicit
+    intersection semantics is one edit rather than eight.
+15. As an XLibur maintainer, I want a newly registered range-accepting function to get correct
+    reference handling without writing any reduction code, so that the next function cannot ship with
+    this defect.
+16. As an XLibur maintainer, I want the dead reduction branches deleted, so that reading a function
+    family does not suggest a code path that never executes.
+17. As an XLibur maintainer, I want the value model to stop handing callers a type they cannot use, so
+    that the type system enforces the step callers currently have to remember.
+18. As a contributing agent, I want one documented answer to "how do I get a scalar out of an
+    argument", so that I do not copy whichever nearby helper I happen to find.
+
+## Implementation Decisions
+
+**The seam is on the value model.** All eight existing copies already hold the same argument type, so
+the reduction becomes a member of that type. No new abstraction is introduced and no call site has to
+learn a new concept — it swaps one call for another.
+
+**The reduction is an ordered ladder, stated once:**
+
+1. already a scalar — return it;
+2. an array — take its first element;
+3. a reference to a single cell — read that cell;
+4. a reference to more than one cell — apply implicit intersection against the calling formula's
+   address, then read the resulting cell;
+5. a multi-area reference, or an intersection that selects nothing — return the appropriate error.
+
+Only one of the eight existing copies implements all five steps. Two implement step 1 alone. Five
+implement steps 1–3 and then attempt step 4 through an idiom that can never succeed.
+
+**The root cause is an interface, not a typo.** The existing implicit-intersection member returns a
+*reference* for the single-cell case, and the scalar accessor its callers then use rejects references
+by definition. Every caller is therefore obliged to remember an extra unwrap that nothing in the
+signature asks for, and seven of eight forgot. The fix is not to add the unwrap seven times: the
+intersection member stops being part of the public reduction path — it becomes an implementation
+detail of the new one.
+
+**Existing correct behaviour is the reference.** The calc engine's own cell-content reduction already
+implements the full ladder correctly and has done so all along. Its behaviour is what the new module
+must reproduce; it then becomes a caller like the others.
+
+**The function-definition intersection pass stays.** Arguments to functions registered as scalar are
+already reduced before the function body runs, which is why five of the copies escape the defect
+today. That pass is not removed by this spec — it is why the dead branches are dead. Removing it is
+spec 30's and spec 32's territory.
+
+**No public API change.** Everything here is internal to the calc engine. The observable change is
+that formulas which returned `#VALUE!` now return values.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test is a formula and its expected result. It sets cell
+values, sets a formula, reads the answer, and compares against what Excel produces. It does not
+assert that a particular reduction helper was called, and it does not test the reduction module in
+isolation from the functions that use it — the defect lived precisely in the gap between a correct
+rule and the functions that failed to apply it.
+
+**The centrepiece is a matrix over argument shapes.** For each function that takes a scalar
+parameter, and for each of six input shapes in that parameter — a literal, a single-cell reference, a
+one-cell array, a row range requiring implicit intersection, a column range requiring implicit
+intersection, and a multi-area reference — assert the result. That is the test the current shape
+cannot express, because there is no single place where the rule lives.
+
+**Every affected function gets at least one reference-argument case.** The suite currently passes
+literals in every scalar slot of every dynamic-array function, which is exactly why 22 broken
+functions shipped. A test per function, using a reference, is the minimum that would have caught it.
+
+**Excel is the oracle, not the current implementation.** Expected values are Excel's answers,
+recorded in the test. Where XLibur's answer differs and the difference is deliberate, the test says
+so.
+
+**Prior art.** The dynamic-array function tests and the regression function tests are the right homes;
+they already build a worksheet, set a formula and assert a spilled result. The change is to their
+inputs, not their shape.
+
+**Test seam.** Setting a formula through `IXLCell` and reading the result. Highest available; no new
+seam.
+
+## Out of Scope
+
+- The function registration overloads and the argument encoding they carry. That is spec 32, which
+  this spec must precede.
+- Per-element array application inside the function definition — spec 30.
+- Excel's 2016-versus-365 difference in implicit intersection semantics. This spec reproduces one
+  behaviour consistently; choosing which is a separate question, and the new module is where that
+  choice would later be made.
+- Adding functions. This spec makes existing functions work with existing argument kinds.
+- The text-function throw noted in spec 30, which has its own owner.
+
+## Further Notes
+
+This is the widest live defect the round-3 review found, and the cheapest to characterise: eight
+implementations of one rule, five of them containing a branch that provably never executes.
+
+The test gap is the interesting part. Nothing about the suite is careless — there are tests for every
+one of these functions. They all pass literals, because a literal is the natural thing to write when
+you are demonstrating what a function does. The defect lives in the difference between demonstrating
+a function and using one.
+
+All the wrong answers above were reproduced against a scratch build before this spec was written.
+
+## Results
+
+**Implemented 2026-08-30 on `task/37` (worktree `xl-wt-37`), head `42bf46f8`,
+13 commits, cut from `upstream/main` `37c986bb`. Not yet pushed or merged.** Full suite green on
+both TFMs: 14,285 total, 14,280 passed, 5 pre-existing skips, per TFM.
+
+**What the spec predicted that turned out wrong.**
+
+- **22 affected functions is 20.** `HSTACK` and `VSTACK` take no scalar parameter at all. The live
+  set is 16 in `DynamicArray.cs`, `TEXTSPLIT`, and the four regression functions.
+  `CHOOSEROWS`/`CHOOSECOLS` already worked — their index goes through `TryPickCollectionArray`,
+  which happens to handle a single-cell reference — but they got reference-argument tests anyway.
+- **"Five copies contain a branch that provably never executes" is right about the idiom, wrong about
+  the consequence.** Four of those five (`DateAndTime.ToScalar`, `SampleStatistics.TryGetScalarNumber`,
+  `Financial.TryScalarNumber`, `MathTrig.TryGetAggregateArgument`) were already correct for a
+  single-cell reference through a `TryGetSingleCellValue` step the spec's description elides, and
+  were *unreachable* dead code besides — every caller is registered `AllowRange.Except`/`Only`, so the
+  function-definition intersection pass pre-reduces the argument first. The live bugs were
+  `DynamicArray.TryScalarArg` and `Text.TryOptionalInt` (step 1 only) and `Regression.TryGetBoolean`
+  (no step 3). The eighth copy, `XLCalcEngine.ToCellContentValue`, is the full ladder, as stated.
+- **The fix itself introduced a regression the suite could not see**: `SORTBY`'s order-vs-`by_array`
+  disambiguation broke for a one-row sort once a single-cell reference became a valid order. Found by
+  the in-branch `/code-review`, pinned by `SortBy_TwoSingleCellByArraysStayByArraysWhenTheSortedRangeIsOneRow`,
+  fixed in `389972b5`. Same lesson as round 2: run the review inside the task.
+
+**What was done.** `AnyValue.TryReduceToScalar(ctx, out scalar, out error)` is the one ladder
+(scalar → array[0] → single-cell ref → implicit intersection against the calling cell → error).
+`ToCellContentValue` became a caller. All eight copies plus four more found by the same sweep now
+delegate to it. Semantics reproduced: the pre-existing Excel-2016-style single implicit intersection
+via `Reference.ImplicitIntersection(IXLAddress)`; no 365 `@`/spill semantics introduced. That choice
+lives only in `AnyValue.TryReduceToScalar`.
+
+**Deliberately not done.** The function-definition intersection pass (`FunctionDefinition.IntersectArguments`)
+and `AnyValue.ImplicitIntersection` that backs it are untouched, per the brief — spec 30/32 territory.
+The shape matrix is full six-shape for `SEQUENCE`, partial for `TEXTSPLIT` and `LINEST`, and one
+reference case each for the other 17 — a scope call disclosed in `c760d375`'s body.
+
+**Found, not fixed — recorded as D23.** A defined name's own formula is evaluated with
+`FormulaAddress: null`, so any function inside it that needs a real implicit intersection throws
+`MissingContextException` instead of returning `#VALUE!`. Pre-existing; spec 37 narrows one
+`TEXTSPLIT` path onto it slightly.
+
+**Least sure of (agent's own list).** The `SORTBY` fallback order (try `by_array` shape first, then
+order) is checked against two constructed cases, not against Excel across pair counts; the eight-copy
+census came from targeted greps, not an end-to-end read of `Functions/`.
+
+**What the next consumer inherits.** Spec 32 rewrites registrations across these families and must
+rebase onto this branch; every scalar slot now has a reference-argument test that will notice if a
+rewrite regresses it. Spec 30's per-element array application should call `TryReduceToScalar` rather
+than reintroduce a ladder.

--- a/docs/specs/38-sheet-view-state.md
+++ b/docs/specs/38-sheet-view-state.md
@@ -1,0 +1,199 @@
+# Spec 38 — Sheet view state gets one module
+
+**Area:** Architecture · **Defect (4 shipped)**
+**Effort:** M (~4–5 days)
+**Dependencies:** None. Checked against specs 29 and 31 — neither claims these properties.
+**Status:** 🟩 Implemented on `task/38` (2026-08-30), unmerged — see Results. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+How a worksheet looks when it is opened — gridlines, headers, zoom, freeze panes, the view mode, the
+tab colour — is described in six different places in the library, each written out by hand. Four of
+the six have drifted from the other two.
+
+What a user sees:
+
+- **Copying a worksheet loses its appearance.** The copy comes back with gridlines on when the
+  original had them off, with the default zoom rather than the original's, and in Normal view rather
+  than the original's view mode. Copying between workbooks is worse: the copy picks up the *target*
+  workbook's defaults rather than the source sheet's settings.
+- **The view mode is lost on every round trip.** Open a workbook that Excel saved in Page Layout or
+  Page Break Preview, save it, reopen it — it is in Normal view. The attribute is written on save and
+  never read on load.
+- **Zoom survives a save but not a copy.** The two paths disagree about the same four settings.
+
+None of this is exotic. Copying a sheet and re-saving a file are two of the most common things anyone
+does with the library.
+
+## Solution
+
+The view state of a worksheet becomes one module that owns the whole property list — the boolean
+display flags, the four zoom scales, the view mode, the tab colour, and the pane and split settings it
+already holds.
+
+Loading, saving, copying and seeding a new sheet's defaults each become one operation against that
+module rather than a hand-written list of properties. The properties stay exactly where they are on
+the public worksheet interface and delegate inward, so nothing a consumer can see changes shape.
+
+## User Stories
+
+1. As a library consumer, I want a copied worksheet to keep its gridline setting, so that the copy
+   looks like the sheet I copied.
+2. As a library consumer, I want a copied worksheet to keep its row and column header setting, so that
+   a header-less sheet stays header-less.
+3. As a library consumer, I want a copied worksheet to keep its zoom level, so that the copy opens at
+   the magnification I chose.
+4. As a library consumer, I want a copied worksheet to keep its view mode, so that a sheet designed in
+   Page Layout is still in Page Layout after copying.
+5. As a library consumer, I want a copied worksheet to keep its tab colour, so that colour-coded
+   sheets stay colour-coded.
+6. As a library consumer, I want a worksheet copied into a *different* workbook to keep its own
+   appearance rather than adopting the destination's defaults, so that cross-workbook copying is
+   predictable.
+7. As a library consumer, I want a workbook saved in Page Layout view to reopen in Page Layout view,
+   so that re-saving a file does not change how it presents.
+8. As a library consumer, I want a workbook saved in Page Break Preview to reopen the same way, so
+   that a print-layout session survives a round trip through my application.
+9. As a library consumer, I want all four zoom scales to survive both a save and a copy, so that the
+   two operations agree.
+10. As a library consumer, I want the formula-display, zero-display, outline-symbol, whitespace and
+    tab-selected settings to survive a round trip, so that no display setting is silently dropped.
+11. As a library consumer, I want freeze panes and splits to keep behaving exactly as they do today,
+    so that this change is invisible where the library is already correct.
+12. As a library consumer, I want every view property to remain on `IXLWorksheet` with the same name
+    and type, so that my code does not have to change.
+13. As an XLibur maintainer, I want adding a view property to be one edit rather than six, so that the
+    next property cannot ship half-wired.
+14. As an XLibur maintainer, I want each property's OOXML default polarity stated next to the property
+    it belongs to, so that the omit-when-default rule cannot be got wrong in one place and right in
+    another.
+15. As an XLibur maintainer, I want a test that iterates the property list, so that a property added
+    later is covered without anyone remembering to write a test for it.
+16. As an XLibur maintainer, I want copy fidelity and round-trip fidelity to be verified by the same
+    mechanism, so that the two cannot diverge again.
+17. As a contributing agent, I want one obvious place to look for "what is a sheet's view state", so
+    that I do not have to find six lists and diff them.
+
+## Implementation Decisions
+
+**The seam is the existing sheet-view type, promoted.** It already owns panes, splits, the top-left
+address and the zoom scales. It absorbs the eight boolean display flags and the tab colour, which
+currently live as fields directly on the worksheet. This was preferred to a new type: the seam already
+exists, it is already the thing the writer reads from for half these properties, and promoting it
+keeps the number of seams at one.
+
+**The property list becomes data.** The module carries the list — name, accessor, OOXML default — and
+the four operations are driven from it rather than each restating it. This is the same shape spec 39
+proposes for the pivot definition and, like that one, it is what makes an enumerating test possible.
+
+**Copying becomes a single operation on the module.** The worksheet's copy currently lists seven
+things and stops; the sheet-view type's own copy constructor lists five and resets the rest by
+delegating to the default constructor. Both are replaced by one copy of the view state.
+
+**Default seeding is a distinct operation from copying, and stays one.** A new sheet takes workbook
+defaults; a copied sheet takes the source's values. Today those two paths are conflated because the
+copy silently falls through to the constructor's seeding. They become explicit and separate.
+
+**The unread view-mode attribute gets a reader.** The enum mapping for it already exists in both
+directions; only the load-side call is missing. Wiring it is a one-line consequence of the module
+owning the list, and it removes the library's only currently-unused enum mapping in that area.
+
+**No public API change.** Every property keeps its name, type and location on the public worksheet
+interface and delegates. `PublicAPI.Shipped.txt` is untouched. This was a deliberate constraint on the
+design, not an outcome.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test sets view properties through the public worksheet
+interface, performs an observable operation — save and reload, or copy — and asserts the properties
+through the same interface. It does not inspect the module's internals and does not assert on the
+emitted XML except where the omit-when-default rule is the thing under test.
+
+**The centrepiece is a property-enumerating test, run twice.** Set every view property to a
+non-default value; then (a) save and reload, and (b) copy the sheet — and in both cases assert that
+every property came back. Because the module owns the list, the test can iterate it, so a property
+added later is covered without a new test. This is the test the current shape cannot express, and its
+absence is why four of six enumerations drifted.
+
+**Named regression tests for the four defects**, so a failure identifies itself: gridlines lost on
+copy, zoom lost on copy, view mode lost on round trip, cross-workbook copy adopting the wrong
+defaults.
+
+**One byte-level assertion for default polarity.** Several of these attributes are omitted when they
+hold their OOXML default, and two are written with inverted polarity. A reload-based test cannot see
+a polarity error because the reader inverts it back. One test that reads the emitted attributes
+covers this, in the style of the existing write-path agreement tests.
+
+**Prior art.** The worksheet element round-trip tests are organised one case per worksheet element,
+which is why the sheet-view element has a single assertion covering one property and twelve others
+are invisible to it. The sheet-view copy test asserts exactly one property — the one the copy
+constructor happens to handle. Both tests are correct as far as they go; this spec makes them go
+further.
+
+**Test seam.** `IXLWorksheet`, worksheet copy, and a save/reload round trip. No new seam.
+
+## Out of Scope
+
+- Panes and splits, beyond keeping their current behaviour. Spec 29 resolved the frozen-pane
+  divergence between the two write paths and that work stands.
+- The other twelve responsibility clusters on the worksheet type. The review's conclusion was that
+  most of the worksheet's width is the public interface and cannot move; view state is the one cluster
+  that both can move and has defects.
+- Print setup and page setup, which are a separate concern with their own module.
+- The streaming write path's view handling, except where it shares the resolver work spec 29 already
+  established.
+
+## Further Notes
+
+The worksheet type is the repository's single hottest file, and the last several commits touching it
+are all structural-edit propagation work. It is not an undifferentiated blob: the clusters that can be
+extracted have been extracted, one at a time — the outline tracker, the range shifter, the data
+inserter, the merged-range and drawing-anchor listeners. View state is the conspicuous cluster that
+has never had that treatment, and it is where the defects are. That is the argument for doing this
+one next rather than any other part of the file.
+
+The four defects were confirmed by reading both sides of each divergence; the unread view attribute
+was verified directly against the reader and writer while writing this spec.
+
+## Results
+
+**Implemented 2026-08-30 on `task/38` (worktree `xl-wt-38`), head `ba9af10d`, 11 commits, cut from
+`upstream/main` `37c986bb`. Not yet pushed or merged.** Full suite green on both TFMs: 28,516 total,
+0 failed, 10 pre-existing skips. `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` untouched.
+
+**Named regression tests** (`XLSheetViewTests.cs`, all seen red at `286920d0`): `Copy_loses_gridlines`,
+`Copy_loses_zoom`, `ViewMode_lost_on_round_trip`,
+`CrossWorkbookCopy_keeps_source_appearance_not_targets_defaults`. Enumerating tests:
+`AllViewProperties_survive_save_and_reload`, `AllViewProperties_survive_copy`, plus a themed
+`TabColor` cross-workbook copy case. Byte-level: `SheetViewDefaultPolarityTests` (fresh-save and
+load-mutate-resave, both directions), proven non-vacuous by inverting one writer condition and
+watching all four fail.
+
+**What the spec predicted that turned out wrong.** "Two attributes are written with inverted
+polarity today" — **disproved.** All nine booleans were probed against the ECMA-376 `CT_SheetView`
+defaults by reading the emitted bytes, left at default and flipped, fresh and after a
+load-mutate-resave cycle. All nine were already correct. The polarity test now pins that; no writer
+change was made for it. The four copy/round-trip defects were real and are fixed.
+
+**What was done.** `sheetView/@view` is now read on load (`6e408f0f`, the one-line fix the spec
+predicted). `XLSheetView` absorbed the nine display flags and the tab colour (`e45286e6`); the load
+and DOM-save paths read and write them straight from the module (`be8c3d2a`, `7f5657d4`). Copy and
+default-seeding are now **two explicit constructors** on `XLSheetView` — bare-default,
+workbook-seed, copy — each listing every non-pane property once. The property list exists as typed
+data: `XLViewProperty.All` (`XLibur/Excel/XLViewProperty.cs`, 15 entries — property, attribute,
+default, polarity) drives both enumerating tests and doubles as the readable table.
+
+**Deliberately not done, and why.** The four production consumers do **not** iterate
+`XLViewProperty.All` at runtime — only the tests do. A reflection- or delegate-driven reader/writer
+would have touched `WorksheetPartWriter`/`WorksheetElementReader` structurally, in the repo's hottest
+file, for marginal benefit over two symmetric constructors that an enumerating test already polices.
+Adding a property is one field, one line in each of three constructors, one `XLViewProperty.All`
+entry — and the test catches a missed one. The streaming write path emits none of these attributes
+(panes only, via `XLPaneSettings`), so `WritePathAgreementTests` is unchanged and has nothing new to
+cover; whether streaming *should* emit them is spec 31's §5.1 question.
+
+**Defects found outside the spec:** none.
+
+**What the next consumer inherits.** Spec 31 rebases onto a `SheetViewWriter` whose flag emission
+reads from `XLSheetView`, and inherits `SheetViewDefaultPolarityTests` as a byte gate for the
+sheet-view element. Spec 29's pane resolver is untouched.

--- a/docs/specs/39-pivot-definition-attribute-table.md
+++ b/docs/specs/39-pivot-definition-attribute-table.md
@@ -1,0 +1,243 @@
+# Spec 39 — One attribute table for the pivot table definition
+
+**Area:** Architecture · **Defect (wrong source, phantom API, documented crash)** · API (additive)
+**Effort:** M–L (~6–8 days)
+**Dependencies:** None hard. Shares no file with spec 35, which is complete. Fold in the pivot
+write-path enum duplication noted below.
+**Status:** 🟩 Implemented on `task/39` (2026-08-30), unmerged — see Results. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+A pivot table carries roughly sixty settings. They are enumerated by hand in five places — the
+reader, the writer, the Excel-defaults initialiser, the copy operation, and a hand-written test of
+forty assertions. Nothing checks that the five lists are the same list, and they are not.
+
+What a user sees:
+
+- **A pivot table re-saves with formatting the user never asked for.** The "show last column"
+  emphasis is read from the *column stripes* attribute. A file with stripes on and last-column
+  emphasis off re-saves with the emphasis switched on; a file with the emphasis on and stripes off
+  loses it.
+- **Two public properties do nothing.** A pivot table's title and description can be set through the
+  public interface, are documented, and are touched by neither the reader nor the writer. Set them,
+  save, reload, and they are empty.
+- **Copying a pivot table silently resets twenty-three settings** that both the reader and the writer
+  carry — including compact and outline form, visual totals, the grand-total caption and the data
+  caption.
+- **A documented crash condition is reachable.** The subsystem's own notes record that a definition
+  whose row or column fields reference the values field must carry the data-position attribute. The
+  loader never sets it, so a file that needs it is written without it.
+
+## Solution
+
+The sixty settings are described once, as data: for each setting, its attribute name, the property it
+maps to, and its OOXML default. Reading, writing, default-seeding and copying are all driven from that
+one description.
+
+A setting can then no longer be present in the writer and absent from the copy, or read from the wrong
+source, or given one default in one place and a different default in another — because there is only
+one place.
+
+## User Stories
+
+1. As a library consumer, I want a pivot table's last-column emphasis to round-trip independently of
+   its column stripes, so that re-saving a file does not change how it looks.
+2. As a library consumer, I want a pivot table's column-stripe setting to round-trip without altering
+   any other setting, so that one change does not have side effects.
+3. As a library consumer, I want the title I set on a pivot table to be saved and reloaded, so that a
+   public property that accepts a value keeps it.
+4. As a library consumer, I want the description I set on a pivot table to be saved and reloaded, for
+   the same reason.
+5. As a library consumer, I want a copied pivot table to keep its compact and outline form, so that
+   the copy is laid out like the original.
+6. As a library consumer, I want a copied pivot table to keep its grand-total and data captions, so
+   that the copy reads the same.
+7. As a library consumer, I want a copied pivot table to keep its visual-totals, drop-zone and
+   asterisk-totals settings, so that copying is not a partial operation.
+8. As a library consumer, I want every setting the reader and writer both carry to survive a copy, so
+   that I do not have to know which subset is supported.
+9. As a library consumer, I want a pivot whose axes reference the values field to be written with the
+   attribute that makes it valid, so that the file opens without repair.
+10. As a library consumer, I want a setting left at its Excel default to be omitted from the file, so
+    that XLibur's output stays close to what Excel itself writes.
+11. As a library consumer, I want a setting explicitly set to a non-default to be written, so that my
+    intent reaches the file.
+12. As a library consumer, I want the defaults a new pivot table starts with to match the defaults the
+    reader assumes, so that a created pivot and a loaded pivot behave the same.
+13. As a library consumer, I want `ShowLastColumn` available on the public pivot table interface
+    alongside its four siblings, so that I can set and assert it like any other display setting.
+14. As an XLibur maintainer, I want adding a pivot setting to be one row of data, so that it cannot be
+    added to the writer and forgotten in the copy.
+15. As an XLibur maintainer, I want a setting's default stated exactly once, so that two places cannot
+    disagree about what the default is.
+16. As an XLibur maintainer, I want the copy operation derived from the same list as the round trip, so
+    that it cannot be a subset of it.
+17. As an XLibur maintainer, I want one property-based test to replace forty hand-written assertions,
+    so that the roughly twenty settings the hand-written test misses become covered.
+18. As an XLibur maintainer, I want the pivot write path to use the shared enum mapping rather than its
+    own string table, so that nine duplicated enums stop needing to agree by hand.
+19. As a contributing agent, I want the attribute list to be readable as a single table, so that I can
+    answer "does XLibur support setting X" without cross-referencing four files.
+
+## Implementation Decisions
+
+**The seam is a declarative attribute table.** Each entry names the OOXML attribute, the property it
+binds to, and the value that counts as the default. Reading, writing, defaulting and copying are four
+consumers of that one table. This is the same shape as spec 38's view-state module, and the two should
+read similarly.
+
+**Derived attributes are computed, not stored.** Some attributes are functions of the pivot's other
+state rather than settings in their own right — the row and column page counts, and the data position
+that records where the values field sits on its axis. These are marked as derived in the table and
+recomputed on write. The data-position defect exists precisely because it is treated as stored state
+that only one of the two construction paths sets.
+
+**`ShowLastColumn` becomes public.** Its four siblings are already on the public pivot table
+interface; it alone is internal, which is why no test can reach the defect through the interface. This
+is an additive change to `PublicAPI.Unshipped.txt`. Confirmed as the preferred option with the owner
+before this spec was written.
+
+**Title and description get resolved, not left ambiguous.** They are public, settable, and persisted
+nowhere. The spec's decision is to give them their real home in the file rather than remove them from
+the interface — removal would be a breaking change, and the attributes exist in the format. If they
+turn out not to have a home, the finding is reported rather than worked around.
+
+**The nine duplicated pivot enums fold in.** The pivot write path carries its own raw-string table for
+nine enums that the shared enum converter also maps, with four of the converter's methods dead as a
+result. They agree today — including the two spellings that differ only in case, which is exactly the
+kind of agreement that fails silently. Since this spec is already rewriting how the writer produces
+attributes, the enums move to the shared converter here rather than in a spec of their own.
+
+**Ordering.** The wrong-source defect and its test land first, on their own, because it is a one-line
+fix with a user-visible effect and should not wait for the table. The table follows, then the four
+consumers migrate one at a time.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test sets pivot settings through the public interface, saves,
+reloads, and asserts through the same interface. Where the thing under test is whether an attribute is
+omitted at its default, the test reads the emitted attributes instead — that is the one case a reload
+cannot see, because the reader supplies the default again on the way back.
+
+**The centrepiece is a property-based round trip.** Set every attribute in the table to a non-default
+value, save, reload, and compare the whole table. Then do the same through a copy. Because the table
+is data, the test iterates it, so a setting added later is covered automatically. This subsumes the
+existing forty-assertion test and covers the roughly twenty settings it does not reach.
+
+**Named regression tests for the four defects.** The last-column emphasis read from the wrong source;
+the title and description that vanish; the twenty-three settings a copy resets; the missing
+data-position attribute on a pivot whose axis references the values field.
+
+**Default polarity gets byte-level assertions.** For each attribute, assert that it is absent from the
+output when it holds its default and present when it does not. This is the check that would have
+caught the two places where the defaults disagree.
+
+**The enum fold-in gets a round-trip test per enum.** Nine enums, both directions, every member —
+including the two whose spellings differ only in case, which is the pair most likely to drift.
+
+**Prior art.** The existing pivot table options round-trip test is the right shape and the right home;
+it builds a workbook, sets options, saves, reloads and asserts. Its weakness is that its assertion
+list is written by hand, so it can only ever check what someone remembered. The pivot filter criteria
+reader and writer are the area's good example of a symmetric pair and are worth reading before
+starting.
+
+**Test seam.** `IXLPivotTable` and a save/reload round trip, plus emitted-attribute assertions for
+default polarity. No new seam.
+
+## Out of Scope
+
+- The pivot cache — its value encoding, its records part and its field definitions. That is spec 41.
+- Pivot conditional formatting and the priority handshake that links it to the sheet's rules.
+  Recorded as a backlog note from the same review.
+- Pivot table area movement on a structural edit, which spec 33 covered and merged.
+- Timelines, which spec 35 delivered.
+- Adding pivot features. This spec makes existing settings round-trip and copy correctly.
+
+## Further Notes
+
+Five enumerations of one list is the clearest instance of this round's shape, and the wrong-source
+defect is a good illustration of why it matters: it is a single wrong identifier, in a line that looks
+exactly like the four lines above it, in a file where sixty such lines are written out by hand. No
+amount of care makes that line reliably correct. Making the list data makes it impossible to write.
+
+The `ShowLastColumn` case is worth noting for its own sake — the one property in the group that no
+test could reach through the interface is the one that is wrong. That is what "the interface is the
+test surface" means in practice.
+
+The wrong-source line was verified directly while writing this spec.
+
+## Results
+
+**Implemented 2026-08-30 on `task/39` (worktree `xl-wt-39`), head `f78a2fe8`, 11 commits, cut from
+`upstream/main` `37c986bb`. Not yet pushed or merged.** Full suite **run independently by the
+orchestrator** on both TFMs: 28,526 total, 0 failed, 10 pre-existing skips.
+
+**The agent's final report was lost** — its session was `/clear`ed from the tab before the
+orchestrator read it — so this section is reconstructed from the commit bodies, the diff, and the
+orchestrator's own checks. The "least sure of" answer for this spec was never captured; treat the
+review findings below as the substitute.
+
+**Order landed as briefed.** `060bf988` the wrong-source fix alone, red-first
+(`ShowLastColumn_reads_from_its_own_attribute_not_column_stripes`); `9777a892` `ShowLastColumn`
+public (four lines in `PublicAPI.Unshipped.txt`); `1e1468d3` the other three regressions red;
+`d2db5b4c`/`72355690` prerequisites; `5e2625cb` the table + reader; `2c17cddc` writer; `a890197d` the
+three fixes + copy; `e2f1b7d2` enum fold-in; `f8df87d0` the table-driven property test replacing the
+40-assertion `PivotTableOptionsSaveTest`.
+
+**Answers to the two questions the brief asked to be settled.**
+
+- **Title/Description have a home**: the x14 `pivotTableDefinition` extension's `altText` /
+  `altTextSummary` — the same extension element that already carried `EnableCellEditing` and
+  `ShowValuesRow`, and the pair Excel surfaces as a pivot table's Alt Text. Read and written there;
+  `Title_and_description_round_trip_through_save_and_reload`.
+- **`dataPosition`**: the loader added the `data` (-2) field straight to an axis without passing
+  through the one path that set `DataPosition`, so a loaded-then-resaved file lost the attribute. Now
+  a **computed** property derived from where -2 sits in `RowAxis`/`ColumnAxis`, never stored;
+  `DataPosition_is_written_after_a_reload_when_an_axis_references_the_values_field`. Whether Excel
+  actually crashes on the omission was not re-verified in-branch — the commit body records only the
+  documented condition and the fix.
+
+**What the spec predicted that turned out wrong.** The "Excel-defaults initialiser" as a fifth
+enumeration barely existed: of `SetExcelDefaults()`'s 28 assignments, 23 duplicated a field
+initialiser or the CLR default; only five carried real information, now inline on the property.
+`ShowRowHeaders`/`ShowColumnHeaders` default `true` for a fresh pivot but `false` as the OOXML
+round-trip default — pre-existing, intentional, now stated in the table rather than silently split.
+
+**The table.** `XLibur/Excel/IO/PivotTableAttributes.cs` (243 lines): each row is attribute name,
+bound property, read/write/copy accessors and default. `dataPosition` and the location element's
+page counts are deliberately **not** rows — derived, recomputed on write. The two enumerating tests
+(`Pivot_table_attribute_table_round_trips_through_save_and_reload`,
+`..._through_copy`) iterate it; the copy arm was shown to fail on the first attribute when the
+`CopyTo` migration was temporarily reverted. The x14 flags and the `pivotTableStyleInfo` group stay
+explicitly copied, now including `ShowLastColumn`.
+
+**Enum fold-in.** The writer's nine-enum string table is gone; `EnumConverter` gained forward
+`ToOpenXml` for the five it lacked; `EnumConverterPivotTests` round-trips every member of all nine
+both ways and pins the case-only pair (`stdDevp`/`varp` on `ST_DataConsolidateFunction` vs
+`stdDevP`/`varP` on `ST_ItemType`). Byte-identical output against the golden fixtures.
+
+**Eight golden `.xlsx` fixtures were regenerated**, six in `060bf988` and two in `a890197d`. The
+orchestrator diffed one part-by-part: the only change in `PivotTableWithoutSourceData-output.xlsx` is
+`showLastColumn="1"` appearing on `pivotTableStyleInfo` — the attribute the old reader discarded.
+The other seven were not individually diffed; a reviewer should spot-check the two from `a890197d`
+(`PivotTables.xlsx`, `PivotSubtotalsSource/output.xlsx`), which should show the x14 alt-text and/or
+`dataPosition` changes and nothing else.
+
+**Owner's review pass, 2026-08-30 evening — committed as `5e3a0a27`, `27f54e6a`, `d5d73267` (head `d5d73267`, 14 commits).** Four `/code-review` findings: (1)
+`CopyTo` copied the table-level layout but not each field's Compact/Outline pair — now copied
+per field, since fields in a loaded file can legitimately differ; test
+`CopyTo_carries_the_layout_of_every_pivot_field_not_just_the_table`, shown to fail with one line
+disabled. (2) `ToAttr<T>` allocated an `EnumValue<T>` per attribute; `IEnumValue.Value` already
+exposes the interned string — zero allocations, byte-identical output. (3) **`ShowLastColumn` on
+`IXLPivotTable` is source- and binary-breaking for external implementers** — moved in `CHANGELOG.md`
+from Bug Fixes to ⚠️ Breaking Changes (the `IXLSheetView.FreezePanes` precedent). The PR title needs
+the `!`. (4) `chartFormat`'s next-free id was copied without the `ChartFormats` collection it indexes;
+now an explicit, documented copy exemption, and the copy test asserts the exemption plus a count so a
+future silent exemption fails. Suite green on net10.0 across all four projects after the pass.
+
+**Deliberately not done.** Pivot cache (spec 41), pivot CF handshake (backlog), area movement (33).
+
+**What the next consumer inherits.** Spec 41 finds the definition side already table-driven and
+should mirror the shape for the cache. Spec 38 built the same shape for sheet view; the two should be
+read together as the round's pattern. `CHANGELOG.md` carries five `### Fixed` entries under
+`## Unreleased`.

--- a/docs/specs/40-dirty-versus-visited.md
+++ b/docs/specs/40-dirty-versus-visited.md
@@ -1,0 +1,219 @@
+# Spec 40 — The dirty flag stops doubling as a visited marker
+
+**Area:** Architecture · **Defect (propagation pruned)**
+**Effort:** S–M (~3 days)
+**Dependencies:** None hard. Shares the calc-engine staleness model with specs 42 and 43; one owner
+should take all three, in the order 40 → 42 → 43.
+**Status:** 🟩 Implemented on `task/40` (2026-08-30), unmerged — see Results, including the one open performance decision. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+When a cell changes, the calc engine walks the dependency graph marking everything downstream as
+needing recalculation. That walk uses a formula's *dirty* flag as its "have I already visited this
+node" marker.
+
+Those are two different facts. A formula can already be dirty for reasons that have nothing to do
+with the current walk — the public invalidation method on a cell sets it, and so do sheet renames,
+reference shifts and range moves. When the walk reaches such a node it concludes it has already been
+there, stops, and never visits anything downstream of it.
+
+What a user sees:
+
+```
+A1=1 · B1 "=A1+1" · C1 "=B1+1" · D1 "=C1+1"     ->  2, 3, 4
+ws.Cell("C1").InvalidateFormula();               // documented public API
+ws.Cell("A1").Value = 10;
+   B1 = 11  correct    C1 = 12  correct    D1 = 4   <-- should be 13
+```
+
+Calling a public method whose entire purpose is to force recalculation causes a *later* edit to
+under-recalculate. The deeper the graph beyond the invalidated cell, the more cells go stale. Nothing
+reports it; the values are simply old.
+
+A second, smaller problem sits alongside it: the code documents a three-state epoch model for
+tracking staleness, and the method that would advance the epoch is never called anywhere. The epoch
+is a constant, so the documented model does not exist and the flag is really a boolean.
+
+## Problem the user actually hits
+
+Any application that invalidates a cell — to force a refresh, after a bulk edit, or as part of its own
+caching — silently degrades the correctness of every subsequent recalculation in that region of the
+sheet.
+
+## Solution
+
+The traversal keeps its own record of what it has visited, separate from whether a formula is stale.
+Marking dirty means marking dirty; visiting means visiting. A node that was already dirty is still
+traversed, so everything downstream of it is reached.
+
+The epoch machinery is resolved at the same time: either it is wired up and does what it documents, or
+it is removed and the flag is honestly a boolean. Leaving code that documents a model it does not
+implement is the thing that made this defect hard to see.
+
+## User Stories
+
+1. As a library consumer, I want editing a cell to recalculate everything that depends on it, however
+   deep the chain, so that the values I read are current.
+2. As a library consumer, I want calling `InvalidateFormula` on a cell to have no effect on how later
+   edits propagate, so that a refresh hint does not corrupt subsequent calculations.
+3. As a library consumer, I want invalidating an intermediate cell in a chain to leave the rest of the
+   chain reachable, so that partial refreshes are safe.
+4. As a library consumer, I want a sheet rename not to reduce how far a later edit propagates, so that
+   renaming is not silently destructive.
+5. As a library consumer, I want a row or column insertion, which shifts references, not to prune a
+   later recalculation, so that structural edits and value edits compose.
+6. As a library consumer, I want a moved range not to prune propagation, for the same reason.
+7. As a library consumer, I want a cyclic dependency to still terminate the walk, so that fixing this
+   does not reintroduce a hang.
+8. As a library consumer, I want a diamond-shaped dependency graph to recalculate every path, so that a
+   node reachable by two routes is not skipped on the second.
+9. As a library consumer, I want propagation across worksheets to behave the same as within one, so
+   that sheet boundaries are not a special case.
+10. As a library consumer, I want the recalculation cost of an edit to stay proportional to what
+    actually depends on it, so that correcting this does not make edits slow.
+11. As an XLibur maintainer, I want cycle termination to be a property of the traversal, so that no
+    other subsystem can affect it by setting a flag.
+12. As an XLibur maintainer, I want the dirty flag to mean exactly one thing, so that reading the code
+    does not require knowing which meaning is in play.
+13. As an XLibur maintainer, I want the epoch model either implemented or deleted, so that the comments
+    and the code agree.
+14. As an XLibur maintainer, I want a test that dirties an intermediate node and then edits the root, so
+    that this defect class is pinned.
+15. As an XLibur maintainer, I want the public invalidation method to have tests at all, so that a
+    shipped public method is not entirely uncovered.
+16. As a contributing agent, I want the difference between "stale" and "visited" to be visible in the
+    types, so that I do not reuse one for the other.
+
+## Implementation Decisions
+
+**The seam is the existing dependency-tree walk.** Nothing new is introduced. The walk gains its own
+visited set — or a generation counter compared per node, if measurement shows the allocation matters —
+and stops consulting the formula's dirty flag for that purpose.
+
+**Marking stays idempotent.** A node already marked dirty by this walk is not re-enqueued; a node
+marked dirty by anything *else* is. That distinction is the whole fix.
+
+**Cycle termination is preserved and tested explicitly.** The dirty flag currently provides
+termination as a side effect. The replacement must provide it deliberately, and the test for it comes
+before the change, not after.
+
+**The epoch decision is made on evidence.** The method that would advance the edit epoch has no
+callers, so the epoch is constant and the two states the code distinguishes are identical. The spec's
+default is to delete the machinery and document the flag as boolean, because that is what the code
+does. If implementing the epoch turns out to be cheap and to buy something measurable, that is a
+finding to report rather than a silent substitution.
+
+**No public API change.** The observable change is that more cells recalculate — which is to say, the
+right ones.
+
+**Performance is a gate, not a goal.** The walk is on the edit path. The change must not regress the
+structural-edit or bulk-edit benchmarks; a measurement before and after is part of the work.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test builds a dependency chain through public API, performs
+public operations, and asserts cell values. It does not inspect the dirty flag, the visited set or the
+dependency tree — those are the implementation. The defect is fully observable as wrong values.
+
+**The centrepiece is the interference matrix.** For each way a formula can become dirty outside a walk
+— the public invalidation method, a sheet rename, a row or column insert, a range move — dirty a node
+partway along a chain, then edit the chain's root, then assert every downstream value. That is the
+test the current shape cannot pass and, once passing, the one that keeps it fixed.
+
+**Graph-shape tests.** A straight chain, a diamond, a cross-sheet chain, and a cycle. The cycle test
+asserts termination and must be written *before* the change, so that it is known to be meaningful.
+
+**A control case in every test.** The same graph and the same edit without the interfering operation,
+asserting the correct values. Without the control, a test that passes proves nothing about whether the
+interference was the cause.
+
+**Prior art.** The calc engine's recalculation tests are the right home. Note that the public
+invalidation method currently has no tests anywhere in the suite, so this spec creates its first
+coverage rather than extending existing coverage.
+
+**Test seam.** `IXLCell` value and formula assignment, `InvalidateFormula`, and worksheet-level
+structural operations. No new seam.
+
+## Out of Scope
+
+- Which cells are *registered* in the dependency tree, and how the tree is built. Only the walk over
+  it changes.
+- The formula write path's failure to invalidate at all — that is spec 42, and the two are
+  independent: 42 adds a missing call, 40 fixes what happens once it is made.
+- Spill-aware reads — spec 43.
+- Demand-driven evaluation, which is spec 04.
+- Making recalculation faster. This spec makes it correct and must not make it slower.
+
+## Further Notes
+
+Reusing one bit for two meanings is a classic and usually harmless economy. It is harmless when the
+bit has exactly one writer. Here it has at least four, and three of them are in unrelated subsystems
+that have no reason to know the dependency walk exists.
+
+The dead epoch method is worth treating as evidence rather than tidying. Code that documents a
+three-state model and implements one state is a sign that the model was designed, partly built, and
+then left — and the comment is now actively misleading anyone who reads the flag and believes it.
+
+Both wrong answers above were reproduced against a scratch build before this spec was written.
+
+## Results
+
+**Implemented 2026-08-30 on `task/40` (worktree `xl-wt-40`), head `9a070669`, 9 commits, cut from
+`upstream/main` `37c986bb`. Not yet pushed or merged.** Full suite green on both TFMs: 14,265 per
+TFM, 0 failed, 5 pre-existing skips; Report 481, Fonts.SixLabors 31, Fonts.SkiaSharp 37 all green.
+
+**The commit order the brief demanded held**: cycle-termination safety net green first (`6fbab32a`),
+interference matrix red (`8c610852`), graph shapes red (`50595721`), the fix (`576e76da`), the epoch
+deletion on evidence (`f7244615`), then two perf commits and a review-driven fix.
+
+**The fix.** `MarkDirty` carries a process-wide walk id and `XLCellFormula.TryVisit` compares a
+per-node generation against it; dirty state is no longer consulted for traversal. The spec's default
+(a `HashSet` visited set) was measured first — ~7× allocation, ~3× time — and the generation counter
+replaced it on that evidence. The epoch machinery: `BumpEditEpoch` had zero callers, `EditEpoch` was
+pinned at 1, and `_evalEpoch` was a two-state bool in disguise; deleted and replaced by
+`bool _isClean` across 8 call sites in 5 files.
+
+**What the spec predicted that turned out wrong.** Two of the four named dirtiers — sheet rename and
+row/column insert — **cannot reproduce the defect through their public operations**: both trigger
+`XLCalcEngine.Purge`, which marks the whole workbook dirty and masks the narrow bug. Their live-API
+tests are green before and after and are kept as regression cover; the primitive both actually use
+(a formula text rewrite) is isolated in `Formula_marked_dirty_by_a_text_rewrite_does_not_prune_a_later_edit`,
+which is genuinely red/green. `InvalidateFormula` and range move reproduce exactly as the spec says.
+
+**The in-branch review found a High-severity regression the fix had introduced**: walk ids were reused
+across a dependency-tree rebuild, so a graph built after a purge could be pruned. The interference
+matrix could not see it — every test built its graph after the last purge. Fixed in `b08faf00` with
+`Walk_ids_are_not_reused_after_the_dependency_tree_is_rebuilt`. Same lesson as every round: run the
+review inside the task.
+
+**The performance gate — one shape regressed, deliberately.** Three-run medians:
+
+| Probe | main | HEAD |
+|---|---|---|
+| 200k edits, 200×10 chains | 821.5 MB / 1588 ms | 791.0 MB / 1848 ms |
+| 200k edits, no dependents | 46.5 MB / 41 ms | 16.0 MB / 46 ms |
+| **20k unsettled edits, 50-deep model** | **12.6 MB / 48 ms** | **221.3 MB / 216 ms** |
+
+The third row is real and was independently reproduced by the reviewer. Reusing the dirty flag also
+short-circuited *between* calls — bulk writes into a shared, still-dirty model skipped the walk after
+the first edit. That saving was never sound; it is the same shortcut that pruned legitimate walks.
+The allocation is RBush search lists, one per hop, not the queue. **The agent chose correctness and
+documented the cost in the changelog rather than restore the skip; it flagged this as a product call
+for a second opinion — open as of 2026-08-31.** Restoring a *sound* cross-call skip needs a third
+state — a `_dirtiedByWalk` bit distinct from `_isClean` — and `BulkEditDirtyWalkProfile`
+(`profile bulkedit`, permanent) is the guard for whoever attempts it. Structural-edit benchmarks are
+within noise, as expected — `Purge` never calls the changed method.
+
+**Found, not fixed — recorded as D25 and D26.** `XLRange.TransposeRange` swaps its offsets on the
+wrong axes (silent data misplacement). `XLCell.InvalidateFormula` marks only its own formula and runs
+no walk, so dependents stay stale until an unrelated edit sweeps them — a missing call, spec 42's
+territory, outside "only the walk changes".
+
+**Least sure of (agent's own list).** The matrix is organised by dirtier and the regression was in the
+tree's lifecycle — other lifecycle axes may be unenumerated. Whether the unsettled bulk-edit cost is
+shippable. `WalkQueueRetainedCapacity = 4096` is a judgement, not a measurement.
+
+**What the next consumer inherits.** Spec 42 adds the missing invalidation on the array-formula write
+path and now has a walk that will actually propagate it; it should also take D26. Spec 43 builds on
+both. `Mark_dirty_stops_at_dirty_cell` was rewritten — it had asserted the defect's symptom as
+intended behaviour.

--- a/docs/specs/41-pivot-cache-value-codec.md
+++ b/docs/specs/41-pivot-cache-value-codec.md
@@ -1,0 +1,162 @@
+# Spec 41 — One codec for a pivot cache value
+
+**Area:** Architecture · **Defect (2 shipped, both data-destroying)**
+**Effort:** M (~5–6 days)
+**Dependencies:** None hard. File-disjoint from spec 39, which owns the pivot *definition*; the two
+can run in parallel under different owners.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+A pivot table's cache stores the source data twice over — once as a list of distinct shared items per
+field, once as the records themselves. Both are sequences of values, and a value can be a number, a
+date, a string, a boolean, an error or blank. How each of those is spelled in XML is decided in four
+separate places: a reader and a writer for the shared items, and a reader and a writer for the
+records. Nothing checks that the four agree, and they do not.
+
+What a user sees:
+
+- **A pivot over data containing an error value corrupts the file.** An error in the source range is
+  written into the records as a *boolean* element. Reload it and the boolean parser is handed
+  `#N/A`, which it cannot read; Excel reports the cache as needing repair. The shared-items writer, in
+  a different file, gets the same value type right — which is exactly why nobody noticed.
+- **Grouping is destroyed on re-save.** Open a pivot grouped by months, change nothing, save. The
+  grouping is gone, and worse, the definition now promises more fields than each record carries, so
+  the part is structurally invalid. XLibur then refuses to load its own output. The element that
+  describes a grouping is modelled nowhere, and the save path cannot pass it through untouched
+  because it clears the loaded fields before writing.
+
+Three smaller asymmetries sit in the same code: a record count that is read and never written; the
+numeric range of a field that mixes dates and numbers, lost on every save; and a public setting for
+how many items to retain that has three meanings on read and two on write, so one of them silently
+does nothing.
+
+## Solution
+
+There is one description of how a pivot cache value is spelled in XML, and all four places use it.
+The records part gets a reader module of its own, beside its writer, so that the two can be tested
+against each other — today the records are read from inside the definition reader, so there is no
+seam to test across.
+
+The rule that a definition and its records must agree about field count becomes a property of that
+module rather than an accident of two writers making compatible decisions.
+
+## User Stories
+
+1. As a library consumer, I want a pivot over source data containing `#N/A` to produce a file Excel
+   opens without repair, so that error values in my data are not fatal.
+2. As a library consumer, I want the same for `#DIV/0!`, `#REF!` and every other error value, so that
+   no error type is a special case.
+3. As a library consumer, I want an error value in a pivot cache to reload as the same error value, so
+   that round-tripping preserves my data.
+4. As a library consumer, I want to open a pivot grouped by months, save it, and still have the
+   grouping, so that XLibur can be used on files that use a standard Excel feature.
+5. As a library consumer, I want the same for grouping by quarters, years, and numeric ranges, so that
+   no grouping kind is destroyed.
+6. As a library consumer, I want a file XLibur has saved to be loadable by XLibur, so that the library
+   is never the sole producer of files it rejects.
+7. As a library consumer, I want a cache field mixing dates and numbers to keep its recorded minimum
+   and maximum, so that Excel's own filtering behaves correctly.
+8. As a library consumer, I want the record count in the file to match the records actually written,
+   so that consumers relying on it are not misled.
+9. As a library consumer, I want `SetItemsToRetainPerField` to take effect for every value it accepts,
+   so that a setting the interface offers is not silently ignored.
+10. As a library consumer, I want every value type — number, date, string, boolean, error, blank — to
+    survive a cache round trip unchanged, so that no data type is lossy.
+11. As a library consumer, I want a cache with a calculated field to keep working exactly as it does
+    today, so that this change does not regress the case that currently works.
+12. As an XLibur maintainer, I want the spelling of a cache value defined once, so that a value type
+    cannot be written as one element and read as another.
+13. As an XLibur maintainer, I want the records part to have a reader module, so that its writer has
+    something to be tested against.
+14. As an XLibur maintainer, I want the field-count agreement between the definition and the records to
+    be enforced in one place, so that two writers cannot promise different shapes.
+15. As an XLibur maintainer, I want a round-trip property test over the whole value union, so that
+    adding a value type later is covered without remembering to write a test.
+16. As an XLibur maintainer, I want non-database fields handled by the same module that decides field
+    counts, so that skipping a column and declaring a column cannot disagree.
+17. As a contributing agent, I want one place to look up how a cache value is encoded, so that I do not
+    copy whichever of the four encodings I find first.
+
+## Implementation Decisions
+
+**The seam is a value-to-element codec, used in both directions by both parts.** It owns the mapping
+from value type to element name and back, and it is the only thing that knows those names. Getting the
+error case wrong becomes impossible because there is one case statement, not four.
+
+**The records part gets a reader module.** It currently has none — the records are parsed from inside
+the cache definition reader — which is why the records writer has never been tested against a reader.
+Creating it is most of what makes the defects testable.
+
+**Field-count agreement becomes an invariant of the module.** Two separate decisions must currently
+match by hand: whether the definition declares a field, and whether the records writer emits a column
+for it. They move behind one decision.
+
+**Grouping fields get modelled, or the save path stops destroying them.** The element describing a
+grouping is not modelled at all, and pass-through is unavailable because the save path clears the
+loaded cache fields before writing. The spec's preference is to model it, because the surrounding
+attributes are already modelled and a half-modelled part is what caused the invalidity. If modelling
+proves larger than this spec, the fallback is to preserve the loaded element verbatim for fields
+XLibur does not otherwise touch — but that fallback must be a deliberate, recorded decision, not a
+default.
+
+**The three smaller asymmetries are folded in**, because each is a one-line consequence of the codec
+owning the element's attribute set: the record count, the numeric range on a mixed-type field, and the
+retention setting's missing write case.
+
+**Ordering.** The error-value defect lands first with its test — it is small, isolated and
+data-destroying. The records reader follows. Grouping lands last, because it is the one with genuine
+design content.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test round-trips a workbook and asserts on what came back
+through the public pivot interface, or — where the file's own validity is the point — asserts that the
+saved file loads. For grouping, an Excel-authored fixture is required, because XLibur cannot currently
+produce the input at all.
+
+**The centrepiece is a property test over the value union.** For every value type the cache can hold,
+write it, read it back, and assert equality. That single test covers the error defect and every future
+value type. It is the test that could not exist while there was no records reader.
+
+**A self-consistency test.** Save a workbook, reload it with XLibur, assert it loads. Sounds trivial;
+the grouping defect is exactly a case where it fails, and the failure is a thrown exception rather
+than a wrong value.
+
+**Excel-authored fixtures for grouping.** Group by month, quarter, year and numeric range in Excel,
+save the fixtures into the test resources, and assert each survives a load-and-save. XLibur-authored
+fixtures cannot cover this, which is the reason the defect shipped.
+
+**A field-count invariant test.** After any save, the number of fields the definition declares equals
+the number of columns each record carries. Asserting this once catches the whole class.
+
+**Prior art.** The pivot filter criteria reader and writer are the area's genuinely symmetric pair and
+are the model to follow — they cover every attribute of every criteria child and preserve what they do
+not model as raw XML. Read them before starting. The existing pivot cache tests build their fixtures
+through XLibur's own writer, which is why they cannot see any of this.
+
+**Test seam.** `IXLPivotTable` and its cache, plus save/reload and Excel-authored fixtures. The
+records reader is new but is not a test seam in its own right — it is tested through the round trip.
+
+## Out of Scope
+
+- The pivot table *definition*'s sixty attributes — spec 39.
+- Pivot conditional formatting and the priority handshake — backlog note from the same review.
+- Timelines and slicers, both delivered.
+- Adding grouping as an authoring feature. This spec is about not destroying grouping that already
+  exists in a file; creating a grouping through the public interface is a separate feature.
+- Cache refresh semantics and the relationship between a cache and its source range.
+
+## Further Notes
+
+The error-value defect is a good illustration of why "two implementations, agreement by hand" is worth
+treating as a defect class rather than a style preference. The shared-items writer and the records
+writer are two switch statements over the same enumeration, in two files, written at different times.
+One of them is right. There is no mechanism by which the other would have been corrected.
+
+The grouping defect is the more serious of the two because its output is structurally invalid rather
+than merely wrong, and because the library rejects its own product — which means any round trip
+through XLibur is a one-way door for those files.
+
+Both were reproduced by reading the reader against the writer element by element; the self-rejection
+was confirmed against the loader's own structural check.

--- a/docs/specs/42-formula-write-invalidation.md
+++ b/docs/specs/42-formula-write-invalidation.md
@@ -1,0 +1,157 @@
+# Spec 42 — One formula write path, and it invalidates
+
+**Area:** Architecture · **Defect (stale reads after an array-formula edit)**
+**Effort:** S–M (~3 days)
+**Dependencies:** None hard. Shares the calc-engine staleness model with specs 40 and 43; one owner
+should take all three, in the order 40 → 42 → 43.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+Writing a formula into a cell has two halves: store it, and tell the calc engine that everything
+depending on that cell is now out of date. The single-cell path does both. The array-formula path
+does the first and only part of the second — it marks the formula itself, and never reaches the
+engine's dependency walk.
+
+What a user sees:
+
+```
+A1..A3 = 1,2,3 · D1:D3 {=A1:A3*2} · F1 "=SUM(D1:D3)"    ->  D = 2,4,6   F1 = 12
+replace D1:D3 with {=A1:A3*10}
+                                                          ->  D = 10,20,30   F1 = 12
+```
+
+`F1` should be 60. The array's own cells update; everything that depends on them does not. The same
+happens the other way round: read a formula that references a region, *then* put an array formula in
+that region, and the reader keeps its old answer.
+
+The equivalent single-cell edit is correct, which makes this hard to spot — the behaviour a developer
+would test first is the behaviour that works.
+
+## Solution
+
+The module that stores formulas is the one that invalidates dependents. Callers hand it a formula and
+a location; they do not also have to remember to notify the engine afterwards, and they cannot get the
+order wrong, because there is no order left to get wrong.
+
+Loading a file is the one case that legitimately skips invalidation — a freshly loaded workbook has
+nothing stale. That becomes an explicit, named mode rather than a caller-side omission that looks
+identical to a bug.
+
+## User Stories
+
+1. As a library consumer, I want a formula that sums an array formula's range to update when I replace
+   that array formula, so that my totals are correct.
+2. As a library consumer, I want the same when I first write an array formula into a region something
+   already references, so that the order in which I build a sheet does not matter.
+3. As a library consumer, I want removing an array formula to update its dependents, so that deletion
+   is as safe as replacement.
+4. As a library consumer, I want an array formula that depends on another array formula to update, so
+   that chains of array formulas work.
+5. As a library consumer, I want a cell formula and an array formula to behave identically with respect
+   to invalidation, so that I do not have to know which kind I used.
+6. As a library consumer, I want a formula written through a range operation to invalidate its
+   dependents, so that bulk authoring is as correct as cell-by-cell authoring.
+7. As a library consumer, I want a formula written during a copy or paste to invalidate its dependents,
+   so that duplicated regions are current.
+8. As a library consumer, I want a formula rewritten by a row or column insertion to invalidate its
+   dependents, so that structural edits leave a consistent sheet.
+9. As a library consumer, I want loading a workbook not to trigger a full recalculation, so that
+   opening a file stays fast.
+10. As a library consumer, I want a loaded workbook's cached values to be trusted until something is
+    edited, so that load performance is unchanged by this fix.
+11. As a library consumer, I want to be able to read a dependent value immediately after writing an
+    array formula, without calling a full recalculation first, so that the object model behaves the way
+    the single-cell path already does.
+12. As an XLibur maintainer, I want invalidation to sit next to the write, so that the two cannot be
+    separated by a caller.
+13. As an XLibur maintainer, I want a new formula write path to inherit invalidation, so that the next
+    one cannot forget it.
+14. As an XLibur maintainer, I want the storage module's interface to stop exposing an ordering rule
+    between its own methods, so that callers have nothing to sequence.
+15. As an XLibur maintainer, I want the load-time skip to be explicit and named, so that it reads as a
+    decision rather than an oversight.
+16. As an XLibur maintainer, I want tests that assert on a *consumer* of an array formula, so that this
+    defect class is pinned rather than only the array's own cells.
+17. As a contributing agent, I want one way to write a formula, so that I do not have to discover which
+    of several methods also notifies the engine.
+
+## Implementation Decisions
+
+**The seam is the existing formula storage module.** It already registers formulas in the dependency
+tree and the calculation chain; adding invalidation to it puts all three effects of a write in one
+place. No new type.
+
+**Its interface shrinks.** It currently offers separate operations for setting a single formula,
+setting an array formula, setting during load, and marking dirty — and leaves callers to combine them
+correctly. After this spec, marking dirty is not a caller-facing operation at all, and the load-time
+variant is the only way to opt out.
+
+**Load remains the sole opt-out.** Loading writes formulas for a workbook that by definition has no
+stale dependents, and the load path must not pay for a graph walk per formula. That mode stays, named
+for what it is.
+
+**The single-cell path is the reference behaviour.** It already does the right thing. This spec moves
+the call rather than inventing a new policy, so the risk is concentrated in *where* the call happens,
+not in *what* it does.
+
+**Performance is a gate.** Formula writing is on the create path and the structural-edit path. The
+change must not regress the create-path or structural-edit benchmarks; measure before and after. If
+the array path's newly-added invalidation proves expensive for large arrays, the fix is to mark the
+array's whole footprint once rather than per cell — not to skip it.
+
+**Interaction with spec 40.** That spec fixes what happens once the dependency walk is entered; this
+one fixes a path that never enters it. They are independent and can land in either order, but 40 first
+means this spec's tests exercise a correct walk.
+
+**No public API change.**
+
+## Testing Decisions
+
+**What makes a good test here.** A good test writes formulas through the public object model, reads a
+*dependent* cell, and asserts its value — without calling a full recalculation in between. The moment
+a test inserts a full recalculation, it stops being able to see this defect, which is precisely what
+the current suite does.
+
+**The centrepiece is a write-kind by operation matrix.** For each kind of formula write — single cell,
+array formula, formula set through a range, formula produced by a copy, formula rewritten by a
+structural edit — and for each operation — first write, replacement, removal — assert that a
+downstream consumer of the written region is current afterwards.
+
+**Consumer-side assertions, not producer-side.** The existing array formula tests assert on the array's
+own cells and on expected exceptions. Both are correct and stay. What is missing, in all
+twenty-five of them, is any assertion about a cell that *reads* the array's range. That is the
+assertion this spec adds.
+
+**A no-recalculation rule for the new tests.** They must not call a full recalculation. If a test needs
+one to pass, it is not testing this.
+
+**A load-path guard test.** Load a workbook with many formulas and assert that loading does not trigger
+evaluation — otherwise the opt-out could be silently lost later and only show up as a performance
+regression.
+
+**Prior art.** The array formula tests are the right home and the right shape; they need consumer
+assertions. The single-cell equivalents already demonstrate the correct behaviour and make good
+control cases — every new test should have one.
+
+**Test seam.** `IXLCell.FormulaA1`, `IXLRange.FormulaArrayA1`, and reading `.Value`. No new seam.
+
+## Out of Scope
+
+- What the dependency walk does once entered — spec 40.
+- Reading a spilled cell's value — spec 43.
+- Demand-driven evaluation — spec 04.
+- The dependency tree's construction and what gets registered in it.
+- Changing when a workbook recalculates as a whole.
+
+## Further Notes
+
+The asymmetry here is one missing call, which makes it sound trivial. It is worth being precise about
+why it happened: the single-cell path assembles the sequence in the cell type, and the array path
+assembles a different sequence in the range type. Neither is wrong on its own terms; there is simply
+no module that says what the sequence *is*. The fix is not to add the missing call to the second
+caller — that leaves a third caller free to make the same mistake — but to remove the possibility of a
+caller assembling the sequence at all.
+
+Both stale reads were reproduced against a scratch build, along with a single-cell control that
+behaves correctly, before this spec was written.

--- a/docs/specs/43-spill-aware-cell-read.md
+++ b/docs/specs/43-spill-aware-cell-read.md
@@ -1,0 +1,167 @@
+# Spec 43 — Reading a cell is spill-aware, once
+
+**Area:** Architecture · **Defect (order-dependent value)**
+**Effort:** M (~4–5 days)
+**Dependencies:** Shares the calc-engine staleness model with specs 40 and 42; one owner should take
+all three, in the order 40 → 42 → 43.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+A dynamic-array formula occupies one anchor cell and spills its result into neighbouring cells. Those
+neighbours hold values but no formula of their own.
+
+Two different pieces of code answer the question "what is this cell's current value". The one the calc
+engine uses when evaluating a formula knows about spilling: for a cell with no formula it checks
+whether the cell belongs to a spill whose anchor is stale, and forces the anchor to evaluate first.
+The one the public interface uses does not: it recomputes only if the cell has a formula of its own,
+and a spilled cell has none. So it returns whatever was last written there.
+
+What a user sees:
+
+```
+A1:A4 = 1,2,3,4 · C1 {=UNIQUE(A1:A4)} spilling into C1:C4 · E1 "=C4&\"\""
+edit A4 so the result shrinks to three rows
+   [1] read C4 directly   -> '4'     stale
+   [2] read E1            -> ''      correct — the formula read forces the anchor
+   [3] read C4 again      -> ''      the same call as [1], now different
+```
+
+Reading a cell gives a different answer depending on what was read before it. That is worse than a
+consistently stale value, because caching or reordering in the caller's code changes the result.
+
+A third copy of the same knowledge sits alongside: the engine keeps its own list of which cells belong
+to which spill anchor, maintained by hand across three methods, and duplicating information the
+formula's own recorded range already implies. Clearing that list drops half the answer.
+
+## Solution
+
+There is one module that resolves a cell location to its current value. It knows the three things
+that matter — whether the location has a formula, whether it belongs to a spill, and whether what it
+depends on is stale — and it is the only thing that knows them.
+
+Its two callers differ in one respect only: what to do when the value is stale. The public read
+recomputes and returns; the in-formula read signals the engine to evaluate the anchor first and come
+back. That single difference is the whole of the distinction between them.
+
+Spill ownership becomes something that module derives rather than a list two other types maintain.
+
+## User Stories
+
+1. As a library consumer, I want reading a spilled cell to give the same answer regardless of what I
+   read before it, so that my code's behaviour does not depend on access order.
+2. As a library consumer, I want a spilled cell to be current after I edit something its anchor depends
+   on, so that I do not have to force a full recalculation.
+3. As a library consumer, I want a spill that shrinks to clear the cells it no longer occupies, so that
+   stale values do not remain visible.
+4. As a library consumer, I want a spill that grows to fill the cells it now occupies, so that the new
+   region is populated.
+5. As a library consumer, I want `NeedsRecalculation` on a spilled cell to tell me the truth, so that I
+   can decide whether to recalculate.
+6. As a library consumer, I want the cached-value accessor on a spilled cell to be consistent with the
+   value accessor, so that the two do not disagree.
+7. As a library consumer, I want a saved workbook to contain the current spilled values, so that the
+   file matches what the object model reports.
+8. As a library consumer, I want enumerating a range that overlaps a spill to yield current values, so
+   that bulk reads agree with individual reads.
+9. As a library consumer, I want a spill that becomes blocked to report the blocking error, so that I
+   can detect the condition.
+10. As a library consumer, I want reading a spilled cell to be no slower in the common case where
+    nothing is stale, so that correctness here does not cost throughput.
+11. As a library consumer, I want an anchor cell to keep behaving exactly as it does today, so that the
+    case that currently works is not disturbed.
+12. As an XLibur maintainer, I want one implementation of "is this value current", so that the public
+    and internal readers cannot disagree.
+13. As an XLibur maintainer, I want spill ownership derived from the formula's recorded range, so that a
+    separate list cannot fall out of sync or be cleared independently.
+14. As an XLibur maintainer, I want the spill test suite to assert on cell values directly, so that it
+    stops routing around the defect with a full recalculation.
+15. As an XLibur maintainer, I want the two staleness policies stated side by side, so that the
+    difference between the public and in-formula reads is a visible decision.
+16. As a contributing agent, I want one place to ask what a cell's value is, so that I do not pick the
+    naive reader by accident.
+
+## Implementation Decisions
+
+**The seam is a single value resolver.** Both existing readers become callers. The resolver answers
+"the current value at this location", and takes the caller's staleness policy as the one thing that
+varies — recompute, or signal to reorder evaluation.
+
+**Spill ownership is derived, not stored.** The engine's separate ownership list duplicates what a
+formula's own recorded range already says. Deriving it removes a third copy and removes the failure
+mode where clearing the list silently disables spill awareness for the public reader. If measurement
+shows the derivation is too slow on the read path, a cache is acceptable — but as a cache owned by the
+resolver, invalidated by it, not as a second source of truth maintained by other types.
+
+**The in-formula reader's behaviour is the reference.** It is the one that is correct. The public
+reader adopts its knowledge and differs only in its response to staleness.
+
+**The naive checks move behind the resolver.** The public "does this need recalculating" predicate and
+the cached-value accessor currently ask whether the cell has a formula. They ask the resolver instead,
+which is what makes them correct for spilled cells.
+
+**Performance is a gate.** Cell reading is the hottest path in the library — the read-heavy benchmark
+is dominated by it. The resolver must add nothing measurable when no spill is present, and the
+fast-path check for "this workbook has no spills at all" must be preserved. Measure before and after;
+a regression here is a blocker, not a trade.
+
+**The adjacent duplication is recorded, not fixed here.** The engine's fast single-cell evaluation
+path and its general formula-application path share a substantial literal duplicate and disagree about
+data tables — the fast path defers to a general path that throws. This was not reproduced. It is noted
+as a lead for whoever takes this spec, to be confirmed or dismissed with evidence, not fixed blind.
+
+**No public API change.** The observable change is that spilled cells report current values.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test edits a precedent and then reads a spilled cell through
+the public interface, asserting its value — with no full recalculation in between. Every existing
+mutating spill test inserts one, which is exactly why none of them can see this defect. The new tests
+must not.
+
+**The centrepiece is the read-order test.** Edit a precedent, then read the spilled cell *first*,
+before anything else touches the engine, and assert it is current. Then repeat the sequence reading a
+dependent formula first. Both orders must give the same answer. That equality is the property the
+defect violates.
+
+**Footprint-change tests.** A spill that shrinks, one that grows, one that becomes blocked, and one
+that becomes unblocked — asserting both the newly occupied and the newly vacated cells.
+
+**Consistency tests across accessors.** For the same spilled cell, the value accessor, the cached-value
+accessor and the needs-recalculation predicate must agree.
+
+**A save-path test.** Edit a precedent, save without recalculating, reopen, and assert the file
+contains the current spilled values.
+
+**A performance guard.** The read-heavy benchmark before and after, recorded in the spec's results.
+
+**Prior art.** The spill evaluation tests are the right home. They are well constructed and their use
+of a full recalculation is deliberate — it makes them deterministic. The new tests are a different
+category and should be grouped separately so that nobody later "fixes" them by adding the recalculation
+back.
+
+**Test seam.** `IXLCell.Value`, `CachedValue`, `NeedsRecalculation`, and a save/reload round trip. No
+new seam.
+
+## Out of Scope
+
+- The dependency walk's pruning behaviour — spec 40.
+- Formula writes that never invalidate — spec 42.
+- Demand-driven evaluation — spec 04.
+- Spill phase B work, which has its own note.
+- The data-table disagreement between the two application paths, recorded above as an unverified lead.
+- Changing spill semantics. This spec makes reads report what the engine already computes.
+
+## Further Notes
+
+An order-dependent read is a distinctive failure. A consistently stale value is a bug a caller can
+work around once they know about it; a value that changes depending on what was read first cannot be
+worked around at all, because the workaround depends on knowing the whole program's read order.
+
+The suite's use of a full recalculation between mutation and assertion is worth calling out without
+criticism — it is the obvious way to make a spill test deterministic, and it was almost certainly
+added for that reason. It is also, exactly, the thing that hides this. That pattern is worth looking
+for elsewhere: a test helper that makes tests reliable by forcing the system into a known state also
+stops the tests from noticing when the system does not reach that state on its own.
+
+The order-dependent read was reproduced against a scratch build before this spec was written.

--- a/docs/specs/44-data-validation-mapping.md
+++ b/docs/specs/44-data-validation-mapping.md
@@ -1,0 +1,156 @@
+# Spec 44 — Data validation: one mapping, two adapters
+
+**Area:** Architecture · **Correctness (divergence)**
+**Effort:** M (~4–5 days)
+**Dependencies:** None hard. Same shape as spec 29's write-path resolvers and should read like them.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+A data validation rule is thirteen settings — what is allowed, the operator, two formulas, whether
+blanks are ignored, whether the dropdown shows, the input and error messages and their titles and
+style. Excel spells a validation rule two ways: the standard element, and an extension element used
+when a rule needs something the standard form cannot express, such as a list that refers to another
+sheet or a formula over 255 characters.
+
+That thirteen-item list is written out by hand **seven times** in the library: a reader and a writer
+for each of the two spellings, the copy operation, the initialiser, and the equality test used when
+consolidating adjacent rules. Nothing checks that the seven agree.
+
+Two of them already disagree:
+
+- The standard writer always emits both formula elements, even when empty; the extension writer omits
+  an empty one. Two files describing the same rule.
+- The standard path applies a sheet-level "has anything changed" gate before writing; the extension
+  path applies no gate at all.
+
+A third piece of evidence sits in the consolidation equality test: it compares one property twice
+under two names, because one is an alias for the other. A comparison that can never fail is what a
+hand-copied list looks like after someone adds a property.
+
+There is also no data-validation IO module at all. The extension reader lives inside the conditional
+formatting reader, which the file's own summary comment apologises for.
+
+## Solution
+
+One module describes what a validation rule is and how it is spelled, with two adapters at its seam —
+one per spelling. The choice between them, and the rule that decides when a validation needs the
+extension form, sit behind that seam rather than in the writer's control flow.
+
+The copy operation and the consolidation equality test derive from the same property list instead of
+restating it.
+
+## User Stories
+
+1. As a library consumer, I want a validation rule to round-trip identically whether it is written in
+   the standard or the extension form, so that which form was chosen is invisible to me.
+2. As a library consumer, I want a list validation that refers to another worksheet to survive a save
+   and reload, so that cross-sheet lists work.
+3. As a library consumer, I want a validation with a formula longer than the standard form allows to
+   survive a round trip, so that long formulas are usable.
+4. As a library consumer, I want the ignore-blanks setting to round-trip in both forms, so that it does
+   not depend on which form my rule happened to need.
+5. As a library consumer, I want the in-cell dropdown setting to round-trip in both forms, for the same
+   reason.
+6. As a library consumer, I want input messages and their titles to round-trip in both forms.
+7. As a library consumer, I want error messages, error titles and the error style to round-trip in both
+   forms.
+8. As a library consumer, I want the operator and the allowed-value type to round-trip in both forms.
+9. As a library consumer, I want an empty formula to be written consistently, so that two files
+   describing the same rule are not spelled differently.
+10. As a library consumer, I want a validation I have not modified to be written the same way whichever
+    form it uses, so that the dirty-tracking gate does not apply to only half of my rules.
+11. As a library consumer, I want copying a validation to carry every setting, so that a copy is a copy.
+12. As a library consumer, I want consolidating adjacent identical validations to merge them and
+    non-identical ones to stay separate, so that consolidation is correct on every property.
+13. As a library consumer, I want two validations differing only in a property the equality test
+    currently ignores to remain separate, so that consolidation does not merge unlike rules.
+14. As an XLibur maintainer, I want the thirteen settings listed once, so that adding a fourteenth is
+    one edit rather than seven.
+15. As an XLibur maintainer, I want the "does this rule need the extension form" decision stated in one
+    place, so that the two writers cannot make it differently.
+16. As an XLibur maintainer, I want the extension reader to live with the other validation code rather
+    than inside conditional formatting, so that the file layout reflects the concepts.
+17. As an XLibur maintainer, I want a table-driven test that round-trips every property through both
+    adapters, so that a divergence between them fails a test.
+18. As a contributing agent, I want two adapters at a named seam, so that I can tell which spellings
+    exist without reading both writers.
+
+## Implementation Decisions
+
+**The seam is a validation-rule-to-element mapping with two adapters.** This is a genuine seam rather
+than a hypothetical one: two spellings exist, both are exercised in production, and the library must
+choose between them. That satisfies the two-adapters test — a seam is worth introducing because
+something actually varies across it.
+
+**The property list becomes the single source.** Reading, writing, copying, initialising and comparing
+are five consumers of one list. The consolidation equality test is derived from it, which removes the
+duplicated-alias comparison as a side effect rather than as a separate fix.
+
+**The extension predicate moves behind the seam.** The decision to use the extension form currently
+lives in the writer's control flow, expressed as two conditions — whether the rule references another
+sheet, and whether a formula exceeds the length limit. It becomes a property of the mapping.
+
+**Empty-formula emission is unified, and the choice is made deliberately.** The two writers disagree
+today. The spec does not assume one is right: the correct behaviour is whatever Excel itself emits,
+established by inspecting an Excel-authored file, and recorded in the spec's results.
+
+**The dirty gate applies uniformly or not at all.** Today it filters the standard path at sheet level
+and does not touch the extension path. Whichever behaviour is kept, it is the same for both adapters.
+
+**The extension reader moves.** It currently sits inside the conditional formatting reader for
+historical reasons the file itself notes. It moves to the validation module.
+
+**No public API change.** `IXLDataValidation` keeps its shape; only where the mapping lives changes.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test builds a validation through the public interface, saves,
+reloads, and asserts the settings came back. Where the two spellings must agree byte for byte, the
+test reads the emitted elements instead — a reload cannot see a spelling difference, because the
+reader normalises both spellings back to one model. That is the same reasoning the existing write-path
+agreement tests state, and the reason the frozen-pane divergence shipped unnoticed.
+
+**The centrepiece is a property-by-adapter matrix.** For each of the thirteen properties, set it to a
+non-default value, round-trip it through the standard adapter and through the extension adapter, and
+assert equality in both. Today the entire extension path has one test, covering one validation type
+with one long value.
+
+**A byte-level agreement test between the adapters.** For a rule expressible in both forms, assert the
+two adapters agree about what they emit for each property — in particular the empty-formula case. This
+is the test that catches the class rather than the instance.
+
+**A consolidation equality test per property.** Two validations differing in exactly one property must
+not merge. Thirteen cases, one per property, driven from the same list.
+
+**A copy fidelity test.** Copy a validation with every property set off-default and assert all thirteen
+survive.
+
+**Prior art.** The existing write-path agreement tests are the model for the byte-level half and their
+header states the reasoning. The existing data validation tests are the right home for the round-trip
+half. The conditional formats consolidation tests show the shape for the equality cases.
+
+**Test seam.** `IXLDataValidation` and `IXLDataValidations` through a save/reload round trip, plus the
+existing byte-level harness. No new test seam.
+
+## Out of Scope
+
+- Conditional formatting, beyond moving the misplaced extension reader out of it. Conditional format
+  defects are specs 48 and 49.
+- Adding validation types or operators.
+- The sheet-level dirty-tracking mechanism itself; this spec only makes its application consistent.
+- Extension-list content beyond data validation.
+
+## Further Notes
+
+Seven restatements of one list is the largest count this review round found, and the dead comparison in
+the equality test is the most direct evidence available that the list is copied rather than derived —
+it is what happens when someone adds a property to a list by copying the line above it.
+
+The two live divergences are both benign today in the sense that no user has reported them, and both
+are exactly the kind that becomes a data-loss defect the moment a third form is added or a reader
+becomes stricter. The frozen-pane divergence spec 29 fixed had the same character right up until it
+did not.
+
+The divergences were established by reading the two writers against each other; the dead comparison
+was verified against the property it aliases.

--- a/docs/specs/45-text-codec-at-the-seam.md
+++ b/docs/specs/45-text-codec-at-the-seam.md
@@ -1,0 +1,142 @@
+# Spec 45 — The text codec applies at the seam, not per caller
+
+**Area:** Architecture · **Defect (crash on save, silent corruption in Excel)**
+**Effort:** S (~2 days)
+**Dependencies:** None. Touches no file any other open spec touches.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3). The cheapest real win in the
+round.
+
+## Problem Statement
+
+XML cannot carry certain characters. The spreadsheet format works around this with an escape
+convention: a character XML forbids is written as an underscore-delimited hexadecimal code, and a
+literal occurrence of that pattern in a user's text is itself escaped so it survives the round trip.
+
+XLibur has a correct, unit-tested codec for this. It is applied at five of the seven places that need
+it. The two that miss it are both ends of the *inline string* path — the way cell text is written when
+string sharing is turned off, and the way it is read back.
+
+What a user sees:
+
+- **A save that throws.** Put a control character in a cell — the kind that arrives routinely in data
+  scraped from other systems — and save with string sharing off, or through the streaming writer with
+  inline storage. The XML writer rejects the character and the save fails. The same text saves without
+  complaint when sharing is on, so whether the library works depends on a setting unrelated to the
+  data.
+- **Silent corruption, visible only in Excel.** A cell containing the literal text `_x0041_` is
+  written unescaped. Excel decodes it on open and shows `A`. XLibur skips the decode too, so its own
+  round trip looks clean and no save-and-reload test can see it. The corruption appears only in the
+  application the file is written for.
+
+Both switches that reach the unencoded path are public.
+
+## Solution
+
+The codec applies where the text element is written and where it is read, rather than at each caller.
+A caller writing cell text cannot skip it, because the caller no longer chooses.
+
+The five sites that currently encode correctly stop doing it themselves, so the encoding happens
+exactly once and cannot be applied twice.
+
+## User Stories
+
+1. As a library consumer, I want a cell containing a control character to save successfully with string
+   sharing off, so that my data does not dictate a configuration setting.
+2. As a library consumer, I want the same through the streaming writer with inline string storage, so
+   that the streaming path is as robust as the DOM path.
+3. As a library consumer, I want a cell containing a control character to reload as the same text, so
+   that the round trip is lossless.
+4. As a library consumer, I want a cell containing the literal text `_x0041_` to appear in Excel as
+   `_x0041_`, so that my text is not silently rewritten.
+5. As a library consumer, I want the same for any literal text that resembles an escape sequence, so
+   that the rule has no exceptions.
+6. As a library consumer, I want text to round-trip identically whether it is stored as a shared string
+   or inline, so that the storage mode is an implementation detail.
+7. As a library consumer, I want text to round-trip identically through the DOM writer and the
+   streaming writer, so that the write path is also an implementation detail.
+8. As a library consumer, I want rich text runs to keep their current correct behaviour, so that this
+   change does not disturb what already works.
+9. As a library consumer, I want leading and trailing spaces to keep being preserved, so that the
+   existing whitespace handling is unaffected.
+10. As a library consumer, I want a worksheet name or a defined name containing awkward characters to
+    behave as it does today, so that the change is scoped to cell text.
+11. As an XLibur maintainer, I want the encode and decode to be unskippable, so that a future write path
+    inherits them.
+12. As an XLibur maintainer, I want the encoding applied exactly once, so that moving it to the seam
+    cannot double-escape text at the sites that already encode.
+13. As an XLibur maintainer, I want the character-checking setting on the XML writers to be deliberate
+    rather than defaulted, so that the crash cannot come back through a different route.
+14. As an XLibur maintainer, I want a round-trip test across both write paths and both storage modes, so
+    that all four combinations are covered rather than the two that happen to work.
+15. As a contributing agent, I want the codec's application to be a property of the element, so that I
+    do not have to know which callers need it.
+
+## Implementation Decisions
+
+**The seam is the text element itself.** The helper that writes the text element applies the encode;
+the code that reads it applies the decode. This is the highest available seam — every path that
+produces cell text goes through that helper — and it already exists, so nothing new is introduced.
+
+**Callers stop encoding.** The three write sites that currently encode correctly must be changed in the
+same commit as the seam, or text will be escaped twice. This is the only real risk in the spec and is
+why it is one commit rather than several.
+
+**The character-checking setting becomes deliberate.** One reader in the library already disables it
+explicitly, which shows the hazard was understood in one place and not propagated. After this spec the
+encode makes the setting irrelevant for cell text, but it is set consciously on both sheet writers
+rather than left at its default, so that a future change cannot silently reintroduce the crash.
+
+**Rich text and shared strings are unaffected in behaviour.** They already encode and decode; they
+simply stop doing it themselves.
+
+**No public API change.**
+
+## Testing Decisions
+
+**What makes a good test here.** A good test writes a string through the public object model, saves,
+reloads, and asserts the string came back unchanged. For the corruption case, an assertion on the
+emitted bytes is also required, because XLibur's own round trip is clean — the encode and the decode
+are both missing, so the error cancels out and only Excel sees it.
+
+**The centrepiece is a four-combination matrix.** Two write paths — DOM and streaming — by two storage
+modes — shared and inline. For each combination, round-trip a set of awkward strings: a control
+character, a literal escape-sequence lookalike, text with leading and trailing spaces, a newline, and
+ordinary text as a control. Today only the two shared-string combinations are exercised.
+
+**A byte-level assertion for the lookalike case.** Assert that the literal escape sequence appears
+escaped in the emitted XML. This is the only way to catch a defect where both halves of a codec are
+missing.
+
+**A double-encoding guard.** Round-trip a string containing an already-escaped-looking sequence
+through the shared-string path, which previously encoded at the caller, and assert it is not escaped
+twice. This is the regression the seam move could introduce.
+
+**Prior art.** The codec has its own unit tests, which are correct and stay — what is missing is any
+test asserting that the paths which need it actually call it. The existing streaming write tests
+validate their output against the SDK schema validator, which passes here because the problem is not a
+schema violation.
+
+**Test seam.** `IXLCell.Value` with `ShareString`, the streaming worksheet's string storage option, and
+a save/reload round trip plus emitted-byte assertions. No new seam.
+
+## Out of Scope
+
+- Text handling outside cell values — sheet names, defined names, and part names have their own rules.
+- Rich text structure. Only its text content is in scope, and its behaviour does not change.
+- The codec's own escaping rules, which are correct and tested.
+- Choosing when to use shared versus inline storage.
+
+## Further Notes
+
+This is the smallest spec in the round and one of the two most severe, which is an unusual pairing. The
+severity comes from the failure modes rather than the size: one is an unavoidable crash on data a user
+did not choose to have, and the other is invisible to every test the library could write about itself.
+
+The self-cancelling nature of the second defect is worth dwelling on. A missing encode paired with a
+missing decode produces a system that is perfectly consistent with itself and wrong about the outside
+world. No amount of round-trip testing finds it. The only tests that can are ones that assert on the
+bytes, or ones that use a fixture the library did not write — which is the same lesson specs 41 and 46
+arrive at from different directions.
+
+The five encoding and two decoding sites were enumerated directly, and the unencoded write site was
+verified while writing this spec.

--- a/docs/specs/46-table-part-reader.md
+++ b/docs/specs/46-table-part-reader.md
@@ -1,0 +1,164 @@
+# Spec 46 — The table part gets a reader
+
+**Area:** Architecture · **Defect (wrong colour filter, dropped attributes)**
+**Effort:** M (~5–6 days)
+**Dependencies:** None hard. Reads the differential format collection that spec 28 established;
+no file conflict with it.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+A table's definition — its name, its columns, its totals row, its styling and its autofilter — has a
+writer module. It has no reader module. The read half is three private methods inside the workbook
+load routine, so there is nowhere that states what the two halves owe each other, and no seam at which
+a test could check.
+
+The writer also replaces the whole table part on save rather than editing it, so anything it does not
+model is destroyed even on an open-and-resave that changes nothing.
+
+What a user sees:
+
+- **A colour filter on a table filters by the wrong colour after a round trip.** The reader that
+  handles autofilter columns needs the workbook's differential formats to recognise a colour filter,
+  and it takes them as an *optional* argument. The table call site omits it. The filter is therefore
+  never recognised as a colour filter, the styles writer skips it when rebuilding the differential
+  format collection, and the function that exists specifically to keep such a reference valid cannot
+  find its entry. Since the collection is rebuilt from scratch on every save, the preserved reference
+  now points at a different format. Reopen the file and the filter is by some other colour.
+- **A table's sort state is dropped.** The writer emits it; the table read path never reads it back, so
+  it is lost on load and then not rewritten.
+- **A table can be renamed by saving it.** The writer forces the display name equal to the name and
+  strips characters from it. A table whose two names differ, or whose name contains a stripped
+  character, comes back renamed — which breaks every structured reference to it.
+- **A totals row that is configured but hidden comes back as not configured.**
+- **Column-level and table-level styling is destroyed**: the differential format applied to a column's
+  data, the header and totals row formats, the border formats and the named cell styles are neither
+  read nor written.
+
+## Solution
+
+The table definition part gets a reader module beside its writer, and the attribute set is stated once
+for both directions. The differential formats the reader needs become part of its interface rather
+than an optional argument a caller can leave out.
+
+What the library does not model is carried through rather than dropped, so an open-and-resave stops
+being lossy.
+
+## User Stories
+
+1. As a library consumer, I want a table's colour filter to filter by the same colour after a save and
+   reload, so that reopening my file does not silently change what it shows.
+2. As a library consumer, I want a colour filter to behave identically on a table and on a worksheet
+   range, so that where the filter lives does not change whether it works.
+3. As a library consumer, I want a table's sort state to survive a round trip, so that a sorted table
+   stays sorted.
+4. As a library consumer, I want a table's name to be unchanged by saving, so that structured references
+   to it keep resolving.
+5. As a library consumer, I want a table whose display name differs from its name to keep both, so that
+   files authored elsewhere are not rewritten.
+6. As a library consumer, I want a configured but hidden totals row to stay configured, so that
+   unhiding it restores what was there.
+7. As a library consumer, I want a column's data formatting to survive a round trip, so that table
+   styling is not lost.
+8. As a library consumer, I want header row and totals row formatting to survive a round trip, for the
+   same reason.
+9. As a library consumer, I want a table's named cell styles to survive a round trip.
+10. As a library consumer, I want a calculated column's formula to survive a round trip, so that
+    computed columns keep computing.
+11. As a library consumer, I want table attributes XLibur does not model to survive an open-and-resave,
+    so that the library is safe to use on files richer than its object model.
+12. As a library consumer, I want opening and immediately saving a table-bearing file to produce an
+    equivalent file, so that a no-op round trip is a no-op.
+13. As an XLibur maintainer, I want the reader and writer to be a visible pair, so that an attribute
+    present in one and missing from the other is apparent.
+14. As an XLibur maintainer, I want the differential formats to be a required part of the reader's
+    interface, so that a caller cannot omit them.
+15. As an XLibur maintainer, I want the totals row's two attributes treated as one fact, so that they
+    cannot describe contradictory states.
+16. As an XLibur maintainer, I want the reader testable against the writer's output, so that the two
+    halves can be checked directly.
+17. As an XLibur maintainer, I want Excel-authored table fixtures in the suite, so that attributes
+    XLibur never writes are still covered on load.
+18. As a contributing agent, I want the table part's attribute set in one place, so that I can answer
+    "does XLibur preserve X" without reading a writer and a load routine.
+
+## Implementation Decisions
+
+**The seam is a table definition part reader, paired with the existing writer.** Creating it is most of
+the value: it gives the writer something to be tested against and gives the attribute set somewhere to
+live.
+
+**The differential format collection becomes a required argument.** The optional parameter is the
+mechanism of the colour-filter defect — it turned a genuine interface requirement into something a
+caller could silently skip, and one caller did. Making it required means the compiler enforces what
+the interface always meant.
+
+**The totals row is one fact with two attributes.** The count and the shown flag together describe the
+totals row's state; reading only the count is why a configured-but-hidden row comes back wrong. They
+are read and written as a unit.
+
+**Name and display name are distinct.** The writer's current behaviour — force them equal, strip
+characters — is a normalisation that belongs at the point a user *sets* a name, not at the point a
+file is written. Saving must not rename.
+
+**Unmodelled content is carried through.** The writer replaces the whole part, so anything not modelled
+is lost. Either the unmodelled attributes get modelled, or the reader keeps them and the writer emits
+them back. The area's pivot filter criteria code already does the latter for its own unmodelled
+children and is the pattern to follow.
+
+**Ordering.** The colour-filter defect lands first, on its own, with its test — it is silent data
+corruption with a clear mechanism and should not wait for the reader module. The reader follows, then
+the attribute set, then pass-through.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test builds or loads a table, saves, reloads, and asserts
+through the public table interface. For attributes XLibur cannot currently produce, the input must be
+an Excel-authored fixture — a test built from XLibur's own writer can only ever check that the reader
+agrees with this writer, which is the exact blind spot that let these defects ship.
+
+**The centrepiece is a load-save-load fixture test.** Take Excel-authored tables covering the styling
+attributes, the differing names, the hidden totals row, the calculated column and the sort state; load,
+save, load again, and assert the second load equals the first. This catches every write-but-never-read
+and never-touched attribute at once.
+
+**A named regression test for the colour filter.** A table with a colour filter in a workbook that also
+has other differential formats — the extra formats matter, because the defect is a reference pointing
+at the wrong entry in a rebuilt collection, and with only one entry it would accidentally be right.
+Save, reopen, assert the filter's colour.
+
+**A parallel test on a worksheet range** asserting the same colour filter behaviour, so the two paths
+are pinned as equivalent.
+
+**An attribute inventory test.** For the attribute set the spec defines, assert each is read and
+written. This is the mechanical check that the pair stays a pair.
+
+**Prior art.** The existing colour filter tests all apply the filter to a worksheet range and never to a
+table, which is why the table path is uncovered. The round-trip fidelity tests are the model for the
+pass-through half. The pivot filter criteria reader and writer are the model for the symmetric pair.
+
+**Test seam.** `IXLTable` and `IXLAutoFilter` through a save/reload round trip, plus Excel-authored
+fixtures. The new reader is not itself a test seam — it is exercised through the round trip.
+
+## Out of Scope
+
+- The differential format decoding itself, which spec 28 owns and has merged.
+- Table features as such — adding columns, calculated column authoring, totals functions.
+- The autofilter criteria reader and writer, which are already symmetric.
+- Structured reference resolution in formulas.
+- Worksheet-level autofilter behaviour, except as the control case for the colour filter test.
+
+## Further Notes
+
+The optional parameter is the part of this worth generalising. `differentialFormats = null` looks like
+a convenience and is in fact a statement that the reader can work without the workbook's formats — which
+is not true, and the one caller that took the offer at face value produces corrupted output. Optional
+arguments that are only optional for some callers are a way of encoding "you must know something the
+signature does not tell you", which is the definition of a leaky interface.
+
+The colour-filter case also shows why "the library round-trips its own output correctly" is a weak
+guarantee. Everything here is consistent from XLibur's point of view; the damage is to a reference into
+a collection that Excel reads and XLibur rebuilds.
+
+The divergences were established by diffing the writer's emitted attributes against the load path's
+consumed attributes; the optional-argument omission was verified at the call site.

--- a/docs/specs/47-value-assignment-protocol.md
+++ b/docs/specs/47-value-assignment-protocol.md
@@ -1,0 +1,155 @@
+# Spec 47 — One implementation of assigning a value to a cell
+
+**Area:** Architecture · **Defect (quote prefix survives; a public method skips invalidation)**
+**Effort:** S–M (~3 days)
+**Dependencies:** None hard. Touches the calc-engine invalidation call that spec 42 relocates; if both
+are scheduled, 42 lands first and this spec calls the relocated seam.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3).
+
+## Problem Statement
+
+Assigning a value to a cell is not one operation. It is a short protocol: work out whether the value
+requires a style change, apply that style, strip the leading apostrophe that marks text as literal
+because the style now records it, store the value, and tell the calc engine that dependents are stale.
+
+The rule that decides the style is a single well-factored module. The protocol around it is written out
+four times — in the cell type, in the worksheet's direct value setter, in the bulk data inserter and in
+the streaming writer — and one comment in the library even notes that its copy is "the same as" another
+one.
+
+Two of the four are wrong:
+
+- **The bulk inserter keeps the apostrophe.** It performs the strip only inside a branch that runs when
+  the style actually changed. Style values are interned, so when the inherited style *already* records
+  the quote prefix, nothing changes, the branch is skipped, and the apostrophe stays in the stored
+  text. Setting the same value through a cell strips it. The two disagree:
+
+  ```
+  ws.Column(1).Style.IncludeQuotePrefix = true;
+  ws.Cell("A1").Value = "'abc";                 // stored: abc
+  ws.Cell("A2").InsertData(new[] { "'abc" });   // stored: 'abc
+  ```
+
+- **The worksheet's direct value setter never invalidates.** It is public and shipped. Its documentation
+  lists three things it deliberately skips and does not mention this one. A value written through it
+  leaves dependent formulas stale, once anything in the workbook has been evaluated. Its only caller in
+  the repository is a benchmark, and it has no tests.
+
+## Solution
+
+The protocol joins the rule. A caller supplies a value and a location and receives back what to store
+and what style to set; it no longer decides how to strip, when to strip, or whether to invalidate.
+
+Callers keep whatever performance shortcuts they have around that call — the bulk inserter still writes
+in bulk, the streaming writer still streams — but they stop re-deciding the rule inside it.
+
+## User Stories
+
+1. As a library consumer, I want text beginning with an apostrophe to be stored the same way whether I
+   assign it to a cell or insert it in bulk, so that the two entry points agree.
+2. As a library consumer, I want that to hold when the target already carries the quote-prefix style, so
+   that pre-existing formatting does not change how my data is stored.
+3. As a library consumer, I want the same behaviour through the streaming writer, so that all three
+   write routes agree.
+4. As a library consumer, I want a value that looks like a number, a date or a boolean to receive the
+   same inferred style through every entry point, so that bulk and single writes format alike.
+5. As a library consumer, I want a value written through the worksheet's direct setter to invalidate
+   dependent formulas, or to be documented as not doing so, so that I can use it correctly.
+6. As a library consumer, I want a formula that reads a bulk-inserted range to recalculate, so that
+   `InsertData` composes with the calc engine.
+7. As a library consumer, I want inserting data over existing formulas to behave as documented, so that
+   overwriting is predictable.
+8. As a library consumer, I want bulk insertion to stay as fast as it is today, so that correctness here
+   does not cost throughput.
+9. As a library consumer, I want a value assigned to a cell to keep behaving exactly as it does today,
+   so that the entry point that is already correct is not disturbed.
+10. As an XLibur maintainer, I want the strip rule stated once, so that a gate around it cannot be added
+    in one copy and not another.
+11. As an XLibur maintainer, I want the invalidation rule stated once, so that an entry point cannot omit
+    it.
+12. As an XLibur maintainer, I want a new write path to inherit both rules, so that the next one cannot
+    drift.
+13. As an XLibur maintainer, I want the worksheet's direct setter's documented exclusions to match what it
+    actually skips, so that its contract is true.
+14. As an XLibur maintainer, I want that public method to have tests, so that a shipped entry point is not
+    entirely uncovered.
+15. As an XLibur maintainer, I want one table-driven test covering all four entry points, so that a
+    divergence between them fails a test.
+16. As a contributing agent, I want one documented way to assign a value, so that I do not copy whichever
+    of four protocols I find first.
+
+## Implementation Decisions
+
+**The seam is the existing value-style rule module, widened to own the protocol.** It currently answers
+"what style should this value have" and returns nothing when the style is unchanged. It grows to answer
+"what should be stored and what style should be set", which is the question its callers actually have.
+
+**The interned-style return is the mechanism of the defect and is designed out.** Returning "no change"
+and returning "no strip needed" are currently the same value, which is why one caller conflated them.
+After this spec, the value to store and the style to set are independent parts of the answer.
+
+**Invalidation becomes part of the protocol, with an explicit opt-out.** The load path and the streaming
+writer legitimately do not invalidate — the first has nothing stale, the second has no engine. That is
+a named mode, not an omission.
+
+**The worksheet's direct setter's contract is fixed either way, deliberately.** Either it invalidates
+like its siblings, or its documentation states that it does not and why. What it must not remain is a
+public method whose documented exclusions are incomplete. The spec's preference is that it invalidate,
+since it is a general-purpose public entry point; if measurement shows that defeats its purpose, the
+finding is recorded and the documentation corrected instead.
+
+**Callers keep their shortcuts.** The bulk inserter marks its whole inserted region dirty once rather
+than per cell, and that stays — this spec unifies the rule, not the batching.
+
+**Performance is a gate.** Bulk insertion and the create path are benchmarked. Measure before and after.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test writes a value through one of the four public entry points
+and asserts what is stored and what style resulted, through the public interface. It does not test the
+rule module in isolation — the rule was always right; the defect is in how it was called, which is
+exactly the case a pure-function unit test cannot see.
+
+**The centrepiece is an entry-point by input matrix.** For each of the four entry points, and for each
+input — text with a leading apostrophe, the same with the quote-prefix style already applied to the
+target, ordinary text, a number, a date, a boolean, an empty string — assert the stored value and the
+resulting style. The second input is the defect; the rest are the regression net.
+
+**Dependent-recalculation cases.** For each entry point, write a value that a formula depends on and
+assert the formula updates without a forced full recalculation.
+
+**First tests for the direct setter.** It is public, shipped, and has none. Whatever its contract ends
+up being, it gets tests asserting it.
+
+**A performance guard.** The bulk insertion benchmark before and after, recorded in the results.
+
+**Prior art.** The cell value tests are the right home and demonstrate the correct behaviour, which makes
+them the control arm for every new case. The rule module's own tests are correct and stay; they are just
+not sufficient, and that is the point worth recording.
+
+**Test seam.** `IXLCell.Value`, `IXLCell.InsertData`, `IXLWorksheet.SetCellValue`, and the streaming
+worksheet. No new seam.
+
+## Out of Scope
+
+- The style inference rules themselves, which are correct.
+- Number format detection and culture handling.
+- The bulk inserter's batching strategy and its dirty-marking granularity.
+- Formula writes, which are spec 42.
+- Adding new value types.
+
+## Further Notes
+
+This candidate is a useful counter-example to the assumption that extracting a pure function makes
+something testable. The rule *is* extracted, it *is* a pure function, and it *does* have unit tests
+that pass. The bug is one branch away from it, in a caller, in a condition that looks reasonable and is
+wrong only because of a property of the value being returned. Locality did not follow the extraction:
+the knowledge stayed in four places while only the calculation moved to one.
+
+The second leg — a shipped public method that skips invalidation, has one benchmark as its only caller,
+and no tests — is worth resolving in this spec rather than leaving as a note, because whichever way it
+is resolved it is a one-line change plus documentation, and leaving it ambiguous is what allowed it to
+sit unexamined.
+
+The divergence was reproduced through public API before this spec was written; the missing invalidation
+was established by tracing all four entry points to the engine.

--- a/docs/specs/48-conditional-format-defects.md
+++ b/docs/specs/48-conditional-format-defects.md
@@ -1,0 +1,141 @@
+# Spec 48 — Conditional format defects: the crash, the throw, and the lost data bar
+
+**Area:** **Defect (crash on load)** · Compat
+**Effort:** S–M (~3 days)
+**Dependencies:** None. **Deliberately scoped to require no public interface change**, so that it can
+ship without waiting on spec 49. Spec 49 supersedes its internal shape but not its behaviour.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3). Split from the value-object
+candidate at the owner's direction so the crash fix is not blocked behind an API decision.
+
+## Problem Statement
+
+Three failures in conditional formatting, all reachable from files Excel routinely produces, none of
+them reachable from files XLibur produces — which is why the suite cannot see any of them.
+
+- **A data bar crashes the load.** When a user sets a data bar's negative fill to match its positive
+  fill, Excel omits the negative-fill element entirely; the format allows this. XLibur dereferences it
+  unconditionally and throws. The whole workbook fails to open. XLibur's own writer always emits the
+  element, so no XLibur-authored fixture can produce the input.
+- **A threshold without a value throws on save.** A conditional format value object may omit its value.
+  The colour-scale converter guards against that; the icon-set converter does not, and dereferences
+  it. Load such a file and saving throws.
+- **An Excel-authored data bar comes back stripped.** The border, border colour, negative border
+  colour and the two "same as positive" flags are neither read nor written, and the minimum and
+  maximum bar lengths are reset to fixed values on every save regardless of the file. A bordered data
+  bar becomes borderless; a bar with custom lengths gets default ones.
+
+## Solution
+
+Optional elements are treated as optional. Missing children produce the format's defined default
+rather than an exception, and the data bar's full attribute set is read and written.
+
+This spec changes behaviour only. The four parallel collections that make this class of defect easy to
+introduce are left alone; replacing them is spec 49.
+
+## User Stories
+
+1. As a library consumer, I want a workbook containing a data bar with "negative fill same as positive"
+   to open, so that a standard Excel setting does not make my file unreadable.
+2. As a library consumer, I want that data bar to keep rendering the same way after a round trip, so
+   that opening the file in XLibur does not change it.
+3. As a library consumer, I want a conditional format value object with no explicit value to load
+   without error, so that a valid file is accepted.
+4. As a library consumer, I want to be able to save a workbook containing such a value object, so that
+   loading it is not a dead end.
+5. As a library consumer, I want that to hold for icon sets as well as colour scales, so that the two
+   conditional format types behave alike.
+6. As a library consumer, I want a data bar's border to survive a round trip, so that bordered bars stay
+   bordered.
+7. As a library consumer, I want a data bar's border colour and negative border colour to survive a
+   round trip.
+8. As a library consumer, I want the "negative bar colour same as positive" and "negative border colour
+   same as positive" flags to survive a round trip, so that the setting that triggers the crash is also
+   the setting that is preserved.
+9. As a library consumer, I want a data bar's minimum and maximum lengths to survive a round trip, so
+   that saving does not resize my bars.
+10. As a library consumer, I want a data bar I created through XLibur to keep behaving exactly as it does
+    today, so that the fix does not disturb the working case.
+11. As a library consumer, I want every conditional format type to survive an open-and-resave of an
+    Excel-authored file, so that XLibur is safe to use on files it did not create.
+12. As an XLibur maintainer, I want optional elements handled as optional throughout the conditional
+    format readers, so that this class of crash is eliminated rather than patched once.
+13. As an XLibur maintainer, I want Excel-authored conditional format fixtures in the suite, so that
+    inputs XLibur cannot produce are covered.
+14. As an XLibur maintainer, I want each defect pinned by a test that fails before the fix, so that the
+    fixes are proofs rather than assertions.
+15. As a contributing agent, I want the format's optional children documented where they are read, so
+    that the next reader does not assume presence.
+
+## Implementation Decisions
+
+**Optionality is read from the format, not inferred from XLibur's own output.** Each child element the
+readers dereference is checked against the schema for whether it is required. Where it is optional, the
+reader supplies the format's default. The negative-fill element is the known instance; the audit covers
+the rest of the conditional format readers in the same pass, because one unguarded dereference
+strongly suggests others.
+
+**The two converters are brought into agreement.** One guards a missing value and one does not. The
+guarded behaviour is correct and becomes the behaviour of both.
+
+**The data bar's attribute set is completed.** The unmodelled attributes are added to the model, read
+and written. The fixed minimum and maximum lengths become values carried from the file rather than
+constants written on every save.
+
+**No public interface change.** The four parallel collections stay, along with their alignment
+requirement. This is a deliberate constraint: it keeps the crash fix independent of the API decision in
+spec 49. Where a new data bar attribute needs a home, it is added additively.
+
+**Ordering.** The load crash lands first, alone. Then the save throw. Then the data bar attributes.
+Each with the fixture that fails before it.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test loads an Excel-authored fixture, asserts the load
+succeeded and the model is right, saves, reloads, and asserts equality. Fixtures produced by XLibur's
+own writer cannot express any of these defects — the writer always emits what the reader assumes — so
+the fixtures are the substance of the testing work, not an incidental.
+
+**Fixtures required.** Authored in Excel and committed to the test resources: a data bar with negative
+fill matching positive; a data bar with a border and custom lengths; an icon set whose value object
+omits its value; a colour scale with the same. Each fixture's provenance recorded in a comment, because
+a fixture nobody can regenerate is a liability.
+
+**A load-save-load equality test per fixture.** Load, save, load again, assert the two loads agree. This
+covers both the crash and the attribute loss in one assertion.
+
+**A negative test for the save throw.** Load the fixture with the missing value, save, assert no
+exception, reload, assert the model.
+
+**An unguarded-dereference audit as a test.** For each optional child the conditional format readers
+consume, a fixture omitting it. This is the check that turns a single fix into a class fix.
+
+**Prior art.** The existing conditional format tests all build their workbooks through the public
+interface, save, reload and assert — a good shape that cannot reach these inputs. The round-trip
+fidelity tests are the model for the load-save-load pattern and already carry Excel-authored fixtures.
+
+**Test seam.** `IXLConditionalFormat` and a load-save-load round trip over Excel-authored fixtures. No
+new seam.
+
+## Out of Scope
+
+- The four parallel collections and their alignment requirement — spec 49.
+- The alignment defect itself, where a value object without a type shifts every later entry onto the
+  wrong type. That is a consequence of the collection shape and is fixed in 49; it cannot be fixed here
+  without the interface change.
+- The two data bar converter hierarchies and the string match that joins them — spec 49.
+- Differential format decoding — spec 28.
+- The pivot conditional format priority handshake — backlog note from the same review.
+- Adding conditional format types.
+
+## Further Notes
+
+All three defects share a cause that is not really about conditional formatting: XLibur's reader is
+written against XLibur's writer rather than against the format. Where the writer always emits an
+element, the reader assumes it; where the writer hardcodes a value, the reader never learns to carry
+one. The library is self-consistent and wrong about files from anywhere else.
+
+That is a general risk in any read-write library and the only reliable defence is fixtures the library
+did not author. This spec's real deliverable may be those fixtures rather than the three fixes.
+
+The crash mechanism was established by reading the reader against the schema's optionality; the
+converter asymmetry was established by diffing the two converters.

--- a/docs/specs/49-conditional-format-value-object.md
+++ b/docs/specs/49-conditional-format-value-object.md
@@ -1,0 +1,155 @@
+# Spec 49 — One conditional format value object
+
+**Area:** Architecture · **API (breaking)** · **Defect (silent misalignment)**
+**Effort:** M–L (~1–1.5 weeks)
+**Dependencies:** **Spec 48 should land first.** It fixes the crash and the data loss without an API
+change; this spec then fixes the shape that made them easy to write. Running this one first would
+block a crash fix behind an API decision.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3). Split from spec 48 at the
+owner's direction.
+
+## Problem Statement
+
+A conditional format's thresholds are exposed on the public interface as four separate collections —
+the values, the colours, the content types and the icon-set operators — which the caller must keep
+index-aligned. Nothing enforces the alignment, and the reader does not maintain it: it appends to
+three of the collections unconditionally and to the fourth only when the corresponding attribute is
+present.
+
+The result is that a single threshold with no explicit type shifts every later entry onto the wrong
+type. An icon set or colour scale re-saves with its thresholds attached to the wrong comparison — no
+error, no exception, just a rule that now means something else.
+
+The same shape shows up in how a data bar is assembled: its two halves live in different namespaces
+and are joined by matching a string identifier, so the information about one visual element is split
+across two converter hierarchies with nothing tying them together.
+
+For a caller, the interface is as wide as the implementation: four collections, a one-based indexing
+convention, an alignment requirement, and a per-format-type arity rule, all of which they must know and
+none of which the types express.
+
+## Solution
+
+A threshold becomes one thing — its type, its value, its colour and its operator together — held in
+order. Alignment is a property of construction rather than a rule the caller follows. The arity rules
+for each conditional format type live on that concept.
+
+The data bar becomes one module with two spellings, the way spec 44 proposes for data validation,
+rather than two converter hierarchies joined by a string match.
+
+## User Stories
+
+1. As a library consumer, I want a conditional format's thresholds to be a single ordered collection, so
+   that I cannot misalign them.
+2. As a library consumer, I want each threshold to carry its own type, value, colour and operator, so
+   that reading one threshold does not mean indexing four collections.
+3. As a library consumer, I want a threshold with no explicit type to take the format's default rather
+   than shift its neighbours, so that a valid file loads with the right meaning.
+4. As a library consumer, I want an icon set loaded from a file to re-save with the same thresholds
+   attached to the same types, so that the rule keeps its meaning.
+5. As a library consumer, I want the same for a colour scale, so that the two types behave alike.
+6. As a library consumer, I want an invalid threshold count for a given format type to be reported when I
+   build it, so that I find out at the point of the mistake.
+7. As a library consumer, I want a three-stop colour scale and a two-stop colour scale to both be
+   expressible and both validated, so that arity is enforced rather than assumed.
+8. As a library consumer, I want a data bar's main and extension settings to be one object, so that I do
+   not have to know the format has two halves.
+9. As a library consumer, I want to set a data bar's border and bar lengths through the same object as
+   its colours, so that one visual element has one home.
+10. As a library consumer, I want a migration path from the four collections, so that upgrading is
+    mechanical.
+11. As a library consumer, I want the change documented with before-and-after examples for each
+    conditional format type, so that I can update my code without guessing.
+12. As an XLibur maintainer, I want the alignment invariant enforced at construction, so that no reader
+    or converter can break it.
+13. As an XLibur maintainer, I want the arity rules stated once per format type, so that each converter
+    stops assuming them.
+14. As an XLibur maintainer, I want a threshold testable on its own, so that the type-missing and
+    value-missing cases are unit tests rather than fixture-dependent integration tests.
+15. As an XLibur maintainer, I want the data bar's two halves joined by a type rather than a string
+    match, so that the join cannot silently fail.
+16. As an XLibur maintainer, I want new data bar attributes to be a field on one type, so that adding one
+    is not an edit to a reader, two converters and a public interface.
+17. As a contributing agent, I want the arity and alignment rules discoverable from the types, so that I
+    do not have to infer them from converter code.
+
+## Implementation Decisions
+
+**The seam is a threshold value object, ordered.** It replaces the four collections. Its construction
+enforces that every threshold has a type — supplying the format's default where the file omits one —
+which is where the misalignment defect is designed out.
+
+**Arity belongs to the format type.** A colour scale takes two or three thresholds; an icon set takes
+as many as its icon count; a data bar takes two. These rules currently live implicitly in each
+converter's indexing. They move onto the concept and are validated once.
+
+**This is a breaking change to the public conditional format interface, and it is the point of the
+spec.** It needs a deprecation path: the four collections remain, marked obsolete, projecting onto the
+new collection for at least one release, so that consumers have a mechanical migration rather than a
+compile break. `PublicAPI` files change; the change is called out in the release notes.
+
+**The data bar's two halves become one module with two spellings.** This mirrors spec 44's two-adapter
+seam. The string match that currently joins them is removed — a join that can fail silently is worse
+than one the type system checks.
+
+**Spec 48's behavioural fixes are preserved, not redone.** If 48 has landed, this spec must not
+regress its fixtures; they are the acceptance evidence that the reshape is behaviour-preserving.
+
+**Ordering.** The value object and its construction rules land first, with the four collections
+projecting onto it and every existing test still passing. Then the reader and converters move to it.
+Then the data bar unification. The obsolete collections are removed in a later release, not here.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test exercises the public interface and asserts observable
+results. The threshold value object is small enough to have direct unit tests for its construction
+rules, and those are legitimate — it is a value type with invariants, not an extracted helper.
+
+**The centrepiece is behaviour preservation.** Every existing conditional format test, and every
+fixture from spec 48, must pass unchanged through the reshape. That is the acceptance criterion for the
+projection stage; if a test needs changing, the reshape has altered behaviour and the change must be
+justified in the results.
+
+**Construction rule tests.** A threshold with no type takes the default. A threshold count wrong for the
+format type is rejected. Alignment is not expressible as a mistake. These are unit tests on the value
+object.
+
+**The misalignment regression test.** An Excel-authored fixture whose value object omits a type, loaded,
+saved and reloaded, asserting each threshold keeps its meaning. This test can only pass after the
+reshape, which makes it the spec's proof.
+
+**Migration tests.** The obsolete collections continue to return what they did, projected from the new
+one, for every conditional format type.
+
+**A data bar unification test.** Setting main-namespace and extension settings through one object and
+asserting both reach the file.
+
+**Prior art.** The conditional format converter dispatch table is the area's clean seam — one
+dictionary, one interface, seventeen adapters — and is worth reading as the model for what good looks
+like here. Spec 44's two-adapter design is the model for the data bar.
+
+**Test seam.** `IXLConditionalFormat` through a save/reload round trip, plus direct unit tests on the
+value object. The value object is a new seam, justified because it carries invariants.
+
+## Out of Scope
+
+- The three behavioural defects in spec 48 — the load crash, the save throw and the stripped data bar
+  attributes. They ship first, without an API change.
+- Removing the obsolete collections, which happens a release later.
+- Differential format decoding — spec 28.
+- Adding conditional format types or icon sets.
+- The pivot conditional format priority handshake.
+
+## Further Notes
+
+Four parallel collections with a positional relationship is a shape worth naming, because it recurs: it
+is what a record type looks like when it has been flattened into its fields and the fields have been
+stored separately. Every operation then has to re-establish the relationship, and every operation is an
+opportunity to fail to.
+
+The give-away in this instance is that the reader appends to three collections unconditionally and to
+the fourth conditionally. Nobody would write that if the four values were one object; it is only
+writable because the collections are independent, and it is only wrong because they are not.
+
+Splitting this from spec 48 was the right call: the crash is worth fixing this week, and a breaking
+change to a public interface deserves its own decision on its own timetable.

--- a/docs/specs/50-intersection-one-convention.md
+++ b/docs/specs/50-intersection-one-convention.md
@@ -1,0 +1,139 @@
+# Spec 50 — One `Intersection`, one absence convention
+
+**Area:** Architecture · **Correctness (undeclared error mode)** · API (behaviour clarification)
+**Effort:** S (~2 days)
+**Dependencies:** None hard. Soft ordering after spec 36 — that spec makes the geometry it relies on
+consistent, though this spec does not depend on it.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3). Smallest architecture spec of
+the round.
+
+## Problem Statement
+
+Asking for the intersection of two ranges gives an answer whose *kind* depends on whether an optional
+predicate was supplied.
+
+| input | no predicate | with predicate |
+|---|---|---|
+| disjoint ranges | an invalid `#REF!` address, not null | null |
+| overlapping ranges | the overlap | the overlap |
+
+The declared return type is nullable, so the obvious caller check — test for null — is correct with a
+predicate and wrong without one, where the disjoint answer is a non-null address that happens to be
+invalid. Which convention applies is not documented; the interface says only that it returns the
+address of the intersection.
+
+There is a second, quieter difference. With a predicate, the result is not an intersection at all: it
+is the bounding box of the cells that match. Two matching cells at opposite corners produce a
+rectangle containing cells that do not match and were never in the intersection.
+
+Both behaviours are unpinned — nothing in the suite asserts either convention.
+
+## Solution
+
+One implementation of intersecting two ranges, with the predicate applied as a filter over the result
+rather than as a switch onto a different algorithm. One stated convention for "there is no
+intersection", used in both cases and documented on the interface.
+
+## User Stories
+
+1. As a library consumer, I want the same absence convention whether or not I pass a predicate, so that
+   one null check is correct everywhere.
+2. As a library consumer, I want that convention documented on the interface, so that I do not have to
+   read the implementation to know what an empty result looks like.
+3. As a library consumer, I want disjoint ranges to report no intersection in a way I can test in one
+   line, so that the common case is simple.
+4. As a library consumer, I want overlapping ranges to give the overlap, unchanged from today, so that
+   the working case is undisturbed.
+5. As a library consumer, I want a predicate to narrow the intersection rather than change what
+   intersection means, so that the parameter is a filter and not a mode switch.
+6. As a library consumer, I want a predicate that matches nothing to report absence using the same
+   convention as a disjoint intersection, so that the two empty outcomes look alike.
+7. As a library consumer, I want a predicate that matches every cell to give the same result as no
+   predicate at all, so that the parameter is neutral when it excludes nothing.
+8. As a library consumer, I want the result of a predicated intersection to contain only cells inside the
+   geometric intersection, so that the result is a subset of the unfiltered one.
+9. As a library consumer, I want ranges on different worksheets to report absence consistently, so that
+   cross-sheet calls follow the same rule.
+10. As a library consumer, I want a range intersected with itself to return itself, so that the identity
+    case is obvious.
+11. As a library consumer, I want touching-but-not-overlapping ranges to report absence, so that adjacency
+    is not mistaken for intersection.
+12. As an XLibur maintainer, I want one implementation, so that a change to intersection semantics is one
+    edit.
+13. As an XLibur maintainer, I want the absence convention expressed in the signature, so that the type
+    tells the caller what to check.
+14. As an XLibur maintainer, I want the four-cell behaviour matrix asserted, so that the contract is
+    pinned rather than emergent.
+15. As a contributing agent, I want the predicate's role stated in one sentence, so that I do not have to
+    infer it from two code paths.
+
+## Implementation Decisions
+
+**The seam is the existing public intersection method.** No new seam; this spec removes one
+implementation rather than adding anything.
+
+**The predicate becomes a filter over one algorithm.** Compute the geometric intersection, then apply
+the predicate. The current predicated path computes something else entirely — the bounding box of
+matching cells — which is why it can include non-matching cells.
+
+**The bounding-box behaviour is a decision, not an accident, and must be made explicitly.** Two
+readings are defensible: a caller filtering an intersection probably wants the matching cells, not a
+rectangle around them; but a method returning a range address can only return a rectangle. The spec's
+preference is that the predicated result be the smallest rectangle containing the matching cells
+*within* the geometric intersection — which preserves the rectangle-returning contract while fixing
+the case where the result escapes the intersection. Whichever is chosen is documented on the interface.
+
+**One absence convention, and it is the invalid address.** Returning an invalid `#REF!` address is
+consistent with how the library represents an unresolvable reference elsewhere, and it is what the
+more commonly used unpredicated path already does. The predicated path changes to match. The return
+type stops being nullable, which makes the convention visible in the signature rather than documented
+in prose.
+
+**This changes observable behaviour for predicated callers**, who currently receive null. It is a small
+surface and the current behaviour is undocumented and untested, but it is a change and belongs in the
+release notes.
+
+**The interface documentation is part of the deliverable.** The current summary describes neither
+convention. That omission is the reason both behaviours could coexist unnoticed.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test calls the public method with two ranges and asserts on the
+returned address — its validity, and its extent. There is nothing internal worth testing; the whole
+defect is in the observable contract.
+
+**The centrepiece is the behaviour matrix.** Disjoint and overlapping, by predicate and no predicate:
+four cases, asserting both the absence convention and the extent. This is the matrix the review used to
+characterise the divergence and it becomes the contract test.
+
+**Extended cases.** Identity, adjacency without overlap, a predicate matching everything, a predicate
+matching nothing, a predicate matching only opposite corners, and ranges on different worksheets.
+
+**The corner case is the one that matters.** A predicate matching two opposite corners of the
+intersection asserts what the predicated result means. It is the case that distinguishes the three
+possible designs, so it is the case the test must state.
+
+**Prior art.** The range address tests are the right home. Note that neither convention is currently
+asserted anywhere, so this spec creates the coverage rather than extending it.
+
+**Test seam.** `IXLRangeBase.Intersection`. No new seam.
+
+## Out of Scope
+
+- Range geometry and normalisation — spec 36. This spec assumes whatever geometry it is given.
+- The other set operations on ranges — union, difference, grow, shrink.
+- Implicit intersection in the calc engine, which is a different concept with the same name and is
+  covered by spec 37.
+- Performance.
+
+## Further Notes
+
+Small, but a good example of a specific failure: an optional parameter that changes not just what is
+computed but what the return value *means*. A caller reading the signature sees a nullable address and
+writes the obvious check; that check is right half the time, and which half depends on an argument they
+may have passed for unrelated reasons.
+
+The fact that neither convention is asserted anywhere is what allowed two to coexist. A single test of
+the disjoint case, written at any point, would have forced the question.
+
+The four-cell matrix was measured against a scratch build before this spec was written.

--- a/docs/specs/51-one-consolidation-engine.md
+++ b/docs/specs/51-one-consolidation-engine.md
@@ -1,0 +1,136 @@
+# Spec 51 — One consolidation engine, two adapters
+
+**Area:** Architecture · Refactor
+**Effort:** S–M (~3 days)
+**Dependencies:** **Spec 36 should land first.** The only live divergence between the two engines is
+caused by the un-normalised geometry that spec 36 removes; running this spec first would collapse two
+implementations onto one while that input still misbehaves.
+**Status:** Proposed. From the 2026-08-30 architecture review (round 3). **Structural, not
+defect-driven** — see the caveat below.
+
+## Problem Statement
+
+Merging a set of overlapping and adjacent rectangles into the smallest set of maximal blocks is
+implemented twice: once over the value-typed rectangle, and once over live worksheet ranges.
+
+Three of the seven method pairs are byte-identical. The rest differ only in how they reach a
+rectangle's corners and in what they yield. The duplication is documented in a comment rather than
+tested.
+
+The two have disjoint consumers and disjoint test suites — conditional formats and data validations
+use one, the public range consolidation uses the other — so nothing runs both on the same input, and
+neither suite protects the other. A change to one is not a change to the other, and there is no
+mechanism by which anyone would notice.
+
+## Solution
+
+One implementation, over the value-typed rectangle, with the live-range consumer becoming an adapter
+that projects its ranges into rectangles, consolidates, and projects the results back.
+
+This is the shape spec 26 established for the grid axis: one algorithm, two adapters, one place to
+change and one place to test.
+
+## User Stories
+
+1. As a library consumer, I want consolidating a set of ranges to give the same blocks as consolidating
+   the equivalent conditional format areas, so that the two features agree.
+2. As a library consumer, I want overlapping ranges to merge into maximal blocks, unchanged from today.
+3. As a library consumer, I want horizontally adjacent ranges to merge, unchanged from today.
+4. As a library consumer, I want vertically adjacent ranges to merge, unchanged from today.
+5. As a library consumer, I want ranges that touch only at a corner not to merge, so that adjacency is
+   interpreted consistently.
+6. As a library consumer, I want a set of ranges that cannot be merged to come back unchanged and in a
+   predictable order, so that consolidation is stable.
+7. As a library consumer, I want consolidation to be deterministic for a given input, so that saved files
+   are reproducible.
+8. As a library consumer, I want conditional formats and data validations to keep consolidating exactly as
+   they do today, so that saved output is unchanged.
+9. As a library consumer, I want consolidation performance to be no worse than today, so that saving large
+   styled sheets does not slow down.
+10. As an XLibur maintainer, I want the bit-matrix algorithm to exist once, so that a fix applies to both
+    consumers.
+11. As an XLibur maintainer, I want the two existing test suites to become two views of one
+    implementation, so that each suite's cases protect the other's consumer.
+12. As an XLibur maintainer, I want a differential test across both entry points, so that any future
+    divergence fails a test rather than being discovered by a review.
+13. As an XLibur maintainer, I want the live-range adapter to be thin enough to read in one sitting, so
+    that the projection is obviously correct.
+14. As a contributing agent, I want one consolidation implementation to find, so that I do not fix the
+    one my consumer does not use.
+
+## Implementation Decisions
+
+**The seam is the existing value-typed consolidator.** It is the more constrained of the two — it
+operates on immutable value types with no worksheet dependency, which makes it the easier one to test
+and the natural implementation. The live-range engine becomes an adapter.
+
+**The adapter projects both ways.** Live ranges become rectangles on the way in and are recreated from
+the worksheet on the way out. That projection is the whole of the adapter; nothing else survives from
+the second implementation.
+
+**Enumeration order must be preserved.** The two implementations yield in the same order today, and
+saved output depends on it. The adapter preserves the existing order for its consumer, and a
+byte-comparison of saved output before and after is part of the acceptance evidence.
+
+**No public API change.** The public consolidation method keeps its signature and behaviour.
+
+**Performance is a gate.** Consolidation runs on every save for every sheet with conditional formats or
+validations. The projection adds an allocation per range; if that proves measurable on the bulk-styling
+benchmark, the projection is made allocation-free rather than the merge abandoned.
+
+**This spec is scheduled after spec 36 deliberately.** The only divergence found between the engines is
+that one handles a reversed rectangle and the other silently contributes nothing. That is spec 36's
+defect, not this one's, and fixing it first means this spec is a pure refactor with a byte-identical
+output guarantee — which is a much safer thing to review.
+
+## Testing Decisions
+
+**What makes a good test here.** A good test supplies a set of rectangles through a public entry point
+and asserts the set of cells covered by the result — not the number of blocks or their order, except
+where order is separately pinned. Asserting covered cells rather than block identity is what allows the
+same test to run against both entry points.
+
+**The centrepiece is a differential test.** For a generated corpus of multi-rectangle inputs, run both
+public entry points — range consolidation, and consolidation via identical data validations — and
+assert the covered-cell sets are equal. The review ran four hundred such cases as a one-off probe and
+found no disagreement on normalised input; this spec makes that probe a permanent test.
+
+**A byte-identity baseline.** Save a corpus of workbooks with conditional formats and validations
+before the change, and assert byte-identical output after. This is the acceptance evidence that the
+refactor is behaviour-preserving, and it is the same technique spec 22 used.
+
+**Both existing suites must pass unchanged.** The range consolidation tests and the conditional format
+consolidation tests are the regression net; neither should need editing. If one does, the refactor
+changed behaviour and the change needs justifying in the results.
+
+**Order stability tests.** Assert the yield order for a fixed input, so that a future change to the
+projection cannot silently reorder saved output.
+
+**Prior art.** Spec 26's grid axis is the model — one algorithm, two adapters, with the adapters
+carrying only the projection. Its results section is worth reading for how the byte-identity baseline
+was used.
+
+**Test seam.** `IXLRanges.Consolidate()` and the conditional format and data validation save paths. No
+new seam.
+
+## Out of Scope
+
+- Rectangle normalisation — spec 36, which this spec depends on.
+- The consolidation algorithm itself. This spec merges two implementations of it; it does not improve
+  it.
+- The range index and its quad-tree, which are a different spatial structure.
+- Adding consolidation to features that do not currently consolidate.
+
+## Further Notes
+
+**Honest caveat, and the reason this is not marked Strong.** A four-hundred-case differential fuzz
+across both engines found *zero* disagreement on normalised input. The only divergence that exists
+today is the one spec 36 removes. So this spec is not fixing a bug — it is removing the possibility of
+one, in a place where the same algorithm is maintained twice by hand with nothing testing the
+agreement.
+
+That is a weaker case than the rest of this round and should be scheduled accordingly. It is included
+because the cost is low, the risk is low once spec 36 has landed, and one hundred and fifty lines of
+bit-matrix arithmetic maintained in duplicate is exactly the shape that produced four of this round's
+confirmed defects elsewhere. The argument is prevention, and it should be presented as prevention
+rather than dressed up as a fix.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -42,13 +42,44 @@ Grounding: specs 01–10 were derived from a July 2026 survey of the codebase (a
 | 26 | [Give the grid one axis](26-grid-axis.md) | Arch · Refactor · **3 defects** | L | ✅ **Merged** (#409; see Results) | One `IGridAxis`, two adapters; 3 defects fixed; allocations down 12–50% |
 | 27 | [One font conformance module](27-font-conformance-suite.md) | Test · Arch (seam) | S–M | Proposed | Single owner; **gates 34** |
 | 28 | [One OOXML style decoder](28-single-style-decoder.md) | Arch · Refactor · **Defect (data loss)** | M | ✅ **Merged** (#411; see Results) | Single owner; 3 defects fixed; one premise disproved; load allocations flat or down |
-| 29 | [One resolver per emitted element](29-write-path-resolvers.md) | Arch · **Correctness (divergence)** | M | ✅ **Merged** ([#413](https://github.com/XLibur/XLibur/pull/413) as `8d2acfc7`, 2026-08-27; see Results) | 10 commits, 28,358 green both TFMs; pane divergence fixed; **D18 found here, fixed 2026-08-27 on `fix/D17-D18`**; merged before 33 as planned; **31 is now unblocked** |
+| 29 | [One resolver per emitted element](29-write-path-resolvers.md) | Arch · **Correctness (divergence)** | M | ✅ **Merged** ([#413](https://github.com/XLibur/XLibur/pull/413) as `8d2acfc7`, 2026-08-27; see Results) | 10 commits, 28,358 green both TFMs; pane divergence fixed; **D18 found here and since fixed on [#416](https://github.com/XLibur/XLibur/pull/416) (`37c986bb`)**, which revived `IXLSheetView.FreezePanes` and made `XLPaneSettings.Resolve` return `Split` rather than hardcoding `Frozen`; merged before 33 as planned; **31 is now unblocked** |
 | 30 | [Array application gets an interface](30-array-application-seam.md) | Arch · **Defect (241 functions)** | S–M | Proposed | Single owner; **before 32** |
 | 31 | [Worksheet element writers get one interface](31-worksheet-element-writers.md) | Arch · Refactor | M–L | Proposed (**29 has merged — unblocked**) | Single owner; tasks sequential |
 | 32 | [Collapse the 61-overload registration](32-function-argument-spec.md) | Arch · Refactor | L | Proposed (**needs 30**) | Single owner; task 2 is a go/no-go gate |
-| 33 | [Every sheet feature reacts through one seam](33-sheet-listener-seam.md) | Arch · **Defect (4 unshifted)** | M–L | ✅ **Merged** ([#414](https://github.com/XLibur/XLibur/pull/414) as `ca3ed3d5`, 2026-08-27; see Results) | 29,542 green across **all four** test projects, both TFMs. Shifter 222→65 lines, names no feature; 11 adapters (was 2); the 4 dead features move; **D15–D17 recorded**, D15 pinned here and since fixed on `fix/D15`, D17 fixed on `fix/D17-D18`, D16 still live; criterion 2 reported unreachable. Merged up onto `8d2acfc7` after #413 landed. Does **not** unblock 34, which waits on 27 |
+| 33 | [Every sheet feature reacts through one seam](33-sheet-listener-seam.md) | Arch · **Defect (4 unshifted)** | M–L | ✅ **Merged** ([#414](https://github.com/XLibur/XLibur/pull/414) as `ca3ed3d5`, 2026-08-27; see Results) | 29,542 green across **all four** test projects, both TFMs. Shifter 222→65 lines, names no feature; 11 adapters (was 2); the 4 dead features move; **D15–D17 recorded; D15 since fixed by [#415](https://github.com/XLibur/XLibur/pull/415) (`199b3e2b`), D17 by [#416](https://github.com/XLibur/XLibur/pull/416) (`37c986bb`), D16 still live**; criterion 2 reported unreachable. Landed after #413 as planned. Does **not** unblock 34, which waits on 27 |
 | 34 | [Split the font port: mechanism vs policy](34-font-port-split.md) | Arch · Refactor | M | Proposed (**needs 27**) | Single owner; tasks sequential |
 | 35 | [Pivot table timelines](35-pivot-timelines.md) | Feature · Compat | M | ✅ **Done** (#406; see Results) | Task 1 (extraction) standalone; 2→3→4 ordered |
+| 36 | [One rectangle, normalised once](36-one-normalised-rectangle.md) | Arch · **Defect (5, one fatal)** | M | 🟩 **Implemented**, `task/36` unmerged (see Results; residual D24) | Conversion fix first, then one consumer per commit; **before 51** |
+| 37 | [One way to reduce an argument to a scalar](37-scalar-argument-reduction.md) | Arch · **Defect (22 functions)** | M | 🟩 **Implemented**, `task/37` unmerged (see Results) | Single owner; **must precede 32** |
+| 38 | [Sheet view state gets one module](38-sheet-view-state.md) | Arch · **Defect (4)** | M | 🟩 **Implemented**, `task/38` unmerged (see Results) | Single owner; **conflicts with 31** — 38 landed first, as planned |
+| 39 | [One attribute table for the pivot definition](39-pivot-definition-attribute-table.md) | Arch · **Defect** · API (additive) | M–L | 🟩 **Implemented**, `task/39` unmerged (see Results) | Wrong-source fix standalone first, then the table |
+| 40 | [The dirty flag stops doubling as a visited marker](40-dirty-versus-visited.md) | Arch · **Defect (propagation)** | S–M | 🟩 **Implemented**, `task/40` unmerged (see Results; one open perf decision) | One owner with 42 and 43, in that order |
+| 41 | [One codec for a pivot cache value](41-pivot-cache-value-codec.md) | Arch · **Defect (2, data-destroying)** | M | Proposed | File-disjoint from 39 — genuinely parallel |
+| 42 | [One formula write path, and it invalidates](42-formula-write-invalidation.md) | Arch · **Defect (stale reads)** | S–M | Proposed | After 40; before 47 |
+| 43 | [Reading a cell is spill-aware, once](43-spill-aware-cell-read.md) | Arch · **Defect (order-dependent)** | M | Proposed | After 40 and 42 |
+| 44 | [Data validation: one mapping, two adapters](44-data-validation-mapping.md) | Arch · **Correctness (divergence)** | M | Proposed | **Before 48/49** — removes code from the file they edit |
+| 45 | [The text codec applies at the seam](45-text-codec-at-the-seam.md) | Arch · **Defect (crash + corruption)** | **S** | Proposed | One commit; **conflicts with 31**. Cheapest real win |
+| 46 | [The table part gets a reader](46-table-part-reader.md) | Arch · **Defect (wrong colour filter)** | M | Proposed | Colour-filter fix standalone first, then the reader |
+| 47 | [One implementation of assigning a value](47-value-assignment-protocol.md) | Arch · **Defect (quote prefix)** | S–M | Proposed | Soft: after 42 |
+| 48 | [Conditional format defects](48-conditional-format-defects.md) | **Defect (load crash)** · Compat | S–M | Proposed | **No API change** — ships before 49; Excel-authored fixtures |
+| 49 | [One conditional format value object](49-conditional-format-value-object.md) | Arch · **API (breaking)** | M–L | Proposed (**needs 48**) | Single owner; obsolete-then-remove migration |
+| 50 | [One `Intersection`, one absence convention](50-intersection-one-convention.md) | Arch · Correctness | **S** | Proposed | Soft: after 36 |
+| 51 | [One consolidation engine, two adapters](51-one-consolidation-engine.md) | Arch · Refactor | S–M | Proposed (**needs 36**) | **Prevention, not a fix** — 400-case fuzz found no divergence |
+
+**Specs 36–51 came out of a third architecture review on 2026-08-30.** Their progress board,
+dependency graph, conflict map, wave plan and the backlog notes for four candidates that did *not*
+earn a spec live in [TASKLIST-architecture-deepening-3.md](TASKLIST-architecture-deepening-3.md).
+
+Same shape as the two rounds before it — **one fact with two or more implementations, kept in
+agreement by hand** — found fifteen times, with most of the agreements already failed in shipped code.
+**Every defect was executed against a scratch build, not inferred**, except where a spec marks a
+finding unverified. Round 3 also names a second pattern: **XLibur's readers are written against
+XLibur's writer rather than against the format**, so the inputs that break them cannot be authored by
+the library — which is why several of these specs deliver Excel-authored fixtures as their real
+product.
+
+**Start with 37** (22 shipped functions unusable with cell references), then **36** (the only failure
+in the round a user cannot work around), then **45** (a crash and a silent corruption, days of work).
 
 **Specs 26–34 came out of a second architecture review on 2026-08-24.** Their progress board,
 dependency graph, conflict map and wave plan live in

--- a/docs/specs/TASKLIST-architecture-deepening-2.md
+++ b/docs/specs/TASKLIST-architecture-deepening-2.md
@@ -152,7 +152,9 @@ Branch `refactor/29-write-path-resolvers`, **merged as [#413](https://github.com
 exactly the predicted two — `docs/specs` and the `## Unreleased` changelog entries — with no source
 file shared; resolved on #414's branch by keeping both. Suite green on both TFMs:
 28,358 tests, 0 failed. Found and recorded **D18** on the way (an unfrozen split pane is lost on
-load, and any split is written back as a freeze) — not fixed, it needs a public API change.
+load, and any split is written back as a freeze) — not fixed here, because it needs a public API
+change. **That change was authorised and D18 is now fixed on [#416](https://github.com/XLibur/XLibur/pull/416) (`37c986bb`)**: `IXLSheetView.FreezePanes`
+is public again and `XLPaneSettings.Resolve` returns `Split` instead of hardcoding `Frozen`.
 
 ### Spec 30 — Array application seam ⬜ Ready
 
@@ -233,7 +235,9 @@ brief template**: a spec that changes library behaviour can break a consumer pac
 port, up from 2; all four dead features move. Full suite green on net8.0 and net10.0, five assertions
 deliberately reversed and renamed, no other test changed. Structural-edit profile: full workload
 −0.9% time, −0.0% bytes on medians of three runs. Three defects recorded (D15, D16, D17) and one
-criterion reported as unreachable (≥12 adapter types; the design lists 11).
+criterion reported as unreachable (≥12 adapter types; the design lists 11). **D15 and D17 have since
+been fixed** — D15 by [#415](https://github.com/XLibur/XLibur/pull/415) (`199b3e2b`), D17 by
+[#416](https://github.com/XLibur/XLibur/pull/416) (`37c986bb`) — leaving D16, which is fixed for drawing anchors here and still live at the source.
 
 **Two gates each caught something the other could not.** Task 7 caught a regression it had itself
 introduced — the note pass materialised an `XLCell` per used cell on every edit — fixed at source

--- a/docs/specs/TASKLIST-architecture-deepening-3.md
+++ b/docs/specs/TASKLIST-architecture-deepening-3.md
@@ -1,0 +1,213 @@
+# Tasklist — Architecture deepening, round 3 (specs 36–51)
+
+Progress board and parallel-execution plan for the sixteen architecture specs that came out of the
+**2026-08-30** architecture review. Round 1 (specs 22–25) and round 2 (specs 26–34) have their own
+boards in [TASKLIST-architecture-deepening.md](TASKLIST-architecture-deepening.md) and
+[TASKLIST-architecture-deepening-2.md](TASKLIST-architecture-deepening-2.md).
+
+**Update this file as tasks land.** Tick the boxes, and put the PR number next to the task.
+
+## What this round found
+
+The same shape as the last two rounds: **one fact has two or more implementations, kept in agreement
+by hand.** Round 1 found it twice. Round 2 found it nine times, five already broken. Round 3 found it
+fifteen times, and **most of the agreements have already failed in shipped code**.
+
+Every defect below was **executed against a scratch build**, not inferred, except where the spec marks
+a finding unverified. The repository was not modified during the review.
+
+| Spec | Drift | Effect |
+|---|---|---|
+| 36 | Eight implementations of "where is this rectangle"; four disagree | **`SaveAs` throws** on a conditional format over a reversed range — the workbook cannot be saved at all. Plus: data validation lost on round trip, styling silently does nothing, negative row/column counts, tables with zero fields, consolidation dropping ranges |
+| 37 | Eight copies of "reduce an argument to a scalar", three behaviours | **All 18 dynamic-array functions and 4 regression functions return `#VALUE!`** when a scalar parameter is a cell reference. `=SEQUENCE(A1)`, `=SORT(data,C1)`, `=XLOOKUP(k,a,b,,C1)`. Five of the eight copies contain a branch that provably never executes |
+| 38 | Six enumerations of the sheet's view properties; four have drifted | Copying a sheet loses gridlines, zoom, view mode and tab colour, and picks up the *target* workbook's defaults. `sheetView/@view` is written and never read — Page Layout files reopen as Normal |
+| 39 | Sixty pivot settings enumerated five times | `showLastColumn` is read from `showColStripes` — re-saving adds emphasis the user never asked for. `Title`/`Description` are public, settable and persisted nowhere. `CopyTo` resets 23 settings. `dataPosition` never set on load, against the subsystem's own documented crash condition |
+| 40 | The dirty flag doubles as the BFS visited-marker | Calling the public `InvalidateFormula` makes a **later** edit under-recalculate — the walk treats an already-dirty node as visited and prunes its whole subtree. `BumpEditEpoch` is never called, so the documented three-state epoch model does not exist |
+| 41 | Four serialisers of one pivot cache value union | An error value is written as a **boolean** element — Excel reports the cache as repairable. Grouping is **destroyed** on re-save and the part becomes structurally invalid; **XLibur then refuses to load its own output** |
+| 42 | Two formula write paths, one skips invalidation | Replacing an array formula leaves its consumers stale — `SUM` over the array keeps the old total. The single-cell control is correct, which is why it was never noticed |
+| 43 | Two readers of "a cell's current value", one spill-blind | Reading a spilled cell gives **a different answer depending on what was read before it**. Third copy of spill ownership maintained by hand |
+| 44 | Thirteen validation settings written out **seven times** | Standard and extension writers already disagree on empty-formula emission and on the dirty gate. The consolidation equality test compares one property twice under two names — a dead comparison, and direct evidence the list is copied rather than derived |
+| 45 | The text codec applied at 5 of 7 sites | **Save throws** on a control character with string sharing off. A literal `_x0041_` is silently rewritten to `A` by Excel — and XLibur skips the decode too, so its own round trip looks clean and no test can see it |
+| 46 | A table writer with no reader module | A table's **colour filter filters by the wrong colour** after a round trip — a `dxfId` into a collection rebuilt every save. Sort state dropped; tables renamed on save; column/header/totals formatting destroyed. The mechanism is an **optional parameter** one call site omits |
+| 47 | Four copies of the value-assignment protocol | `InsertData` keeps the leading apostrophe where `Cell.Value` strips it, when the inherited style already carries the quote prefix. The shipped public `SetCellValue` never invalidates and has no tests |
+| 48 | Readers written against XLibur's writer, not the format | **Load crashes** on an Excel data bar with "negative fill same as positive". Save throws on a value object with no value. Bordered data bars come back borderless |
+| 49 | Four parallel index-aligned collections on a public interface | One threshold with no type shifts every later entry onto the wrong type — an icon set silently re-saves meaning something else |
+| 50 | One `Intersection`, two algorithms, two error modes | Disjoint returns a non-null `#REF!` without a predicate and `null` with one. Neither convention is documented or tested |
+| 51 | Two consolidation engines, three methods byte-identical | **No divergence found** on normalised input across a 400-case fuzz. Prevention, not a fix — scheduled and presented as such |
+
+**The through-line, again: the missing test is not an oversight, it is a consequence of the shape.**
+Round 3 adds a second pattern worth naming — **XLibur's readers are written against XLibur's writer
+rather than against the format.** Where the writer always emits an element, the reader assumes it
+(48); where both halves of a codec are missing, the error cancels out and only Excel sees it (45);
+where a fixture can only be authored by the library, the input that breaks it cannot be constructed
+(41, 46). Several of these specs deliver **Excel-authored fixtures** as their real product.
+
+---
+
+## 1. Progress board
+
+| Spec | Title | Effort | Blocked by | Status |
+|---|---|---|---|---|
+| [36](36-one-normalised-rectangle.md) | One rectangle, normalised once | M | — | 🟩 **Implemented** on `task/36` (`80a5b77a`, 15 commits; green on both TFMs at head — net8.0 14,268 verified by the orchestrator); not yet merged. Residual class recorded as D24. See Results |
+| [37](37-scalar-argument-reduction.md) | One way to reduce an argument to a scalar | M | — (**must precede 32**) | 🟩 **Implemented** on `task/37` (`42bf46f8`, 13 commits, 14,285 green ×2 TFMs); not yet merged. See Results |
+| [38](38-sheet-view-state.md) | Sheet view state gets one module | M | — (**conflicts with 31**) | 🟩 **Implemented** on `task/38` (`ba9af10d`, 11 commits, 28,516 green ×2 TFMs); not yet merged. Inverted-polarity premise disproved. See Results |
+| [39](39-pivot-definition-attribute-table.md) | One attribute table for the pivot definition | M–L | — | 🟩 **Implemented** on `task/39` (`d5d73267`, 14 commits; 28,526 green ×2 TFMs at `f78a2fe8` verified by the orchestrator, net10.0 green at head after the owner's review pass); not yet merged. Eight golden fixtures regenerated. PR must be `feat!`/`fix!`: `ShowLastColumn` on `IXLPivotTable` breaks external implementers |
+| [40](40-dirty-versus-visited.md) | The dirty flag stops doubling as a visited marker | S–M | — | 🟩 **Implemented** on `task/40` (`9a070669`, 9 commits, 14,265 green ×2 TFMs); not yet merged. **One open decision**: 4×/17× cost on the unsettled bulk-edit shape, accepted for correctness — see Results |
+| [41](41-pivot-cache-value-codec.md) | One codec for a pivot cache value | M | — | ⬜ Ready |
+| [42](42-formula-write-invalidation.md) | One formula write path, and it invalidates | S–M | soft: 40 (implemented, unmerged — branch off `task/40` or wait for its merge); **takes D26** | ⬜ Ready |
+| [43](43-spill-aware-cell-read.md) | Reading a cell is spill-aware, once | M | soft: 40 (implemented, unmerged), 42 | ⬜ Ready |
+| [44](44-data-validation-mapping.md) | Data validation: one mapping, two adapters | M | — (**conflicts with 48/49**) | ⬜ Ready |
+| [45](45-text-codec-at-the-seam.md) | The text codec applies at the seam | **S** | — (**conflicts with 31**) | ⬜ Ready |
+| [46](46-table-part-reader.md) | The table part gets a reader | M | — | ⬜ Ready |
+| [47](47-value-assignment-protocol.md) | One implementation of assigning a value | S–M | soft: 42 | ⬜ Ready |
+| [48](48-conditional-format-defects.md) | Conditional format defects | S–M | — (**before 49**) | ⬜ Ready |
+| [49](49-conditional-format-value-object.md) | One conditional format value object | M–L | **48** | ⬜ Blocked |
+| [50](50-intersection-one-convention.md) | One `Intersection`, one absence convention | **S** | soft: 36 | ⬜ Ready |
+| [51](51-one-consolidation-engine.md) | One consolidation engine, two adapters | S–M | **36** (implemented, unmerged — unblocks on merge) | ⬜ Blocked |
+
+## 2. Dependency graph
+
+```
+36 ──────────────► 51            (36 removes 51's only live divergence)
+36 ┄┄┄┄┄┄┄┄┄┄┄┄┄► 50            (soft: consistent geometry, not required)
+
+37 ──────────────► spec 32       (37 must land BEFORE 32; see conflicts)
+
+40 ──► 42 ──► 43                 (one owner, one branch, this order)
+       42 ┄┄► 47                 (soft: 47 calls the seam 42 relocates)
+
+48 ──────────────► 49            (crash fix ships without an API decision)
+
+38, 39, 41, 44, 45, 46  — independent of each other
+```
+
+## 3. Conflict map
+
+**Read this before assigning two specs to run in parallel.**
+
+| Pair | Conflict | Resolution |
+|---|---|---|
+| **37 ↔ spec 32** | 32 rewrites 411 registrations across the same function families 37 touches. Head-on collision | **37 lands first**, or 37 folds into 32's scope. 30 is file-disjoint from both and unaffected |
+| **38 ↔ spec 31** | Both work inside the sheet-view writer | Sequence them. 31 is the larger; 38 is easier to rebase. Recommend **38 first** — it is smaller and 31 has not started |
+| **45 ↔ spec 31** | 45 touches the cell XML writer and both sheet data writers | Small and surgical (one commit). Land **45 before 31 starts**, or accept a trivial rebase |
+| **44 ↔ 48/49** | 44 moves the x14 validation reader *out* of the conditional format reader; 48 and 49 work *inside* it | Sequence. Recommend **44 first** — it removes code from the file the other two then edit |
+| **48 ↔ 49** | Same files by design | Strictly sequential, one owner |
+| **39 ↔ 41** | Both pivot, **file-disjoint** — definition vs cache | Genuinely parallel, two owners |
+| **46 ↔ spec 28** | 46 reads the differential format collection 28 established | 28 has merged. No conflict |
+| **40/42/43** | Same calc-engine staleness model | One owner, one branch, in order |
+
+## 4. Suggested waves
+
+**Wave A — parallel, four owners, no conflicts between them:**
+36 · 37 · 41 · 46
+
+**Wave B — after A:**
+40→42→43 (one owner) · 39 · 45 · 48
+
+**Wave C:**
+38 · 44 · 47 · 50 · 51 · 49
+
+**If only one thing is done this round: 37.** It is the widest live defect — an entire shipped feature
+family unusable with cell references — and the deepening is unusually clean.
+
+**If a second: 36.** An unconditional `SaveAs` throw is the only failure in the round a user cannot
+work around.
+
+**Cheapest real win: 45.** A crash and a silent corruption, fixed by moving two calls to a seam. Days,
+not weeks.
+
+---
+
+## 5. Backlog notes — reviewed, deliberately not specced
+
+Four candidates from the round-3 report that did not earn a spec. Recorded so the next review does not
+re-walk them.
+
+### 5.1 Extend the write-path agreement harness
+
+**Not a spec because it is spec 31's harness, not new content.** The existing write-path agreement
+tests cover two elements — the pane and the column — both claimed by spec 29. Meanwhile the streaming
+path emits no `<dimension>`, no `<sheetFormatPr>`, no `_xlnm._FilterDatabase` defined name and no
+theme part. All are schema-optional, so the SDK validator passes on every one.
+
+**The theme omission has a visible effect:** a theme-coloured style resolves against Excel's built-in
+theme instead of the workbook's, so the same `IXLStyle` renders differently depending on which path
+wrote it.
+
+**Action:** add to spec 31's task list — extend the harness to `<dimension>`, `<sheetFormatPr>`, a
+cell-level comparison and the shared strings part, then decide per divergence whether streaming should
+emit the element or the omission is deliberate.
+
+### 5.2 Name the range index's two adapters
+
+**Worth exploring; no divergence found that is reachable today.** Eight methods branch on whether the
+quad-tree exists — two complete implementations of one interface in one class, switched by a hidden
+one-way promotion at 20 ranges. They disagree on identity (the list path rejects a duplicate by
+reference, the tree path by address) and on removal (all address matches versus one). Neither is
+reachable today because the index holds strong references.
+
+**The real finding is the test gap:** every test builds a 10,000-range fixture, so the flat-list
+path — the one nearly every real workbook takes — has never been directly exercised.
+
+**Action:** if the promotion threshold is ever changed, or the range repository's weak references ever
+allow two live ranges with one address, this becomes urgent. Until then, a note.
+
+**Related:** the quad-tree allocates 128 child quadrants and discards them on every add that does not
+descend — which is every whole-row range. Perf, not architecture; belongs with spec 19's survey.
+
+### 5.3 Name the pivot-CF handshake
+
+**Worth exploring; severity rests on reading the schema, not a repro that was run.** A pivot's
+conditional format lives in two parts joined only by `priority`. The sheet-side reader drops a rule
+with no `@type` before registering it, so a malformed pivot rule — or two rules that both fall back to
+the same sentinel priority — fails the **entire workbook load**. On save the handshake depends on an
+unwritten ordering constraint: priorities are renumbered, and the pivot part must be written
+afterwards. It is, but only because one line happens to precede another.
+
+**Action:** could not construct the malformed input from XLibur's own writer. If an Excel-authored
+fixture that triggers it turns up, promote to a spec. The degraded-but-loading failure mode is the
+right target.
+
+### 5.4 The nine `*Helper` files are file splits, not seams
+
+**Speculative; structural observation only.** Seven of the nine have exactly one caller — the class
+they were carved out of — take that class as their first parameter, and reach straight back into it.
+The stated rationale is size: "to keep the main class smaller." Six are named nowhere in the test
+project. Deletion test: inline any of them and complexity reappears in exactly *one* caller, which
+already knew everything the interface asked for.
+
+**Not "re-inline them."** Where a helper is worth keeping, narrow its interface to the data it actually
+needs — an `Area` and a worksheet — which is what would make it testable without building a workbook.
+
+**Exceptions:** the shift and insert helpers are genuine. Spec 26 gave them a real axis seam and tests
+name them.
+
+### 5.5 Incidentals
+
+- `XLRanges.AddToNamed(string, XLScope)` **discards its `scope` argument** and hardcodes workbook
+  scope. A worksheet-scoped named range silently becomes workbook-scoped. One-line fix, no spec.
+- Dead code in the area type: `ShiftOrExtendRight`, `ShiftOrExtendDown` and `ToAreaList` have zero
+  callers. `Overlaps` has no production caller and is misnamed — its body is a containment test.
+- `ReadingOrder` is a raw enum cast in one styles-writer site and goes through the shared converter in
+  another. They agree only because the enum's implicit values happen to match the format's. Latent;
+  spec 23/28 territory.
+- **Three second mapping sites bypass the shared enum converter.** The largest is the **pivot write
+  path's own raw-string enum table** — nine enums duplicated from the shared converter, agreeing today
+  including the two spellings that differ only in case, with four converter methods dead as a result.
+  **Folded into spec 39**, which is already rewriting how that writer emits attributes. Two smaller
+  ones have no spec and are recorded here: **`XLLineStyle` in the drawing part reader** and
+  **`XLPictureFormat` in the rich data reader**. Both are one-directional local mappings that the
+  shared converter also covers. Small enough to fold into whichever spec next touches those files —
+  candidates would be spec 15 (shapes) or spec 17 (picture styling), both open.
+- **The shared enum converter itself is clean, and this was checked mechanically.** All 43 pairs are
+  symmetric and complete in both directions, verified by reflection against the real
+  `DocumentFormat.OpenXml` 3.5.1 enum members rather than by reading the tables. No asymmetries, no
+  collisions. The single exception is the `sheetView/@view` mapping, whose load-side call is missing
+  entirely — that is spec 38's, not the converter's.
+- **There is no `EnumConverterTests.cs`.** The only direct coverage is the lenient-casing path in the
+  alignment tests, plus round-trip tests for the one deliberate gap. Given the tables are currently
+  symmetric this is a latent risk rather than a defect, but it is why a fourth duplicate mapping could
+  be added tomorrow without anything noticing.
+- `XLCalcEngine.TryEvaluateSingleCell` and `ApplyFormula` share a 15-line literal duplicate and
+  disagree on data tables — the fast path "falls back to the safe general path", which throws. **Not
+  reproduced.** Recorded in spec 43 as a lead to confirm or dismiss with evidence.


### PR DESCRIPTION
Implements [spec 40](docs/specs/40-dirty-versus-visited.md).

## The defect

`DependencyTree.MarkDirty` walks the dependency graph from an edited cell and marks every
dependent formula dirty. It needs an "already visited" marker or a cyclic graph loops forever —
and it used the formula's own dirty flag for that.

So anything that dirtied a formula *outside* the walk made the next walk mistake pre-existing
dirty state for "already visited", stop there, and prune everything downstream. Four things do
that: the public `InvalidateFormula`, a sheet rename's reference rewrite, a row/column insert's
reference shift, and a range move.

```csharp
// A1=1, B1=A1+1, C1=B1+1, D1=C1+1
ws.Cell("C1").InvalidateFormula();
ws.Cell("A1").Value = 10;
// D1 == 4, expected 13 — the walk stopped at the already-dirty C1
```

The values are silently stale: no exception, and a save writes them out.

## The fix

- **The walk tracks its own visits.** A monotonic walk id is stamped on each formula
  `MarkDirty` enqueues (`XLCellFormula.TryVisit`). Traversal no longer consults dirty state, so
  a node dirtied for an unrelated reason is still walked through. Cycles still terminate.
- **The dirty flag means one thing again**: "this formula needs recalculating". Nothing else
  reads it as a traversal marker.
- **The edit-epoch machinery is deleted.** `XLWorkbook.BumpEditEpoch` had **zero callers** on
  `main`, so `EditEpoch` was permanently `1` and `XLCellFormula._evalEpoch` was already a
  two-state bool in disguise — the two states the code documented differ by nothing. Replaced
  with a plain `bool _isClean`; 8 call sites across 5 files simplified. Verified
  semantics-preserving in review.

No public API change. Only the walk changed — tree construction, what gets registered, and the
formula write path's missing invalidation (spec 42) are untouched.

## A High regression the in-branch review caught

Worth calling out, because the interference matrix could not have found it.

The walk-id counter initially lived on `DependencyTree`. But `XLCalcEngine.Purge` discards and
rebuilds the whole tree on a sheet add or rename and on *every* row/column insert or delete —
while the `XLCellFormula` objects carrying the stamps survive. The counter restarted at zero
and handed surviving formulas an id they were already stamped with, so the **first walk after
every rebuild pruned at its first hop**: the original defect, in a narrower window.

Fixed in `b08faf00` by making the counter process-wide, so an id is never reused against a
formula that outlived the tree that issued it. Covered by
`Walk_ids_are_not_reused_after_the_dependency_tree_is_rebuilt`.

Every test in the interference matrix builds its graph *after* the last purge, which is why the
matrix stayed green. The matrix was organised by *dirtier*; this defect lived in the *tree's
lifecycle*. Recorded as a follow-up in `docs/dirty-walk-bulk-edit.md`.

## Benchmarks — including a real cost

`XLibur.Benchmarks`, `profile bulkedit`. **Allocations are exact and were byte-identical across
repeated runs; times are single-shot on a machine with ~40% variance** — medians of three.

| Probe | `main` | this branch |
|---|---|---|
| 200k edits, 200×10 chains (real walk) | 821.5 MB / 1588 ms | 791.0 MB / 1848 ms |
| 200k edits, no dependents | 46.5 MB / 41 ms | **16.0 MB** / 46 ms |
| **20k unsettled edits, 50-deep shared model** | **12.6 MB / 48 ms** | **221.3 MB / 216 ms** |

### ⚠️ Please review the third row explicitly

Reusing the dirty flag also short-circuited *between* calls, not just within one. A formula left
dirty by one edit was still dirty at the next, so bulk writes into a shared model marked it dirty
once and skipped the walk thereafter — roughly `O(edits + model)` instead of `O(edits × closure)`.

**That saving was never sound.** It is the same shortcut that pruned legitimate walks and
produced the stale values above; the cheapness and the bug were one behaviour seen from two
sides. So it is gone, and the shape that used to be free now costs 17.6x allocation and ~4x
time. Independently reproduced during review on a throwaway worktree of `main` (49 ms / 12.6 MB
vs 191 ms / 221.3 MB).

The allocation is RBush `FindDependentsAreas` search lists, one per hop — 1M searches instead of
20k — not the walk queue, and it scales linearly with model depth. Normal usage is unaffected:
anything that reads or saves between edits settles the graph, and edits to cells nothing depends
on now allocate about a third of what `main` did.

**A sound cross-call skip needs a third state** — a `_dirtiedByWalk` bit distinct from
`_isClean` and cleared by `MarkClean()` — to distinguish "dirty because a walk reached it" from
"dirty for an unrelated reason". The dirty flag alone cannot carry that; reintroducing a skip on
it reintroduces this bug. `BulkEditDirtyWalkProfile`'s third probe is permanent and is the guard
any such attempt has to move.

The judgement made here was to take correctness now and document the cost rather than gamble on
a soundness argument. **That is a product call and the main thing worth a second opinion on this
PR.** Structural-edit benchmarks are within noise, as expected — `Purge` never calls the changed
method.

## Tests

19 tests added in `DirtyPropagationTests.cs`: a cycle-termination safety net (written and seen
green *before* any change), an interference matrix over all four dirtiers, graph-shape coverage
(chain, diamond, cross-sheet, cycle), and the tree-rebuild case — each with a control. Every one
was seen red before the fix, except the safety net and the two noted below.

`Mark_dirty_stops_at_dirty_cell` was rewritten: it had asserted the defect's symptom as intended
behaviour.

**One honest note on the matrix.** Sheet rename and row/column insert do *not* reproduce the
defect through their public operations — both trigger `XLCalcEngine.Purge`, which marks the
whole workbook dirty and masks the narrow bug. Their live-API tests are green before *and* after
and are kept as regression cover, documented as such;
`Formula_marked_dirty_by_a_text_rewrite_does_not_prune_a_later_edit` isolates the primitive both
actually use and is genuinely red/green.

| Suite | Result |
|---|---|
| `XLibur.Tests` net8.0 | **14,265 total, 0 failed** (5 pre-existing skips) |
| `XLibur.Tests` net10.0 | **14,265 total, 0 failed** (5 pre-existing skips) |
| `XLibur.Report.Tests` | 481 / 481 |
| `XLibur.Fonts.SixLabors.Tests` | 31 / 31 |
| `XLibur.Fonts.SkiaSharp.Tests` | 37 / 37 |

Library builds with 0 warnings under `TreatWarningsAsErrors`.

## Found, not fixed

Both outside "only the walk changes", recorded in the spec as **D25** and **D26**:

- **D25 — `XLRange.TransposeRange` swaps its offsets on the wrong axes.**
  `XLibur/Excel/Ranges/XLRange.cs` computes `new Point(col + colOffset, row + rowOffset)` where
  the axis-correct form is `new Point(col + rowOffset, row + colOffset)`, so a range whose first
  row number differs from its first column number transposes to the wrong cell —
  `ws.Range("B1:C2").Transpose(...)` moves C1 to A3 instead of B2. Silent data misplacement, no
  exception. Touches range geometry that may overlap spec 36. The range-move test here uses
  `C3:D4` (equal offsets) to avoid depending on it.
- **D26 — `XLCell.InvalidateFormula` marks only its own formula and runs no walk**, so
  dependents stay stale until an unrelated edit sweeps them. A missing call rather than a broken
  walk; spec 42's territory, and spec 42 now has a walk that will actually propagate it.

## Also included

- `docs/dirty-walk-bulk-edit.md` — the bulk-edit trade-off written up for review, plus the two
  follow-ups (the matrix's missing lifecycle axis; `WalkQueueRetainedCapacity = 4096` is a
  judgement, not a measurement).
- `docs/specs` synced from the source of truth (specs 36–51, tasklist 3).
- CHANGELOG entry covering both the correctness win and the bulk-edit cost.

https://claude.ai/code/session_01LZyVFLskXmtBEGoJM2xY6w


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed formula recalculation so changes propagate through all dependent cells, even when some formulas were already marked for recalculation by another operation.
  - Improved recalculation consistency across scenarios such as renamed sheets, moved ranges, inserted rows or columns, and invalidated formulas.
  - Note: certain unsettled bulk-edit workloads may require additional recalculation processing.

- **Documentation**
  - Added documentation covering recalculation behavior, performance considerations, and related architecture updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->