### PR TITLE
feat!: page breaks can no longer be edited around the page setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 
 ## Unreleased
 
+### ⚠️ Breaking Changes
+
+#### Page setup
+
+- **`IXLPageSetup.RowBreaks` and `ColumnBreaks` are now `IReadOnlyList<int>` rather than `List<int>`.** Both handed out the page setup's own list, so a caller could add to it directly and skip `AddHorizontalPageBreak` and `AddVerticalPageBreak`, which keep the breaks sorted and free of duplicates — and whatever the list held was written to the file. Code that only enumerates, counts or indexes the breaks compiles unchanged; code that called `Add`, `Remove`, `Clear` or the indexer setter on them, or stored them in a `List<int>` variable, no longer does. Add a break with `AddHorizontalPageBreak` or `AddVerticalPageBreak` as before, and take one away with the new `RemoveHorizontalPageBreak`, `RemoveVerticalPageBreak`, `ClearHorizontalPageBreaks` and `ClearVerticalPageBreaks`. Those four new members are also source-breaking for anyone implementing `IXLPageSetup` outside the library.
+
 ### 🐛 Bug Fixes
 
 - **`MDETERM` and `MINVERSE` now answer a matrix with an all-zero column instead of throwing.** `=MDETERM({0,1;0,2})` threw `InvalidOperationException: The matrix is singular!` out of the formula rather than returning 0, and the matching `MINVERSE` threw rather than returning `#NUM!`. The LU decomposition behind both reported a column it could not pivot on by throwing, and neither function caught it. A singular matrix that still pivots, such as `{1,2;1,2}`, was already handled.

--- a/XLibur.Tests/Excel/PageSetup/PageBreaksTests.cs
+++ b/XLibur.Tests/Excel/PageSetup/PageBreaksTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
@@ -107,5 +108,99 @@ public class PageBreaksTests
         var columnBreak = worksheet.GetFirstChild<ColumnBreaks>()!.Elements<Break>().Single();
         await Assert.That(columnBreak.Id!.Value).IsEqualTo(4u);
         await Assert.That(columnBreak.Max!.Value).IsEqualTo(1048575u); // last row, 0-based
+    }
+
+    [Test]
+    public async Task Page_break_lists_cannot_be_edited_around_the_page_setup()
+    {
+        // AddHorizontalPageBreak and AddVerticalPageBreak keep the breaks sorted and free of
+        // duplicates. A list the caller can edit directly lets both slip through.
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+
+        await Assert.That(sheet.PageSetup.RowBreaks is ICollection<int> { IsReadOnly: false }).IsFalse();
+        await Assert.That(sheet.PageSetup.ColumnBreaks is ICollection<int> { IsReadOnly: false }).IsFalse();
+    }
+
+    [Test]
+    public async Task RemoveHorizontalPageBreak_removes_only_that_break()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        sheet.PageSetup.AddHorizontalPageBreak(5);
+        sheet.PageSetup.AddHorizontalPageBreak(10);
+
+        await Assert.That(sheet.PageSetup.RemoveHorizontalPageBreak(5)).IsTrue();
+        await Assert.That(sheet.PageSetup.RemoveHorizontalPageBreak(7)).IsFalse();
+        await Assert.That(sheet.PageSetup.RowBreaks).IsEquivalentTo([10]);
+    }
+
+    [Test]
+    public async Task RemoveVerticalPageBreak_removes_only_that_break()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        sheet.PageSetup.AddVerticalPageBreak(5);
+        sheet.PageSetup.AddVerticalPageBreak(10);
+
+        await Assert.That(sheet.PageSetup.RemoveVerticalPageBreak(5)).IsTrue();
+        await Assert.That(sheet.PageSetup.RemoveVerticalPageBreak(7)).IsFalse();
+        await Assert.That(sheet.PageSetup.ColumnBreaks).IsEquivalentTo([10]);
+    }
+
+    [Test]
+    public async Task ClearHorizontalPageBreaks_leaves_the_vertical_ones()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        sheet.PageSetup.AddHorizontalPageBreak(5);
+        sheet.PageSetup.AddVerticalPageBreak(3);
+
+        sheet.PageSetup.ClearHorizontalPageBreaks();
+
+        await Assert.That(sheet.PageSetup.RowBreaks).IsEmpty();
+        await Assert.That(sheet.PageSetup.ColumnBreaks).IsEquivalentTo([3]);
+    }
+
+    [Test]
+    public async Task ClearVerticalPageBreaks_leaves_the_horizontal_ones()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet1");
+        sheet.PageSetup.AddHorizontalPageBreak(5);
+        sheet.PageSetup.AddVerticalPageBreak(3);
+
+        sheet.PageSetup.ClearVerticalPageBreaks();
+
+        await Assert.That(sheet.PageSetup.ColumnBreaks).IsEmpty();
+        await Assert.That(sheet.PageSetup.RowBreaks).IsEquivalentTo([5]);
+    }
+
+    [Test]
+    public async Task A_break_removed_from_a_loaded_sheet_is_not_written_back()
+    {
+        using var original = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var sheet = wb.AddWorksheet("Sheet1");
+            sheet.Cell("A1").Value = "x";
+            sheet.PageSetup.AddHorizontalPageBreak(5);
+            sheet.PageSetup.AddHorizontalPageBreak(10);
+            wb.SaveAs(original);
+        }
+
+        original.Position = 0;
+        using var saved = new MemoryStream();
+        using (var wb = new XLWorkbook(original))
+        {
+            wb.Worksheet("Sheet1").PageSetup.RemoveHorizontalPageBreak(5);
+            wb.SaveAs(saved);
+        }
+
+        saved.Position = 0;
+        using var doc = SpreadsheetDocument.Open(saved, false);
+        var ids = doc.WorkbookPart!.WorksheetParts.Single().Worksheet!.GetFirstChild<RowBreaks>()!
+            .Elements<Break>().Select(b => b.Id!.Value);
+        await Assert.That(ids).IsEquivalentTo([10u]);
     }
 }

