### PR TITLE
fix!: unsupported pivot sources throw NotSupportedException, plus guard and build-setting cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@
 
 - **`IXLPageSetup.RowBreaks` and `ColumnBreaks` are now `IReadOnlyList<int>` rather than `List<int>`.** Both handed out the page setup's own list, so a caller could add to it directly and skip `AddHorizontalPageBreak` and `AddVerticalPageBreak`, which keep the breaks sorted and free of duplicates — and whatever the list held was written to the file. Code that only enumerates, counts or indexes the breaks compiles unchanged; code that called `Add`, `Remove`, `Clear` or the indexer setter on them, or stored them in a `List<int>` variable, no longer does. Add a break with `AddHorizontalPageBreak` or `AddVerticalPageBreak` as before, and take one away with the new `RemoveHorizontalPageBreak`, `RemoveVerticalPageBreak`, `ClearHorizontalPageBreaks` and `ClearVerticalPageBreaks`. Those four new members are also source-breaking for anyone implementing `IXLPageSetup` outside the library.
 
+#### Pivot tables
+
+- **Refreshing a pivot cache whose source XLibur cannot read now throws `NotSupportedException` instead of `NotImplementedException`.** A cache fed by a scenario, a consolidation, a data connection or another workbook cannot be refreshed, because XLibur has no way to read that data — which is out of scope rather than unfinished, and `NotSupportedException` is the type that says so. The message names the source kind, and `IXLPivotCache.SourceKind` reports it before you try. **A `catch (NotImplementedException)` around `Refresh` no longer runs**, and there is no compile-time signal. A source that can be read but no longer resolves still throws `InvalidReferenceException`, unchanged.
+
+#### Helpers
+
+- **`XLHelper.GetColumnNumberFromLetter("")` now throws `ArgumentException` rather than `ArgumentNullException`.** An empty string is not a missing argument. `null` still throws `ArgumentNullException`; because that derives from `ArgumentException`, a handler for the base type sees both cases as before, but a handler for `ArgumentNullException` alone no longer sees the empty one.
+
 ### 🐛 Bug Fixes
 
 - **`MDETERM` and `MINVERSE` now answer a matrix with an all-zero column instead of throwing.** `=MDETERM({0,1;0,2})` threw `InvalidOperationException: The matrix is singular!` out of the formula rather than returning 0, and the matching `MINVERSE` threw rather than returning `#NUM!`. The LU decomposition behind both reported a column it could not pivot on by throwing, and neither function caught it. A singular matrix that still pivots, such as `{1,2;1,2}`, was already handled.

--- a/XLibur.Examples/XLibur.Examples.csproj
+++ b/XLibur.Examples/XLibur.Examples.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <LangVersion>default</LangVersion>
     <RootNamespace>XLibur.Examples</RootNamespace>
     <Company>XLibur</Company>
   </PropertyGroup>

--- a/XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj
+++ b/XLibur.Fonts.SixLabors.V1/XLibur.Fonts.SixLabors.V1.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>$(NoWarn);NU1605;CS1591;CA2255</NoWarn>
+        <NoWarn>$(NoWarn);CA2255</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/XLibur.Fonts.SixLabors/XLibur.Fonts.SixLabors.csproj
+++ b/XLibur.Fonts.SixLabors/XLibur.Fonts.SixLabors.csproj
@@ -17,10 +17,6 @@
         <DebugType>Portable</DebugType>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);NU1605;CS1591</NoWarn>
-    </PropertyGroup>
-
     <ItemGroup>
         <None Include="..\resources\logo\nuget-logo.png" Pack="true" PackagePath="\" />
         <None Include="NUGET_README.md" Pack="true" PackagePath="\" />

--- a/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
+++ b/XLibur.Fonts.SkiaSharp/XLibur.Fonts.SkiaSharp.csproj
@@ -17,10 +17,6 @@
         <DebugType>Portable</DebugType>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);NU1605;CS1591</NoWarn>
-    </PropertyGroup>
-
     <ItemGroup>
         <!--
             CarlitoBare is a Calibri metric-compatible, metric-only font (no glyph outlines) embedded as the

--- a/XLibur.Report.DynamicLinq/XLibur.Report.DynamicLinq.csproj
+++ b/XLibur.Report.DynamicLinq/XLibur.Report.DynamicLinq.csproj
@@ -20,10 +20,6 @@
         <DebugType>Portable</DebugType>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);NU1605;CS1591</NoWarn>
-    </PropertyGroup>
-
     <ItemGroup>
         <None Include="..\.editorconfig" Link=".editorconfig" />
         <None Include="..\resources\logo\nuget-logo.png" Pack="true" PackagePath="\" />

