### PR TITLE
fix: a defect inside a formula reaches the caller instead of reading as "no value"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 
 ## Unreleased
 
+### 🐛 Bug Fixes
+
+- **`MDETERM` and `MINVERSE` now answer a matrix with an all-zero column instead of throwing.** `=MDETERM({0,1;0,2})` threw `InvalidOperationException: The matrix is singular!` out of the formula rather than returning 0, and the matching `MINVERSE` threw rather than returning `#NUM!`. The LU decomposition behind both reported a column it could not pivot on by throwing, and neither function caught it. A singular matrix that still pivots, such as `{1,2;1,2}`, was already handled.
+
+- **`TryGetValue`, `GetFormattedString` and `Search` no longer report a defect in the library as "no value".** All three promise an answer for a cell whose formula cannot be evaluated, and kept that promise by catching every exception, so a bug inside a function — the `MDETERM` one above, for instance — read as a cell with no value, its cached value, or no match. They now tolerate only what a formula can legitimately produce: an unimplemented function or operator, text the parser cannot read, a missing worksheet or cell context, and a circular reference. Anything else reaches the caller. A circular reference is still reported as an `InvalidOperationException` with the same message, so a handler for that is unaffected.
+
 ## v0.400.0 - 2026-09-01
 
 ### ⚠️ Breaking Changes

--- a/XLibur.Tests/Excel/CalcEngine/EvaluationFailureTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/EvaluationFailureTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+using XLibur.Excel.CalcEngine;
+using XLibur.Excel.CalcEngine.Exceptions;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// The read APIs that tolerate a formula they cannot evaluate - <c>TryGetValue</c>,
+/// <c>GetFormattedString</c> and <c>Search</c> - tolerate only the failures a formula can
+/// legitimately produce. Anything else is a defect in the library and reaches the caller.
+/// </summary>
+public class EvaluationFailureTests
+{
+    [Test]
+    public async Task Failures_a_formula_can_legitimately_produce_are_expected()
+    {
+        Exception[] failures =
+        [
+            new NotImplementedException(),
+            new NotSupportedException(),
+            new ExpressionParseException("unreadable"),
+            new MissingContextException(),
+            new XLNoWorksheetContextException(),
+            new CircularReferenceException("cycle"),
+        ];
+
+        var rejected = failures.Where(f => !EvaluationFailure.IsExpected(f)).Select(f => f.GetType().Name);
+
+        await Assert.That(rejected).IsEmpty();
+    }
+
+    [Test]
+    public async Task Defects_are_not_expected()
+    {
+        Exception[] defects =
+        [
+            new NullReferenceException(),
+            new IndexOutOfRangeException(),
+            new InvalidCastException(),
+            new ArgumentException(),
+            // What an internal invariant throws - a calculation chain entry with no formula, say.
+            new InvalidOperationException(),
+        ];
+
+        var accepted = defects.Where(EvaluationFailure.IsExpected).Select(d => d.GetType().Name);
+
+        await Assert.That(accepted).IsEmpty();
+    }
+
+    [Test]
+    public async Task TryGetValue_on_an_unimplemented_operator_returns_false()
+    {
+        using var wb = new XLWorkbook();
+        var cell = wb.AddWorksheet().Cell("A1");
+        cell.FormulaA1 = "SUM(B1:C2 C1:D2)";
+
+        await Assert.That(cell.TryGetValue(out double _)).IsFalse();
+    }
+
+    [Test]
+    public async Task GetFormattedString_on_a_circular_formula_falls_back_to_the_cached_value()
+    {
+        using var wb = new XLWorkbook();
+        var cell = (XLCell)wb.AddWorksheet().Cell("A1");
+        cell.FormulaA1 = "A1+1";
+        cell.SetOnlyValue(42);
+
+        await Assert.That(cell.GetFormattedString()).IsEqualTo("42");
+    }
+
+    [Test]
+    public async Task Search_skips_cells_whose_formula_cannot_be_evaluated()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").FormulaA1 = "A1+1";
+        ws.Cell("A2").FormulaA1 = "SUM(B1:C2 C1:D2)";
+        ws.Cell("A3").Value = "needle";
+
+        var found = string.Join(",", ws.Search("needle").Select(c => c.Address.ToString()));
+
+        await Assert.That(found).IsEqualTo("A3");
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/FormulaExtentTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FormulaExtentTests.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using XLibur.Excel;
+using XLibur.Excel.CalcEngine.Visitors;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+public class FormulaExtentTests
+{
+    [Test]
+    public async Task Measures_the_furthest_reference()
+    {
+        var extent = FormulaExtent.Of("SUM(B3,D2)");
+
+        await Assert.That(extent.MaxRow).IsEqualTo(3);
+        await Assert.That(extent.MaxColumn).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task A_formula_the_parser_rejects_reaches_the_whole_sheet()
+    {
+        // A path-qualified external reference is text the parser cannot tokenize. Reporting the
+        // whole sheet keeps it in front of the shifter and its fallback.
+        var extent = FormulaExtent.Of(@"'C:\x\[book.xlsx]Sheet1'!A1");
+
+        await Assert.That(extent.MaxRow).IsEqualTo(XLHelper.MaxRowNumber);
+        await Assert.That(extent.MaxColumn).IsEqualTo(XLHelper.MaxColumnNumber);
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/LookupTests.cs
@@ -1056,6 +1056,19 @@ public class LookupTests
     }
 
     [Test]
+    [Arguments("A99999999999")]
+    [Arguments("A1:A99999999999")]
+    [Arguments("A1:B")]
+    [Arguments("$:$")]
+    [Arguments("ZZZZ1")]
+    public async Task Indirect_address_shaped_text_naming_no_cell_returns_reference_error(string address)
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet();
+        await Assert.That(sheet.Evaluate($"INDIRECT(\"{address}\")")).IsEqualTo(XLError.CellReference);
+    }
+
+    [Test]
     public async Task Indirect_DefinedName()
     {
         using var wb = new XLWorkbook();

--- a/XLibur.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1431,6 +1431,14 @@ public class MathTrigTests
     }
 
     [Test]
+    public async Task MDeterm_matrix_with_an_all_zero_column_returns_zero()
+    {
+        // No row can pivot the first column, which the LU decomposition reported by throwing
+        // rather than by the determinant it implies.
+        await Assert.That(XLWorkbook.EvaluateExpr("MDETERM({0,1;0,2})")).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task MDeterm_requires_all_array_elements_are_numbers()
     {
         using var wb = new XLWorkbook();
@@ -1490,6 +1498,12 @@ public class MathTrigTests
             (1, 2),
         });
         await Assert.That(ws.Evaluate("MINVERSE(A1:B2)")).IsEqualTo(XLError.NumberInvalid);
+    }
+
+    [Test]
+    public async Task MInverse_matrix_with_an_all_zero_column_returns_error()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("MINVERSE({0,1;0,2})")).IsEqualTo(XLError.NumberInvalid);
     }
 
     [Test]