--- a/XLibur/Excel/IO/WorksheetElementReader.cs
+++ b/XLibur/Excel/IO/WorksheetElementReader.cs
@@ -373,16 +373,20 @@ internal static class WorksheetElementReader
     {
         ArgumentNullException.ThrowIfNull(rowBreaks);
 
+        // Appended in file order rather than through AddHorizontalPageBreak, which would sort and
+        // de-duplicate them, so the file round-trips as written.
+        var pageSetup = (XLPageSetup)ws.PageSetup;
         foreach (var rowBreak in rowBreaks.Elements<Break>())
-            ws.PageSetup.RowBreaks.Add(int.Parse(rowBreak.Id!.InnerText!));
+            pageSetup.RowBreaks.Add(int.Parse(rowBreak.Id!.InnerText!));
     }
 
     private static void LoadColumnBreaks(ColumnBreaks columnBreaks, XLWorksheet ws)
     {
         ArgumentNullException.ThrowIfNull(columnBreaks);
+        var pageSetup = (XLPageSetup)ws.PageSetup;
         foreach (var columnBreak in columnBreaks.Elements<Break>().Where(columnBreak => columnBreak.Id != null))
         {
-            ws.PageSetup.ColumnBreaks.Add(int.Parse(columnBreak.Id!.InnerText!));
+            pageSetup.ColumnBreaks.Add(int.Parse(columnBreak.Id!.InnerText!));
         }
     }
 

--- a/XLibur/Excel/PageSetup/IXLPageSetup.cs
+++ b/XLibur/Excel/PageSetup/IXLPageSetup.cs
@@ -258,13 +258,15 @@ public interface IXLPageSetup
     XLShowCommentsValues ShowComments { get; set; }
 
     /// <summary>
-    /// Gets a list with the row breaks (for printing).
+    /// Gets the row breaks (for printing). Change them with <see cref="AddHorizontalPageBreak"/>,
+    /// <see cref="RemoveHorizontalPageBreak"/> and <see cref="ClearHorizontalPageBreaks"/>.
     /// </summary>
-    List<int> RowBreaks { get; }
+    IReadOnlyList<int> RowBreaks { get; }
     /// <summary>
-    /// Gets a list with the column breaks (for printing).
+    /// Gets the column breaks (for printing). Change them with <see cref="AddVerticalPageBreak"/>,
+    /// <see cref="RemoveVerticalPageBreak"/> and <see cref="ClearVerticalPageBreaks"/>.
     /// </summary>
-    List<int> ColumnBreaks { get; }
+    IReadOnlyList<int> ColumnBreaks { get; }
     /// <summary>
     /// Adds a horizontal page break after the given row.
     /// </summary>
@@ -276,6 +278,30 @@ public interface IXLPageSetup
     /// </summary>
     /// <param name="column">The column to insert the break.</param>
     void AddVerticalPageBreak(int column);