--- a/XLibur.Report.Tests/XLibur.Report.Tests.csproj
+++ b/XLibur.Report.Tests/XLibur.Report.Tests.csproj
@@ -10,7 +10,6 @@
     <!-- CS4014 (call not awaited) must fail the build. TUnit assertions are awaitable, so an
          un-awaited assertion never executes and the test passes no matter what it asserts. -->
     <WarningsAsErrors>$(WarningsAsErrors);CS4014</WarningsAsErrors>
-    <NoWarn>$(NoWarn);NU1605;CS1591</NoWarn>
     <!-- TUnit runs on Microsoft.Testing.Platform rather than VSTest. -->
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>

--- a/XLibur.Report/XLibur.Report.csproj
+++ b/XLibur.Report/XLibur.Report.csproj
@@ -20,10 +20,6 @@
         <DebugType>Portable</DebugType>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);NU1605;CS1591</NoWarn>
-    </PropertyGroup>
-
     <ItemGroup>
         <None Include="..\.editorconfig" Link=".editorconfig" />
         <None Include="..\resources\logo\nuget-logo.png" Pack="true" PackagePath="\" />

--- a/XLibur.Tests/Excel/Misc/XlHelperTests.cs
+++ b/XLibur.Tests/Excel/Misc/XlHelperTests.cs
@@ -13,6 +13,13 @@ public class XlHelperTests
     }
 
     [Test]
+    public async Task An_empty_column_letter_is_reported_as_empty_not_as_null()
+    {
+        await Assert.That(() => XLHelper.GetColumnNumberFromLetter("")).ThrowsExactly<ArgumentException>();
+        await Assert.That(() => XLHelper.GetColumnNumberFromLetter(null!)).ThrowsExactly<ArgumentNullException>();
+    }
+
+    [Test]
     public async Task InvalidA1Addresses()
     {
         await Assert.That(XLHelper.IsValidA1Address("")).IsFalse();

--- a/XLibur.Tests/Excel/PivotTables/XLPivotCacheSourceTests.cs
+++ b/XLibur.Tests/Excel/PivotTables/XLPivotCacheSourceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using XLibur.Excel;
 using XLibur.Excel.Coordinates;
@@ -147,15 +148,7 @@ public class XLPivotCacheSourceTests
         XLPivotSourceKind expected)
     {
         using var wb = WorkbookWithData(out var sheet);
-        IXLPivotSource source = expected switch
-        {
-            XLPivotSourceKind.Scenario => new XLPivotSourceScenario(),
-            XLPivotSourceKind.Connection => new XLPivotSourceConnection(1),
-            XLPivotSourceKind.Consolidation => new XLPivotSourceConsolidation(),
-            _ => new XLPivotSourceExternalWorkbook("rId1", SheetArea.From(sheet.Range("A1:B4"))),
-        };
-
-        var cache = new XLPivotCache(source, wb);
+        var cache = new XLPivotCache(UnreadableSource(expected, sheet), wb);
 
         await Assert.That(cache.SourceKind).IsEqualTo(expected);
 
@@ -165,4 +158,43 @@ public class XLPivotCacheSourceTests
         await Assert.That(cache.SourceWorksheet).IsNull();
         await Assert.That(cache.SourceName).IsNull();
     }
+
+    [Test]
+    [Arguments(XLPivotSourceKind.Scenario)]
+    [Arguments(XLPivotSourceKind.Connection)]
+    [Arguments(XLPivotSourceKind.Consolidation)]
+    [Arguments(XLPivotSourceKind.ExternalWorkbook)]
+    public async Task A_source_XLibur_cannot_read_answers_TryGetSource_with_false(XLPivotSourceKind kind)
+    {
+        using var wb = WorkbookWithData(out var sheet);
+        var source = UnreadableSource(kind, sheet);
+
+        var found = source.TryGetSource(wb, out var foundSheet, out var foundArea);
+
+        await Assert.That(found).IsFalse();
+        await Assert.That(foundSheet).IsNull();
+        await Assert.That(foundArea.HasValue).IsFalse();
+    }
+
+    [Test]
+    [Arguments(XLPivotSourceKind.Scenario)]
+    [Arguments(XLPivotSourceKind.Connection)]
+    [Arguments(XLPivotSourceKind.Consolidation)]
+    [Arguments(XLPivotSourceKind.ExternalWorkbook)]
+    public async Task Refreshing_a_cache_whose_source_XLibur_cannot_read_is_not_supported(XLPivotSourceKind kind)
+    {
+        using var wb = WorkbookWithData(out var sheet);
+        var cache = new XLPivotCache(UnreadableSource(kind, sheet), wb);
+
+        var ex = await Assert.That(() => cache.Refresh()).ThrowsExactly<NotSupportedException>();
+        await Assert.That(ex!.Message).Contains(kind.ToString());
+    }
+
+    private static IXLPivotSource UnreadableSource(XLPivotSourceKind kind, IXLWorksheet sheet) => kind switch
+    {
+        XLPivotSourceKind.Scenario => new XLPivotSourceScenario(),
+        XLPivotSourceKind.Connection => new XLPivotSourceConnection(1),
+        XLPivotSourceKind.Consolidation => new XLPivotSourceConsolidation(),
+        _ => new XLPivotSourceExternalWorkbook("rId1", SheetArea.From(sheet.Range("A1:B4"))),
+    };
 }

