### PR TITLE
refactor: the last #nullable disable goes, and XLTable stops asserting its fields exist

### DIFF
--- a/XLibur/Excel/PivotTables/XLPivotTables.cs
+++ b/XLibur/Excel/PivotTables/XLPivotTables.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/XLibur/Excel/Tables/XLTable.cs
+++ b/XLibur/Excel/Tables/XLTable.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Globalization;
 using System.Linq;
@@ -45,7 +46,7 @@ internal sealed class XLTable : XLRange, IXLTable
 
             RescanFieldNames();
 
-            return _fieldNames!;
+            return _fieldNames;
         }
     }
 
@@ -54,6 +55,7 @@ internal sealed class XLTable : XLRange, IXLTable
     /// </summary>
     internal Area Area => Area.FromRangeAddress(RangeAddress);
 
+    [MemberNotNull(nameof(_fieldNames))]
     private void RescanFieldNames()
     {
         if (ShowHeaderRow)
@@ -62,20 +64,22 @@ internal sealed class XLTable : XLRange, IXLTable
             RescanSyntheticFieldNames();
     }
 
+    [MemberNotNull(nameof(_fieldNames))]
     private void RescanFieldNamesFromHeaderRow()
     {
         var oldFieldNames = _fieldNames ?? CreateFieldNames();
         _fieldNames = CreateFieldNames();
         var cellPos = 0;
         foreach (var xlCell in HeadersRow(false)!.Cells())
-            ProcessHeaderCell((XLCell)xlCell, cellPos++, oldFieldNames);
+            ProcessHeaderCell((XLCell)xlCell, cellPos++, oldFieldNames, _fieldNames);
     }
 
     /// <summary>
     /// Maps a single header cell to a table field, reusing existing fields by name when possible.
     /// Generates a unique name for empty cells and fixes cell values that differ from the field name.
     /// </summary>
-    private void ProcessHeaderCell(XLCell cell, int cellPos, Dictionary<string, IXLTableField> oldFieldNames)
+    private void ProcessHeaderCell(XLCell cell, int cellPos, Dictionary<string, IXLTableField> oldFieldNames,
+        Dictionary<string, IXLTableField> fieldNames)
     {
         var cellValue = cell.CachedValue;
         var name = cellValue.ToString(CultureInfo.CurrentCulture);
@@ -83,7 +87,7 @@ internal sealed class XLTable : XLRange, IXLTable
         if (oldFieldNames.TryGetValue(name, out var tableField))
         {
             ((XLTableField)tableField).Index = cellPos;
-            _fieldNames!.Add(name, tableField);
+            fieldNames.Add(name, tableField);
             return;
         }
 
@@ -91,10 +95,10 @@ internal sealed class XLTable : XLRange, IXLTable
         if (string.IsNullOrEmpty(name))
             name = GetUniqueName(DefaultColumnPrefix, cellPos + 1, true);
 
-        if (_fieldNames!.ContainsKey(name))
+        if (fieldNames.ContainsKey(name))
             throw new ArgumentException("The header row contains more than one field name '" + name + "'.");
 
-        _fieldNames.Add(name, new XLTableField(this, name) { Index = cellPos });
+        fieldNames.Add(name, new XLTableField(this, name) { Index = cellPos });
 
         // Field names are the source of the truth that is projected
         // to the cells, and field names can be only text. Fix the cell,
@@ -103,6 +107,7 @@ internal sealed class XLTable : XLRange, IXLTable
             cell.SetValue(name, false, false);
     }
 
+    [MemberNotNull(nameof(_fieldNames))]
     private void RescanSyntheticFieldNames()
     {
         _fieldNames ??= CreateFieldNames();
@@ -130,11 +135,19 @@ internal sealed class XLTable : XLRange, IXLTable
 
     internal void RenameField(string oldName, string newName)
     {
-        if (!_fieldNames!.Remove(oldName, out var field))
+        if (!LastReadFieldNames.Remove(oldName, out var field))
             throw new ArgumentException("The field does not exist in this table", nameof(oldName));
 
-        _fieldNames.Add(newName, field);
+        LastReadFieldNames.Add(newName, field);
     }
+
+    /// <summary>
+    /// The fields as last read, for the operations that only run once <see cref="FieldNames"/> has
+    /// built them. Reaching one before then is a defect, and is reported as one rather than as a
+    /// <see cref="NullReferenceException"/>.
+    /// </summary>
+    private Dictionary<string, IXLTableField> LastReadFieldNames =>
+        _fieldNames ?? throw new InvalidOperationException("The table's fields have not been read yet.");
 
     internal string? RelId { get; set; }
 
@@ -212,7 +225,7 @@ internal sealed class XLTable : XLRange, IXLTable
         set;
     }
 