+
+    /// <summary>
+    /// Removes the horizontal page break after the given row.
+    /// </summary>
+    /// <param name="row">The row whose break to remove.</param>
+    /// <returns><c>true</c> if the row had a break; otherwise <c>false</c>.</returns>
+    bool RemoveHorizontalPageBreak(int row);
+
+    /// <summary>
+    /// Removes the vertical page break after the given column.
+    /// </summary>
+    /// <param name="column">The column whose break to remove.</param>
+    /// <returns><c>true</c> if the column had a break; otherwise <c>false</c>.</returns>
+    bool RemoveVerticalPageBreak(int column);
+
+    /// <summary>
+    /// Removes every horizontal page break. Vertical page breaks are kept.
+    /// </summary>
+    void ClearHorizontalPageBreaks();
+
+    /// <summary>
+    /// Removes every vertical page break. Horizontal page breaks are kept.
+    /// </summary>
+    void ClearVerticalPageBreaks();
 
     /// <summary>
     /// Gets or sets how error values will be printed.

--- a/XLibur/Excel/PageSetup/XLPageSetup.cs
+++ b/XLibur/Excel/PageSetup/XLPageSetup.cs
@@ -192,8 +192,20 @@ internal sealed class XLPageSetup : IXLPageSetup, ISheetListener
     public XLPageOrderValues PageOrder { get; set; }
     public XLShowCommentsValues ShowComments { get; set; }
 
+    /// <summary>
+    /// The page setup's own break lists, which the loader appends to and an insert or delete moves.
+    /// Callers outside the library see <see cref="IXLPageSetup.RowBreaks"/> and
+    /// <see cref="IXLPageSetup.ColumnBreaks"/>, read-only views of these, so the Add methods'
+    /// sorted, duplicate-free order cannot be edited around.
+    /// </summary>
     public List<int> RowBreaks { get; private set; }
     public List<int> ColumnBreaks { get; private set; }
+
+    private IReadOnlyList<int>? _rowBreaksView;
+    private IReadOnlyList<int>? _columnBreaksView;
+
+    IReadOnlyList<int> IXLPageSetup.RowBreaks => _rowBreaksView ??= RowBreaks.AsReadOnly();
+    IReadOnlyList<int> IXLPageSetup.ColumnBreaks => _columnBreaksView ??= ColumnBreaks.AsReadOnly();
     public void AddHorizontalPageBreak(int row)
     {
         if (!RowBreaks.Contains(row))
@@ -206,6 +218,16 @@ internal sealed class XLPageSetup : IXLPageSetup, ISheetListener
             ColumnBreaks.Add(column);
         ColumnBreaks.Sort();
     }
+
+    // RemoveAll rather than Remove: a loaded file keeps its breaks as written, duplicates included,
+    // and removing only the first would leave the break in place.
+    public bool RemoveHorizontalPageBreak(int row) => RowBreaks.RemoveAll(b => b == row) > 0;
+
+    public bool RemoveVerticalPageBreak(int column) => ColumnBreaks.RemoveAll(b => b == column) > 0;
+
+    public void ClearHorizontalPageBreaks() => RowBreaks.Clear();
+
+    public void ClearVerticalPageBreaks() => ColumnBreaks.Clear();
 
     #region ISheetListener
 

--- a/XLibur/PublicAPI.Unshipped.txt
+++ b/XLibur/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@
 *REMOVED*XLibur.Excel.IXLCFDataBarMax.HighestValue() -> void
 *REMOVED*XLibur.Excel.IXLCFDataBarMax.Maximum(XLibur.Excel.XLCFContentType type, double value) -> void
 *REMOVED*XLibur.Excel.IXLCFDataBarMax.Maximum(XLibur.Excel.XLCFContentType type, string! value) -> void
+*REMOVED*XLibur.Excel.IXLPageSetup.ColumnBreaks.get -> System.Collections.Generic.List<int>!
+*REMOVED*XLibur.Excel.IXLPageSetup.RowBreaks.get -> System.Collections.Generic.List<int>!
 *REMOVED*XLibur.Excel.XLAlignmentKey
 *REMOVED*XLibur.Excel.XLAlignmentKey.Horizontal.get -> XLibur.Excel.XLAlignmentHorizontalValues
 *REMOVED*XLibur.Excel.XLAlignmentKey.Horizontal.init -> void
@@ -449,3 +451,9 @@ XLibur.Excel.IXLPivotTable.ShowLastColumn.set -> void
 XLibur.Excel.IXLPivotTable.SetShowLastColumn() -> XLibur.Excel.IXLPivotTable!
 XLibur.Excel.IXLPivotTable.SetShowLastColumn(bool value) -> XLibur.Excel.IXLPivotTable!
 XLibur.Excel.CalcEngine.ExpressionParseException.ExpressionParseException(string! message, System.Exception! innerException) -> void