--- a/XLibur/Excel/CalcEngine/Exceptions/CircularReferenceException.cs
+++ b/XLibur/Excel/CalcEngine/Exceptions/CircularReferenceException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace XLibur.Excel.CalcEngine.Exceptions;
+
+/// <summary>
+/// A formula depends, directly or through other cells, on its own value.
+/// </summary>
+/// <remarks>
+/// It derives from <see cref="InvalidOperationException"/>, the type a cycle has always been
+/// reported as, so a caller catching that is unaffected. The distinct type is what lets
+/// <see cref="EvaluationFailure"/> tell a cycle - a property of the workbook - from an internal
+/// invariant failing with the same base type.
+/// </remarks>
+internal sealed class CircularReferenceException(string message) : InvalidOperationException(message);

--- a/XLibur/Excel/CalcEngine/Exceptions/EvaluationFailure.cs
+++ b/XLibur/Excel/CalcEngine/Exceptions/EvaluationFailure.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace XLibur.Excel.CalcEngine.Exceptions;
+
+/// <summary>
+/// Tells the failures a formula can legitimately produce from defects in the library.
+/// </summary>
+/// <remarks>
+/// A few read APIs - <c>IXLCell.TryGetValue</c>, <c>IXLCell.GetFormattedString</c> and
+/// <c>IXLRangeBase.Search</c> - promise an answer for a cell whose formula cannot be evaluated. They
+/// used to keep that promise by catching everything, which also turned a defect inside a function
+/// into "this cell has no value". Only the failures listed here are a property of the formula;
+/// anything else reaches the caller.
+/// </remarks>
+internal static class EvaluationFailure
+{
+    internal static bool IsExpected(Exception exception) => exception is
+        // A function, operator or formula type the engine does not evaluate.
+        NotImplementedException or NotSupportedException
+        // Text the parser cannot read.
+        or ExpressionParseException
+        // Evaluated without the worksheet or cell address it needs.
+        or MissingContextException or XLNoWorksheetContextException
+        // A formula that depends on its own value.
+        or CircularReferenceException;
+}