--- a/XLibur.Tests/XLibur.Tests.csproj
+++ b/XLibur.Tests/XLibur.Tests.csproj
@@ -12,7 +12,7 @@
          TreatWarningsAsErrors in Directory.Build.props already covers this; the rule is kept
          explicit so that it survives if that is ever relaxed again. -->
     <WarningsAsErrors>$(WarningsAsErrors);CS4014</WarningsAsErrors>
-    <NoWarn>$(NoWarn);NU1605;CS1591;CS1658;CS1584;</NoWarn>
+    <NoWarn>$(NoWarn);CS1658;CS1584</NoWarn>
     <!-- TUnit runs on Microsoft.Testing.Platform rather than VSTest. -->
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>

--- a/XLibur/Excel/InsertData/InsertDataReaderFactory.cs
+++ b/XLibur/Excel/InsertData/InsertDataReaderFactory.cs
@@ -37,7 +37,8 @@ internal sealed class InsertDataReaderFactory
 
     public static IInsertDataReader CreateReader<T>(IEnumerable<T[]> data)
     {
-        return data == null ? throw new ArgumentNullException(nameof(data)) : new ArrayReader(data);
+        ArgumentNullException.ThrowIfNull(data);
+        return new ArrayReader(data);
     }
 
     public static IInsertDataReader CreateReader(IEnumerable<IEnumerable> data)
@@ -52,6 +53,7 @@ internal sealed class InsertDataReaderFactory
 
     public static IInsertDataReader CreateReader(DataTable dataTable)
     {
-        return dataTable == null ? throw new ArgumentNullException(nameof(dataTable)) : new DataTableReader(dataTable);
+        ArgumentNullException.ThrowIfNull(dataTable);
+        return new DataTableReader(dataTable);
     }
 }

--- a/XLibur/Excel/PivotTables/IXLPivotSource.cs
+++ b/XLibur/Excel/PivotTables/IXLPivotSource.cs
@@ -18,9 +18,9 @@ internal interface IXLPivotSource : IEquatable<IXLPivotSource>
     XLPivotSourceKind Kind { get; }
 
     /// <summary>
-    /// Try to determine actual area of the source reference in the
-    /// workbook. Source reference might not be valid in the workbook, some might
-    /// not be supported.
+    /// Try to determine actual area of the source reference in the workbook. Answers
+    /// <c>false</c>, rather than throwing, both for a reference that no longer resolves and for a
+    /// kind XLibur cannot read at all; <see cref="Kind"/> is what tells the two apart.
     /// </summary>
     bool TryGetSource(XLWorkbook workbook, out XLWorksheet? sheet, out Area? sheetArea);
 }

--- a/XLibur/Excel/PivotTables/XLPivotCache.cs
+++ b/XLibur/Excel/PivotTables/XLPivotCache.cs
@@ -70,19 +70,7 @@ internal sealed class XLPivotCache : IXLPivotCache
 
     public string? SourceName => (Source as XLPivotSourceReference)?.Name;
 
-    public IXLWorksheet? SourceWorksheet
-    {
-        get
-        {
-            // Only these two can resolve to a sheet at all. The others throw from TryGetSource
-            // rather than returning false, and a property that reports "no worksheet" by throwing
-            // would be no use to a caller deciding what to do about a pivot it cannot re-point.
-            if (Source.Kind is not (XLPivotSourceKind.Range or XLPivotSourceKind.Name))
-                return null;
-
-            return Source.TryGetSource(_workbook, out var sheet, out _) ? sheet : null;
-        }
-    }
+    public IXLWorksheet? SourceWorksheet => Source.TryGetSource(_workbook, out var sheet, out _) ? sheet : null;
 
     /// <summary>
     /// Number of fields in the cache.
