### PR TITLE
fix!: a formula the parser refuses throws ExpressionParseException from CopyTo and FormulaR1C1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 
 - **`XLHelper.GetColumnNumberFromLetter("")` now throws `ArgumentException` rather than `ArgumentNullException`.** An empty string is not a missing argument. `null` still throws `ArgumentNullException`; because that derives from `ArgumentException`, a handler for the base type sees both cases as before, but a handler for `ArgumentNullException` alone no longer sees the empty one.
 
+#### Formulas
+
+- **A formula the parser cannot read now throws `ExpressionParseException` when it is converted between A1 and R1C1, instead of `ClosedXML.Parser.ParsingException`.** Copying a cell, reading or setting `FormulaR1C1`, and loading a shared formula all make that conversion. They let the parser's own exception type out of XLibur's API, while evaluating the same formula already threw `ExpressionParseException`. Setting `FormulaA1` does not parse the text, so a formula such as `'[file.xlsx]Sheet'!A1` — the form the formula bar shows for an external reference, not the `[1]Sheet!A1` a file stores — is accepted and then fails on the first copy. **A `catch (ParsingException)` around these calls no longer runs**, and there is no compile-time signal. The parser's exception is kept as `InnerException`.
+
 ### 🐛 Bug Fixes
 
 - **Copying a data validation or a conditional format no longer mangles a formula that has whitespace around it.** The copy converts the formula to R1C1 and back. Each conversion trimmed the text, took off a leading `=`, and then rebuilt what it had removed from the difference in length, as if all of it came before the formula. So a custom validation of `" = A1 "` copied down one row became `" =  A2"`: the space after the `=` doubled and the space at the end was lost. A formula with trailing whitespace and no `=` lost characters instead: a conditional format loaded from a file with the formula `E1 ` came out of a copy as `ERC[4]`, which is no longer a reference. The leading whitespace and the `=` are now kept as written, and the parser converts the rest with its whitespace in place. A cell's `FormulaA1` trims its text when it is set, and so does a conditional format value set through the API, so neither was affected.

--- a/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -593,14 +593,22 @@ internal class DependencyTreeTests
             // Unary implicit intersection is propagated
             yield return
             [
-                // `D3:@A1:C2` failed to parse up to XLibur.ClosedXML.Parser 2.1.0-alpha.276 and
-                // parses on 2.1.0-beta.293, but its dependencies are not pinned here yet
-                // (https://github.com/XLibur/XLibur/issues/313).
                 "@A1:A4",
                 new[]
                 {
                     // Implicit intersection
                     new SheetArea("Sheet", Area.Parse("A1:A4")),
+                }
+            ];
+
+            // Implicit intersection binds tighter than the range operator, so this is
+            // D3:(@A1):C2 and the range spans all three references
+            yield return
+            [
+                "D3:@A1:C2",
+                new[]
+                {
+                    new SheetArea("Sheet", Area.Parse("A1:D3")),
                 }
             ];
 

--- a/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/XLibur.Tests/Excel/CalcEngine/InformationTests.cs
@@ -29,8 +29,7 @@ public class InformationTests
     [Arguments("#NUM!", 6)]
     [Arguments("#N/A", 7)]
     //[TestCase("#GETTING_DATA", 8)] OLAP Cube not supported