--- a/XLibur/Excel/CalcEngine/Exceptions/SingularMatrixException.cs
+++ b/XLibur/Excel/CalcEngine/Exceptions/SingularMatrixException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace XLibur.Excel.CalcEngine.Exceptions;
+
+/// <summary>
+/// An LU decomposition found a column with nothing to pivot on: the matrix is singular.
+/// </summary>
+/// <remarks>
+/// It derives from <see cref="InvalidOperationException"/>, which the regression functions already
+/// catch for this case. The distinct type is what lets <c>MDETERM</c> and <c>MINVERSE</c> answer a
+/// singular matrix without also swallowing every other invalid operation.
+/// </remarks>
+internal sealed class SingularMatrixException() : InvalidOperationException("The matrix is singular!");

--- a/XLibur/Excel/CalcEngine/Functions/Lookup.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Lookup.cs
@@ -726,8 +726,10 @@ internal static class Lookup
 
             return new Reference(rangeAddress.Normalize());
         }
-        catch
+        catch (Exception ex) when (ex is FormatException or ArgumentException or OverflowException)
         {
+            // The checks above admit only address-shaped text, which can still name a cell that does
+            // not exist - XLAddress.Create reads the row with int.Parse.
             return XLError.CellReference;
         }
     }

--- a/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/XLibur/Excel/CalcEngine/Functions/MathTrig.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using XLibur.Excel.CalcEngine.Exceptions;
 using XLibur.Excel.CalcEngine.Functions;
 using static XLibur.Excel.CalcEngine.Functions.SignatureAdapter;
 
@@ -662,7 +663,16 @@ internal static class MathTrig
             return XLError.IncompatibleValue;
 
         var matrix = new XLMatrix(array);
-        return matrix.Determinant();
+        try
+        {
+            return matrix.Determinant();
+        }
+        catch (SingularMatrixException)
+        {
+            // No pivot means a column of zeros on and below the diagonal, so the determinant is
+            // exactly zero.
+            return 0.0;
+        }
     }
 
     private static AnyValue MInverse(CalcContext ctx, AnyValue value)
@@ -675,7 +685,16 @@ internal static class MathTrig
             return XLError.IncompatibleValue;
 
         var matrix = new XLMatrix(array);
-        var inverse = matrix.Invert();
+        XLMatrix inverse;
+        try
+        {
+            inverse = matrix.Invert();
+        }
+        catch (SingularMatrixException)
+        {
+            return XLError.NumberInvalid;
+        }
+
         if (inverse.IsSingular())
             return XLError.NumberInvalid;
 

--- a/XLibur/Excel/CalcEngine/Functions/Text.cs
+++ b/XLibur/Excel/CalcEngine/Functions/Text.cs
@@ -1166,8 +1166,10 @@ internal static class Text
         {
             return nf.Format(number, ctx.Culture);
         }
-        catch
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentOutOfRangeException)
         {
+            // ExcelNumberFormat catches its own cast and parse failures. What still escapes it is a
+            // section type it does not know and a date serial it cannot turn into a DateTime.
             return XLError.IncompatibleValue;
         }
     }

--- a/XLibur/Excel/CalcEngine/Functions/XLMatrix.cs
+++ b/XLibur/Excel/CalcEngine/Functions/XLMatrix.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
 using System.Text.RegularExpressions;
+using XLibur.Excel.CalcEngine.Exceptions;
 
 #pragma warning disable S1244 // Intentional exact float comparison for Excel formula compatibility
 
@@ -116,7 +117,7 @@ internal sealed class XLMatrix
                 k0 = i;
             }
         }
-        return p == 0 ? throw new InvalidOperationException("The matrix is singular!") : k0;
+        return p == 0 ? throw new SingularMatrixException() : k0;
     }
 
     private void SwapLuRows(int k, int k0)