@@ -93,6 +81,12 @@ internal sealed class XLPivotCache : IXLPivotCache
 
     public IXLPivotCache Refresh()
     {
+        // A source XLibur cannot read is out of scope, not broken, and a caller tells it apart from a
+        // reference that no longer resolves by the exception type.
+        if (Source.Kind is not (XLPivotSourceKind.Range or XLPivotSourceKind.Name))
+            throw new NotSupportedException(
+                $"A pivot cache whose source is {Source.Kind} cannot be refreshed: XLibur cannot read that data.");
+
         // Refresh can only happen if the reference is valid.
         if (!Source.TryGetSource(_workbook, out var sheet, out var foundArea))
             throw new InvalidReferenceException();

--- a/XLibur/Excel/PivotTables/XLPivotSourceConnection.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceConnection.cs
@@ -40,8 +40,11 @@ internal sealed class XLPivotSourceConnection : IXLPivotSource
         return HashCode.Combine(ConnectionId).GetHashCode();
     }
 
+    /// <summary>XLibur cannot read through a data connection, so there is never a sheet area to report.</summary>
     public bool TryGetSource(XLWorkbook workbook, out XLWorksheet? sheet, out Area? sheetArea)
     {
-        throw new NotImplementedException("Pivot cache source using a connection is not supported.");
+        sheet = null;
+        sheetArea = null;
+        return false;
     }
 }

--- a/XLibur/Excel/PivotTables/XLPivotSourceConsolidation.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceConsolidation.cs
@@ -53,8 +53,11 @@ internal sealed class XLPivotSourceConsolidation : IXLPivotSource
         return false;
     }
 
+    /// <summary>XLibur cannot read a consolidation, so there is never a sheet area to report.</summary>
     public bool TryGetSource(XLWorkbook workbook, out XLWorksheet? sheet, out Area? sheetArea)
     {
-        throw new NotImplementedException("Consolidation pivot cache data source is not supported.");
+        sheet = null;
+        sheetArea = null;
+        return false;
     }
 }

--- a/XLibur/Excel/PivotTables/XLPivotSourceExternalWorkbook.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceExternalWorkbook.cs
@@ -45,9 +45,12 @@ internal sealed class XLPivotSourceExternalWorkbook : IXLPivotSource
         TableOrName = tableOrName;
     }
 
+    /// <summary>XLibur cannot read another workbook, so there is never a sheet area to report.</summary>
     public bool TryGetSource(XLWorkbook workbook, out XLWorksheet? sheet, out Area? sheetArea)
     {
-        throw new NotImplementedException("External workbook source is not supported.");
+        sheet = null;
+        sheetArea = null;
+        return false;
     }
 
     public bool Equals(IXLPivotSource? otherSource)

--- a/XLibur/Excel/PivotTables/XLPivotSourceScenario.cs
+++ b/XLibur/Excel/PivotTables/XLPivotSourceScenario.cs
@@ -26,8 +26,11 @@ internal sealed class XLPivotSourceScenario : IXLPivotSource
         return 0;
     }
 
+    /// <summary>XLibur cannot read scenario data, so there is never a sheet area to report.</summary>
     public bool TryGetSource(XLWorkbook workbook, out XLWorksheet? sheet, out Area? sheetArea)
     {
-        throw new NotImplementedException("Scenario pivot cache data source is not supported.");
+        sheet = null;
+        sheetArea = null;
+        return false;
     }
 }