-    // #SPILL! (ERROR.TYPE 9) can't be written as a literal — the parser doesn't tokenize it —
-    // so it is covered against a real spilled #SPILL! cell in SpillEvaluationTests.
+    [Arguments("#SPILL!", 9)]
     public async Task ErrorType_ReturnsNumberForError(string error, int expectedNumber)
     {
         await Assert.That(XLWorkbook.EvaluateExpr($"ERROR.TYPE({error})")).IsEqualTo(expectedNumber);

--- a/XLibur.Tests/Excel/Cells/XLCellFormulaTests.cs
+++ b/XLibur.Tests/Excel/Cells/XLCellFormulaTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using XLibur.Excel;
+using XLibur.Excel.CalcEngine;
 using XLibur.Excel.Coordinates;
 using System.Threading.Tasks;
 
@@ -39,6 +40,58 @@ public class XLCellFormulaTests
     {
         var a1 = XLCellFormula.GetFormula(r1c1, FormulaConversionType.R1C1ToA1, new Point(2, 2));
         await Assert.That(a1).IsEqualTo(expectedA1);
+    }
+
+    [Test]
+    public async Task CopyTo_KeepsABareDynamicDataExchangeItem()
+    {
+        // The parser reads a bare DDE item as a sheet reference. It used to write the prefix back
+        // quoted, as 'Sdemo123|tik'!SomeItem.
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("C2").FormulaA1 = "Sdemo123|tik!SomeItem";
+
+        ws.Cell("C2").CopyTo(ws.Cell("E5"));
+
+        await Assert.That(ws.Cell("C2").FormulaR1C1).IsEqualTo("Sdemo123|tik!SomeItem");
+        await Assert.That(ws.Cell("E5").FormulaA1).IsEqualTo("Sdemo123|tik!SomeItem");
+    }
+
+    [Test]
+    public async Task SaveAndLoad_KeepsABareDynamicDataExchangeItem()
+    {
+        using var ms = new MemoryStream();
+        using (var wb = new XLWorkbook())
+        {
+            wb.AddWorksheet().Cell("C2").FormulaA1 = "Sdemo123|tik!SomeItem";
+            wb.SaveAs(ms);
+        }
+
+        ms.Position = 0;
+        using var loaded = new XLWorkbook(ms);
+        await Assert.That(loaded.Worksheet(1).Cell("C2").FormulaA1).IsEqualTo("Sdemo123|tik!SomeItem");
+    }
+
+    // The formula bar shows an external reference as '[file.xlsx]Sheet'!A1, but a file stores it as
+    // [1]Sheet!A1, and the parser refuses the displayed form. Setting FormulaA1 doesn't parse it.
+    [Test]
+    public async Task CopyTo_OfAFormulaTheParserRefuses_ThrowsExpressionParseException()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("C2").FormulaA1 = "'[file.xlsx]Sheet'!A1";
+
+        await Assert.That(() => ws.Cell("C2").CopyTo(ws.Cell("E5"))).Throws<ExpressionParseException>();
+    }
+
+    [Test]
+    public async Task FormulaR1C1_OfAFormulaTheParserRefuses_ThrowsExpressionParseException()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("C2").FormulaA1 = "'[file.xlsx]Sheet'!A1";
+
+        await Assert.That(() => ws.Cell("C2").FormulaR1C1).Throws<ExpressionParseException>();
     }
 
     [Test]

--- a/XLibur/Excel/CalcEngine/Visitors/FormulaTransformation.cs
+++ b/XLibur/Excel/CalcEngine/Visitors/FormulaTransformation.cs
@@ -41,9 +41,9 @@ internal static class FormulaTransformation
         }
         catch (Exception)
         {
-            // Parser doesn't support all formula constructs (e.g. external workbook
-            // references like '[file.xlsx]Sheet'!A1). If parsing fails, the formula
-            // can't contain a future function that needs remapping, so return as-is.
+            // A caller can set text the parser rightly refuses, such as an external reference
+            // in the form the formula bar shows, '[file.xlsx]Sheet'!A1 (a file stores [1]Sheet!A1).
+            // Text that doesn't parse can't have a future function to remap, so return it as-is.
             return formula;
         }
     }
@@ -63,21 +63,37 @@ internal static class FormulaTransformation
     /// Wrapper around <see cref="FormulaConverter.ToR1C1"/> that protects colons inside
     /// single-bracket structured reference column names.
     /// </summary>
+    /// <exception cref="ExpressionParseException">The formula can't be parsed.</exception>
     internal static string SafeToR1C1(string formulaA1, int row, int column)
     {
-        var protected_ = ProtectStructuredRefColons(formulaA1, out var wasProtected);
-        var result = FormulaConverter.ToR1C1(protected_, row, column);
-        return wasProtected ? result.Replace(ColonPlaceholder, ':') : result;
+        return Convert(formulaA1, row, column, FormulaConverter.ToR1C1);
     }
 
     /// <summary>
     /// Wrapper around <see cref="FormulaConverter.ToA1"/> that protects colons inside
     /// single-bracket structured reference column names.
     /// </summary>
