### PR TITLE
fix: the formula parser comes from our fork, now at 3.0.0

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -19,7 +19,7 @@ directly.
 | Target frameworks  | net8.0, net9.0, net10.0                                     |
 | License            | MIT                                                         |
 | Core dependency    | DocumentFormat.OpenXml 3.4.1                                |
-| Parser             | XLibur.ClosedXML.Parser 2.1.0-alpha.276                     |
+| Parser             | XLibur.ClosedXML.Parser 2.1.0-beta.293                      |
 | Font handling       | SixLabors.Fonts 1.0.1                                       |
 | Spatial indexing   | RBush.Signed 4.0.0                                          |
 | Number formatting  | ExcelNumberFormat 1.1.0                                     |

--- a/Architecture.md
+++ b/Architecture.md
@@ -19,7 +19,7 @@ directly.
 | Target frameworks  | net8.0, net9.0, net10.0                                     |
 | License            | MIT                                                         |
 | Core dependency    | DocumentFormat.OpenXml 3.4.1                                |
-| Parser             | XLibur.ClosedXML.Parser 2.1.0-beta.293                      |
+| Parser             | XLibur.ClosedXML.Parser 3.0.0                               |
 | Font handling       | SixLabors.Fonts 1.0.1                                       |
 | Spatial indexing   | RBush.Signed 4.0.0                                          |
 | Number formatting  | ExcelNumberFormat 1.1.0                                     |

--- a/Architecture.md
+++ b/Architecture.md
@@ -19,7 +19,7 @@ directly.
 | Target frameworks  | net8.0, net9.0, net10.0                                     |
 | License            | MIT                                                         |
 | Core dependency    | DocumentFormat.OpenXml 3.4.1                                |
-| Parser             | ClosedXML.Parser 2.0.0                                      |
+| Parser             | XLibur.ClosedXML.Parser 2.1.0-alpha.276                     |
 | Font handling       | SixLabors.Fonts 1.0.1                                       |
 | Spatial indexing   | RBush.Signed 4.0.0                                          |
 | Number formatting  | ExcelNumberFormat 1.1.0                                     |
@@ -411,8 +411,9 @@ streamed date round-trips as a date rather than as a number.
 
 ### 7.1 Parsing & AST
 