--- a/XLibur/XLHelper.cs
+++ b/XLibur/XLHelper.cs
@@ -125,7 +125,7 @@ public static partial class XLHelper
     /// <param name="columnLetter"> The column letter to translate into a column number. </param>
     public static int GetColumnNumberFromLetter(string columnLetter)
     {
-        if (string.IsNullOrEmpty(columnLetter)) throw new ArgumentNullException(nameof(columnLetter));
+        ArgumentException.ThrowIfNullOrEmpty(columnLetter);
 
         //Extra check because we allow users to pass row col positions in as strings
         if (columnLetter[0] <= '9')

--- a/XLibur/XLibur.csproj
+++ b/XLibur/XLibur.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <LangVersion>default</LangVersion>
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
         <RootNamespace>XLibur</RootNamespace>
         <Company>XLibur</Company>
@@ -15,10 +14,6 @@
 
     <PropertyGroup>
         <DebugType>Portable</DebugType>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <NoWarn>$(NoWarn);NU1605;CS1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Last of five stacked PRs from a coding-standards review. **This PR is based on #462, not `main`**, and the diff shows only its own change. Merge #459–#462 first.

Three commits: one behaviour change to pivot caches, a small argument-guard fix, and a build-settings cleanup.

## 1. Refreshing a pivot cache XLibur cannot read throws `NotSupportedException`

A pivot cache fed by a scenario, a consolidation, a data connection or another workbook cannot be refreshed, because XLibur has no way to read that data. `Refresh` found this out by calling `IXLPivotSource.TryGetSource`, and those four sources answered by **throwing `NotImplementedException` from a `Try` method**. That interface's own doc comment says "some might not be supported". `NotImplementedException` also says the feature is unfinished, when it is really out of scope.

| | Before | After |
|---|---|---|
| `TryGetSource` on the four unreadable kinds | throws `NotImplementedException` | returns `false` |
| `IXLPivotCache.Refresh()` on those kinds | `NotImplementedException` | `NotSupportedException`, with the source kind in the message |
| `Refresh()` on a readable source that no longer resolves | `InvalidReferenceException` | unchanged |
| `IXLPivotCache.SourceWorksheet` | `null`, via a kind check that dodged the throwing `Try` | `null`, straight from `TryGetSource`; the workaround is gone |

A caller can still tell "cannot be read" from "no longer points anywhere", now by exception type, and `SourceKind` reports it before the call.

## 2. Argument guards

- **`XLHelper.GetColumnNumberFromLetter("")`** threw `ArgumentNullException` for an empty string, telling the caller the argument was missing. It now uses `ArgumentException.ThrowIfNullOrEmpty`: `null` is still `ArgumentNullException`, and `""` is `ArgumentException`.
- **`InsertDataReaderFactory.CreateReader`**'s two `x == null ? throw … : …` ternaries now use `ArgumentNullException.ThrowIfNull`, like the overload between them. The exception and the parameter name are the same.

**Correction to the review.** It said 32 old-style guards "could become `ThrowIfNull`". Most of them are `x ?? throw new ArgumentNullException(nameof(x))` assignments. Those are already idiomatic, and `ThrowIfNull` would make them longer, not shorter. The four colour setters carry a "Color cannot be null" message that `ThrowIfNull` cannot keep. Only the three above were worth changing.

## 3. Projects stop restating `Directory.Build.props`

`Directory.Build.props` sets `LangVersion` to `latest` and `NoWarn` to `NU1605;CS1591` for every project.

- `XLibur` and `XLibur.Examples` overrode `LangVersion` with `default`. With the SDK in use both select the same version; the library already compiles C# 14's `field` keyword on every target framework. The overrides are gone.
- Eight projects appended `NU1605;CS1591` to `NoWarn` again. They now keep only their own suppressions: `CA2255` in `Fonts.SixLabors.V1`, and `CS1658` and `CS1584` in `XLibur.Tests`.
- **Kept:** the test projects' `LangVersion latest`. It is deliberate, with a comment saying why: TUnit's overload resolution needs C# 13 or later.

`git diff --numstat` shows 1–5 changed lines per project file, so the CRLF endings survived; `.gitattributes` enforces CRLF.

## Also corrected from the review

The review listed `XLTable.cs:349` ("Resizing of tables with no headers not supported **yet**") next to the pivot sources. That one describes a feature that hasn't been built yet, which is exactly what `NotImplementedException` means, so it is unchanged.

## ⚠️ Breaking changes

There is no compile-time signal for either:

- `IXLPivotCache.Refresh()` on a scenario, consolidation, connection or external-workbook source throws `NotSupportedException`. A `catch (NotImplementedException)` around it no longer runs.
- `XLHelper.GetColumnNumberFromLetter("")` throws `ArgumentException`. A `catch (ArgumentException)` still covers it; a `catch (ArgumentNullException)` no longer does.

`CHANGELOG.md` has both under *Unreleased → Breaking Changes*.

## Testing

Nine new test cases, all watched failing first:

- `XLPivotCacheSourceTests`, for each of the four unreadable kinds: `TryGetSource` answers `false` (failed with `NotImplementedException`), and `Refresh` throws exactly `NotSupportedException` naming the kind (failed with the wrong type). The existing kind test now shares their source-building helper.
- `XlHelperTests`: `""` throws exactly `ArgumentException` (failed with `ArgumentNullException`), and `null` still throws `ArgumentNullException`.

All four test projects pass on both frameworks:

| Project | net10.0 | net8.0 |
|---|---|---|
| XLibur.Tests | 14,471 passed, 5 skipped | 14,471 passed, 5 skipped |
| XLibur.Report.Tests | 481 | 481 |
| XLibur.Fonts.SixLabors.Tests | 31 | 31 |
| XLibur.Fonts.SkiaSharp.Tests | 37 | 37 |

`dotnet build XLibur.slnx -c Release` is clean: 0 warnings, 0 errors across all 16 projects and every target framework. That is the check that matters for the project-file cleanup.