--- a/XLibur/Excel/CalcEngine/Visitors/FormulaExtent.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/FormulaExtent.cs
@@ -48,8 +48,10 @@ internal readonly struct FormulaExtent
                 collector,
                 ExtentVisitor.Instance);
         }
-        catch
+        catch (ParsingException)
         {
+            // ParsingException specifically, as XLCellFormulaShifter catches it: a formula the
+            // parser rejects is what this fallback is for, and the shifter parses the same text next.
             return Unbounded;
         }
 

--- a/XLibur/Excel/CalcEngine/XLCalcEngine.cs
+++ b/XLibur/Excel/CalcEngine/XLCalcEngine.cs
@@ -358,7 +358,7 @@ internal sealed class XLCalcEngine : ISheetListener, IWorkbookListener
                 throw new InvalidOperationException($"Unable to find sheet with sheetId {sheetId} for a point ${current.Point}.");
 
             if (chain.IsCurrentInCycle)
-                throw new InvalidOperationException($"Formula in a cell '${sheetInfo.Sheet.Name}'!${current.Point} is part of a cycle.");
+                throw new CircularReferenceException($"Formula in a cell '${sheetInfo.Sheet.Name}'!${current.Point} is part of a cycle.");
 
             var cellFormula = sheetInfo.FormulaSlice.Get(current.Point);
             if (cellFormula is null)

--- a/XLibur/Excel/Cells/XLCell.cs
+++ b/XLibur/Excel/Cells/XLCell.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using XLibur.Excel.CalcEngine.Exceptions;
 using XLibur.Excel.CalcEngine.Visitors;
 using XLibur.Excel.Coordinates;
 using XLibur.Excel.Drawings;
@@ -311,9 +312,9 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         {
             currentValue = Value;
         }
-        catch
+        catch (Exception ex) when (EvaluationFailure.IsExpected(ex))
         {
-            // May fail for formula evaluation
+            // The formula cannot be evaluated - a cycle, an unimplemented function.
             value = default!;
             return false;
         }
@@ -337,11 +338,11 @@ internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized
         try
         {
             // Need to get actual value because formula might be out of date or value wasn't set at all
-            // Unimplemented functions and features throw exceptions
             value = Value;
         }
-        catch
+        catch (Exception ex) when (EvaluationFailure.IsExpected(ex))
         {
+            // A formula that cannot be evaluated shows what was last calculated for it.
             value = CachedValue;
         }
 

--- a/XLibur/Excel/Ranges/XLRangeBase.cs
+++ b/XLibur/Excel/Ranges/XLRangeBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using XLibur.Excel.CalcEngine.Exceptions;
 using XLibur.Excel.CalcEngine.Visitors;
 using XLibur.Excel.ConditionalFormats;
 using XLibur.Excel.Coordinates;
@@ -584,8 +585,9 @@ internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
                 return culture.CompareInfo.IndexOf(c.Value.ToString(CultureInfo.CurrentCulture), searchText,
                     compareOptions) >= 0;
             }
-            catch
+            catch (Exception ex) when (EvaluationFailure.IsExpected(ex))
             {
+                // A cell whose formula cannot be evaluated has no value to match.
                 return false;
             }
         });


### PR DESCRIPTION
First of five stacked PRs from a coding-standards review. Each one targets the branch before it, so review and merge them in order.

## The problem

`IXLCell.TryGetValue`, `IXLCell.GetFormattedString` and `IXLRangeBase.Search` promise an answer for a cell whose formula cannot be evaluated. They kept that promise with a bare `catch`, which also turned a bug inside a function into "this cell has no value". Nobody could tell a formula the engine does not support from a defect in the library.

This hid a real defect. `=MDETERM({0,1;0,2})` threw `InvalidOperationException: The matrix is singular!` out of the formula. Through all three APIs it read as a missing value.

## 1. MDETERM and MINVERSE answer a matrix with an all-zero column

The LU decomposition reported a column it cannot pivot on by throwing, and neither function caught it:

```
MDETERM({0,1;0,2})   InvalidOperationException  →  0
MINVERSE({0,1;0,2})  InvalidOperationException  →  #NUM!
```

The existing singular-matrix tests use `{1,2;1,2}`. That matrix pivots, so it never reached the throw.

