### PR TITLE
fix: a defined name holding a bang reference or bang name evaluates instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 - **`XLWorkbook.EvaluateExpr` can now be called from several threads at once.** The method is static and every caller shared one engine, whose parse cache could not be filled from two threads at the same time. Two threads evaluating the same new expression both missed the cache, and the second threw `ArgumentException: An item with the same key has already been added` from a call that had nothing to do with the other thread. Each thread now has its own engine. A workbook itself is still not safe to use from several threads.
 
+- **A defined name holding a bang reference (`!$A$1`) or a bang name (`!Total`) now evaluates instead of throwing.** Both were accepted when set and when loaded, but a cell using such a name threw `NotImplementedException: Evaluation of Bang reference is not implemented.` (or `Bang name`). Both now resolve on the sheet of the cell that uses the name. `!$A$1` is that sheet's `A1`. `!Total` is that sheet's own `Total`, or the workbook-scoped `Total` if the sheet has none. The cell also recalculates when the cell it resolves to changes. A relative reference such as `!A1` is not yet offset by the position of the cell using the name; this is true of every defined name in XLibur, bang or not.
+
 ### Changed
 
 - The formula parser is now `XLibur.ClosedXML.Parser`, our fork of `ClosedXML.Parser`, in

--- a/XLibur.Tests/Excel/NamedRanges/DefinedNameBangTests.cs
+++ b/XLibur.Tests/Excel/NamedRanges/DefinedNameBangTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using XLibur.Excel;
+using XLibur.Tests.Excel.IO;
+
+namespace XLibur.Tests.Excel.NamedRanges;
+
+/// <summary>
+/// A bang reference (<c>!$A$1</c>) and a bang name (<c>!Total</c>) in a defined name mean "on the
+/// sheet the formula is evaluated for" — the sheet of the cell that uses the name, not the sheet the
+/// name belongs to. That is what makes <c>!$A$1</c> the form Excel expects in place of the sheet-less
+/// <c>$A$1</c> it refuses in a defined name. See https://github.com/XLibur/XLibur/issues/446.
+/// </summary>
+/// <remarks>
+/// Every reference here is absolute. A relative reference in a defined name should be offset by the
+/// cell that uses it, and XLibur does not do that for any defined name yet, bang or not.
+/// </remarks>
+public class DefinedNameBangTests
+{
+    [Test]
+    public async Task A_bang_reference_resolves_against_the_sheet_of_the_cell_using_the_name()
+    {
+        using var wb = new XLWorkbook();
+        var first = wb.AddWorksheet("First");
+        var second = wb.AddWorksheet("Second");
+        first.Cell("A1").Value = 1;
+        second.Cell("A1").Value = 2;
+        wb.DefinedNames.Add("Here", "!$A$1");
+        first.Cell("C1").FormulaA1 = "Here";
+        second.Cell("C1").FormulaA1 = "Here";
+
+        await Assert.That(first.Cell("C1").Value).IsEqualTo(1);
+        await Assert.That(second.Cell("C1").Value).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task A_bang_name_resolves_the_sheet_scoped_name_of_the_sheet_using_it()
+    {
+        using var wb = new XLWorkbook();
+        var first = wb.AddWorksheet("First");
+        var second = wb.AddWorksheet("Second");
+        first.Cell("A1").Value = 7;
+        second.Cell("A1").Value = 9;
+        first.DefinedNames.Add("Total", "First!$A$1");
+        second.DefinedNames.Add("Total", "Second!$A$1");
+        wb.DefinedNames.Add("LocalTotal", "!Total");
+        first.Cell("C1").FormulaA1 = "LocalTotal";
+        second.Cell("C1").FormulaA1 = "LocalTotal";
+
+        await Assert.That(first.Cell("C1").Value).IsEqualTo(7);
+        await Assert.That(second.Cell("C1").Value).IsEqualTo(9);
+    }
+
+    /// <summary>
+    /// Excel shadows rather than isolates: a sheet-scoped name wins only on a sheet that has one.
+    /// Elsewhere the workbook-scoped name of the same identifier answers, not <c>#NAME?</c>.
+    /// </summary>
+    [Test]
+    public async Task A_bang_name_falls_back_to_the_workbook_scoped_name_where_the_sheet_has_none()
+    {
+        using var wb = new XLWorkbook();
+        var first = wb.AddWorksheet("First");
+        var second = wb.AddWorksheet("Second");
+        first.Cell("A1").Value = 7;
+        first.Cell("B1").Value = 5;
+        first.DefinedNames.Add("Total", "First!$A$1");
+        wb.DefinedNames.Add("Total", "First!$B$1");
+        wb.DefinedNames.Add("LocalTotal", "!Total");
+        first.Cell("C1").FormulaA1 = "LocalTotal";
+        second.Cell("C1").FormulaA1 = "LocalTotal";
+
+        await Assert.That(first.Cell("C1").Value).IsEqualTo(7);
+        await Assert.That(second.Cell("C1").Value).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task A_bang_name_that_names_nothing_is_a_name_error()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("First");
+        wb.DefinedNames.Add("LocalTotal", "!Total");
+        ws.Cell("C1").FormulaA1 = "LocalTotal";
+
+        await Assert.That(ws.Cell("C1").Value).IsEqualTo(XLError.NameNotRecognized);
+    }
+
+    /// <summary>
+    /// The precedent has to be registered on the sheet of the cell using the name. Registered on any
+    /// other sheet — or not at all — the edit would leave the cell holding its first answer.
+    /// </summary>
+    [Test]
+    public async Task A_cell_using_a_bang_reference_recalculates_when_the_referenced_cell_changes()
+    {
+        using var wb = new XLWorkbook();
+        var first = wb.AddWorksheet("First");
+        var second = wb.AddWorksheet("Second");
+        first.Cell("A1").Value = 1;
+        second.Cell("A1").Value = 2;
+        wb.DefinedNames.Add("Here", "!$A$1");
+        second.Cell("C1").FormulaA1 = "Here";
+        await Assert.That(second.Cell("C1").Value).IsEqualTo(2);
+
+        second.Cell("A1").Value = 20;
+
+        await Assert.That(second.Cell("C1").Value).IsEqualTo(20);
+    }
+
+    [Test]
+    public async Task A_cell_using_a_bang_name_recalculates_when_the_named_cell_changes()
+    {
+        using var wb = new XLWorkbook();
+        var first = wb.AddWorksheet("First");
+        var second = wb.AddWorksheet("Second");
+        first.Cell("A1").Value = 7;
+        second.Cell("A1").Value = 9;
+        first.DefinedNames.Add("Total", "First!$A$1");
+        second.DefinedNames.Add("Total", "Second!$A$1");
+        wb.DefinedNames.Add("LocalTotal", "!Total");
+        second.Cell("C1").FormulaA1 = "LocalTotal";
+        await Assert.That(second.Cell("C1").Value).IsEqualTo(9);
+
+        second.Cell("A1").Value = 90;
+
+        await Assert.That(second.Cell("C1").Value).IsEqualTo(90);
+    }
+
+    [Test]
+    public async Task A_bang_name_loaded_from_a_file_evaluates()
+    {
+        using var package = BookWithBangName();
+        using var wb = new XLWorkbook(package);
+        var ws = wb.Worksheet("Sheet1");
+        ws.Cell("C1").FormulaA1 = "x";
+
+        await Assert.That(ws.Cell("C1").Value).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task A_bang_name_loaded_from_a_file_keeps_its_text_on_save()
+    {
+        using var package = BookWithBangName();
+        using var saved = new MemoryStream();
+        using (var wb = new XLWorkbook(package))
+            wb.SaveAs(saved);
+
+        using var reloaded = new XLWorkbook(saved);
+
+        await Assert.That(reloaded.DefinedNames.Single(dn => dn.Name == "x").RefersTo).IsEqualTo("!Total");
+    }
+
+    /// <summary>
+    /// A package whose <c>Sheet1!A1</c> holds 7, with a name <c>Total</c> scoped to <c>Sheet1</c>
+    /// pointing at it and a workbook-scoped name <c>x</c> whose text is exactly <c>!Total</c> — written
+    /// into the workbook part directly, so the reader sees the text as Excel would store it.
+    /// </summary>
+    private static MemoryStream BookWithBangName()
+    {
+        var package = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            wb.AddWorksheet("Sheet1").Cell("A1").Value = 7;
+            wb.SaveAs(package);
+        }
+
+        return package.RewriteWorkbook(xml =>
+        {
+            const string definedNames =
+                "<x:definedNames>" +
+                "<x:definedName name=\"Total\" localSheetId=\"0\">Sheet1!$A$1</x:definedName>" +
+                "<x:definedName name=\"x\">!Total</x:definedName>" +
+                "</x:definedNames>";
+            var rewritten = xml.Replace("<x:definedNames />", definedNames);
+            if (ReferenceEquals(rewritten, xml) || !rewritten.Contains("definedName name=\"x\"", StringComparison.Ordinal))
+                throw new InvalidOperationException("The defined names were not spliced into the workbook part.");
+
+            return rewritten;
+        });
+    }
+}

--- a/XLibur/Excel/CalcEngine/FormulaParser.cs
+++ b/XLibur/Excel/CalcEngine/FormulaParser.cs
@@ -126,7 +126,10 @@ internal sealed class FormulaParser
 
         public ValueNode BangReference(string context, SymbolRange range, ReferenceArea reference)
         {
-            return new NotSupportedNode("Bang reference");
+            // `!A1` means "on the sheet the formula is evaluated for", which is what a reference
+            // without a sheet already gets: evaluation falls back to the context's sheet, and a
+            // defined name is evaluated in the context of the cell that uses it.
+            return new ReferenceNode(null, reference, _isA1);
         }
 
         public ValueNode Reference3D(string context, SymbolRange range, string firstSheet, string lastSheet,
@@ -226,7 +229,10 @@ internal sealed class FormulaParser
 
         public ValueNode BangName(string context, SymbolRange range, string name)
         {
-            return new NotSupportedNode("Bang name");
+            // `!Total` means the name as seen from the sheet the formula is evaluated for: that
+            // sheet's own `Total` if it has one, otherwise the workbook's. A name without a prefix
+            // already resolves that way, against the sheet of the cell using the defined name.
+            return new NameNode(null, name);
         }
 
         public ValueNode ExternalName(string context, SymbolRange range, int workbookIndex, string name)

--- a/XLibur/Excel/DefinedNames/XLDefinedName.cs
+++ b/XLibur/Excel/DefinedNames/XLDefinedName.cs
@@ -163,13 +163,10 @@ internal sealed class XLDefinedName : IXLDefinedName, IWorkbookListener
         {
             // `[MS-XLSX] 2.2.2.5: The formula MUST NOT use the local-cell-reference production
             // rule.` Excel will refuse to load a workbook with such a defined name (e.g. `A1`).
-            // A bang reference is the replacement Excel expects, and one gets past this guard:
-            // the parser reads `!A1` and hands it to `IAstFactory.BangReference`, so it is not
-            // counted as a sheet-less reference. What is missing is on our side —
-            // `FormulaParser` answers that callback with `NotSupportedNode`, so evaluating such
-            // a name throws. A bang *name* (`!Total`) parses as of XLibur.ClosedXML.Parser
-            // 2.1.0-beta.293 and meets the same `NotSupportedNode`, from `BangName`.
-            // See https://github.com/XLibur/XLibur/issues/313.
+            // A bang reference is the replacement Excel expects, and it gets past this guard: the
+            // parser hands `!A1` to `IAstFactory.BangReference`, not `Reference`, so it is not
+            // counted here. It evaluates against the sheet of the cell using the name, and so
+            // does a bang name (`!Total`). See https://github.com/XLibur/XLibur/issues/446.
             return new ArgumentException($"Formula '{formula}' contains references without a sheet.", paramName);
         }
 


### PR DESCRIPTION
Closes #446. Also covers item 2a of #444.

## Problem

A defined name holding a bang reference (`!$A$1`) or a bang name (`!Total`) was accepted when set and when loaded, but a cell using it threw:

```
NotImplementedException: Evaluation of Bang reference is not implemented.
NotImplementedException: Evaluation of Bang name is not implemented.
```

`FormulaParser` answered `IAstFactory.BangReference` and `BangName` with `NotSupportedNode`.

## Fix

Both forms mean "on the sheet the formula is evaluated for". XLibur already evaluates a defined name in the context of the cell that uses it, so no new node type is needed:

- `BangReference` returns a `ReferenceNode` with no prefix. Evaluation resolves a sheet-less reference against the context's sheet.
- `BangName` returns a `NameNode` with no prefix. It looks up the calling sheet's own name first, then the workbook-scoped name (`NameNode.TryGetNameRange`).

The open question in #446 is settled as **fall back to the workbook-scoped name**. This matches Excel: a sheet-scoped name shadows the workbook-scoped one only on a sheet that has it.

`DependenciesVisitor` already resolves both forms against the formula's sheet, so it needed no change. A cell using such a name recalculates when the cell it resolves to changes.

The comment in `XLDefinedName.RejectionOf` said evaluating a bang name throws. It now says what it does.

## Tests

`DefinedNameBangTests`, 8 tests through the public API:

| Case | Result |
|---|---|
| `!$A$1` used from two sheets | each sheet's own `A1` |
| `!Total`, `Total` scoped to each of two sheets | each sheet's own `Total` |
| `!Total`, calling sheet has no `Total` | the workbook-scoped `Total` |
| `!Total`, no `Total` anywhere | `#NAME?` |
| `!$A$1`, the target cell changes | the cell recalculates |
| `!Total`, the named cell changes | the cell recalculates |
| Raw `<definedName name="x">!Total</definedName>` loaded | evaluates |
| The same, saved and reloaded | text is still `!Total` |

- Before the fix, the first seven failed with `NotImplementedException`. The last one already passed; it guards the text on save.
- The two recalculation tests were checked against a mutation: with dependency tracking off for sheet-less nodes, both fail with a stale value.

All four test projects pass on net10.0. `XLibur.Tests` passes 14,501 with 4 skipped (none of them new), and `XLibur.Report.Tests`, `XLibur.Fonts.SixLabors.Tests` and `XLibur.Fonts.SkiaSharp.Tests` all pass. I did not run net8.0.

## Not covered

- **Relative references.** `!A1` is not offset by the position of the cell that uses the name. No defined name in XLibur does this yet, bang or not, so the tests use `!$A$1`. `DependencyTreeTests` already has a skipped test for the gap.
- **Redefining the target name.** This PR does not test whether changing what `Total` refers to recalculates cells that use `!Total`. Nothing in the library reads `FormulaDependencies.Names`, so this may be a gap for plain names too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed evaluation of bang-prefixed references and names, such as `!$A$1` and `!Total`, using the sheet where the formula is evaluated.
  - Defined names now recalculate when referenced cells change.
  - Unresolved bang names now return `#NAME?` instead of throwing an error.
  - Bang references can be loaded from and saved to workbook files.
  - Relative references such as `!A1` are not yet adjusted based on the position of the formula cell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->