-Formulas are parsed by `ClosedXML.Parser` (external NuGet) into an AST. The
-`FormulaParser` class wraps it:
+Formulas are parsed by `ClosedXML.Parser` (external NuGet, shipped as the
+`XLibur.ClosedXML.Parser` package — a fork of the ClosedXML original, same assembly
+and namespace) into an AST. The `FormulaParser` class wraps it:
 
 ```
 string formula  →  FormulaParser.GetAst(...)  →  Formula (AST root)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,40 @@
 
 - **`XLWorkbook.EvaluateExpr` can now be called from several threads at once.** The method is static and every caller shared one engine, whose parse cache could not be filled from two threads at the same time. Two threads evaluating the same new expression both missed the cache, and the second threw `ArgumentException: An item with the same key has already been added` from a call that had nothing to do with the other thread. Each thread now has its own engine. A workbook itself is still not safe to use from several threads.
 
+### Changed
+
+- The formula parser is now `XLibur.ClosedXML.Parser`, our fork of `ClosedXML.Parser`, in
+  place of the community package at 2.0.0. The assembly name and the `ClosedXML.Parser`
+  namespace are unchanged, so nothing in XLibur's own source moved and no public API of
+  XLibur changed. The community package's last release was 2.0.0 in April 2025, and its
+  `develop` branch is a half-finished 3.0 rewrite with no 2.0.x line to take a patch, so
+  there was no route to ship a parser fix — see
+  [#313](https://github.com/XLibur/XLibur/issues/313). Consumers see a different package in
+  their dependency graph; a project that also pulls in `ClosedXML.Parser` gets both, and the
+  fork wins on assembly version without a build warning.
+
+### Fixed
+
+Carried in from the forked parser, each verified against 2.0.0:
+
+- A defined name or formula holding a structured reference whose whole inner reference is a
+  keyword list — `Sales[[#Headers],[#Data]]` — no longer throws `IndexOutOfRangeException`
+  out of the parser.
+- An R1C1 round trip no longer fails under a culture whose negative sign is U+2212
+  (`sv-SE`, `fi-FI`, `nb-NO`). The writer used the current culture, emitting `R[−1]C[−1]`,
+  which the reader could not read back.
+- A sheet name is quoted the way Excel's file format requires rather than the way its
+  formula bar displays it: 41 codepoints in the first position and 37 in a later one were
+  left unquoted where Excel quotes, and for some of them Excel refuses to open the workbook.
+  A sheet named `TRUE` or `FALSE` is now quoted too.
+- Malformed UTF-16 is treated as invalid input instead of throwing. Text ending in a lone
+  high surrogate threw `IndexOutOfRangeException`, and a high surrogate followed by anything
+  else threw `ArgumentOutOfRangeException`.
+- An R1C1 axis number of zero is refused. `C0` parsed as if it were `C`, so it silently
+  became a whole-column reference instead of the defined name it is.
+- The called cell of a cell function is read in the formula's own reference style. In R1C1,
+  `R7C3(TRUE)` was read as the A1 cell `R7` and the `C3` was discarded.
+
 ## v0.400.0 - 2026-09-01
 
 ### ⚠️ Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
   [#313](https://github.com/XLibur/XLibur/issues/313). Consumers see a different package in
   their dependency graph; a project that also pulls in `ClosedXML.Parser` gets both, and the
   fork wins on assembly version without a build warning.
-- The parser is `XLibur.ClosedXML.Parser` 2.1.0-beta.293. When a sheet or table is renamed or
+- The parser is `XLibur.ClosedXML.Parser` 3.0.0. When a sheet or table is renamed or
   deleted, a formula is now rewritten only where it names that sheet or table, and the rest of
   its text is kept as written. The parser used to write every reference again, so a rename also
   dropped quotes a sheet name doesn't need (`'Wk2'!C5` became `Wk2!C5`), collapsed a one-cell
@@ -56,7 +56,7 @@
 
 ### Fixed
 
-From 2.1.0-beta.293:
+From 3.0.0:
 
 - A dynamic data exchange formula, such as `Sdemo123|tik!'id1?req?AAPL'`, now parses.
   Evaluating it throws `NotImplementedException`, as other unsupported syntax does.
@@ -64,6 +64,11 @@ From 2.1.0-beta.293:
 - A formula holding `#GETTING_DATA` throws `ExpressionParseException` when it is parsed, not
   `InvalidOperationException`, because `XLError` has no member for it. The newer error values
   the parser now reads, such as `#CALC!` and `#FIELD!`, are refused the same way.
+- Renaming a sheet to a name shaped like a cell, such as `PWD1`, quotes it when it is the first
+  sheet of a 3D reference: `'PWD1:Last'!A1`. It was written bare, and `PWD1:Last!A1` doesn't read
+  back as the same reference.
+- A space intersection after an expression in braces, `(A1) B2`, now parses. Evaluating it throws
+  `NotImplementedException`, as any range intersection does.
 
 Carried in from the forked parser, each verified against 2.0.0:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,22 @@
   [#313](https://github.com/XLibur/XLibur/issues/313). Consumers see a different package in
   their dependency graph; a project that also pulls in `ClosedXML.Parser` gets both, and the
   fork wins on assembly version without a build warning.
+- The parser is `XLibur.ClosedXML.Parser` 2.1.0-beta.293. When a sheet or table is renamed or
+  deleted, a formula is now rewritten only where it names that sheet or table, and the rest of
+  its text is kept as written. The parser used to write every reference again, so a rename also
+  dropped quotes a sheet name doesn't need (`'Wk2'!C5` became `Wk2!C5`), collapsed a one-cell
+  area (`'Org Chart'!D5:D5` became `'Org Chart'!D5`) and dropped the whitespace before a formula.
 
 ### Fixed
+
+From 2.1.0-beta.293:
+
+- A dynamic data exchange formula, such as `Sdemo123|tik!'id1?req?AAPL'`, now parses.
+  Evaluating it throws `NotImplementedException`, as other unsupported syntax does.
+- The `#SPILL!` error literal now parses, as `XLError.SpillRange`.
+- A formula holding `#GETTING_DATA` throws `ExpressionParseException` when it is parsed, not
+  `InvalidOperationException`, because `XLError` has no member for it. The newer error values
+  the parser now reads, such as `#CALC!` and `#FIELD!`, are refused the same way.
 
 Carried in from the forked parser, each verified against 2.0.0:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,9 @@ Other notes:
 - **DocumentFormat.OpenXml** 3.4.1 - Core OpenXML implementation ([source](https://github.com/dotnet/Open-XML-SDK))
 - **ExcelNumberFormat** 1.1.0 - Excel number formatting ([source](https://github.com/andersnm/ExcelNumberFormat))
 - **SixLabors.Fonts** 1.0.1 - Font handling
-- **ClosedXML.Parser** 2.0.0 - Parser utilities ([source](https://github.com/ClosedXML/ClosedXML.Parser))
+- **XLibur.ClosedXML.Parser** 2.1.0-alpha.276 - Parser utilities; our fork of ClosedXML.Parser,
+  keeping the `ClosedXML.Parser` assembly name and namespace ([source](https://github.com/XLibur/ClosedXML.Parser),
+  [upstream](https://github.com/ClosedXML/ClosedXML.Parser))
 - **RBush.Signed** 4.0.0 - Spatial indexing
 
 ## Shell Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Other notes:
 - **DocumentFormat.OpenXml** 3.4.1 - Core OpenXML implementation ([source](https://github.com/dotnet/Open-XML-SDK))
 - **ExcelNumberFormat** 1.1.0 - Excel number formatting ([source](https://github.com/andersnm/ExcelNumberFormat))
 - **SixLabors.Fonts** 1.0.1 - Font handling
-- **XLibur.ClosedXML.Parser** 2.1.0-beta.293 - Parser utilities; our fork of ClosedXML.Parser,
+- **XLibur.ClosedXML.Parser** 3.0.0 - Parser utilities; our fork of ClosedXML.Parser,
   keeping the `ClosedXML.Parser` assembly name and namespace ([source](https://github.com/XLibur/ClosedXML.Parser),
   [upstream](https://github.com/ClosedXML/ClosedXML.Parser))
 - **RBush.Signed** 4.0.0 - Spatial indexing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Other notes:
 - **DocumentFormat.OpenXml** 3.4.1 - Core OpenXML implementation ([source](https://github.com/dotnet/Open-XML-SDK))
 - **ExcelNumberFormat** 1.1.0 - Excel number formatting ([source](https://github.com/andersnm/ExcelNumberFormat))
 - **SixLabors.Fonts** 1.0.1 - Font handling
-- **XLibur.ClosedXML.Parser** 2.1.0-alpha.276 - Parser utilities; our fork of ClosedXML.Parser,
+- **XLibur.ClosedXML.Parser** 2.1.0-beta.293 - Parser utilities; our fork of ClosedXML.Parser,
   keeping the `ClosedXML.Parser` assembly name and namespace ([source](https://github.com/XLibur/ClosedXML.Parser),
   [upstream](https://github.com/ClosedXML/ClosedXML.Parser))
 - **RBush.Signed** 4.0.0 - Spatial indexing

--- a/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -593,10 +593,9 @@ internal class DependencyTreeTests
             // Unary implicit intersection is propagated
             yield return
             [
-                // Implicit intersection is not a part of ref_expression, so `D3:@A1:C2` cannot
-                // be used as a test case — it still fails to parse on XLibur.ClosedXML.Parser
-                // 2.1.0-alpha.276, re-checked against https://github.com/XLibur/XLibur/issues/313.
-                // The unary form below does parse.
+                // `D3:@A1:C2` failed to parse up to XLibur.ClosedXML.Parser 2.1.0-alpha.276 and
+                // parses on 2.1.0-beta.293, but its dependencies are not pinned here yet
+                // (https://github.com/XLibur/XLibur/issues/313).
                 "@A1:A4",
                 new[]
                 {

--- a/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -593,8 +593,10 @@ internal class DependencyTreeTests
             // Unary implicit intersection is propagated
             yield return
             [
-                // Due to issue ClosedParser#1, implicit intersection is not a part
-                // of ref_expression and I can't use `D3:@A1:C2` as a test case
+                // Implicit intersection is not a part of ref_expression, so `D3:@A1:C2` cannot
+                // be used as a test case — it still fails to parse on XLibur.ClosedXML.Parser
+                // 2.1.0-alpha.276, re-checked against https://github.com/XLibur/XLibur/issues/313.
+                // The unary form below does parse.
                 "@A1:A4",
                 new[]
                 {

--- a/XLibur.Tests/Excel/CalcEngine/FormulaConversionFidelityTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FormulaConversionFidelityTests.cs
@@ -1,0 +1,98 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+
+namespace XLibur.Tests.Excel.CalcEngine;
+
+/// <summary>
+/// Formula text that has to survive a conversion through R1C1 — the form a shared formula is
+/// stored in — and a sheet prefix that has to be quoted the way the file format requires.
+/// </summary>
+/// <remarks>
+/// Both are parser-side defects fixed by moving to XLibur.ClosedXML.Parser; see
+/// https://github.com/XLibur/XLibur/issues/313. They are pinned here because nothing in the suite
+/// exercised them from XLibur's own API, so the swap would otherwise have had no guard.
+/// </remarks>
+public class FormulaConversionFidelityTests
+{
+    /// <summary>
+    /// A shared formula is written as R1C1 and read back as A1. The parser used to write the
+    /// offsets with the current culture's negative sign, so under a culture whose sign is U+2212
+    /// it emitted <c>R[−1]C[−1]</c>, which its own reader could not read back.
+    /// </summary>
+    [Test]
+    [SetCulture("sv-SE")]
+    public async Task AFormulaConvertsThroughR1C1UnderACultureWithAMinusSign()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").Value = 2;
+        ws.Cell("B2").FormulaA1 = "A1+B1";
+
+        await Assert.That(ws.Cell("B2").FormulaR1C1).IsEqualTo("R[-1]C[-1]+R[-1]C");
+
+        ws.Cell("C3").FormulaR1C1 = ws.Cell("B2").FormulaR1C1;
+
+        await Assert.That(ws.Cell("C3").FormulaA1).IsEqualTo("B2+C2");
+    }
+
+    /// <summary>
+    /// A sheet whose name Excel's formula bar shows unquoted but whose file format requires
+    /// quotes. The quotation tables were collected from the formula bar, so the prefix came back
+    /// unquoted and Excel refused the workbook.
+    /// </summary>
+    /// <remarks>
+    /// <c>TRUE</c> is the readable case — unquoted, <c>TRUE!A1</c> reads as a logical literal.
+    /// U+FF5E is one of the 41 codepoints the tables got wrong in the first position.
+    /// </remarks>
+    [Test]
+    [Arguments("TRUE")]
+    [Arguments("ABC～")]
+    public async Task ASheetPrefixKeepsItsQuotesThroughAnR1C1RoundTrip(string sheetName)
+    {
+        using var wb = new XLWorkbook();
+        var other = wb.AddWorksheet(sheetName);
+        other.Cell("A1").Value = 7;
+        var ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("B2").FormulaA1 = $"'{sheetName}'!A1";
+
+        // The prefix survives the trip out to R1C1 and back, quotes intact.
+        await Assert.That(ws.Cell("B2").FormulaR1C1).IsEqualTo($"'{sheetName}'!R[-1]C[-1]");
+        await Assert.That(ws.Cell("B2").FormulaA1).IsEqualTo($"'{sheetName}'!A1");
+        await Assert.That(ws.Cell("B2").Value).IsEqualTo(7);
+    }
+
+    /// <summary>
+    /// The same prefix has to reach the saved file quoted, since that is where Excel reads it.
+    /// </summary>
+    /// <remarks>
+    /// Unlike the two above, this passed on ClosedXML.Parser 2.0.0 as well: the save path writes
+    /// the A1 text the caller authored and never asks the parser to quote a prefix. It is here to
+    /// say so — the quoting defect only surfaces once a formula is rewritten, which is what a
+    /// shared formula, a shift and a sheet rename all do.
+    /// </remarks>
+    [Test]
+    [Arguments("TRUE")]
+    [Arguments("ABC～")]
+    public async Task ASheetPrefixIsQuotedInTheSavedFile(string sheetName)
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            var other = wb.AddWorksheet(sheetName);
+            other.Cell("A1").Value = 7;
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("B2").FormulaA1 = $"'{sheetName}'!A1";
+            wb.SaveAs(ms, validate: false);
+        }
+
+        ms.Position = 0;
+        using var reloaded = new XLWorkbook(ms);
+        var cell = reloaded.Worksheet("Sheet1").Cell("B2");
+
+        await Assert.That(cell.FormulaA1).IsEqualTo($"'{sheetName}'!A1");
+        await Assert.That(cell.Value).IsEqualTo(7);
+    }
+}

--- a/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -301,10 +301,11 @@ public class FormulaParserTests
     }
 
     [Test]
-    [Arguments]
-    public async Task Reference_function_call_can_be_intersection_of_two_references()
+    [Arguments("=A1:A3 A2:B2")]
+    [Arguments("=(A1) B2")]
+    public async Task Reference_function_call_can_be_intersection_of_two_references(string formula)
     {
-        await AssertCanParseButNotEvaluate("=A1:A3 A2:B2", "Evaluation of range intersection operator is not implemented.");
+        await AssertCanParseButNotEvaluate(formula, "Evaluation of range intersection operator is not implemented.");
     }
 
     [Test]

--- a/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -278,10 +278,11 @@ public class FormulaParserTests
     }
 
     [Test]
-    [Arguments]
-    public async Task Reference_can_be_dynamic_data_exchange()
+    [Arguments("=Sdemo123|tik!'id1?req?AAPL_STK_SMART_USD_~/'")]
+    [Arguments("=[1]!'id1?req?AAPL_STK_SMART_USD_~/'")]
+    public async Task Reference_can_be_dynamic_data_exchange(string formula)
     {
-        await AssertCanParseButNotEvaluate("=Sdemo123|tik!'id1?req?AAPL_STK_SMART_USD_~/'", "Evaluation of dynamic data exchange is not implemented.");
+        await AssertCanParseButNotEvaluate(formula, "Evaluation of dynamic data exchange is not implemented.");
     }
 
     #endregion
@@ -418,6 +419,13 @@ public class FormulaParserTests
     public async Task Reference_item_can_be_ref_error()
     {
         await Assert.That(XLWorkbook.EvaluateExpr("#REF!")).IsEqualTo(XLError.CellReference);
+    }
+
+    [Test]
+    [Arguments]
+    public async Task Reference_item_can_be_sheet_qualified_ref_error()
+    {
+        await Assert.That(XLWorkbook.EvaluateExpr("Sheet1!#REF!")).IsEqualTo(XLError.CellReference);
     }
 
     [Test]
@@ -571,7 +579,8 @@ public class FormulaParserTests
         var ws = wb.AddWorksheet();
         var calcEngine = new XLCalcEngine(CultureInfo.InvariantCulture);
         _ = calcEngine.Parse(formula);
-        await Assert.That(() => ws.Evaluate(formula, "A1")).Throws<Exception>();
+        var ex = await Assert.That(() => ws.Evaluate(formula, "A1")).Throws<NotImplementedException>();
+        await Assert.That(ex!.Message).IsEqualTo(notSupportedMessage);
     }
 
     private static async Task AssertCanParseAndEvaluateToRefError(string formula)

--- a/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -135,10 +135,26 @@ public class FormulaParserTests
     [Arguments("#N/A", XLError.NoValueAvailable)]
     [Arguments("#NULL!", XLError.NullValue)]
     [Arguments("#NUM!", XLError.NumberInvalid)]
+    [Arguments("#SPILL!", XLError.SpillRange)]
     public async Task Constant_can_be_error(string formula, object expectedError)
     {
         var error = (XLError)XLWorkbook.EvaluateExpr(formula);
         await Assert.That(error).IsEqualTo(ExpectedCellValue.From(expectedError));
+    }
+
+    /// <summary>
+    /// The parser lexes every error value Excel knows, but <see cref="XLError"/> has no member for
+    /// most of the newer ones, so a formula holding one is refused the way an unreadable formula is.
+    /// </summary>
+    [Test]
+    [Arguments("#CALC!")]
+    [Arguments("#FIELD!")]
+    [Arguments("#GETTING_DATA")]
+    [Arguments("ERROR.TYPE(#BLOCKED!)")]
+    public async Task Constant_error_without_an_XLError_is_a_parse_error(string formula)
+    {
+        var calcEngine = new XLCalcEngine(CultureInfo.InvariantCulture);
+        await Assert.That(() => calcEngine.Parse(formula)).Throws<ExpressionParseException>();
     }
     #endregion
 
@@ -263,7 +279,6 @@ public class FormulaParserTests
 
     [Test]
     [Arguments]
-    [Skip("ClosedXML.Parser can't tokenize a dynamic data exchange reference.")]
     public async Task Reference_can_be_dynamic_data_exchange()
     {
         await AssertCanParseButNotEvaluate("=Sdemo123|tik!'id1?req?AAPL_STK_SMART_USD_~/'", "Evaluation of dynamic data exchange is not implemented.");

--- a/XLibur.Tests/Excel/NamedRanges/DefinedNameLoadResilienceTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/DefinedNameLoadResilienceTests.cs
@@ -65,6 +65,7 @@ public class DefinedNameLoadResilienceTests
     [Arguments(" ")]
     [Arguments("SUM(Sheet1!$A$1")]
     [Arguments("@@@")]
+    [Arguments("#CALC!")]
     public async Task A_defined_name_the_parser_rejects_does_not_abort_the_load(string refersToText)
     {
         using var package = BookWithRawDefinedName(refersToText);
@@ -283,6 +284,8 @@ public class DefinedNameLoadResilienceTests
     [Arguments("   ")]
     [Arguments("SUM(Sheet1!$A$1")]
     [Arguments("@@@")]
+    [Arguments("#CALC!")]
+    [Arguments("{1,#FIELD!}")]
     public async Task Setting_RefersTo_to_a_formula_the_parser_rejects_throws_ExpressionParseException(string formula)
     {
         using var wb = BookWithAUsableName();

--- a/XLibur.Tests/Excel/NamedRanges/DefinedNameStructuredReferenceTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/DefinedNameStructuredReferenceTests.cs
@@ -16,10 +16,10 @@ namespace XLibur.Tests.Excel.NamedRanges;
 /// than always answering with the first column's data.
 /// </para>
 /// <para>
-/// The two-specifier form Excel writes as <c>Sales[[#Headers],[#Data]]</c> is not covered: it
-/// throws inside ClosedXML.Parser while the formula is being parsed, before any of this is
-/// reached, so it is not something resolution can answer for either way. The resolver does handle
-/// the combination once a formula carrying it parses.
+/// The two-specifier form Excel writes as <c>Sales[[#Headers],[#Data]]</c> used to throw
+/// <see cref="System.IndexOutOfRangeException"/> inside ClosedXML.Parser while the formula was
+/// being parsed, before any of this was reached. It parses on XLibur.ClosedXML.Parser, and the
+/// resolver already handled the combination, so it is covered here.
 /// </para>
 /// </remarks>
 public class DefinedNameStructuredReferenceTests
@@ -182,6 +182,27 @@ public class DefinedNameStructuredReferenceTests
         table.Resize(ws.Range("A1:A4"));
 
         await Assert.That(name.Ranges.Single().RangeAddress.ToString()).IsEqualTo("A2:A4");
+    }
+
+    /// <summary>
+    /// Two area specifiers select the span between them, the form Excel writes when a selection
+    /// crosses the header or totals boundary.
+    /// </summary>
+    /// <remarks>
+    /// This is the case that used to abort with <c>IndexOutOfRangeException</c> out of
+    /// ClosedXML.Parser 2.0.0, where a keyword list forming the whole inner reference — no column
+    /// name after it — ran off the end of an array. Reachable from an ordinary load, so the
+    /// exception escaped as a load failure rather than as a bad name. Fixed in
+    /// XLibur.ClosedXML.Parser; see https://github.com/XLibur/XLibur/issues/313.
+    /// </remarks>
+    [Test]
+    [Arguments("Sales[[#Headers],[#Data]]", "A1:C3")]
+    [Arguments("Sales[[#Data],[#Totals]]", "A2:C4")]
+    public async Task TwoAreaSpecifiersSelectTheSpanBetweenThem(string formula, string expected)
+    {
+        using var wb = TableBook();
+
+        await Assert.That(RangesOf(wb, formula)).IsEquivalentTo(new[] { expected });
     }
 
     /// <summary>A table with no totals row has no totals to point at.</summary>

--- a/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -25,6 +25,24 @@ public class NamedRangesTests
         await Assert.That(() => wb.DefinedNames.Add("Test", "SUM(Sheet7!A4")).Throws<ExpressionParseException>();
     }
 
+    /// <summary>
+    /// A defined name can hold a dynamic data exchange reference, in the form Excel stores and the
+    /// form it displays. It names no cell, so it is valid; evaluating it is not implemented.
+    /// </summary>
+    [Test]
+    [Arguments("Sdemo123|tik!'id1?req?AAPL'")]
+    [Arguments("[1]!'id1?req?AAPL'")]
+    public async Task Defined_name_can_hold_a_dynamic_data_exchange_reference(string formula)
+    {
+        using var wb = new XLWorkbook();
+        wb.AddWorksheet();
+
+        var name = wb.DefinedNames.Add("Quote", formula);
+
+        await Assert.That(name.RefersTo).IsEqualTo(formula);
+        await Assert.That(name.IsValid).IsTrue();
+    }
+
     [Test]
     public async Task CanEvaluateNamedMultiRange()
     {

--- a/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/XLibur.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -1026,6 +1026,25 @@ public class XLWorksheetTests
         await Assert.That(ws.Cell("A2").Value).IsEqualTo(300);
     }
 
+    /// <summary>
+    /// A sheet renamed to a name shaped like a cell (<c>PWD1</c> is column PWD, row 1) is quoted as the
+    /// first sheet of a 3D reference. Bare, <c>PWD1:Last!A1</c> reads back as a range from the cell
+    /// <c>PWD1</c> to <c>Last!A1</c>.
+    /// </summary>
+    [Test]
+    public async Task Rename_sheet_to_a_cell_like_name_quotes_it_as_the_first_sheet_of_a_3D_reference()
+    {
+        using var wb = new XLWorkbook();
+        var first = wb.Worksheets.Add("First");
+        wb.Worksheets.Add("Last");
+        var ws = wb.Worksheets.Add("Summary");
+        ws.Cell("A1").FormulaA1 = "SUM(First:Last!A1)";
+
+        first.Name = "PWD1";
+
+        await Assert.That(ws.Cell("A1").FormulaA1).IsEqualTo("SUM('PWD1:Last'!A1)");
+    }
+
     [Test]
     // ReSharper disable once InconsistentNaming
     public async Task RangesFromDeletedWorksheetContainREF()

--- a/XLibur/Excel/CalcEngine/FormulaParser.cs
+++ b/XLibur/Excel/CalcEngine/FormulaParser.cs
@@ -332,12 +332,6 @@ internal sealed class FormulaParser
             return new FunctionNode(prefixNode, functionName, argumentNodes);
         }
 
-        private static XLError GetErrorValue(ReadOnlySpan<char> error)
-        {
-            // The parser lexes every error Excel knows, but XLError lacks most newer ones (#CALC!, #FIELD!, ...).
-            if (!XLErrorParser.TryParseError(error.ToString(), out var errorEnum))
-                throw new ExpressionParseException($"'{error.ToString()}' is not an error value XLibur supports.");
-            return errorEnum;
-        }
+        private static XLError GetErrorValue(ReadOnlySpan<char> error) => XLErrorParser.ParseFormulaError(error);
     }
 }

--- a/XLibur/Excel/CalcEngine/FormulaParser.cs
+++ b/XLibur/Excel/CalcEngine/FormulaParser.cs
@@ -96,6 +96,13 @@ internal sealed class FormulaParser
             return new ScalarNode(GetErrorValue(error));
         }
 
+        public ValueNode SheetErrorNode(string context, SymbolRange range, int? workbookIndex, string sheet,
+            ReadOnlySpan<char> error)
+        {
+            // The sheet only matters to a rename; Sheet1!#REF! evaluates to #REF! all the same.
+            return new ScalarNode(GetErrorValue(error));
+        }
+
         public ValueNode NumberNode(string context, SymbolRange range, double value)
         {
             return new ScalarNode(value);
@@ -234,6 +241,17 @@ internal sealed class FormulaParser
             return new NameNode(prefixNode, name);
         }
 
+        public ValueNode ExternalDynamicDataExchange(string context, SymbolRange range, int workbookIndex, string item)
+        {
+            return new NotSupportedNode("dynamic data exchange");
+        }
+
+        public ValueNode DynamicDataExchange(string context, SymbolRange range, string application, string topic,
+            string item)
+        {
+            return new NotSupportedNode("dynamic data exchange");
+        }
+
         public ValueNode BinaryNode(string context, SymbolRange range, BinaryOperation operation, ValueNode leftNode,
             ValueNode rightNode)
         {
@@ -316,8 +334,9 @@ internal sealed class FormulaParser
 
         private static XLError GetErrorValue(ReadOnlySpan<char> error)
         {
+            // The parser lexes every error Excel knows, but XLError lacks most newer ones (#CALC!, #FIELD!, ...).
             if (!XLErrorParser.TryParseError(error.ToString(), out var errorEnum))
-                throw new InvalidOperationException($"'{error.ToString()}' is not error.");
+                throw new ExpressionParseException($"'{error.ToString()}' is not an error value XLibur supports.");
             return errorEnum;
         }
     }

--- a/XLibur/Excel/CalcEngine/Visitors/CollectVisitor.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/CollectVisitor.cs
@@ -46,6 +46,12 @@ internal abstract class CollectVisitor<TContext> : IAstFactory<object?, object?,
         return default;
     }
 
+    public virtual object? SheetErrorNode(TContext context, SymbolRange range, int? workbookIndex, string sheet,
+        ReadOnlySpan<char> error)
+    {
+        return default;
+    }
+
     public virtual object? NumberNode(TContext context, SymbolRange range, double value)
     {
         return default;
@@ -154,6 +160,17 @@ internal abstract class CollectVisitor<TContext> : IAstFactory<object?, object?,
     }
 
     public virtual object? ExternalSheetName(TContext context, SymbolRange range, int workbookIndex, string sheet, string name)
+    {
+        return default;
+    }
+
+    public virtual object? ExternalDynamicDataExchange(TContext context, SymbolRange range, int workbookIndex, string item)
+    {
+        return default;
+    }
+
+    public virtual object? DynamicDataExchange(TContext context, SymbolRange range, string application, string topic,
+        string item)
     {
         return default;
     }

--- a/XLibur/Excel/CalcEngine/Visitors/FormulaReferences.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/FormulaReferences.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using ClosedXML.Parser;
 using XLibur.Excel.Coordinates;
+using XLibur.Extensions;
 
 namespace XLibur.Excel.CalcEngine.Visitors;
 
@@ -37,11 +38,13 @@ internal sealed class FormulaReferences
 
     /// <summary>
     /// Collects the references of <paramref name="formula"/>, or answers <c>false</c> and hands back
-    /// the parser's own exception in <paramref name="failure"/>. A formula that fails half way through
-    /// leaves a partly filled collector behind, so the failure yields an empty one rather than that.
+    /// why in <paramref name="failure"/>: the parser's own exception, or an
+    /// <see cref="ExpressionParseException"/> for an error value <see cref="XLError"/> has no member
+    /// for. A formula that fails half way through leaves a partly filled collector behind, so the
+    /// failure yields an empty one rather than that.
     /// </summary>
     internal static bool TryForFormula(string formula, out FormulaReferences references,
-        [NotNullWhen(false)] out ParsingException? failure)
+        [NotNullWhen(false)] out Exception? failure)
     {
         var collected = new FormulaReferences();
         try
@@ -49,7 +52,7 @@ internal sealed class FormulaReferences
             FormulaParser<object?, object?, FormulaReferences>.CellFormulaA1(formula, collected,
                 CollectRefsFactory.Instance);
         }
-        catch (ParsingException ex)
+        catch (Exception ex) when (ex is ParsingException or ExpressionParseException)
         {
             references = new FormulaReferences();
             failure = ex;
@@ -149,8 +152,17 @@ internal sealed class FormulaReferences
     {
         public static readonly CollectRefsFactory Instance = new();
 
+        // An error value the evaluator refuses is refused here too, so a name holding one is not
+        // taken as understood. SheetErrorNode needs no check: the parser only gives it #REF!.
+        public override object? ErrorValue(FormulaReferences context, SymbolRange range, ReadOnlySpan<char> error)
+        {
+            _ = XLErrorParser.ParseFormulaError(error);
+            return base.ErrorValue(context, range, error);
+        }
+
         public override object? ErrorNode(FormulaReferences context, SymbolRange range, ReadOnlySpan<char> error)
         {
+            _ = XLErrorParser.ParseFormulaError(error);
             context.ContainsRefError = true;
             return base.ErrorNode(context, range, error);
         }

--- a/XLibur/Excel/CalcEngine/Visitors/FormulaReferences.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/FormulaReferences.cs
@@ -155,6 +155,14 @@ internal sealed class FormulaReferences
             return base.ErrorNode(context, range, error);
         }
 
+        public override object? SheetErrorNode(FormulaReferences context, SymbolRange range, int? workbookIndex,
+            string sheet, ReadOnlySpan<char> error)
+        {
+            // Sheet1!#REF! is a ref error too; the parser just no longer routes it through ErrorNode.
+            context.ContainsRefError = true;
+            return base.SheetErrorNode(context, range, workbookIndex, sheet, error);
+        }
+
         public override object? Reference(FormulaReferences context, SymbolRange range, ReferenceArea reference)
         {
             context.References.Add(new XLReference(reference));

--- a/XLibur/Excel/CalcEngine/Visitors/FormulaTransformation.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/FormulaTransformation.cs
@@ -52,7 +52,7 @@ internal static class FormulaTransformation
     /// Wrapper around FormulaConverter.ModifyA1 that protects colons inside
     /// single-bracket structured reference column names from being misinterpreted as range operators.
     /// </summary>
-    internal static string SafeModifyA1(string formula, string sheetName, int row, int column, RefModVisitor visitor)
+    internal static string SafeModifyA1(string formula, string sheetName, int row, int column, FormulaModifier visitor)
     {
         var protected_ = ProtectStructuredRefColons(formula, out var wasProtected);
         var result = FormulaConverter.ModifyA1(protected_, sheetName, row, column, visitor);

--- a/XLibur/Excel/CalcEngine/Visitors/RenameFunctionsVisitor.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/RenameFunctionsVisitor.cs
@@ -7,7 +7,7 @@ namespace XLibur.Excel.CalcEngine.Visitors;
 /// <summary>
 /// A visitor for <see cref="FormulaConverter"/> that maps one name of a function to another.
 /// </summary>
-internal sealed class RenameFunctionsVisitor : RefModVisitor
+internal sealed class RenameFunctionsVisitor : FormulaModifier
 {
     /// <summary>
     /// Case-insensitive dictionary of function names.

--- a/XLibur/Excel/CalcEngine/Visitors/RenameRefModVisitor.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/RenameRefModVisitor.cs
@@ -7,7 +7,7 @@ namespace XLibur.Excel.CalcEngine.Visitors;
 /// <summary>
 /// A factory to rename named reference object (sheets, tables ect.).
 /// </summary>
-internal sealed class RenameRefModVisitor : RefModVisitor
+internal sealed class RenameRefModVisitor : FormulaModifier
 {
     private readonly Dictionary<string, string?>? _sheets;
     private readonly Dictionary<string, string>? _tables;

--- a/XLibur/Excel/DefinedNames/XLDefinedName.cs
+++ b/XLibur/Excel/DefinedNames/XLDefinedName.cs
@@ -163,8 +163,12 @@ internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
         {
             // `[MS-XLSX] 2.2.2.5: The formula MUST NOT use the local-cell-reference production
             // rule.` Excel will refuse to load a workbook with such a defined name (e.g. `A1`).
-            // In theory, defined name should support bang references as a replacement for local
-            // references, but ClosedParser doesn't support it yet.
+            // A bang reference is the replacement Excel expects, and one gets past this guard:
+            // the parser reads `!A1` and hands it to `IAstFactory.BangReference`, so it is not
+            // counted as a sheet-less reference. What is missing is on our side —
+            // `FormulaParser` answers that callback with `NotSupportedNode`, so evaluating such
+            // a name throws. A bang *name* (`!Total`) is the one the parser still cannot lex.
+            // See https://github.com/XLibur/XLibur/issues/313.
             return new ArgumentException($"Formula '{formula}' contains references without a sheet.", paramName);
         }
 

--- a/XLibur/Excel/DefinedNames/XLDefinedName.cs
+++ b/XLibur/Excel/DefinedNames/XLDefinedName.cs
@@ -157,7 +157,7 @@ internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
     private static Exception? RejectionOf(string formula, string paramName, out FormulaReferences references)
     {
         if (!FormulaReferences.TryForFormula(formula, out references, out var failure))
-            return new ExpressionParseException(failure.Message, failure);
+            return failure as ExpressionParseException ?? new ExpressionParseException(failure.Message, failure);
 
         if (references.References.Count > 0)
         {

--- a/XLibur/Excel/DefinedNames/XLDefinedName.cs
+++ b/XLibur/Excel/DefinedNames/XLDefinedName.cs
@@ -167,7 +167,8 @@ internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
             // the parser reads `!A1` and hands it to `IAstFactory.BangReference`, so it is not
             // counted as a sheet-less reference. What is missing is on our side —
             // `FormulaParser` answers that callback with `NotSupportedNode`, so evaluating such
-            // a name throws. A bang *name* (`!Total`) is the one the parser still cannot lex.
+            // a name throws. A bang *name* (`!Total`) parses as of XLibur.ClosedXML.Parser
+            // 2.1.0-beta.293 and meets the same `NotSupportedNode`, from `BangName`.
             // See https://github.com/XLibur/XLibur/issues/313.
             return new ArgumentException($"Formula '{formula}' contains references without a sheet.", paramName);
         }

--- a/XLibur/Extensions/XLErrorExtensions.cs
+++ b/XLibur/Extensions/XLErrorExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using XLibur.Excel;
+using XLibur.Excel.CalcEngine;
 
 namespace XLibur.Extensions;
 
@@ -37,4 +38,19 @@ internal static class XLErrorParser
 
     public static bool TryParseError(string input, out XLError error)
         => ErrorMap.TryGetValue(input.Trim(), out error);
+
+    /// <summary>
+    /// The <see cref="XLError"/> an error literal in a formula stands for. The parser reads every error
+    /// value Excel knows, but <see cref="XLError"/> has no member for most of the newer ones
+    /// (<c>#CALC!</c>, <c>#FIELD!</c>, ...), so a formula holding one is refused like unreadable text.
+    /// </summary>
+    /// <exception cref="ExpressionParseException">The literal has no <see cref="XLError"/>.</exception>
+    public static XLError ParseFormulaError(ReadOnlySpan<char> error)
+    {
+        var text = error.ToString();
+        if (!TryParseError(text, out var parsed))
+            throw new ExpressionParseException($"'{text}' is not an error value XLibur supports.");
+
+        return parsed;
+    }
 }

--- a/XLibur/XLibur.csproj
+++ b/XLibur/XLibur.csproj
@@ -39,7 +39,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="RBush.Signed" Version="4.0.0" />
-        <PackageReference Include="ClosedXML.Parser" Version="2.0.0" />
+        <PackageReference Include="XLibur.ClosedXML.Parser" Version="2.1.0-alpha.276" />
         <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/XLibur/XLibur.csproj
+++ b/XLibur/XLibur.csproj
@@ -39,7 +39,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="RBush.Signed" Version="4.0.0" />
-        <PackageReference Include="XLibur.ClosedXML.Parser" Version="2.1.0-alpha.276" />
+        <PackageReference Include="XLibur.ClosedXML.Parser" Version="2.1.0-beta.293" />
         <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/XLibur/XLibur.csproj
+++ b/XLibur/XLibur.csproj
@@ -39,7 +39,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="RBush.Signed" Version="4.0.0" />
-        <PackageReference Include="XLibur.ClosedXML.Parser" Version="2.1.0-beta.293" />
+        <PackageReference Include="XLibur.ClosedXML.Parser" Version="3.0.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

XLibur referenced `ClosedXML.Parser` 2.0.0, which has no maintained 2.0.x line, so there was no way to ship a parser fix (#313). This PR moves the reference to `XLibur.ClosedXML.Parser`, our fork, and takes it at 3.0.0. The assembly name and the `ClosedXML.Parser` namespace are unchanged, and so is XLibur's public API.

## Changes

### Switch to the fork (written against 2.1.0-alpha.276)

- The `PackageReference` points at `XLibur.ClosedXML.Parser`.
- Pins three fork fixes that are reachable from XLibur's API, each confirmed to fail on 2.0.0:
  - A keyword-list structured reference in a defined name threw `IndexOutOfRangeException` on load.
  - An R1C1 round trip failed under a culture whose negative sign is U+2212.
  - Sheet names were quoted the way the formula bar shows them, not the way the file format needs.

### Move to 2.1.0-beta.293

beta.293 changes the parser API, so this commit adapts XLibur to it:

- `RefModVisitor` is now `FormulaModifier`, for the two rename visitors and `SafeModifyA1`.
- `IAstFactory` gains `SheetErrorNode`, `ExternalDynamicDataExchange` and `DynamicDataExchange`. `CollectVisitor` has them as no-ops. The evaluator gives `Sheet1!#REF!` its error and a DDE reference a `NotSupportedNode`.
- `Sheet1!#REF!` no longer goes through `ErrorNode`, so `FormulaReferences` flags it in `SheetErrorNode` too. Without that, a defined name holding it counts as valid. With the line disabled, two `NamedRangeDeletionTests` fail.
- The parser now lexes `#CALC!`, `#FIELD!` and the other newer error values. `XLError` has no member for most of them, so `GetErrorValue` threw `InvalidOperationException` out of `Parse`. It now throws `ExpressionParseException`, the documented type for a formula that cannot be read.

### Move to 3.0.0

3.0.0 adds 11 fix commits to beta.293 and needs no code change in XLibur. The two that reach XLibur users are the last two items below, each pinned by a test.

### What users will see

These are in `CHANGELOG.md` under Unreleased:

- Renaming or deleting a sheet or table rewrites a formula only where it names that sheet or table. The rest keeps its quoting, its one-cell areas and its leading whitespace. This comes from the fork's changelog; XLibur calls the same `FormulaConverter.ModifyA1` path.
- A DDE formula parses. Evaluating one throws `NotImplementedException`.
- `#SPILL!` parses as `XLError.SpillRange`.
- `#GETTING_DATA` throws `ExpressionParseException`, not `InvalidOperationException`.
- Renaming a sheet to a cell-like name such as `PWD1` quotes it as the first sheet of a 3D reference: `'PWD1:Last'!A1`. The bare form doesn't read back.
- `(A1) B2`, a space intersection after braces, parses. Evaluating it throws `NotImplementedException`, as any range intersection does.

## Related Issues

Refs #313

## Testing

- [x] Added or updated unit tests
  - New: `Constant_error_without_an_XLError_is_a_parse_error`, 4 cases. I watched it fail with `InvalidOperationException` before the fix.
  - New: a `#SPILL!` case in `Constant_can_be_error`.
  - `Reference_can_be_dynamic_data_exchange` is no longer skipped, and it passes.
- [x] All existing tests pass. On net10.0, after rebasing onto `main`: XLibur.Tests 14,493 (4 skipped), XLibur.Report.Tests 481, XLibur.Fonts.SixLabors.Tests 31, XLibur.Fonts.SkiaSharp.Tests 37.
- [ ] Tested manually

Two comments about what the parser can't read were wrong on beta.293. I checked each against the package before correcting it:

- `D3:@A1:C2` now parses, but its dependencies are not pinned in `DependencyTreeTests` yet. The comment there now says so.
- A bang name (`!Total`) now parses, and `XLDefinedName` said it could not. Evaluating one still throws, because `FormulaParser.BangName` answers with `NotSupportedNode`.

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced (Debug build of `XLibur.slnx`, 0 warnings)
- [x] PR targets the `main` branch