+XLibur.Excel.IXLPageSetup.ColumnBreaks.get -> System.Collections.Generic.IReadOnlyList<int>!
+XLibur.Excel.IXLPageSetup.RowBreaks.get -> System.Collections.Generic.IReadOnlyList<int>!
+XLibur.Excel.IXLPageSetup.ClearHorizontalPageBreaks() -> void
+XLibur.Excel.IXLPageSetup.ClearVerticalPageBreaks() -> void
+XLibur.Excel.IXLPageSetup.RemoveHorizontalPageBreak(int row) -> bool
+XLibur.Excel.IXLPageSetup.RemoveVerticalPageBreak(int column) -> bool


### PR DESCRIPTION
Third of five stacked PRs from a coding-standards review. **This PR is based on #460, not `main`**, and the diff shows only its own change. Merge #459 and #460 first.

## The problem

`IXLPageSetup.RowBreaks` and `ColumnBreaks` returned the page setup's own `List<int>`. A caller could add to that list directly and skip `AddHorizontalPageBreak` and `AddVerticalPageBreak`, which keep the breaks sorted and free of duplicates. Whatever the list held was written to the file.

```csharp
ws.PageSetup.RowBreaks.Add(10);   // compiled; bypassed sort and de-duplication
ws.PageSetup.RowBreaks.Add(10);   // a duplicate break, written as two <brk id="10">
```

## The change

| | Before | After |
|---|---|---|
| `RowBreaks` | `List<int>` | `IReadOnlyList<int>` |
| `ColumnBreaks` | `List<int>` | `IReadOnlyList<int>` |
| Add a break | `AddHorizontalPageBreak`, `AddVerticalPageBreak` | unchanged |
| Remove one | `RowBreaks.Remove(10)` | `RemoveHorizontalPageBreak(10)`, `RemoveVerticalPageBreak(10)` (new) |
| Remove all | `RowBreaks.Clear()` | `ClearHorizontalPageBreaks()`, `ClearVerticalPageBreaks()` (new) |

Removing a break used to require the mutable list, so without replacements this change would have taken that capability away. The two `Remove` methods return `true` when there was a break to remove, the same as `IXLPersons.Remove`. They remove every copy of the break, because a loaded file keeps its breaks as written, duplicates included.

The new members are a choice I made. If you would rather have a single `ClearPageBreaks()` (Excel's "Reset All Page Breaks"), or no `Clear` methods at all, those are small edits.

### Internals

`XLPageSetup` keeps its own `List<int>` for the two places that must change it: the loader, and the insert/delete shift in `GridAxis`. The interface properties are implemented explicitly as a cached `AsReadOnly()` view of that list, so `PageSetupWriter`'s reads are unchanged. The loader now casts to `XLPageSetup` and still appends breaks in file order. It deliberately does not use `AddHorizontalPageBreak`, which would sort and de-duplicate the breaks on load, so a file keeps round-tripping exactly.

## ⚠️ Breaking change

- Code that only enumerates, counts or indexes the breaks compiles unchanged. That covers every use in this repository, including `XLibur.Report.Tests`.
- Code that calls `Add`, `Remove`, `Clear` or the indexer setter on the breaks, or stores them in a `List<int>` variable, no longer compiles.
- Adding four members to `IXLPageSetup` breaks any implementation of the interface outside the library.

`PublicAPI.Unshipped.txt` records the two `List<int>` getters as `*REMOVED*`, and the two `IReadOnlyList<int>` getters and four methods as added. `CHANGELOG.md` gains a **Breaking Changes → Page setup** entry under *Unreleased*.

## Testing

Six new tests in `PageBreaksTests`, each watched failing first:

- the break lists refuse edits (`ICollection<int>.IsReadOnly`)
- `RemoveHorizontalPageBreak` and `RemoveVerticalPageBreak` remove only that break, and return `false` for a row or column with no break
- `ClearHorizontalPageBreaks` and `ClearVerticalPageBreaks` leave the other axis alone
- a break removed from a loaded sheet is not written back; before the fix the saved file still held both `<brk>` elements

All four test projects pass on both frameworks:

| Project | net10.0 | net8.0 |
|---|---|---|
| XLibur.Tests | 14,462 passed, 5 skipped | 14,462 passed, 5 skipped |
| XLibur.Report.Tests | 481 | 481 |
| XLibur.Fonts.SixLabors.Tests | 31 | 31 |
| XLibur.Fonts.SkiaSharp.Tests | 37 | 37 |

`dotnet build XLibur.slnx -c Release` is clean: 0 warnings, 0 errors. That includes the public API analyzer, which checks `PublicAPI.*.txt` against the compiled surface.