-    public XLTableTheme Theme { get; set; } = null!;
+    public XLTableTheme Theme { get; set; }
 
     public string Name
     {
@@ -431,7 +444,7 @@ internal sealed class XLTable : XLRange, IXLTable
     /// </summary>
     private void UpdateTotalsRowLabels(HashSet<string> newHeaders, int totalsRowChanged, int oldTotalsRowNumber)
     {
-        foreach (var f in _fieldNames!.Values)
+        foreach (var f in LastReadFieldNames.Values)
         {
             var c = TotalsRow()!.Cell(f.Index + 1);
             if (!c.IsEmpty() && newHeaders.Contains(f.Name))
@@ -448,7 +461,7 @@ internal sealed class XLTable : XLRange, IXLTable
     /// </summary>
     private void RelocateTotalsRowLabels(int oldTotalsRowNumber)
     {
-        foreach (var f in _fieldNames!.Values.Cast<XLTableField>())
+        foreach (var f in LastReadFieldNames.Values.Cast<XLTableField>())
         {
             f.UpdateTableFieldTotalsRowFormula();
             var c = TotalsRow()!.Cell(f.Index + 1);
@@ -582,6 +595,7 @@ internal sealed class XLTable : XLRange, IXLTable
 
     #endregion IXLTable Members
 
+    [MemberNotNull(nameof(Theme))]
     private void InitializeValues(bool setAutofilter)
     {
         ShowRowStripes = true;


### PR DESCRIPTION
Fourth of five stacked PRs from a coding-standards review. **This PR is based on #461, not `main`**, and the diff shows only its own change. Merge #459–#461 first.

A refactor with no behaviour change: it removes the last nullable opt-out, and the null-forgiving operators where the compiler can be told the truth instead.

## 1. The last `#nullable disable`

`XLPivotTables.cs` was the only file in the library with nullable annotations turned off. It compiles clean without the directive. Its one nullable-sensitive line, the `TryGetValue` in `Delete`, was already guarded. After this PR, `grep "#nullable disable" XLibur/` finds nothing.

## 2. `XLTable` stops asserting its field dictionary exists

`XLTable` builds `_fieldNames` lazily and reached it through `_fieldNames!` six times.

| Before | After |
|---|---|
| `FieldNames` returned `_fieldNames!` after rescanning | The three rescan methods carry `[MemberNotNull(nameof(_fieldNames))]`, so the compiler knows the dictionary exists afterwards |
| `ProcessHeaderCell` re-read `_fieldNames!` three times | The header scan passes in the dictionary it is filling |
| `RenameField` and the two totals-row label passes used `_fieldNames!` | They go through `LastReadFieldNames`, which throws `InvalidOperationException` with a message if the dictionary is ever missing, rather than a bare `NullReferenceException` |

`XLTable.cs` drops from 26 null-forgiving operators to 19.

## 3. `XLTable.Theme` loses its `= null!`

The initializer was only there to quiet the compiler. The only constructor always sets `Theme` through `InitializeValues`, which now carries `[MemberNotNull(nameof(Theme))]`.

**Correction to the review.** The review said this property "declares itself non-null but can be null". That was wrong: the constructor always assigns it, so it was never observably null. This change removes a misleading placeholder; it does not fix a bug.

## Not in this PR

About 470 null-forgiving operators remain across roughly 120 files. The largest clusters are `XLWorkbook_Load.cs` (30), `WorksheetElementReader.cs` (23), `DynamicArray.cs` (21) and the other `!` in `XLTable.cs`. Most of the `XLTable` ones assert that `DataRange`, `HeadersRow()` or `TotalsRow()` is non-null. Those members return nullable types on the public interface, so fixing them properly means changing that surface, which belongs in its own PR.

## Testing

No new tests, because nothing observable changes. The existing table and pivot suites are the safety net, and with warnings treated as errors the build itself checks every annotation.

All four test projects pass on both frameworks:

| Project | net10.0 | net8.0 |
|---|---|---|
| XLibur.Tests | 14,462 passed, 5 skipped | 14,462 passed, 5 skipped |
| XLibur.Report.Tests | 481 | 481 |
| XLibur.Fonts.SixLabors.Tests | 31 | 31 |
| XLibur.Fonts.SkiaSharp.Tests | 37 | 37 |

`dotnet build XLibur.slnx -c Release` is clean: 0 warnings, 0 errors.