+    /// <exception cref="ExpressionParseException">The formula can't be parsed.</exception>
     internal static string SafeToA1(string formulaR1C1, int row, int column)
     {
-        var protected_ = ProtectStructuredRefColons(formulaR1C1, out var wasProtected);
-        var result = FormulaConverter.ToA1(protected_, row, column);
+        return Convert(formulaR1C1, row, column, FormulaConverter.ToA1);
+    }
+
+    private static string Convert(string formula, int row, int column, Func<string, int, int, string> converter)
+    {
+        var protected_ = ProtectStructuredRefColons(formula, out var wasProtected);
+        string result;
+        try
+        {
+            result = converter(protected_, row, column);
+        }
+        catch (ParsingException ex)
+        {
+            // Copying a cell and reading FormulaR1C1 both come through here, so the parser's own
+            // exception type would otherwise reach the caller.
+            throw new ExpressionParseException(ex.Message, ex);
+        }
+
         return wasProtected ? result.Replace(ColonPlaceholder, ':') : result;
     }
 


### PR DESCRIPTION
## Summary

This is the XLibur side of #444 that was left after #474 and #475: items 1, 3, 4, 6 and A. Item A changes an exception type, so this PR is marked breaking.

## Changes

### Item A — `ParsingException` no longer leaks out of the public API

Copying a cell does `target.FormulaR1C1 = source.FormulaR1C1`, so it converts the formula to R1C1 and back. That conversion, and every other one between A1 and R1C1, goes through `FormulaTransformation.SafeToR1C1` or `SafeToA1`:

- copying a cell, and the data validations and conditional formats with it
- reading or setting `FormulaR1C1`
- swapping formulas when rows or columns are swapped (`XLCellFormula.GetMovedTo`)
- loading a shared formula

Neither method caught anything, so a formula the parser refuses threw `ClosedXML.Parser.ParsingException`, a dependency's type, out of `CopyTo`. Evaluating the same formula already threw `ExpressionParseException`. Both methods now wrap the exception the same way `FormulaParser` does, and keep the parser's exception as `InnerException`.

Wrapping in those two methods, rather than in `GetMovedTo` as #444 first suggested, covers every path with one change. Nothing between them and the public API caught `ParsingException`.

**Breaking:** a `catch (ParsingException)` around these calls no longer runs. It's in `CHANGELOG.md` under Breaking Changes → Formulas.

### Item 1 — the comment in `FixFutureFunctions`

It said the parser "doesn't support" external workbook references like `'[file.xlsx]Sheet'!A1`. The parser is right to refuse that text: it is the form the formula bar shows, and a file stores `[1]Sheet!A1`. The comment now says so.

### Items 3, 4 and 6 — tests that pin what the fork fixed

| Item | Test | Pins |
|---|---|---|
| 3 | `XLCellFormulaTests.CopyTo_KeepsABareDynamicDataExchangeItem`, `SaveAndLoad_KeepsABareDynamicDataExchangeItem` | `Sdemo123\|tik!SomeItem` survives `CopyTo`, `FormulaR1C1` and a save unchanged. It used to come back as `'Sdemo123\|tik'!SomeItem`. |
| 4 | `InformationTests.ErrorType_ReturnsNumberForError` | `ERROR.TYPE(#SPILL!)` returns 9. The comment saying the parser can't tokenize `#SPILL!` is gone. |
| 6 | `DependencyTreeTests.AreaDependenciesTestCases` | `D3:@A1:C2` depends on `A1:D3`. `@` binds tighter than `:`, so it reads as `D3:(@A1):C2`. The comment saying it isn't pinned is gone. |

## Related Issues

Closes #444. Items 5 and the evaluation half of 6 stay open in #445 and #447.

## Testing

- [x] Added or updated unit tests
  - Item A: `CopyTo_OfAFormulaTheParserRefuses_ThrowsExpressionParseException` and `FormulaR1C1_OfAFormulaTheParserRefuses_ThrowsExpressionParseException`. I watched both fail with `ParsingException` before the fix.
  - Items 3, 4 and 6 passed as soon as they were written. They pin behaviour the fork already fixed, which is what #444 asked for.
- [x] All existing tests pass on net10.0: XLibur.Tests 14,521 (4 skipped, as before), XLibur.Report.Tests 481, XLibur.Fonts.SixLabors.Tests 31, XLibur.Fonts.SkiaSharp.Tests 37. Not run on net8.0.
- [ ] Tested manually

## Checklist

- [x] Code follows existing project conventions
- [x] No new warnings introduced (the builds above ran with warnings as errors)
- [x] PR targets the `main` branch
- [x] `CHANGELOG.md` entry under Unreleased → Breaking Changes
