### PR TITLE
fix: concurrent XLWorkbook.EvaluateExpr callers no longer collide in its parse cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 - **`TryGetValue`, `GetFormattedString` and `Search` no longer report a defect in the library as "no value".** All three promise an answer for a cell whose formula cannot be evaluated, and kept that promise by catching every exception, so a bug inside a function — the `MDETERM` one above, for instance — read as a cell with no value, its cached value, or no match. They now tolerate only what a formula can legitimately produce: an unimplemented function or operator, text the parser cannot read, a missing worksheet or cell context, and a circular reference. Anything else reaches the caller. A circular reference is still reported as an `InvalidOperationException` with the same message, so a handler for that is unaffected.
 
+- **`XLWorkbook.EvaluateExpr` can now be called from several threads at once.** The method is static and every caller shared one engine, whose parse cache could not be filled from two threads at the same time. Two threads evaluating the same new expression both missed the cache, and the second threw `ArgumentException: An item with the same key has already been added` from a call that had nothing to do with the other thread. Each thread now has its own engine. A workbook itself is still not safe to use from several threads.
+
 ## v0.400.0 - 2026-09-01
 
 ### ⚠️ Breaking Changes

--- a/XLibur.Tests/Excel/CalcEngine/EvaluateExprConcurrencyTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/EvaluateExprConcurrencyTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+public class EvaluateExprConcurrencyTests
+{
+    [Test]
+    public async Task Concurrent_callers_evaluating_the_same_new_expression_each_get_its_value()
+    {
+        // XLWorkbook.EvaluateExpr is static, so callers that know nothing of each other share
+        // whatever engine sits behind it. Each round, every thread evaluates the same fresh string
+        // instance at the same moment - one the engine's parse cache has never seen.
+        const int threadCount = 8;
+        const int rounds = 300;
+        var expressions = Enumerable.Range(0, rounds).Select(i => $"{i}*2").ToArray();
+        var failures = new ConcurrentQueue<string>();
+        using var barrier = new Barrier(threadCount);
+
+        var threads = Enumerable.Range(0, threadCount).Select(_ => new Thread(() =>
+        {
+            for (var i = 0; i < rounds; i++)
+            {
+                barrier.SignalAndWait();
+                try
+                {
+                    var value = XLWorkbook.EvaluateExpr(expressions[i]);
+                    if (!value.IsNumber || value.GetNumber() != i * 2)
+                        failures.Enqueue($"{expressions[i]} = {value}");
+                }
+                catch (Exception ex)
+                {
+                    failures.Enqueue($"{expressions[i]}: {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+        }) { IsBackground = true }).ToArray();
+
+        foreach (var thread in threads)
+            thread.Start();
+        var finished = threads.All(t => t.Join(TimeSpan.FromMinutes(1)));
+
+        await Assert.That(finished).IsTrue();
+        await Assert.That(failures).IsEmpty();
+    }
+}

--- a/XLibur.Tests/Excel/Charts/ChartTests.cs
+++ b/XLibur.Tests/Excel/Charts/ChartTests.cs
@@ -12,6 +12,45 @@ namespace XLibur.Tests.Excel.Charts;
 public class ChartTests
 {
     [Test]
+    public async Task Extended_chart_parts_are_numbered_from_one_in_every_save()
+    {
+        // Part names are counted per save. A second save on the same thread - of another workbook -
+        // starts again at chartEx1 rather than carrying on from the first.
+        var first = SaveWithWaterfallCharts(2);
+        var second = SaveWithWaterfallCharts(1);
+
+        await Assert.That(first).IsEquivalentTo(["/xl/charts/chartEx1.xml", "/xl/charts/chartEx2.xml"]);
+        await Assert.That(second).IsEquivalentTo(["/xl/charts/chartEx1.xml"]);
+    }
+
+    private static string[] SaveWithWaterfallCharts(int count)
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Data");
+            ws.Cell("A1").Value = "Start"; ws.Cell("B1").Value = 1000;
+            ws.Cell("A2").Value = "Add"; ws.Cell("B2").Value = 500;
+            for (var i = 0; i < count; i++)
+            {
+                var chart = ws.Charts.Add(XLChartType.Waterfall);
+                chart.Series.Add("Amount", "Data!$B$1:$B$2", "Data!$A$1:$A$2");
+                chart.Position.SetColumn(0).SetRow(5 + i * 15);
+                chart.SecondPosition.SetColumn(8).SetRow(18 + i * 15);
+            }
+
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        return doc.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ExtendedChartParts
+            .Select(p => p.Uri.ToString())
+            .OrderBy(u => u, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    [Test]
     public async Task CanCreateColumnClusteredChart()
     {
         using var wb = new XLWorkbook();

--- a/XLibur/Excel/IO/ChartWriter.cs
+++ b/XLibur/Excel/IO/ChartWriter.cs
@@ -87,15 +87,6 @@ internal static class ChartWriter
 
     // ── Extended chart writing (Sunburst, Treemap, Waterfall, Funnel, BoxWhisker) ──
 
-    /// <summary>
-    /// Counter for generating unique extended chart part URIs.
-    /// Reset per save operation via the SaveContext lifecycle.
-    /// </summary>
-    [ThreadStatic]
-    private static int _extChartCounter;
-
-    internal static void ResetExtendedChartCounter() => _extChartCounter = 0;
-
     private static void WriteExtendedChart(
         Worksheet worksheet,
         XLWorksheetContentManager cm,
@@ -113,8 +104,8 @@ internal static class ChartWriter
         // xl/drawings/extendedCharts/ which Excel rejects. Excel expects extended
         // charts at xl/charts/chartExN.xml. Use the IPackageFeature to access the
         // underlying System.IO.Packaging.Package and create the part at the correct URI.
-        _extChartCounter++;
-        var partUri = new Uri($"/xl/charts/chartEx{_extChartCounter}.xml", UriKind.Relative);
+        var chartNumber = ++context.ExtendedChartCount;
+        var partUri = new Uri($"/xl/charts/chartEx{chartNumber}.xml", UriKind.Relative);
 
 #pragma warning disable OOXML0001 // Experimental API needed to place ExtendedChartPart at xl/charts/
         var package = PackageExtensions.GetPackage(worksheetPart.OpenXmlPackage);
@@ -134,7 +125,7 @@ internal static class ChartWriter
 
         // Create relationship from DrawingsPart to the chart part using relative path
         // Excel requires relative target URIs for extended chart relationships
-        var relativeTarget = new Uri("../charts/chartEx" + _extChartCounter + ".xml", UriKind.Relative);
+        var relativeTarget = new Uri("../charts/chartEx" + chartNumber + ".xml", UriKind.Relative);
         var drawingsPackagePart = package.GetPart(drawingsPart.Uri);
         drawingsPackagePart.Relationships.Create(
             relativeTarget,
@@ -143,7 +134,7 @@ internal static class ChartWriter
             chartRelId);
 
         // Excel requires chart style and color files for extended charts
-        WriteExtendedChartStyleAndColor(package, packagePart, _extChartCounter);
+        WriteExtendedChartStyleAndColor(package, packagePart, chartNumber);
 
         AppendExtendedAnchor(worksheetDrawing, xlChart, chartRelId);
 

--- a/XLibur/Excel/XLWorkbook.cs
+++ b/XLibur/Excel/XLWorkbook.cs
@@ -1203,7 +1203,14 @@ public partial class XLWorkbook : IXLWorkbook
         CalcEngine.Recalculate(this, null);
     }
 
+    /// <summary>
+    /// The engine behind <see cref="EvaluateExpr"/>, one per thread. The method is static, so callers
+    /// that know nothing of each other would otherwise share one engine, and its parse cache cannot be
+    /// filled from two threads at once.
+    /// </summary>
+    [ThreadStatic]
     private static XLCalcEngine? _calcEngineExpr;
+
     private readonly SpreadsheetDocumentType _spreadsheetDocumentType;
 
     private static XLCalcEngine CalcEngineExpr

--- a/XLibur/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/XLibur/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -72,6 +72,12 @@ public partial class XLWorkbook
         /// </summary>
         public uint? DynamicArrayMetaIndex { get; set; }
 
+        /// <summary>
+        /// How many extended charts (<c>chartEx</c> parts) this save has written. Their part names
+        /// are numbered from it, so they start again at <c>chartEx1</c> in every save.
+        /// </summary>
+        public int ExtendedChartCount { get; set; }
+
         internal int GetSharedStringId(XLCell xlCell, string text)
         {
             return GetSharedStringId(xlCell.MemorySstId, xlCell.SheetPoint);

--- a/XLibur/Excel/XLWorkbook_Save.cs
+++ b/XLibur/Excel/XLWorkbook_Save.cs
@@ -177,7 +177,6 @@ public partial class XLWorkbook
     // Adds child parts and generates content of the specified part.
     private void CreateParts(SpreadsheetDocument document, SaveOptions options)
     {
-        ChartWriter.ResetExtendedChartCounter();
         var context = new SaveContext();
         var workbookPart = document.WorkbookPart ?? document.AddWorkbookPart();
         var worksheets = WorksheetsInternal;


### PR DESCRIPTION
Second of five stacked PRs from a coding-standards review. **This PR is based on #459, not `main`**; the diff shows only this PR's change. Merge #459 first.

Two pieces of static state that should not be shared.

## 1. Concurrent `XLWorkbook.EvaluateExpr` callers collided in its parse cache

`EvaluateExpr` is static, and every caller in the process shared one lazily created `XLCalcEngine`. Its `ExpressionCache` does `TryGetValue`, then `Add` on a `ConditionalWeakTable`. Each call is thread-safe, but the pair is not atomic. When two threads evaluated the same new expression, both missed, and the second `Add` threw:

```
ArgumentException: An item with the same key has already been added.
```

That exception came out of a call unrelated to whatever the other thread was doing. The new test has eight threads meet at a barrier and evaluate the same fresh string, over 300 rounds. Before the fix it recorded **450 failures out of 2,400 calls**. After the fix it records none.

The engine is now `[ThreadStatic]`. Nothing else on the evaluation path is shared and mutable:

| Piece | Why it is safe to use from one engine per thread |
|---|---|
| `FormulaParser` | Its fields are read-only configuration. |
| `CalculationVisitor` | Holds the function table plus an `ArrayPool<T>.Create` pool, which locks internally. |
| Function table | Static and read-only after start-up (see the remarks on `XLCalcEngine.FunctionTable`). |
| `CalcContext` | Created per call. |

I chose a per-thread engine over a new engine per call, which is what the internal `EvaluateExprCurrent` does. Each thread keeps its own parse cache, so a caller that evaluates the same expression in a loop still parses it only once.

Per-workbook engines are unchanged. A workbook is still not safe to use from several threads; that is a separate contract.

## 2. The extended chart counter belongs to the save

`ChartWriter` numbered `chartEx` parts from a `[ThreadStatic]` field that `CreateParts` reset at the start of every save. It worked, but it was per-save state kept in a hidden global and reset from a distance. `SaveContext` exists for exactly this, and `WriteExtendedChart` already receives it. The count now lives in `SaveContext.ExtendedChartCount`, and the reset call is gone.

This is a refactor. No test pinned the part names before, so `Extended_chart_parts_are_numbered_from_one_in_every_save` was written first and passed against the old code. It checks two saves: two charts give `chartEx1` and `chartEx2`, then a second workbook saved on the same thread starts again at `chartEx1`.

## Testing

- `EvaluateExprConcurrencyTests`: watched failing first with the 450 `ArgumentException`s above.
- `ChartTests.Extended_chart_parts_are_numbered_from_one_in_every_save`: a characterization test, green before and after the refactor.

All four test projects pass on both frameworks:

| Project | net10.0 | net8.0 |
|---|---|---|
| XLibur.Tests | 14,456 passed, 5 skipped | 14,456 passed, 5 skipped |
| XLibur.Report.Tests | 481 | 481 |
| XLibur.Fonts.SixLabors.Tests | 31 | 31 |
| XLibur.Fonts.SkiaSharp.Tests | 37 | 37 |

`dotnet build XLibur.slnx -c Release` is clean: 0 warnings, 0 errors.