The throw is now a `SingularMatrixException`. It still derives from `InvalidOperationException`, so the regression functions' existing catch for this case is unaffected.

## 2. The read APIs tolerate only what a formula can legitimately produce

`EvaluationFailure.IsExpected` names the failures that belong to the formula. Anything else reaches the caller.

| Failure | Type |
|---|---|
| Function, operator or formula type the engine does not evaluate | `NotImplementedException`, `NotSupportedException` |
| Text the parser cannot read | `ExpressionParseException` |
| Evaluated without the worksheet or cell address it needs | `MissingContextException`, `XLNoWorksheetContextException` |
| Circular reference | `CircularReferenceException` (new) |

A cycle used to throw a plain `InvalidOperationException`. That is the same type the calc engine's internal invariants throw ("calculation chain contains a cell without a formula"), so the filter could not tell a cycle from a bug. The new type derives from `InvalidOperationException` and keeps its message, so `ArrayFormulaTests.ReferencingItselfIsCircularError`, which pins both, passes unchanged.

### Three narrower catches

| Site | Now catches | Why |
|---|---|---|
| `TEXT` | `InvalidOperationException`, `ArgumentOutOfRangeException` | ExcelNumberFormat 1.1.0 catches its own cast and parse failures. What can still escape is an unknown section type, or a date serial it cannot turn into a `DateTime`. |
| `INDIRECT` | `FormatException`, `ArgumentException`, `OverflowException` | Address-shaped text can still name no cell. `XLAddress.Create` reads the row with `int.Parse`. |
| `FormulaExtent.Of` | `ParsingException` | Same as `XLCellFormulaShifter` (#398). The shifter parses the same text immediately afterwards and catches only that, so this adds no new failure path. |

### Deliberately left alone

`SheetDataWriter.EvaluateFormulaForSave` keeps its catch-all. A save should not lose the user's work to a calculation defect in one cell; that cell keeps its cached value instead.

## How the filter was chosen

Every `throw` in `CalcEngine/` was read. Then a throwaway probe evaluated 45 edge-case formulas through `IXLCell.Value` and recorded what each threw: external and 3D references, intersections, spills, malformed `INDIRECT` text, odd `TEXT` formats, `LAMBDA`, unknown names and more. External references evaluate to `#REF!` rather than reaching `CalculationVisitor`'s "Node should never be visited" throw. The only throws outside the list above were the two matrix cases this PR fixes.

## Behaviour change

A caller of `TryGetValue`, `GetFormattedString` or `Search` can now see an exception, but only where the library itself is at fault. Before, that case silently returned `false`, the cached value, or no match. There is no API change. `PublicAPI.*.txt` is untouched, because both new exception types are internal.

## Testing

Each new test was watched failing first:

- `MathTrigTests`: an all-zero column for `MDETERM` and `MINVERSE`. Both failed with `The matrix is singular!`.
- `EvaluationFailureTests`: the predicate accepts the six expected types and rejects `NullReferenceException`, `IndexOutOfRangeException`, `InvalidCastException`, `ArgumentException` and a plain `InvalidOperationException`. Guard tests cover `TryGetValue` on an unimplemented operator, `GetFormattedString` falling back to the cached value on a cycle, and `Search` skipping unevaluable cells.
- With the catches narrowed but the cycle type not yet added, exactly four tests failed: the three cycle guards, including the existing `XLCellTests.TryGetValueFormula_EvaluationFail_ReturnFalse`, plus the predicate test. So the guards do catch that regression.
- `LookupTests`: `INDIRECT` over five address-shaped strings that name no cell, including an overflowing row, returns `#REF!`.
- `FormulaExtentTests` (new; there were none): a measured extent, and a parser-rejected formula reaching the whole sheet.

All four test projects pass on both frameworks:

| Project | net10.0 | net8.0 |
|---|---|---|
| XLibur.Tests | 14,454 passed, 5 skipped | 14,454 passed, 5 skipped |
| XLibur.Report.Tests | 481 | 481 |
| XLibur.Fonts.SixLabors.Tests | 31 | 31 |
| XLibur.Fonts.SkiaSharp.Tests | 37 | 37 |

`dotnet build XLibur.slnx -c Release` is clean: 0 warnings, 0 errors.
